### PR TITLE
Add native initial-slice time support and fix local temporal broadcasting in trace evaluation

### DIFF
--- a/jno/architectures/models.py
+++ b/jno/architectures/models.py
@@ -128,8 +128,9 @@ def _resolve_key(key: jax.Array | None):
 
     if _DEFAULT_NN_KEY is None:
         seed = get_seed()
-        if seed is not None:
-            _DEFAULT_NN_KEY = jax.random.PRNGKey(int(seed))
+        if seed is None:
+            seed = 21   # make this consistent with jno.core
+        _DEFAULT_NN_KEY = jax.random.PRNGKey(int(seed))
 
     if _DEFAULT_NN_KEY is None:
         raise ValueError("No PRNG key provided. Pass key=... explicitly, or set [jno].seed " "and call jno.setup(...) before creating models.")

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -1289,6 +1289,7 @@ class domain(MeshIOMixin):
         point_data: bool = False,
         split: bool = False,
         return_indices=False,
+        time_value: float | None = None,
     ) -> Any:
         """Create Variable placeholders for a tagged point set or tensor.
 
@@ -1318,6 +1319,9 @@ class domain(MeshIOMixin):
                     self.context[tag] = sample
                 else:
                     self.add_tensor_tag(tag, sample)
+        # auto-default for the initial slice in time-dependent problems
+        if time_value is None and tag == "initial" and self._is_time_dependent and self.time is not None:
+            time_value = self.time[0]
 
         if tag in self._mesh_pool.keys() and isinstance(sample, tuple) and len(sample) > 0 and isinstance(sample[0], (int, type(None))):
             # Sample points for this tag on demand
@@ -1363,16 +1367,48 @@ class domain(MeshIOMixin):
         # Create Variable placeholder for each spatial dimension
         coord_vars: List[Any] = [Variable(tag=tag, dim=[i, i + 1], domain=self, axis="spatial", fem_meta=fem_meta) for i in range(self.dimension)]
 
-        # Always add temporal variable (constant 1 for stationary problems)
-        coord_vars.append(
-            Variable(
-                tag="__time__",
-                dim=[0, 1],
-                domain=self,
-                axis="temporal",
-                fem_meta=None,
+        # Time variable
+        if self._is_time_dependent:
+            if time_value is None:
+                # default behavior: shared global time variable
+                coord_vars.append(
+                    Variable(
+                        tag="__time__",
+                        dim=[0, 1],
+                        domain=self,
+                        axis="temporal",
+                        fem_meta=None,
+                    )
+                )
+            else:
+                # local fixed-time variable with the same shape as this sampled tag
+                local_time_tag = f"__time_{tag}__"
+
+                if local_time_tag not in self.context:
+                    pts = np.asarray(self.context[tag])
+                    time_dtype = np.asarray(self.context["__time__"]).dtype if "__time__" in self.context else pts.dtype
+                    self.context[local_time_tag] = np.full(pts[..., :1].shape, time_value, dtype=time_dtype)
+
+                coord_vars.append(
+                    Variable(
+                        tag=local_time_tag,
+                        dim=[0, 1],
+                        domain=self,
+                        axis="temporal",
+                        fem_meta=None,
+                    )
+                )
+        else:
+            # stationary problems still expose a time-like variable via __time__
+            coord_vars.append(
+                Variable(
+                    tag="__time__",
+                    dim=[0, 1],
+                    domain=self,
+                    axis="temporal",
+                    fem_meta=None,
+                )
             )
-        )
 
         if normals:
             if reverse_normals:

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -325,30 +325,33 @@ class TraceEvaluator:
     # Helpers shared by differential-operator handlers
     # ------------------------------------------------------------------
     def _build_local_context(self, idx, tag, points, context):
-        """Build dynamically-sliced local context for a single point ``idx``.
+        """Build dynamically-sliced local context for a single point ``idx``."""
+        local = {
+                "__active_spatial_n__": 1,
+            }
 
-        Used by AD-based Jacobian and Hessian handlers
-        to construct per-point evaluation contexts.
-        """
-        local = {}
         for k, v in context.items():
-            # ---Safely pass through FEM dictionaries and scalars ---
+            # keep helper key / scalars / dicts
+            if k == "__active_spatial_n__":
+                continue
             if isinstance(v, dict) or not hasattr(v, "ndim"):
                 local[k] = v
                 continue
+
             if v.ndim < 1:
                 local[k] = v
+
             elif v.ndim == 1:
                 if k == tag or v.shape[0] == points.shape[0]:
                     local[k] = jax.lax.dynamic_slice(v, (idx,), (1,))
                 else:
                     local[k] = v
+
             else:
                 # v.ndim >= 2
                 if k == tag or v.shape[0] == points.shape[0]:
-                    # Handle N-dimensional arrays by padding start_indices and slice_sizes
                     start_indices = (idx,) + (0,) * (v.ndim - 1)
-                    slice_sizes = (1,) + v.shape[1:]
+                    slice_sizes = (1,) + tuple(v.shape[1:])
                     local[k] = jax.lax.dynamic_slice(v, start_indices, slice_sizes)
                 else:
                     local[k] = v
@@ -404,20 +407,58 @@ class TraceEvaluator:
         tag = bound_var.tag
         axis = getattr(bound_var, "axis", "spatial")
 
+        def _broadcast_temporal(result):
+            result = jnp.asarray(result)
+
+            # Prefer explicitly supplied active local point count
+            N = ctx.context.get("__active_spatial_n__", None)
+
+            if N is None:
+                # Fallback: infer from current context
+                for k, v in ctx.context.items():
+                    if k == "__active_spatial_n__":
+                        continue
+                    if str(k).startswith("__time"):
+                        continue
+                    if hasattr(v, "ndim") and v.ndim >= 2:
+                        N = int(v.shape[0])
+                        break
+
+            if N is None:
+                return result
+
+            # scalar -> (N,1)
+            if result.ndim == 0:
+                return jnp.full((N, 1), result)
+
+            # (1,) or (N,) -> (N,1)
+            if result.ndim == 1:
+                if result.shape[0] == 1:
+                    return jnp.broadcast_to(result.reshape(1, 1), (N, 1))
+                if result.shape[0] == N:
+                    return result[:, None]
+                return result
+
+            # (1,1) -> (N,1)
+            if result.ndim == 2 and result.shape[0] == 1:
+                return jnp.broadcast_to(result, (N, result.shape[1]))
+
+            return result
+
         if tag in ctx.context:
             tag_data = ctx.context[tag]
             dim_start, dim_end = bound_var.dim
             result = tag_data[..., dim_start:dim_end]
-            if dim_end is None:
-                pass  # keep full shape
+            if axis == "temporal":
+                return _broadcast_temporal(result)
             return result
+
         elif axis == "temporal" and "__time__" in ctx.context:
-            # Temporal variable reads from the shared time context.
-            # After T-scan peels the T axis this is a scalar (1,).
             tag_data = ctx.context["__time__"]
             dim_start, dim_end = bound_var.dim
             result = tag_data[..., dim_start:dim_end]
-            return result
+            return _broadcast_temporal(result)
+
         else:
             self.log.error(f"Variable tag '{tag}' not found. context: {list(ctx.context.keys())}")
             raise KeyError(f"Variable tag '{tag}' not found in context")
@@ -650,34 +691,53 @@ class TraceEvaluator:
 
             # ── Temporal derivative via AD (default) ──
             # Find any spatial tag to determine N
+            domain = getattr(bound_var, "_domain", None)
+            param_tags = set(getattr(domain, "_param_tags", set())) if domain is not None else set()
+
+            def is_spatial_pointset(tag_name, value):
+                if tag_name == time_key or str(tag_name).startswith("__time"):
+                    return False
+                if tag_name in param_tags:
+                    return False
+                if not hasattr(value, "ndim"):
+                    return False
+                # active sampled coordinates are typically (N, D)
+                return value.ndim >= 2
+
+            # Determine N only from spatial point-set arrays, not parametric tags like GRF
             N = 1
             for k, v in ctx.context.items():
-                if k != time_key and hasattr(v, "ndim") and v.ndim >= 1:
-                    N = max(N, v.shape[0])
+                if is_spatial_pointset(k, v):
+                    N = max(N, int(v.shape[0]))
 
             def grad_time_single(idx):
-                """Grad w.r.t. time for spatial point idx."""
-                # Build local context with point idx sliced out of spatial arrays
-                local_ctx = {}
+                """Grad w.r.t. time for one spatial point idx."""
+                local_ctx = {"__active_spatial_n__": 1}
                 for k, v in ctx.context.items():
                     if k == time_key:
-                        continue  # will be replaced by differentiable t
-                    if hasattr(v, "ndim") and v.ndim >= 2 and v.shape[0] == N:
-                        local_ctx[k] = jax.lax.dynamic_slice(v, (idx, 0), (1, v.shape[1]))
-                    elif hasattr(v, "ndim") and v.ndim == 1 and v.shape[0] == N:
-                        local_ctx[k] = jax.lax.dynamic_slice(v, (idx,), (1,))
+                        continue  # replaced by differentiable t below
+
+                    if is_spatial_pointset(k, v) and int(v.shape[0]) == N:
+                        start_indices = (idx,) + (0,) * (v.ndim - 1)
+                        slice_sizes = (1,) + tuple(v.shape[1:])
+                        local_ctx[k] = jax.lax.dynamic_slice(v, start_indices, slice_sizes)
                     else:
+                        # keep parametric tags like GRF untouched
                         local_ctx[k] = v
 
                 def u_of_t(t_arr):
                     new_ctx_dict = {**local_ctx, time_key: t_arr}
-                    new_ctx = evaluator_self._EvalCtx(new_ctx_dict, ctx.var_bindings, ctx.key, active_region=ctx.active_region)
+                    new_ctx = evaluator_self._EvalCtx(
+                        new_ctx_dict,
+                        ctx.var_bindings,
+                        ctx.key,
+                        active_region=ctx.active_region,
+                    )
                     return jnp.squeeze(evaluator_self._dispatch(target, new_ctx))
 
                 return jax.grad(u_of_t)(time_val)[0]
 
             result = jax.vmap(grad_time_single)(jnp.arange(N))
-            # Ensure (N,) → (N, 1) to match variable / model-output shapes
             return result[:, jnp.newaxis]
 
         # ── Spatial derivative ──


### PR DESCRIPTION
### Summary
This PR improves time handling in jNO for time-dependent DeepONet workflows. It adds native support for returning a valid initial time variable from `domain.variable("initial")` and fixes local AD evaluation so temporal variables, sampled spatial coordinates, and parametric inputs interact consistently.

### Changes included
- Added `time_value` support to `domain.variable(...)`
- Added automatic `time_value=self.time[0]` behavior for `tag == "initial"` in time-dependent domains
- Added internal local fixed-time tag support (for example `__time_initial__`)
- Updated `TraceEvaluator._eval_variable()` to handle temporal broadcasting more robustly
- Updated local AD context handling for Jacobian evaluation
- Prevented parametric inputs such as `GRF` from being treated as sampled spatial point sets during temporal AD evaluation
- Also default random key for deeponet architectures also supported now.

### Result
These changes allow time-dependent battery/operator-learning examples to use the cleaner API:

```python
r, t = domain.variable("interior")
r0, t0 = domain.variable("initial")
```

and remove the need for manual `initial_time` tensor construction while fixing the shape errors previously encountered during training and inference.
