### PR TITLE
Fix LoRA silently no-oping on foundax and eqx.nn.Linear models

### DIFF
--- a/jno/architectures/lora_linear.py
+++ b/jno/architectures/lora_linear.py
@@ -29,8 +29,6 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
-from .linear import Linear
-
 # =====================================================================
 # Equinox LoRA (for jNO Linear layers)
 # =====================================================================
@@ -40,20 +38,22 @@ class LoRALinear(eqx.Module):
     """Linear layer with frozen base weights and trainable LoRA adapters.
 
     Attributes:
-        base:   Original ``Linear`` module (frozen during training).
+        base:   Original linear module (frozen during training). Accepts any
+                linear-like ``eqx.Module`` with ``weight``, ``in_features``,
+                and ``out_features`` attributes (e.g. jNO or foundax Linear).
         lora_A: Down-projection, shape ``(rank, in_features)``.
         lora_B: Up-projection,   shape ``(out_features, rank)``.
         rank:   LoRA rank (static).
         alpha:  Scaling factor (static).
     """
 
-    base: Linear
+    base: eqx.Module
     lora_A: jax.Array
     lora_B: jax.Array
     rank: int = eqx.field(static=True)
     alpha: float = eqx.field(static=True)
 
-    def __init__(self, base: Linear, rank: int, alpha: float, *, key: jax.Array):
+    def __init__(self, base: eqx.Module, rank: int, alpha: float, *, key: jax.Array):
         self.base = base
         self.rank = min(rank, min(base.in_features, base.out_features))
         self.alpha = alpha
@@ -104,6 +104,21 @@ def _path_str(path_keys) -> str:
 # =====================================================================
 
 
+def _is_linear_like(x: Any) -> bool:
+    """Return True for any linear-like eqx.Module that LoRA can wrap.
+
+    Matches both jNO's and foundax's ``Linear`` classes (and any other
+    module with the same interface) without requiring a shared base class.
+    """
+    return (
+        isinstance(x, eqx.Module)
+        and not isinstance(x, LoRALinear)
+        and hasattr(x, "weight")
+        and hasattr(x, "in_features")
+        and hasattr(x, "out_features")
+    )
+
+
 def apply_lora(
     model: eqx.Module,
     rank: int = 0,
@@ -113,18 +128,22 @@ def apply_lora(
     target: str = None,
     specs: Sequence[LoRASpec] | None = None,
 ) -> eqx.Module:
-    """Apply LoRA to every ``Linear`` layer in *model*.
+    """Apply LoRA to every linear-like layer in *model*.
 
     Two calling conventions:
 
     1. **Uniform** (backward-compatible): ``apply_lora(model, rank, alpha, key=key)``
-       Applies the same rank/alpha to all ``Linear`` layers (optionally
+       Applies the same rank/alpha to all linear layers (optionally
        filtered by ``target`` regex).
 
     2. **Per-target**: ``apply_lora(model, key=key, specs=[...])``
        Each spec ``{"target": regex, "rank": int, "alpha": float}``
        is matched against the pytree path. A layer matched by multiple
        specs uses the **first** matching spec.
+
+    Recognises any ``eqx.Module`` with ``weight``, ``in_features``, and
+    ``out_features`` attributes, including both jNO's and foundax's
+    ``Linear`` implementations.
 
     Returns:
         A new model with ``LoRALinear`` replacements.
@@ -142,12 +161,11 @@ def apply_lora(
         pat = _re.compile(target) if target else None
         spec_list = [(pat, int(rank), float(alpha))]
 
-    is_linear = lambda x: isinstance(x, Linear)
-    flat_with_path, treedef = jax.tree_util.tree_flatten_with_path(model, is_leaf=is_linear)
+    flat_with_path, treedef = jax.tree_util.tree_flatten_with_path(model, is_leaf=_is_linear_like)
 
     new_leaves: list[Any] = []
     for path_keys, leaf in flat_with_path:
-        if isinstance(leaf, Linear):
+        if _is_linear_like(leaf):
             pstr = _path_str(path_keys)
             matched_spec = None
             for pat, r, a in spec_list:
@@ -167,19 +185,14 @@ def apply_lora(
 
 
 def merge_lora(model: eqx.Module) -> eqx.Module:
-    """Collapse LoRA adapters back into base weights (``LoRALinear`` → ``Linear``)."""
+    """Collapse LoRA adapters back into base weights (``LoRALinear`` → original linear type)."""
 
     def _merge(leaf):
         if not isinstance(leaf, LoRALinear):
             return leaf
         s = leaf.alpha / leaf.rank
         w = leaf.base.weight + s * (leaf.lora_B @ leaf.lora_A)
-        new = Linear.__new__(Linear)
-        object.__setattr__(new, "weight", w)
-        object.__setattr__(new, "bias", leaf.base.bias)
-        object.__setattr__(new, "in_features", leaf.base.in_features)
-        object.__setattr__(new, "out_features", leaf.base.out_features)
-        return new
+        return eqx.tree_at(lambda m: m.weight, leaf.base, w)
 
     is_lora = lambda x: isinstance(x, LoRALinear)
     leaves, treedef = jax.tree_util.tree_flatten(model, is_leaf=is_lora)

--- a/tests/test_foundax_eqx.py
+++ b/tests/test_foundax_eqx.py
@@ -469,7 +469,10 @@ class TestLoRA:
 
         merged_leaves = [
             leaf
-            for leaf in jax.tree_util.tree_leaves(mlp_merged, is_leaf=lambda x: isinstance(x, eqx.Module) and hasattr(x, "weight") and hasattr(x, "in_features"))
+            for leaf in jax.tree_util.tree_leaves(
+                mlp_merged,
+                is_leaf=lambda x: isinstance(x, eqx.Module) and hasattr(x, "weight") and hasattr(x, "in_features"),
+            )
             if hasattr(leaf, "in_features") and isinstance(leaf, eqx.Module)
         ]
         assert all(isinstance(leaf, FoundaxLinear) for leaf in merged_leaves), (

--- a/tests/test_foundax_eqx.py
+++ b/tests/test_foundax_eqx.py
@@ -403,6 +403,79 @@ class TestLoRA:
         assert net._frozen is True
         assert net._lora_config is not None
 
+    def test_apply_lora_foundax_mlp_creates_adapters(self):
+        """apply_lora must replace foundax.Linear layers — not silently no-op.
+
+        Regression: apply_lora used isinstance(x, jno.Linear) so foundax models
+        (which use foundax.architectures.linear.Linear) got zero adapters.
+        """
+        from jno.architectures.lora_linear import LoRALinear, apply_lora
+
+        key = jax.random.PRNGKey(0)
+        mlp = foundax.mlp(in_features=4, output_dim=1, hidden_dims=32, num_layers=3, key=key)
+        mlp_lora = apply_lora(mlp, rank=4, alpha=1.0, key=key)
+
+        lora_leaves = [
+            leaf
+            for leaf in jax.tree_util.tree_leaves(mlp_lora, is_leaf=lambda x: isinstance(x, LoRALinear))
+            if isinstance(leaf, LoRALinear)
+        ]
+        assert len(lora_leaves) > 0, "apply_lora produced zero LoRALinear layers for foundax.mlp"
+
+    def test_apply_lora_eqx_linear_creates_adapters(self):
+        """apply_lora must recognise eqx.nn.Linear (used by poseidon/ScOT).
+
+        Regression: eqx.nn.Linear is a different class from jno.Linear so the
+        old isinstance check missed it entirely.
+        """
+        from jno.architectures.lora_linear import LoRALinear, apply_lora
+
+        key = jax.random.PRNGKey(0)
+        poseidon = _make_poseidon()
+        poseidon_lora = apply_lora(poseidon, rank=4, alpha=1.0, key=key)
+
+        lora_leaves = [
+            leaf
+            for leaf in jax.tree_util.tree_leaves(poseidon_lora, is_leaf=lambda x: isinstance(x, LoRALinear))
+            if isinstance(leaf, LoRALinear)
+        ]
+        assert len(lora_leaves) > 0, "apply_lora produced zero LoRALinear layers for poseidon/eqx.nn.Linear"
+
+    def test_lora_output_equals_base_at_init(self):
+        """LoRA-wrapped model is identical to base at init (lora_B is zeros)."""
+        from jno.architectures.lora_linear import apply_lora
+
+        key = jax.random.PRNGKey(0)
+        mlp = foundax.mlp(in_features=4, output_dim=1, hidden_dims=32, num_layers=2, key=key)
+        mlp_lora = apply_lora(mlp, rank=4, alpha=1.0, key=key)
+
+        x = jnp.ones((4,))
+        assert jnp.allclose(mlp(x), mlp_lora(x)), "LoRA output at init must match base (lora_B=0)"
+
+    def test_merge_lora_preserves_original_class(self):
+        """merge_lora must return the original linear class, not always jno.Linear.
+
+        Regression: merge_lora used Linear.__new__(Linear) hardcoded to jno.Linear,
+        which would break for foundax.Linear or eqx.nn.Linear bases.
+        """
+        from foundax.architectures.linear import Linear as FoundaxLinear
+
+        from jno.architectures.lora_linear import apply_lora, merge_lora
+
+        key = jax.random.PRNGKey(0)
+        mlp = foundax.mlp(in_features=4, output_dim=1, hidden_dims=16, num_layers=2, key=key)
+        mlp_lora = apply_lora(mlp, rank=4, alpha=1.0, key=key)
+        mlp_merged = merge_lora(mlp_lora)
+
+        merged_leaves = [
+            leaf
+            for leaf in jax.tree_util.tree_leaves(mlp_merged, is_leaf=lambda x: isinstance(x, eqx.Module) and hasattr(x, "weight") and hasattr(x, "in_features"))
+            if hasattr(leaf, "in_features") and isinstance(leaf, eqx.Module)
+        ]
+        assert all(isinstance(leaf, FoundaxLinear) for leaf in merged_leaves), (
+            "merge_lora must reconstruct the original foundax.Linear, not jno.Linear"
+        )
+
 
 # =====================================================================
 # 6. Serialisation round-trip
@@ -482,7 +555,7 @@ class TestJNOPipeline:
         assert jnp.isfinite(stats.training_logs[-1]["total_loss"][-1])
 
     def test_mlp_lora_solves(self):
-        """MLP with LoRA enabled trains (foundax.mlp uses jno Linear)."""
+        """MLP with LoRA enabled trains end-to-end through jno.core."""
         domain = 1 * jno.domain(constructor=jno.domain.line(mesh_size=0.1))
         x, *_ = domain.variable("interior")
 


### PR DESCRIPTION
## Summary

- `apply_lora` used `isinstance(x, jno.Linear)` to find linear layers. foundax models use `foundax.architectures.linear.Linear` or `eqx.nn.Linear` — structurally identical but different Python classes — so the check always returned `False` and zero LoRA adapters were applied silently.
- `merge_lora` was hardcoded to reconstruct `jno.Linear`, which would drop the `use_bias` static field present on `eqx.nn.Linear`.

**Fixes:**
- Replace `isinstance` check with duck-type predicate `_is_linear_like()` matching any `eqx.Module` with `weight`, `in_features`, and `out_features` attributes — covers jNO, foundax, and `eqx.nn.Linear` uniformly
- Widen `LoRALinear.base` type annotation from `Linear` to `eqx.Module`
- Rewrite `merge_lora` to use `eqx.tree_at()` so the original class and all its fields are preserved after merging

## Test plan

- [x] `TestLoRA::test_apply_lora_foundax_mlp_creates_adapters` — verifies adapter count > 0 for `foundax.mlp` (was silently 0 before)
- [x] `TestLoRA::test_apply_lora_eqx_linear_creates_adapters` — verifies adapter count > 0 for poseidon/ScOT (`eqx.nn.Linear`)
- [x] `TestLoRA::test_lora_output_equals_base_at_init` — forward pass is identical at init since `lora_B = 0`
- [x] `TestLoRA::test_merge_lora_preserves_original_class` — `merge_lora` returns `foundax.Linear`, not `jno.Linear`
- [x] All existing `TestLoRA` tests continue to pass