### PR TITLE
refactor: decouple callback interface from core, add EarlyStoppingCal…

### DIFF
--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -57,6 +57,7 @@ class _CallbackNamespace:
 
     from .utils.callbacks import Callback as base  # noqa: F401
     from .utils.callbacks import CheckpointCallback as checkpoint  # noqa: F401
+    from .utils.callbacks import EarlyStoppingCallback as early_stopping  # noqa: F401
 
 
 callback = _CallbackNamespace()

--- a/jno/core.py
+++ b/jno/core.py
@@ -34,7 +34,6 @@ from .trace import (
     cse,
 )
 from .utils import LearningRateSchedule, WeightSchedule, statistics, get_logger, get_seed
-from .utils.monitor import HardwareMonitor
 from .domain import domain, DomainData
 from .trace_evaluator import TraceEvaluator
 from .trace_compiler import TraceCompiler
@@ -1329,8 +1328,6 @@ class core:
             del _tw, _ow, _rw, _ew, _pl
 
             # ── 8. Training loop ──
-            # hw_monitor = HardwareMonitor(logger=self.log, interval=0.5)
-            # hw_monitor.start()
 
             print_rate = max(1, epochs // 10 if epochs < 100_000 else epochs // 1000)
             prev_losses = jax.device_put(jnp.zeros(self.n_constraints), replicated)
@@ -1528,15 +1525,19 @@ class core:
                         "rng": self.rng,
                         "total_loss": total_loss,
                         "individual_losses": individual_losses,
+                        "log": self.log,
                     }
+                    _stop_requested = False
                     for cb in callbacks:
-                        cb.on_epoch_end(self, **cb_info)
+                        if cb.on_epoch_end(**cb_info):
+                            _stop_requested = True
+                    if _stop_requested:
+                        break
 
             if _profile_active:
                 _profile_ctx.__exit__(None, None, None)
 
             et = time.time()
-            # hw_monitor.stop(logger=self.log)
 
             gc.enable()  # restore GC after training loop
 
@@ -1583,7 +1584,7 @@ class core:
         # --- callbacks: on_training_end ---
         if callbacks:
             for cb in callbacks:
-                cb.on_training_end(self)
+                cb.on_training_end()
 
         return statistics(self.training_logs)
 

--- a/jno/utils/callbacks.py
+++ b/jno/utils/callbacks.py
@@ -4,25 +4,23 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
-if TYPE_CHECKING:
-    from ..core import core
-
 
 class Callback:
     """Base callback class.
 
-    Subclass and override the hooks you need.  Every hook receives the
-    ``core`` solver instance as its first positional argument, followed by
-    keyword arguments whose contents depend on the hook.
+    Subclass and override the hooks you need.  Every hook receives
+    keyword arguments whose contents depend on the hook and the
+    caller.  This keeps the interface decoupled from any particular
+    solver implementation.
     """
 
-    def on_epoch_end(self, state: "core", **kwargs) -> None:
+    def on_epoch_end(self, **kwargs) -> bool:
         """Called at the end of every outer training step.
 
         Keyword Args:
@@ -32,9 +30,15 @@ class Callback:
             rng: Current JAX PRNG key.
             total_loss: Scalar total loss (JAX array, still on device).
             individual_losses: Per-constraint losses (JAX array).
-        """
+            log: Logger instance (when called from ``core.solve``).
 
-    def on_training_end(self, state: "core", **kwargs) -> None:
+        Returns:
+            ``True`` to request early termination of the training loop,
+            ``False`` (default) to continue.
+        """
+        return False
+
+    def on_training_end(self, **kwargs) -> None:
         """Called once after the training loop finishes."""
 
 
@@ -132,7 +136,7 @@ class CheckpointCallback(Callback):
 
     # -- hooks ---------------------------------------------------------------
 
-    def on_epoch_end(self, state: "core", **kwargs) -> None:
+    def on_epoch_end(self, **kwargs) -> None:
         ocp = self._ocp
         epoch: int = kwargs["epoch"]
         trainable = kwargs["trainable"]
@@ -167,7 +171,7 @@ class CheckpointCallback(Callback):
             metrics=metadata if self._best_fn is not None else None,
         )
 
-    def on_training_end(self, state: "core", **kwargs) -> None:
+    def on_training_end(self, **kwargs) -> None:
         self._manager.wait_until_finished()
 
     # -- public API ----------------------------------------------------------
@@ -210,3 +214,122 @@ class CheckpointCallback(Callback):
     def close(self) -> None:
         """Close the checkpoint manager (waits for pending writes)."""
         self._manager.close()
+
+
+# ---------------------------------------------------------------------------
+# Early stopping callback
+# ---------------------------------------------------------------------------
+
+
+class EarlyStoppingCallback(Callback):
+    """Stop training when a monitored metric stops improving.
+
+    Monitors a scalar metric (by default the total loss) each epoch and
+    signals the training loop to stop once the metric has not improved
+    for *patience* consecutive checks.
+
+    Three stopping strategies are available via the *mode* parameter:
+
+    ``"min"``
+        Improvement means the metric decreased by more than *min_delta*.
+        Use for losses.
+    ``"max"``
+        Improvement means the metric increased by more than *min_delta*.
+        Use for accuracy-like metrics.
+    ``"rel"``
+        Improvement means the metric decreased by a factor of at least
+        *min_delta* relative to the best value so far
+        (i.e. ``new < best * (1 - min_delta)``).  Useful when the loss
+        spans many orders of magnitude, which is common in PINN training.
+
+    Args:
+        patience: Number of epochs with no improvement after which
+            training is stopped.  Default ``500``.
+        min_delta: Minimum change to qualify as an improvement.
+            For ``"min"``/``"max"`` this is an absolute threshold;
+            for ``"rel"`` it is a relative fraction.  Default ``0.0``.
+        mode: One of ``"min"``, ``"max"``, or ``"rel"``.
+            Default ``"min"``.
+        metric_fn: Callable that extracts the scalar metric from the
+            ``on_epoch_end`` keyword arguments.  Default extracts
+            ``total_loss`` (transferred to host).
+        baseline: An optional baseline value.  Training will stop if
+            the metric never improves beyond this value.
+        verbose: If ``True``, log a message when stopping.
+
+    Example::
+
+        cb = jno.callback.early_stopping(patience=1000, min_delta=1e-6)
+        solver.solve(epochs=100_000, callbacks=[cb])
+
+        print(cb.stopped_epoch)   # epoch at which training was halted
+        print(cb.best_metric)     # best metric value observed
+    """
+
+    def __init__(
+        self,
+        patience: int = 500,
+        min_delta: float = 0.0,
+        mode: str = "min",
+        metric_fn: Optional[Any] = None,
+        baseline: Optional[float] = None,
+        verbose: bool = True,
+    ) -> None:
+        if mode not in ("min", "max", "rel"):
+            raise ValueError(f"mode must be 'min', 'max', or 'rel', got {mode!r}")
+
+        self.patience = patience
+        self.min_delta = abs(min_delta)
+        self.mode = mode
+        self.verbose = verbose
+
+        if metric_fn is None:
+            self._metric_fn = lambda **kw: float(jax.device_get(kw["total_loss"]))
+        else:
+            self._metric_fn = metric_fn
+
+        self.best_metric: Optional[float] = baseline
+        self.stopped_epoch: Optional[int] = None
+        self._wait = 0
+        self._stopped = False
+
+    # -- comparison helpers --------------------------------------------------
+
+    def _is_improvement(self, current: float) -> bool:
+        if self.best_metric is None:
+            return True
+        if self.mode == "min":
+            return current < self.best_metric - self.min_delta
+        elif self.mode == "max":
+            return current > self.best_metric + self.min_delta
+        else:  # rel
+            return current < self.best_metric * (1.0 - self.min_delta)
+
+    # -- hooks ---------------------------------------------------------------
+
+    def on_epoch_end(self, **kwargs) -> bool:
+        current = self._metric_fn(**kwargs)
+        epoch: int = kwargs["epoch"]
+
+        if self._is_improvement(current):
+            self.best_metric = current
+            self._wait = 0
+        else:
+            self._wait += 1
+
+        if self._wait >= self.patience:
+            self._stopped = True
+            self.stopped_epoch = epoch
+            if self.verbose:
+                log = kwargs.get("log")
+                msg = f"Early stopping at epoch {epoch}: " f"no improvement for {self.patience} epochs " f"(best={self.best_metric:.6e})"
+                if log is not None:
+                    log.info(msg)
+            return True  # signal stop
+
+        return False
+
+    @property
+    def has_stopped(self) -> bool:
+        """Whether early stopping was triggered."""
+        return self._stopped

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -50,7 +50,7 @@ class TestCallbackHooks:
             def __init__(self):
                 self.calls = []
 
-            def on_epoch_end(self, state, **kwargs):
+            def on_epoch_end(self, **kwargs):
                 self.calls.append(kwargs.get("epoch"))
 
         rec = Recorder()
@@ -68,7 +68,7 @@ class TestCallbackHooks:
             def __init__(self):
                 self.count = 0
 
-            def on_training_end(self, state, **kwargs):
+            def on_training_end(self, **kwargs):
                 self.count += 1
 
         ctr = Counter()
@@ -81,13 +81,13 @@ class TestCallbackHooks:
         """on_epoch_end should receive the documented keyword arguments."""
         from jno.utils.callbacks import Callback
 
-        required_keys = {"epoch", "trainable", "opt_states", "rng", "total_loss", "individual_losses"}
+        required_keys = {"epoch", "trainable", "opt_states", "rng", "total_loss", "individual_losses", "log"}
 
         class KeyChecker(Callback):
             def __init__(self):
                 self.received_keys = set()
 
-            def on_epoch_end(self, state, **kwargs):
+            def on_epoch_end(self, **kwargs):
                 self.received_keys.update(kwargs.keys())
 
         kc = KeyChecker()
@@ -367,3 +367,123 @@ class TestImportGuard:
 
         with pytest.raises(ImportError, match="orbax-checkpoint"):
             CC(directory="/tmp/test")
+
+
+# ---------------------------------------------------------------------------
+# Early stopping callback
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyStoppingCallback:
+    """Tests for the EarlyStoppingCallback."""
+
+    def test_stops_training(self):
+        """Training should terminate before max epochs when loss plateaus."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        # patience=3 so it stops quickly
+        cb = EarlyStoppingCallback(patience=3, min_delta=0.0, verbose=False)
+        solver = _make_solver(epochs=0)
+        solver.solve(200, callbacks=[cb])
+
+        assert cb.has_stopped, "Early stopping should have triggered"
+        assert cb.stopped_epoch is not None
+        assert cb.stopped_epoch < 199, "Should have stopped before final epoch"
+
+    def test_does_not_stop_when_improving(self):
+        """With high patience, training should complete normally."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        cb = EarlyStoppingCallback(patience=10_000, verbose=False)
+        solver = _make_solver(epochs=0)
+        solver.solve(20, callbacks=[cb])
+
+        assert not cb.has_stopped
+
+    def test_mode_min(self):
+        """mode='min' should detect when loss stops decreasing."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        cb = EarlyStoppingCallback(patience=5, mode="min", verbose=False)
+
+        # Simulate decreasing then flat losses
+        for i, loss_val in enumerate([1.0, 0.5, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]):
+            stop = cb.on_epoch_end(epoch=i, total_loss=jnp.array(loss_val), individual_losses=jnp.array([loss_val]), trainable=None, opt_states=None, rng=None)
+            if stop:
+                break
+
+        assert cb.has_stopped
+        assert cb.best_metric == pytest.approx(0.3)
+
+    def test_mode_max(self):
+        """mode='max' should detect when metric stops increasing."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        cb = EarlyStoppingCallback(
+            patience=3,
+            mode="max",
+            metric_fn=lambda **kw: float(jax.device_get(kw["total_loss"])),
+            verbose=False,
+        )
+
+        for i, val in enumerate([0.1, 0.5, 0.9, 0.9, 0.9, 0.9]):
+            stop = cb.on_epoch_end(epoch=i, total_loss=jnp.array(val), individual_losses=jnp.array([val]), trainable=None, opt_states=None, rng=None)
+            if stop:
+                break
+
+        assert cb.has_stopped
+        assert cb.best_metric == pytest.approx(0.9)
+
+    def test_mode_rel(self):
+        """mode='rel' should use relative improvement threshold."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        cb = EarlyStoppingCallback(patience=2, mode="rel", min_delta=0.1, verbose=False)
+
+        # 1.0 -> 0.95 is only 5% improvement, below 10% threshold
+        losses = [1.0, 0.95, 0.94, 0.93]
+        for i, val in enumerate(losses):
+            stop = cb.on_epoch_end(epoch=i, total_loss=jnp.array(val), individual_losses=jnp.array([val]), trainable=None, opt_states=None, rng=None)
+            if stop:
+                break
+
+        assert cb.has_stopped
+
+    def test_baseline(self):
+        """With a baseline, early stopping fires if metric never beats it."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        cb = EarlyStoppingCallback(patience=2, baseline=0.01, verbose=False)
+
+        # Loss never goes below baseline 0.01
+        for i in range(5):
+            stop = cb.on_epoch_end(epoch=i, total_loss=jnp.array(0.5), individual_losses=jnp.array([0.5]), trainable=None, opt_states=None, rng=None)
+            if stop:
+                break
+
+        assert cb.has_stopped
+
+    def test_invalid_mode_raises(self):
+        """Invalid mode should raise ValueError."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        with pytest.raises(ValueError, match="mode"):
+            EarlyStoppingCallback(mode="invalid")
+
+    def test_custom_metric_fn(self):
+        """A custom metric_fn should be used to extract the metric."""
+        from jno.utils.callbacks import EarlyStoppingCallback
+
+        # Monitor the first individual loss instead of total
+        cb = EarlyStoppingCallback(
+            patience=2,
+            metric_fn=lambda **kw: float(jax.device_get(kw["individual_losses"])[0]),
+            verbose=False,
+        )
+
+        for i, val in enumerate([1.0, 1.0, 1.0]):
+            stop = cb.on_epoch_end(epoch=i, total_loss=jnp.array(0.0), individual_losses=jnp.array([val]), trainable=None, opt_states=None, rng=None)
+            if stop:
+                break
+
+        assert cb.has_stopped

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,20 +14,20 @@ from jno.utils.config import get_seed, load_config, get_runs_base_dir, get_rsa_p
 
 
 class TestGetSeed:
-    def test_returns_none_when_config_empty(self, monkeypatch):
-        """get_seed() returns None when no [jno] section is present."""
+    def test_returns_default_when_config_empty(self, monkeypatch):
+        """get_seed() returns 42 when no [jno] section is present."""
         monkeypatch.setattr(cfg_module, "_CONFIG", {})
-        assert get_seed() is None
+        assert get_seed() == 42
 
     def test_returns_seed_value(self, monkeypatch):
         """get_seed() returns the integer seed from [jno] section."""
         monkeypatch.setattr(cfg_module, "_CONFIG", {"jno": {"seed": 42}})
         assert get_seed() == 42
 
-    def test_returns_none_when_seed_key_absent(self, monkeypatch):
-        """get_seed() returns None when [jno] exists but has no 'seed' key."""
+    def test_returns_default_when_seed_key_absent(self, monkeypatch):
+        """get_seed() returns 42 when [jno] exists but has no 'seed' key."""
         monkeypatch.setattr(cfg_module, "_CONFIG", {"jno": {"other_key": "x"}})
-        assert get_seed() is None
+        assert get_seed() == 42
 
     def test_seed_is_int(self, monkeypatch):
         """get_seed() returns the value as-is from TOML (integer)."""
@@ -143,9 +143,9 @@ class TestEndToEnd:
         load_config(force=True)
         assert get_seed() == 55
 
-    def test_get_seed_returns_none_after_empty_load(self, tmp_path, monkeypatch):
-        """get_seed() returns None when the loaded config has no seed."""
+    def test_get_seed_returns_default_after_empty_load(self, tmp_path, monkeypatch):
+        """get_seed() returns 42 when the loaded config has no seed."""
         (tmp_path / ".jno.toml").write_bytes(b"[runs]\nbase_dir = './r'\n")
         monkeypatch.chdir(tmp_path)
         load_config(force=True)
-        assert get_seed() is None
+        assert get_seed() == 42

--- a/tests/test_core_device.py
+++ b/tests/test_core_device.py
@@ -319,11 +319,11 @@ class TestCoreInit:
     def test_devices_set_after_compile(self, solver):
         assert solver.devices is not None
 
-    def test_default_seed_is_21_without_config(self, monkeypatch):
-        """With no config seed, core uses fallback seed 21."""
+    def test_default_seed_is_42_without_config(self, monkeypatch):
+        """With no config seed, core uses default seed 42."""
         import jno.utils.config as cfg_module
 
-        # Force config to empty so get_seed() returns None
+        # Force config to empty so get_seed() returns default 42
         monkeypatch.setattr(cfg_module, "_CONFIG", {})
 
         dom = 1 * jno.domain(constructor=jno.domain.line(mesh_size=0.1))
@@ -333,7 +333,7 @@ class TestCoreInit:
         u = u_net(x)
         pde = jnn.laplacian(u, [x])
         s = jno.core([pde.mse], dom)
-        assert s.seed == 21
+        assert s.seed == 42
 
     def test_seed_read_from_config(self, monkeypatch):
         """core uses the seed value from [jno] config when present."""

--- a/uv.lock
+++ b/uv.lock
@@ -1176,9 +1176,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-checkpoint = [
-    { name = "orbax-checkpoint" },
-]
 cuda = [
     { name = "jax", extra = ["cuda12"] },
 ]
@@ -1190,7 +1187,6 @@ dev = [
     { name = "lineax" },
     { name = "mypy" },
     { name = "nevergrad" },
-    { name = "orbax-checkpoint" },
     { name = "paramax" },
     { name = "pyfiglet" },
     { name = "pylotte" },
@@ -1236,8 +1232,6 @@ requires-dist = [
     { name = "nevergrad", marker = "extra == 'dev'" },
     { name = "optax" },
     { name = "orbax-checkpoint" },
-    { name = "orbax-checkpoint", marker = "extra == 'checkpoint'" },
-    { name = "orbax-checkpoint", marker = "extra == 'dev'" },
     { name = "paramax", marker = "extra == 'dev'" },
     { name = "pyfiglet", marker = "extra == 'dev'" },
     { name = "pygmsh" },
@@ -1245,7 +1239,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "xprof", marker = "extra == 'dev'" },
 ]
-provides-extras = ["cuda", "checkpoint", "dev", "iree"]
+provides-extras = ["cuda", "dev", "iree"]
 
 [package.metadata.requires-dev]
 fem = [


### PR DESCRIPTION
…lback

- Remove `state: core` positional argument from Callback.on_epoch_end() and on_training_end(); hooks now use **kwargs only, making the callback interface generic and reusable outside of core.solve().
- Pass `log` as a kwarg in cb_info so callbacks can still access the logger without depending on the core object.
- Remove TYPE_CHECKING import of core from callbacks.py.
- Add EarlyStoppingCallback with three modes: "min", "max", and "rel" (relative decrease, useful for PINN multi-order-of-magnitude loss). Supports patience, min_delta, baseline, and custom metric_fn.
- Wire stop signal into solve(): on_epoch_end() returns bool, training loop breaks when any callback returns True.
- Register EarlyStoppingCallback as jno.callback.early_stopping.
- Change get_seed() default from None to 42.
- Update solve() docstring with all parameters.
- Remove self.checkpoints attribute and related code.
- Add 8 EarlyStoppingCallback tests; update 4 existing tests for new get_seed() default. All 23 callback tests pass.