### PR TITLE
Add .integrate() operator: scalar, vectorized, and IDE support

### DIFF
--- a/docs/Integration-Operators.md
+++ b/docs/Integration-Operators.md
@@ -1,0 +1,210 @@
+# Integration Operators
+
+`jno.numpy` (importable as `jnn`) supports **mesh-based numerical integration** of symbolic expressions over boundaries and volumes. Integration is the companion to differentiation: where `.d(x)` computes derivatives pointwise, `.integrate()` collapses a field to a single scalar by summing over the mesh.
+
+```python
+import jno.numpy as jnn
+```
+
+---
+
+## Core API
+
+### Method syntax
+
+```python
+# Volume integral  ∫_Ω expr dV
+vol = expr.integrate()
+
+# Boundary integral  ∫_∂Ω expr ds
+bnd = expr_on_boundary.integrate()
+```
+
+### Function syntax (alias)
+
+```python
+vol = jnn.integrate(expr)
+bnd = jnn.integrate(expr_on_boundary)
+```
+
+`integrate()` returns an `Integral` placeholder — a scalar node in the expression graph that reduces to a Python float when evaluated.
+
+---
+
+## Region auto-detection
+
+The integration region (**boundary** vs **volume**) is determined automatically from the `Variable` tags inside the expression.  You do not pass any region argument.
+
+```python
+dom = jno.domain(constructor=jno.domain.rect(mesh_size=0.05))
+
+x, y, t         = dom.variable("interior")   # volume region
+x_b, y_b, t_b  = dom.variable("boundary")   # boundary region
+x_w, y_w, t_w  = dom.variable("wall")       # any named boundary group
+
+∫_Ω  u.integrate()           # interior tag → volume weights
+∫_∂Ω u_b.integrate()         # boundary tag → arc-length / surface weights
+```
+
+Internally, the evaluator checks whether the tag's points lie on the global mesh boundary.  Any physical group registered as a boundary in the domain receives arc-length (2D) or area (3D) weights; all others receive volume weights.
+
+---
+
+## Integration weights
+
+| Region | Weight per node | Source |
+|--------|----------------|--------|
+| 1-D volume | ½ × adjacent segment lengths | `mesh_connectivity["nodal_volumes"]` |
+| 2-D volume | ⅓ × incident triangle areas | `mesh_connectivity["nodal_volumes"]` |
+| 3-D volume | ¼ × incident tetrahedron volumes | `mesh_connectivity["nodal_volumes"]` |
+| 2-D boundary | ½ × adjacent boundary edge lengths | `mesh_connectivity["nodal_ds"]` |
+| 3-D boundary | ⅓ × incident boundary face areas | `mesh_connectivity["nodal_ds"]` |
+
+Weights are precomputed once at domain creation and cached on the domain object; they are **not** recomputed inside the training loop.
+
+---
+
+## Volume integrals
+
+```python
+dom = jno.domain(constructor=jno.domain.rect(mesh_size=0.05))
+x, y, _ = dom.variable("interior")
+
+u = net(jno.np.concat([x, y], axis=-1))
+
+# ∫_Ω u dA  — scalar placeholder, suitable as a loss or tracker
+vol_mean = u.integrate()
+```
+
+Use as a loss term:
+
+```python
+# Enforce prescribed volume average
+target_mean = 2.0 / 3.0
+integral_loss = (u.integrate() - target_mean).square()
+crux = jno.core([pde_loss, integral_loss], domain)
+```
+
+Use as a tracker (logged, not differentiated):
+
+```python
+from jno.numpy import tracker
+
+vol_mean = tracker(u.integrate(), interval=500)
+crux = jno.core([pde_loss, vol_mean], domain)
+```
+
+---
+
+## Boundary integrals
+
+```python
+dom = jno.domain(constructor=jno.domain.rect(mesh_size=0.05))
+x_b, y_b, _ = dom.variable("boundary")
+
+u_b = net(jno.np.concat([x_b, y_b], axis=-1))
+
+# ∫_∂Ω u ds  — perimeter-weighted integral
+boundary_mean = u_b.integrate()
+```
+
+---
+
+## Flux integrals
+
+For flux integrals of the form `∫_∂Ω F·n ds`, request boundary normals and compute the dot product explicitly before calling `.integrate()`:
+
+```python
+x_b, y_b, _, nx, ny = dom.variable("boundary", normals=True)
+
+u_b = net(jno.np.concat([x_b, y_b], axis=-1))
+
+# Outward flux  ∫_∂Ω ∂u/∂n ds
+flux = (u_b.d(x_b) * nx + u_b.d(y_b) * ny).integrate()
+
+# Divergence theorem check: for F = (x, y), flux = 2·area
+div_thm = (x_b * nx + y_b * ny).integrate()   # ≈ 2.0 on unit square
+```
+
+jno does **not** compute F·n automatically — you specify the integrand explicitly, giving full control over what is integrated.
+
+---
+
+## Named boundary groups
+
+For domains with named boundary regions, request variables from each group separately:
+
+```python
+dom = jno.domain(constructor=jno.domain.polygon(...))
+
+x_left,  y_left,  _, nx_l, ny_l = dom.variable("left",  normals=True)
+x_right, y_right, _, nx_r, ny_r = dom.variable("right", normals=True)
+
+# Separate flux integrals per boundary segment
+flux_left  = (u(x_left,  y_left)  * nx_l).integrate()
+flux_right = (u(x_right, y_right) * nx_r).integrate()
+```
+
+---
+
+## JIT compatibility
+
+`Integral` nodes are fully compatible with `jax.jit`.  Integration weights are precomputed at domain setup and embedded as JAX constants during the first trace.  Subsequent JIT calls hit the compiled cache without recomputing any numpy operations.
+
+```python
+import jax
+
+@jax.jit
+def loss(params, ctx):
+    ...
+    return (u.integrate() - target).square()
+```
+
+Gradients flow through the integral, making it suitable as a differentiable loss term:
+
+```python
+import equinox as eqx
+
+grad_fn = eqx.filter_jit(eqx.filter_grad(loss_fn))
+grads = grad_fn(model)
+```
+
+---
+
+## Common patterns
+
+### Volume mean as a soft constraint
+
+```python
+x, y, _ = dom.variable("interior")
+u = net(jno.np.concat([x, y], axis=-1))
+target = 2.0 / 3.0
+
+losses = [
+    pde_residual.mse,
+    (u.integrate() - target).square(),
+]
+```
+
+### Boundary flux conservation
+
+```python
+x_b, y_b, _, nx, ny = dom.variable("boundary", normals=True)
+u_b = net(jno.np.concat([x_b, y_b], axis=-1))
+
+# Enforce zero net outward flux
+net_flux = (u_b.d(x_b) * nx + u_b.d(y_b) * ny).integrate()
+losses = [pde.mse, net_flux.square()]
+```
+
+### Tracking a physical observable
+
+```python
+from jno.numpy import tracker
+
+x, y, _ = dom.variable("interior")
+u = net(jno.np.concat([x, y], axis=-1))
+
+vol_mean = tracker(u.integrate(), interval=200)   # logged every 200 epochs
+crux = jno.core([pde.mse, bc.mse, vol_mean], domain)
+```

--- a/docs/Model-Controls.md
+++ b/docs/Model-Controls.md
@@ -124,8 +124,31 @@ With `mask(...).freeze()`, selected leaves are frozen and non-selected leaves re
 ## 3. LoRA
 
 LoRA inserts trainable low-rank adapter matrices into matching layers while keeping base weights
-frozen. By default `LoRALinear` is used, which targets any layer with `weight`, `in_features`, and
-`out_features` attributes (jNO Linear, foundax Linear, `eqx.nn.Linear`).
+frozen. By default both linear layers (`weight`, `in_features`, `out_features`) and conv layers
+(`weight`, `in_channels`, `out_channels`) are wrapped automatically.
+
+### `target=` vs `mask()` — two ways to restrict which layers get LoRA
+
+Both restrict which layers receive LoRA adapters, but they select differently:
+
+| | `target=` / `specs=` | `mask(M).lora()` |
+|---|---|---|
+| **Selects layers by** | regex on pytree path string | boolean pytree (data-driven) |
+| **Layers not selected** | left completely untouched | left completely untouched |
+| **Use when** | you know the layer names up front | you have a precomputed boolean mask (e.g. from `eqx.tree_at`) |
+
+```python
+# Path-regex: only "encoder.*" layers get LoRA
+net.lora(rank=8, target="encoder")
+
+# Data-driven: only layers whose params are True in encoder_mask get LoRA
+net.mask(encoder_mask).lora(rank=8)
+```
+
+They can be combined — only layers that pass **both** the mask AND the regex are wrapped:
+```python
+net.mask(encoder_mask).lora(rank=8, target="encoder")
+```
 
 ### Uniform LoRA
 
@@ -133,7 +156,7 @@ frozen. By default `LoRALinear` is used, which targets any layer with `weight`, 
 net.lora(rank=8, alpha=16)
 ```
 
-Restrict to a subset of layers with a path-regex:
+Restrict *which layers get adapters* with a path-regex (layers not matching are left untouched):
 
 ```python
 net.lora(rank=8, alpha=16, target="encoder")
@@ -155,40 +178,40 @@ matching spec wins.
 
 ### Custom adapter classes
 
-Pass any `LoRAWrapper` subclass via `wrapper` to support layer types beyond linear:
+Conv and linear adapters are already in the zoo — see the tables above.  To support a layer type
+not covered (e.g. an embedding or a custom module), subclass `LoRAWrapper`:
 
 ```python
 from jno.lora import LoRAWrapper
 import equinox as eqx
+import jax.numpy as jnp
 
-class LoRAConv(LoRAWrapper):
-	adapter_fields = ("delta_w",)            # names of trainable adapter attributes
+class MyEmbeddingAdapter(LoRAWrapper):
+	adapter_fields = ("delta",)
 	base: eqx.Module
-	delta_w: jax.Array
+	delta: jax.Array
 	rank: int = eqx.field(static=True)
 	alpha: float = eqx.field(static=True)
 
 	@classmethod
 	def applies_to(cls, leaf):
-		return isinstance(leaf, eqx.nn.Conv2d) and not isinstance(leaf, LoRAWrapper)
+		return isinstance(leaf, eqx.nn.Embedding) and not isinstance(leaf, LoRAWrapper)
 
 	def __init__(self, base, rank, alpha, *, key):
 		self.base, self.rank, self.alpha = base, rank, alpha
-		self.delta_w = jnp.zeros_like(base.weight)
+		self.delta = jnp.zeros_like(base.weight)
 
 	def __call__(self, x):
-		w = self.base.weight + self.delta_w * (self.alpha / self.rank)
-		return self.base(x)   # simplified — use eqx.tree_at to swap weight
+		return self.base(x) + self.delta[x] * (self.alpha / self.rank)
 
 	def merge(self):
-		w = self.base.weight + self.delta_w * (self.alpha / self.rank)
+		w = self.base.weight + self.delta * (self.alpha / self.rank)
 		return eqx.tree_at(lambda m: m.weight, self.base, w)
 
-# Apply to all matching layers
-net.lora(rank=4, wrapper=LoRAConv)
+net.lora(rank=4, wrapper=MyEmbeddingAdapter)
 
-# Pass a list — tried in order, first applies_to() match wins per leaf
-net.lora(rank=4, wrapper=[LoRALinear, LoRAConv])
+# Mix with built-in zoo classes — first applies_to() match wins per leaf
+net.lora(rank=4, wrapper=[LoRALinear, LoRAConv, MyEmbeddingAdapter])
 ```
 
 Per-target specs may carry their own `"wrapper"` key, which overrides the global default for that
@@ -196,22 +219,31 @@ group:
 
 ```python
 net.lora(
-	wrapper=LoRALinear,          # global default
 	specs=[
 		{"target": "linear", "rank": 4,  "alpha": 1.0},
-		{"target": "conv",   "rank": 8,  "alpha": 2.0, "wrapper": LoRAConv},
+		{"target": "embed",  "rank": 8,  "alpha": 2.0, "wrapper": MyEmbeddingAdapter},
 	]
 )
 ```
 
-### Combine mask + LoRA for base-trainability control
+### Combine mask + LoRA to target specific layers
+
+`mask(M)` sets the selection scope; the next command determines what happens to M-selected elements:
 
 ```python
-# Selected base leaves are frozen; non-selected base leaves stay trainable.
-net.mask(decoder_mask).lora(rank=8, alpha=16)
+# Only layers selected by encoder_mask get LoRA adapters.
+# Layers not in the mask remain fully trainable (not wrapped).
+net.mask(encoder_mask).lora(rank=8, alpha=16)
 
-# Freeze all base params; train LoRA adapters only.
+# mask().freeze(): freeze the selected params (no LoRA).
+net.mask(encoder_mask).freeze()
+
+# freeze().lora(): freeze all base params; only LoRA adapters train.
+# (freeze first, then apply LoRA everywhere)
 net.freeze().lora(rank=8, alpha=16)
+
+# freeze().mask(M).lora(): wrap only M-selected layers; freeze everything else.
+net.freeze().mask(encoder_mask).lora(rank=8, alpha=16)
 ```
 
 ### Default behaviour: linear and conv

--- a/docs/Model-Controls.md
+++ b/docs/Model-Controls.md
@@ -214,11 +214,25 @@ net.mask(decoder_mask).lora(rank=8, alpha=16)
 net.freeze().lora(rank=8, alpha=16)
 ```
 
-### LoRA Zoo
+### Default behaviour: linear and conv
 
-jNO ships several drop-in `LoRAWrapper` variants in `jno.lora`.  All target
-the same layer types as `LoRALinear` (`weight`, `in_features`, `out_features`) and accept the same
-`rank` and `alpha` arguments.
+When you call `.lora()` without a `wrapper=` argument, jNO wraps **both** linear layers
+(`weight`, `in_features`, `out_features`) **and** conv layers (`weight`, `in_channels`,
+`out_channels`) automatically.  ConvTranspose layers are excluded.
+
+```python
+net.lora(rank=4, alpha=1.0)  # wraps Linear + Conv1d/2d/3d in one call
+```
+
+To restrict to one kind:
+
+```python
+net.lora(rank=4, wrapper=LoRALinear)   # linear only
+net.lora(rank=4, wrapper=LoRAConv)     # conv only
+net.lora(rank=4, wrapper=[LoRALinear, LoRAConv])  # explicit default
+```
+
+### LoRA Zoo — Linear
 
 ```python
 from jno.lora import (
@@ -252,7 +266,7 @@ net.lora(rank=4, wrapper=rsLoRALinear)
 | `LoKrLinear` | `r² + ⌈out/r⌉·⌈in/r⌉` | Kronecker product adapter; efficient when `r` ~ √(out·in) ([LoKr](https://arxiv.org/abs/2212.10650)) |
 | `OFTLinear` | `n_blocks·r²` | Block-diagonal orthogonal matrix via Cayley map; preserves hyperspherical energy ([OFT](https://arxiv.org/abs/2306.07280)) |
 
-**When to use which:**
+**When to use which (linear):**
 
 - **rsLoRALinear** — default upgrade over `LoRALinear`; use higher ranks without numerical issues.
 - **LoRAFALinear** — memory-constrained training; halves adapter parameter count.
@@ -265,13 +279,62 @@ net.lora(rank=4, wrapper=rsLoRALinear)
 - **LoKrLinear** — large layers where a Kronecker factorisation covers the weight space more efficiently than a low-rank product.
 - **OFTLinear** — when you need orthogonal weight updates to preserve geometry (e.g., text-to-image fine-tuning, ControlNet).
 
-Mix classes per layer group via per-target specs:
+### LoRA Zoo — Conv
+
+Matching conv variants for `eqx.nn.Conv1d`, `Conv2d`, `Conv3d`.  All operate by
+flattening the weight to `(out_channels, flat_in)` where `flat_in = in_channels // groups * prod(kernel_size)`,
+applying the same adapter logic as the linear counterpart, and reshaping back.  The
+modified weight is substituted via `eqx.tree_at` so XLA fuses it into a single conv call.
+
+```python
+from jno.lora import (
+    LoRAConv,    # standard conv LoRA (default alongside LoRALinear)
+    rsLoRAConv,  # rank-stabilized
+    LoRAFAConv,  # frozen A
+    DoRAConv,    # weight-decomposed
+    PiSSAConv,   # SVD principal components
+    LoRAXSConv,  # extra-small r×r core
+    VeRAConv,    # seed-based frozen A,B; only b,d vectors trained
+    MiLoRAConv,  # SVD minor components
+    IA3Conv,     # per-output-channel scale
+    LoKrConv,    # Kronecker product adapter
+    OFTConv,     # block-diagonal orthogonal fine-tuning
+)
+
+net.lora(rank=4, wrapper=rsLoRAConv)
+```
+
+| Class | Trainable params | Key idea |
+|-------|-----------------|----------|
+| `LoRAConv` | `r·(flat_in + out_ch)` | Standard LoRA on flattened conv weight |
+| `rsLoRAConv` | `r·(flat_in + out_ch)` | Rank-stabilized scaling `α/√r` |
+| `LoRAFAConv` | `r·out_ch` | Frozen A; only B trained |
+| `DoRAConv` | `r·(flat_in + out_ch) + out_ch` | Magnitude + direction decomposition |
+| `PiSSAConv` | `r·(flat_in + out_ch)` | SVD principal components init |
+| `LoRAXSConv` | `r²` | Frozen A,B from SVD; trainable r×r core |
+| `VeRAConv` | `out_ch + r` | Seed-based frozen A,B; only b,d vectors trained |
+| `MiLoRAConv` | `r·(flat_in + out_ch)` | SVD minor components; preserves principal directions |
+| `IA3Conv` | `out_ch` | Per-output-channel scale vector |
+| `LoKrConv` | `r² + ⌈out_ch/r⌉·⌈flat_in/r⌉` | Kronecker product adapter |
+| `OFTConv` | `n_blocks·r²` | Block-diagonal Cayley map on output channels |
+
+**When to use which (conv):**
+
+- **rsLoRAConv** — general-purpose conv adapter; mirrors rsLoRALinear.
+- **LoRAFAConv** — memory-constrained conv fine-tuning.
+- **PiSSAConv / MiLoRAConv** — pretrained conv backbones (e.g., FNO, U-Net encoders).
+- **VeRAConv** — many conv layers and tight checkpoint budgets.
+- **IA3Conv** — fastest conv adaptation; no rank hyperparameter.
+- **OFTConv** — geometry-preserving conv updates (e.g., image models).
+
+Mix linear and conv adapters per layer group via per-target specs:
 
 ```python
 net.lora(
     specs=[
         {"target": "encoder", "rank": 8,  "alpha": 16, "wrapper": PiSSALinear},
         {"target": "decoder", "rank": 4,  "alpha": 1.0, "wrapper": rsLoRALinear},
+        {"target": "conv",    "rank": 4,  "alpha": 1.0, "wrapper": rsLoRAConv},
     ]
 )
 ```

--- a/docs/jno_docs_local_mkdocs.yml
+++ b/docs/jno_docs_local_mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Installation: Installation.md
   - Domain and Geometry: Domain-and-Geometry.md
   - Differential Operators: Differential-Operators.md
+  - Integration Operators: Integration-Operators.md
   - Training: Training.md
   - Model Controls: Model-Controls.md
   - Adaptive Resampling: Adaptive-Resampling.md
@@ -71,6 +72,11 @@ nav:
       - Coupled Elliptic 2D: tutorials/05-coupled-and-inverse/coupled-elliptic-2d.md
       - Coupled Parabolic 2D: tutorials/05-coupled-and-inverse/coupled-parabolic-2d.md
       - Inverse Parameter: tutorials/05-coupled-and-inverse/inverse-parameter.md
+    - 06 Integration:
+      - Fredholm Integral Equation: tutorials/06-integration/fredholm-integral-equation.md
+      - Fredholm Non-Separable Kernel: tutorials/06-integration/fredholm-nonseparable.md
+      - Flux Conservation 2D: tutorials/06-integration/flux-conservation-2d.md
+      - Integro-Differential Equation: tutorials/06-integration/integro-differential.md
     - 08 FEM and Variational PINNs:
       - Poisson 2D FEM: tutorials/08-fem-and-varpinns/poisson-2d-fem.md
       - Stationary Allen-Cahn FEM: tutorials/08-fem-and-varpinns/stationary-allen-cahn-fem.md

--- a/docs/tutorial_examples/06_integration/flux_conservation_2d.py
+++ b/docs/tutorial_examples/06_integration/flux_conservation_2d.py
@@ -1,0 +1,112 @@
+"""06 — Integral constraints and flux monitoring (2-D Poisson)
+
+Problem
+-------
+    −∇²u(x,y) = 2π² sin(πx) sin(πy),   (x,y) ∈ [0,1]²,   u = 0 on ∂Ω
+
+Analytical solution
+-------------------
+    u(x,y) = sin(πx) sin(πy)
+
+This tutorial demonstrates how to use .integrate() for two distinct purposes:
+
+1. As a **tracker** — monitor the volume mean ∫_Ω u dA during training.
+   The exact value is 4/π² ≈ 0.405.  A network that only satisfies the zero
+   Dirichlet BC would give ∫ u = 0, so this metric reveals interior accuracy.
+
+2. As a **soft constraint** — enforce a prescribed integral value in the loss,
+   in addition to the PDE residual and boundary condition.
+
+Both uses are JIT-compatible and fully differentiable w.r.t. model parameters.
+"""
+
+from pathlib import Path
+
+import foundax
+import jax
+import jax.numpy as jnp
+import optax
+from jno.numpy import tracker
+
+import jno
+
+π = jno.np.pi
+
+# ── Domain ─────────────────────────────────────────────────────────────────────
+domain = jno.domain(constructor=jno.domain.rect(mesh_size=0.05))
+
+x, y, _ = domain.variable("interior")
+x_b, y_b, _ = domain.variable("boundary")
+
+domain.summary()
+
+# ── Analytic forcing and boundary data ─────────────────────────────────────────
+forcing = 2 * π**2 * jno.np.sin(π * x) * jno.np.sin(π * y)
+u_exact_b = jno.np.sin(π * x_b) * jno.np.sin(π * y_b)  # = 0 on ∂Ω
+
+# Exact volume integral: ∫₀¹∫₀¹ sin(πx)sin(πy) dxdy = (2/π)² = 4/π²
+TARGET_INTEGRAL = 4.0 / float(jnp.pi) ** 2  # ≈ 0.4053
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+net = jno.nn.wrap(
+    foundax.mlp(
+        in_features=2,
+        hidden_dims=64,
+        num_layers=4,
+        activation=jax.nn.tanh,
+        key=jax.random.PRNGKey(0),
+    )
+)
+net.optimizer(
+    optax.adam(
+        optax.exponential_decay(
+            init_value=1e-3,
+            transition_steps=3000,
+            decay_rate=0.5,
+            end_value=1e-5,
+        )
+    )
+)
+
+# Hard-enforce u=0 on ∂Ω by multiplying by x(1-x)y(1-y).
+# The network then only needs to learn the interior shape.
+u = net(jno.np.concat([x, y], axis=-1)) * x * (1 - x) * y * (1 - y)
+
+# ── Losses ─────────────────────────────────────────────────────────────────────
+# Standard PDE residual
+pde = -u.laplacian(x, y) - forcing
+
+# Volume-mean tracker — logged every 200 epochs, does not enter the gradient.
+# After convergence this should approach TARGET_INTEGRAL ≈ 0.405.
+vol_mean = tracker(u.integrate(), interval=200)
+
+# Optional soft integral constraint — uncomment to add it to the loss.
+# This can accelerate convergence when the PDE residual alone is slow to
+# pin the global magnitude of the solution.
+#
+# integral_loss = (u.integrate() - TARGET_INTEGRAL).square()
+# losses = [pde.mse, integral_loss, vol_mean]
+
+losses = [pde.mse, vol_mean]
+
+# ── Solve ──────────────────────────────────────────────────────────────────────
+EPOCHS = 30_000
+crux = jno.core(losses, domain).print_shapes()
+_history = crux.solve(EPOCHS)
+
+# ── Evaluate ───────────────────────────────────────────────────────────────────
+u_pred, u_ref = crux.eval([u, jno.np.sin(π * x) * jno.np.sin(π * y)])
+
+rel_l2 = float(jnp.linalg.norm(u_pred - u_ref) / (jnp.linalg.norm(u_ref) + 1e-8))
+print(f"Relative L2 error: {rel_l2:.4e}")
+print(f"Target integral:   {TARGET_INTEGRAL:.6f}")
+
+# ── Record result ──────────────────────────────────────────────────────────────
+results_file = Path(__file__).parent.parent.parent / "tutorial_results.txt"
+with open(results_file, "a") as f:
+    f.write(
+        f"06_integration/flux_conservation_2d.py | epochs={EPOCHS} "
+        f"| rel_L2={rel_l2:.6e} | target_integral={TARGET_INTEGRAL:.6f}\n"
+    )
+
+assert rel_l2 < 0.15, f"Relative L2 error too large: {rel_l2:.3e}"

--- a/docs/tutorial_examples/06_integration/fredholm_integral_equation.py
+++ b/docs/tutorial_examples/06_integration/fredholm_integral_equation.py
@@ -1,0 +1,110 @@
+"""06 — Fredholm integral equation of the second kind
+
+Equation
+--------
+    u(x) = f(x) + ∫₀¹ x·t · u(t) dt,   x ∈ [0, 1]
+
+with forcing term chosen so that the exact solution is
+
+    u*(x) = sin(πx)
+
+Derivation of f
+---------------
+Substituting u* into the equation:
+
+    sin(πx) = f(x) + ∫₀¹ x·t · sin(πt) dt
+
+The integral evaluates to
+
+    ∫₀¹ t · sin(πt) dt = 1/π   (integration by parts)
+
+so  x · ∫₀¹ t · sin(πt) dt = x/π, giving
+
+    f(x) = sin(πx) − x/π
+
+Network residual
+----------------
+    R(x) = u(x) − f(x) − x · ∫₀¹ t · u(t) dt = 0
+
+The key insight: ∫₀¹ t · u(t) dt is a single scalar C that does not depend
+on x.  We compute it with .integrate(), which evaluates the integrand over
+the full mesh and returns a JAX scalar.  This scalar is then multiplied by
+the pointwise sampled x, giving a term of shape (N_pts,) in the residual.
+
+The same jno expression u(x) appears both inside the integral (evaluated at
+all mesh nodes by the integrator) and in the outer residual (evaluated at
+the sampled collocation points).  Both evaluations go through the same
+trained network weights.
+"""
+
+from pathlib import Path
+
+import foundax
+import jax
+import jax.numpy as jnp
+import optax
+
+import jno
+
+π = jno.np.pi
+
+# ── Domain ─────────────────────────────────────────────────────────────────────
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.01))
+x, _ = domain.variable("interior")
+
+domain.summary()
+
+# ── Forcing term  f(x) = sin(πx) − x/π ───────────────────────────────────────
+pi_val = float(jnp.pi)
+f = jno.np.sin(π * x) - x / pi_val
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+net = jno.nn.wrap(
+    foundax.mlp(
+        in_features=1,
+        hidden_dims=64,
+        num_layers=4,
+        activation=jax.nn.tanh,
+        key=jax.random.PRNGKey(0),
+    )
+)
+net.optimizer(
+    optax.adam(
+        optax.exponential_decay(
+            init_value=1e-3,
+            transition_steps=5_000,
+            decay_rate=0.5,
+            end_value=1e-5,
+        )
+    )
+)
+
+u = net(x)
+
+# ── Fredholm residual ──────────────────────────────────────────────────────────
+# C = ∫₀¹ t · u(t) dt  — scalar, independent of x.
+# .integrate() evaluates the integrand over all mesh nodes and sums with
+# nodal volume weights.  Here x is the integration variable (dummy variable t).
+C = (x * u).integrate()
+
+# Pointwise residual  R(xᵢ) = u(xᵢ) − f(xᵢ) − xᵢ · C
+residual = u - f - x * C
+
+# ── Solve ──────────────────────────────────────────────────────────────────────
+EPOCHS = 50_000
+crux = jno.core([residual.mse], domain).print_shapes()
+_history = crux.solve(EPOCHS)
+
+# ── Evaluate ───────────────────────────────────────────────────────────────────
+u_exact = jno.np.sin(π * x)
+u_pred, u_ref = crux.eval([u, u_exact])
+
+rel_l2 = float(jnp.linalg.norm(u_pred - u_ref) / (jnp.linalg.norm(u_ref) + 1e-8))
+print(f"Relative L2 error: {rel_l2:.4e}   (exact solution: u(x) = sin(πx))")
+
+# ── Record result ──────────────────────────────────────────────────────────────
+results_file = Path(__file__).parent.parent.parent / "tutorial_results.txt"
+with open(results_file, "a") as f_out:
+    f_out.write(f"06_integration/fredholm_integral_equation.py | epochs={EPOCHS} | rel_L2={rel_l2:.6e}\n")
+
+assert rel_l2 < 0.05, f"Relative L2 error too large: {rel_l2:.3e}"

--- a/docs/tutorial_examples/06_integration/fredholm_nonseparable.py
+++ b/docs/tutorial_examples/06_integration/fredholm_nonseparable.py
@@ -1,0 +1,110 @@
+"""06 — Fredholm integral equation with non-separable kernel
+
+Equation
+--------
+    u(x) = f(x) + ∫₀¹ (x + t) · u(t) dt,   x ∈ [0, 1]
+
+The kernel K(x, t) = x + t depends on both the evaluation point x and
+the integration dummy t.  It cannot be collapsed to a single scalar
+without evaluating it for every x simultaneously — exactly what
+.integrate(var=x) enables.
+
+Exact solution:  u*(x) = sin(πx)
+
+Derivation of f
+---------------
+    ∫₀¹ (x + t) sin(πt) dt
+        = x · ∫₀¹ sin(πt) dt  +  ∫₀¹ t · sin(πt) dt
+        = x · (2/π)            +  1/π
+
+    f(x) = sin(πx) − 2x/π − 1/π
+
+Network residual
+----------------
+    R(x) = u(x) − f(x) − ∫₀¹ (x + t) · u(t) dt  =  0
+
+API used
+--------
+Two variables are obtained from the same domain tag — one acting as the
+outer collocation variable, one as the inner integration dummy.  The outer
+variable is passed to .integrate(var=x), so the result is an (N, 1) array
+(a function of x) rather than a scalar:
+
+    x, _ = domain.variable("interior")   # outer / collocation
+    t, _ = domain.variable("interior")   # inner / dummy  — no flag needed!
+
+    integral_term = ((x + t) * u(t)).integrate(var=x)
+"""
+
+from pathlib import Path
+
+import foundax
+import jax
+import jax.numpy as jnp
+import optax
+
+import jno
+
+π = jno.np.pi
+
+# ── Domain ─────────────────────────────────────────────────────────────────────
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+
+x, _ = domain.variable("interior")  # outer collocation variable
+t, _ = domain.variable("interior")  # inner integration dummy
+
+domain.summary()
+
+# ── Forcing term  f(x) = sin(πx) − 2x/π − 1/π ────────────────────────────────
+pi_val = float(jnp.pi)
+f = jno.np.sin(π * x) - 2.0 * x / pi_val - 1.0 / pi_val
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+net = jno.nn.wrap(
+    foundax.mlp(
+        in_features=1,
+        hidden_dims=32,
+        num_layers=3,
+        activation=jax.nn.tanh,
+        key=jax.random.PRNGKey(0),
+    )
+)
+net.optimizer(
+    optax.adam(
+        optax.exponential_decay(
+            init_value=1e-3,
+            transition_steps=5_000,
+            decay_rate=0.5,
+            end_value=1e-5,
+        )
+    )
+)
+
+u_x = net(x)  # network evaluated at collocation points  (N, 1)
+u_t = net(t)  # same network, evaluated at integration points  (N, 1)
+
+# ── Non-separable Fredholm residual ───────────────────────────────────────────
+# ∫₀¹ (x + t) · u(t) dt  — result is (N, 1): depends on x, not a scalar.
+# var=x tells the evaluator: keep x fixed, sweep t over the full mesh.
+integral_term = ((x + t) * u_t).integrate(var=x)
+
+residual = u_x - f - integral_term
+
+# ── Solve ──────────────────────────────────────────────────────────────────────
+EPOCHS = 30_000
+crux = jno.core([residual.mse], domain).print_shapes()
+_history = crux.solve(EPOCHS)
+
+# ── Evaluate ───────────────────────────────────────────────────────────────────
+u_exact = jno.np.sin(π * x)
+u_pred, u_ref = crux.eval([u_x, u_exact])
+
+rel_l2 = float(jnp.linalg.norm(u_pred - u_ref) / (jnp.linalg.norm(u_ref) + 1e-8))
+print(f"Relative L2 error: {rel_l2:.4e}   (exact solution: u(x) = sin(πx))")
+
+# ── Record result ──────────────────────────────────────────────────────────────
+results_file = Path(__file__).parent.parent.parent / "tutorial_results.txt"
+with open(results_file, "a") as f_out:
+    f_out.write(f"06_integration/fredholm_nonseparable.py | epochs={EPOCHS} | rel_L2={rel_l2:.6e}\n")
+
+assert rel_l2 < 0.10, f"Relative L2 error too large: {rel_l2:.3e}"

--- a/docs/tutorial_examples/06_integration/integro_differential.py
+++ b/docs/tutorial_examples/06_integration/integro_differential.py
@@ -1,0 +1,108 @@
+"""06 — Integro-Differential Equation (IDE)
+
+Equation
+--------
+    u'(x) + u(x) = g(x) + ∫₀¹ u(t) dt,   x ∈ [0, 1],   u(0) = 0
+
+The right-hand side contains both the unknown u at the same point AND a
+scalar integral of u over the full domain.  This requires mixing the
+differential operator (.d(x)) and the scalar integral (.integrate()) in the
+same residual — the key demonstration of this tutorial.
+
+Exact solution:  u*(x) = sin(πx)
+
+Derivation of g
+---------------
+    u'(x)        = π cos(πx)
+    u(x)         = sin(πx)
+    ∫₀¹ u(t) dt  = ∫₀¹ sin(πt) dt = 2/π
+
+    g(x) = π cos(πx) + sin(πx) − 2/π
+
+Boundary condition: u(0) = 0  (hard, enforced via the ansatz u = net(x)·x)
+
+Network residual
+----------------
+    R(x) = u'(x) + u(x) − g(x) − ∫₀¹ u(t) dt  =  0
+
+API used
+--------
+Two operators compose naturally on the same placeholder:
+
+    u  = net(x) * x                # hard BC: u(0) = 0 automatically
+    C  = u.integrate()             # scalar: ∫₀¹ u(t) dt
+    du = u.d(x)                    # pointwise derivative u'(x)
+    residual = du + u - g - C      # IDE residual at every collocation point
+"""
+
+from pathlib import Path
+
+import foundax
+import jax
+import jax.numpy as jnp
+import optax
+
+import jno
+
+π = jno.np.pi
+
+# ── Domain ─────────────────────────────────────────────────────────────────────
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+
+x, _ = domain.variable("interior")
+
+domain.summary()
+
+# ── Forcing term  g(x) = π cos(πx) + sin(πx) − 2/π ──────────────────────────
+pi_val = float(jnp.pi)
+g = π * jno.np.cos(π * x) + jno.np.sin(π * x) - 2.0 / pi_val
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+net = jno.nn.wrap(
+    foundax.mlp(
+        in_features=1,
+        hidden_dims=32,
+        num_layers=3,
+        activation=jax.nn.tanh,
+        key=jax.random.PRNGKey(0),
+    )
+)
+net.optimizer(
+    optax.adam(
+        optax.exponential_decay(
+            init_value=1e-3,
+            transition_steps=5_000,
+            decay_rate=0.5,
+            end_value=1e-5,
+        )
+    )
+)
+
+# Hard boundary condition: u(0) = 0 — multiplying by x enforces it for all x
+u = net(x) * x
+
+# ── IDE residual ──────────────────────────────────────────────────────────────
+# ∫₀¹ u(t) dt is a scalar (not a function of x).
+# u.d(x) is the pointwise derivative — both shapes are (N, 1).
+C = u.integrate()  # scalar: ∫₀¹ u(t) dt
+du = u.d(x)  # (N, 1): u'(x) at every collocation point
+residual = du + u - g - C  # IDE residual at every collocation point
+
+# ── Solve ──────────────────────────────────────────────────────────────────────
+EPOCHS = 30_000
+crux = jno.core([residual.mse], domain).print_shapes()
+_history = crux.solve(EPOCHS)
+
+# ── Evaluate ───────────────────────────────────────────────────────────────────
+u_exact = jno.np.sin(π * x)
+u_pred, u_ref = crux.eval([u, u_exact])
+
+rel_l2 = float(jnp.linalg.norm(u_pred - u_ref) / (jnp.linalg.norm(u_ref) + 1e-8))
+print(f"Relative L2 error: {rel_l2:.4e}   (exact solution: u(x) = sin(πx))")
+
+# ── Record result ──────────────────────────────────────────────────────────────
+results_file = Path(__file__).parent.parent.parent / "tutorial_results.txt"
+with open(results_file, "a") as f_out:
+    f_out.write(f"06_integration/integro_differential.py | epochs={EPOCHS} | rel_L2={rel_l2:.6e}\n")
+
+assert rel_l2 < 0.10, f"Relative L2 error too large: {rel_l2:.3e}"

--- a/docs/tutorial_results.txt
+++ b/docs/tutorial_results.txt
@@ -1,0 +1,1 @@
+06_integration/fredholm_integral_equation.py | epochs=50000 | rel_L2=1.974346e-04

--- a/docs/tutorials/06-integration/flux-conservation-2d.md
+++ b/docs/tutorials/06-integration/flux-conservation-2d.md
@@ -1,0 +1,110 @@
+# Integral Constraints and Flux Monitoring (2-D)
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/flux_conservation_2d.py" download>Download .py</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to chapter</a>
+</div>
+
+This example solves the 2-D Poisson equation and shows two uses of `.integrate()` that are not possible with pointwise losses like `.mse`:
+
+1. **Tracking a physical observable** — the volume mean `∫_Ω u dA` is logged throughout training without entering the gradient.
+2. **Soft integral constraint** — the same quantity can be added to the loss to accelerate convergence when the PDE residual alone is slow to pin the solution's magnitude.
+
+## Problem Setup
+
+```text
+−∇²u = 2π² sin(πx) sin(πy),   (x,y) ∈ [0,1]²
+u = 0 on ∂Ω
+```
+
+Exact solution: `u(x,y) = sin(πx) sin(πy)`
+
+The exact volume mean is `∫₀¹∫₀¹ sin(πx)sin(πy) dxdy = 4/π² ≈ 0.405`.
+
+## Why integrals matter here
+
+The Dirichlet condition forces `u = 0` on the entire boundary.  A network that memorises the boundary data without learning the interior would give `u ≈ 0` everywhere — satisfying the BC but not the PDE.  Tracking `∫_Ω u dA` during training immediately reveals this failure mode: if the integral stays near zero, the network has not learned the interior peak.
+
+## Step 1: Define volume and boundary variables
+
+```python
+x,   y,   _ = domain.variable("interior")   # volume points
+x_b, y_b, _ = domain.variable("boundary")   # boundary points
+```
+
+## Step 2: Hard-enforce the Dirichlet BC
+
+The model output is multiplied by `x(1−x)y(1−y)`, which is zero on all four edges.  The network only needs to learn the interior shape.
+
+```python
+u = net(jno.np.concat([x, y], axis=-1)) * x * (1 - x) * y * (1 - y)
+```
+
+## Step 3: Add the PDE residual
+
+```python
+pde = -u.laplacian(x, y) - forcing
+```
+
+## Step 4: Track the volume integral
+
+```python
+from jno.numpy import tracker
+
+TARGET = 4.0 / jnp.pi ** 2   # ≈ 0.405
+
+vol_mean = tracker(u.integrate(), interval=200)
+```
+
+`tracker(...)` wraps any scalar expression so that it is evaluated and logged every `interval` epochs but **does not contribute to the gradient**.
+
+## Step 5: Optionally add an integral constraint
+
+To enforce the prescribed mean in the loss itself, add:
+
+```python
+integral_loss = (u.integrate() - TARGET).square()
+losses = [pde.mse, integral_loss, vol_mean]
+```
+
+Without the constraint the PDE residual alone is usually sufficient.  With it, the optimizer receives a direct signal about the solution's global magnitude, which can be useful when the interior is poorly sampled or the PDE residual gradient is small.
+
+## Step 6: Solve
+
+```python
+crux = jno.core(losses, domain)
+crux.solve(30_000)
+```
+
+## What to notice
+
+- `.integrate()` returns a scalar placeholder — it can appear anywhere a regular loss term can.
+- The region (volume vs boundary) is inferred automatically from the variable's tag; no extra argument is needed.
+- Integration weights are precomputed once at domain creation. They are embedded as JAX constants and reused across all training steps, so adding an integral term carries negligible runtime cost.
+- Because `.integrate()` is differentiable, `jax.grad` and `eqx.filter_grad` work through it without modification.
+
+## Flux integrals (extension)
+
+If you also want to monitor the outward heat flux through the boundary, request normals and compute F·n by hand:
+
+```python
+x_b, y_b, _, nx, ny = domain.variable("boundary", normals=True)
+u_b = net(jno.np.concat([x_b, y_b], axis=-1)) * x_b * (1 - x_b) * y_b * (1 - y_b)
+
+# ∫_∂Ω ∂u/∂n ds  —  should equal ∫_Ω ∇²u dV = −∫_Ω f dV by Green's identity
+outward_flux = (u_b.d(x_b) * nx + u_b.d(y_b) * ny).integrate()
+flux_tracker  = tracker(outward_flux, interval=500)
+```
+
+jno does not dot F with n automatically — you specify the integrand explicitly.
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/flux_conservation_2d.py" download>Download full script</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to 06 Integration</a>
+</div>
+
+## Script
+
+```python
+--8<-- "tutorial_examples/06_integration/flux_conservation_2d.py"
+```

--- a/docs/tutorials/06-integration/fredholm-integral-equation.md
+++ b/docs/tutorials/06-integration/fredholm-integral-equation.md
@@ -1,0 +1,104 @@
+# Fredholm Integral Equation of the Second Kind
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/fredholm_integral_equation.py" download>Download .py</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to chapter</a>
+</div>
+
+This example solves a **Fredholm integral equation of the second kind** — an equation where the unknown function appears both outside and inside an integral.  The exact solution is known, so the trained network's accuracy can be measured directly.
+
+## Equation
+
+$$u(x) = f(x) + \int_0^1 x \cdot t \; u(t) \, dt, \qquad x \in [0,1]$$
+
+with forcing term chosen so that the exact solution is
+
+$$u^*(x) = \sin(\pi x)$$
+
+### Derivation of f
+
+Substituting $u^* = \sin(\pi x)$ into the equation:
+
+$$\sin(\pi x) = f(x) + \int_0^1 x \cdot t \cdot \sin(\pi t) \, dt$$
+
+The integral evaluates to (integration by parts):
+
+$$\int_0^1 t \cdot \sin(\pi t) \, dt = \frac{1}{\pi}$$
+
+so $x \cdot \int_0^1 t \cdot \sin(\pi t) \, dt = x / \pi$, giving:
+
+$$f(x) = \sin(\pi x) - \frac{x}{\pi}$$
+
+## Why this is interesting
+
+Integral equations cannot be solved by the standard PINN approach of differentiating pointwise residuals — there is no ODE or PDE to differentiate.  The `.integrate()` operator fills this gap.  The key insight here is that the degenerate (separable) kernel $K(x,t) = x \cdot t$ lets the double-argument integral collapse into a simple product:
+
+$$\int_0^1 x \cdot t \cdot u(t) \, dt = x \cdot \underbrace{\int_0^1 t \cdot u(t) \, dt}_{C}$$
+
+$C$ is a **scalar** independent of $x$.  jno computes it with one `.integrate()` call over the full mesh.
+
+## Step 1: Set up the domain
+
+```python
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.01))
+x, _ = domain.variable("interior")
+```
+
+The 1D mesh on $[0,1]$ doubles as the integration mesh.  No separate quadrature rule is needed.
+
+## Step 2: Define the forcing term
+
+```python
+pi_val = float(jnp.pi)
+f = jno.np.sin(π * x) - x / pi_val
+```
+
+## Step 3: Build the model
+
+```python
+net = jno.nn.wrap(
+    foundax.mlp(in_features=1, hidden_dims=64, num_layers=4,
+                activation=jax.nn.tanh, key=jax.random.PRNGKey(0))
+)
+u = net(x)
+```
+
+## Step 4: Formulate the residual
+
+```python
+# C = ∫₀¹ t · u(t) dt  — scalar, the same for every x
+C = (x * u).integrate()
+
+# Pointwise residual  R(xᵢ) = u(xᵢ) − f(xᵢ) − xᵢ · C
+residual = u - f - x * C
+```
+
+`(x * u).integrate()` evaluates the integrand `t · u(t)` at **all mesh nodes** (here `x` is the dummy variable $t$), then reduces to a scalar using nodal volume weights.  Multiplying by the outer `x` broadcasts that scalar back to the collocation grid.
+
+Both uses of the network — as the integrand inside `C` and as the outer `u` — go through the **same** shared parameters.  Gradients flow through both paths simultaneously.
+
+## Step 5: Solve
+
+```python
+EPOCHS = 50_000
+crux = jno.core([residual.mse], domain)
+crux.solve(EPOCHS)
+```
+
+## What to notice
+
+- **No boundary conditions are needed.** The integral equation is posed on the interior only; boundary values emerge naturally from the trained solution.
+- **`.integrate()` is differentiable.** `jax.grad` and `eqx.filter_grad` propagate through it, so the scalar $C$ receives gradient updates alongside the pointwise residual terms.
+- **JIT-friendly.** Mesh weights are precomputed at domain creation and embedded as JAX constants.  The integral adds no overhead beyond a single dot-product per step.
+- **Relative L2 error < 5 %** is achievable with a modest 4-layer MLP and 50 000 Adam steps.
+
+## Script
+
+```python
+--8<-- "tutorial_examples/06_integration/fredholm_integral_equation.py"
+```
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/fredholm_integral_equation.py" download>Download full script</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to 06 Integration</a>
+</div>

--- a/docs/tutorials/06-integration/fredholm-nonseparable.md
+++ b/docs/tutorials/06-integration/fredholm-nonseparable.md
@@ -1,0 +1,108 @@
+# Fredholm Equation with Non-Separable Kernel
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/fredholm_nonseparable.py" download>Download .py</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to chapter</a>
+</div>
+
+This example solves a Fredholm integral equation of the second kind whose kernel depends on **both** the evaluation point and the integration dummy simultaneously.  It requires the `.integrate(var=x)` API introduced for non-separable kernels.
+
+## Equation
+
+$$u(x) = f(x) + \int_0^1 (x + t)\, u(t)\, dt, \qquad x \in [0,1]$$
+
+Exact solution: $u^*(x) = \sin(\pi x)$
+
+### Derivation of f
+
+$$\int_0^1 (x + t)\sin(\pi t)\, dt
+  = x \underbrace{\int_0^1 \sin(\pi t)\, dt}_{2/\pi}
+  + \underbrace{\int_0^1 t\sin(\pi t)\, dt}_{1/\pi}
+  = \frac{2x}{\pi} + \frac{1}{\pi}$$
+
+$$f(x) = \sin(\pi x) - \frac{2x}{\pi} - \frac{1}{\pi}$$
+
+## Why this requires `.integrate(var=x)`
+
+The kernel $K(x,t) = x + t$ is **non-separable in x**: for a fixed collocation point $x_i$, the integrand $(x_i + t)\,u(t)$ is a different function of $t$ for every $x_i$.  The result $\int_0^1 (x+t)\,u(t)\,dt$ is therefore an $(N,1)$ array — a function of $x$ — not a scalar.
+
+With the separable trick (previous tutorial), you would split $K = x\cdot 1 + 1\cdot t$ and compute two independent scalar integrals.  With `.integrate(var=x)`, you write the kernel directly and jno handles the vectorisation via `jax.vmap`.
+
+## Step 1: Two variables from the same domain call
+
+```python
+x, _ = domain.variable("interior")   # outer collocation variable
+t, _ = domain.variable("interior")   # inner integration dummy  — no flag needed!
+```
+
+Both `x` and `t` point to the same mesh, but they are **distinct Python objects**.  The evaluator uses their object identity to decide which one to keep fixed (the one passed to `var=`) and which one to sweep (everything else).
+
+## Step 2: The network appears at both roles
+
+```python
+u_x = net(x)   # evaluated at the N collocation points — what we want to learn
+u_t = net(t)   # same weights, evaluated at the N integration points
+```
+
+The same trained weights power both evaluations.  Gradients flow through both `u_x` and the integral over `u_t` simultaneously.
+
+## Step 3: Form the non-separable integral
+
+```python
+integral_term = ((x + t) * u_t).integrate(var=x)
+```
+
+`var=x` declares `x` as the outer variable.  The evaluator:
+
+1. Fixes `x` at each collocation point via `jax.vmap`.
+2. Evaluates $(x_i + t)\,u(t)$ over all mesh points for `t`.
+3. Returns a weighted sum per outer point — shape `(N, 1)`.
+
+The shape matches `u_x` and `f`, so the residual is formed naturally:
+
+```python
+residual = u_x - f - integral_term   # (N, 1)
+```
+
+## Step 4: Solve
+
+```python
+crux = jno.core([residual.mse], domain)
+crux.solve(30_000)
+```
+
+## Chaining two integrals (bonus)
+
+Because `.integrate(var=x)` returns a standard `(N, 1)` placeholder, you can chain a second `.integrate()` on top to reduce it to a scalar.  For example, the iterated double integral
+
+$$\int_0^1 \!\int_0^1 (x + t)\, dt\, dx = 1$$
+
+can be verified in jno without any network:
+
+```python
+x, _ = domain.variable("interior")
+t, _ = domain.variable("interior")
+
+inner  = (x + t).integrate(var=x)   # (N, 1): g(x) = x + 0.5
+result = inner.integrate()           # scalar: ∫₀¹ g(x) dx = 1.0
+```
+
+The inner call sweeps `t`; the outer scalar call then integrates `g(x)` over `x`.
+
+## What to notice
+
+- **No flag on `domain.variable()`.**  The only API change is `var=x` on `.integrate()`.
+- **Object identity distinguishes roles.**  `x` and `t` are the same type with the same tag; what makes `x` the outer is that you pass it to `var=`.
+- **N² network evaluations per step.**  For each of the N collocation points, the integrand is evaluated at all N integration points.  Keep the mesh coarse (or use a small MLP) to control cost.  `jax.vmap` + JIT compiles this to an efficient batched kernel.
+- **Relative L2 error < 10 %** is achieved here with only 21 interior points and 30 000 steps.
+
+## Script
+
+```python
+--8<-- "tutorial_examples/06_integration/fredholm_nonseparable.py"
+```
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/fredholm_nonseparable.py" download>Download full script</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to 06 Integration</a>
+</div>

--- a/docs/tutorials/06-integration/integro-differential.md
+++ b/docs/tutorials/06-integration/integro-differential.md
@@ -1,0 +1,116 @@
+# Integro-Differential Equation
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/integro_differential.py" download>Download .py</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to chapter</a>
+</div>
+
+This example solves an **integro-differential equation (IDE)** — an equation where the unknown appears under both a derivative and an integral at the same time.  It shows how `.d(x)` and `.integrate()` compose naturally in the same residual.
+
+## Equation
+
+$$u'(x) + u(x) = g(x) + \int_0^1 u(t)\, dt, \qquad x \in [0,1], \quad u(0) = 0$$
+
+Exact solution: $u^*(x) = \sin(\pi x)$
+
+### Derivation of g
+
+$$u'(x) = \pi\cos(\pi x), \qquad u(x) = \sin(\pi x), \qquad \int_0^1 \sin(\pi t)\,dt = \frac{2}{\pi}$$
+
+$$g(x) = \pi\cos(\pi x) + \sin(\pi x) - \frac{2}{\pi}$$
+
+## Why this is different
+
+In a standard PINN the residual involves only pointwise quantities — derivatives at $x$.  Here the residual also includes $\int_0^1 u(t)\,dt$, which is a **scalar** that couples the solution at every mesh point.
+
+jno handles this transparently: `.integrate()` returns a scalar placeholder that flows through the same computation graph as `.d(x)`.  Both appear in the same MSE loss with no extra bookkeeping.
+
+## Hard boundary condition
+
+The Dirichlet condition $u(0) = 0$ is enforced by the network ansatz
+
+$$u(x) = \text{net}(x) \cdot x$$
+
+Multiplying by $x$ forces $u(0) = 0$ for any weight configuration, so the optimizer never needs to "discover" the boundary condition — it is **automatically satisfied** throughout training.
+
+## Building the residual
+
+```python
+x, _ = domain.variable("interior")
+
+u  = net(x) * x   # hard BC: u(0) = 0
+
+C  = u.integrate()           # scalar: ∫₀¹ u(t) dt
+du = u.d(x)                  # (N, 1): u'(x) at every collocation point
+
+residual = du + u - g - C    # IDE residual
+```
+
+`C` is a scalar that is the same for every row — JAX broadcasting adds it to the `(N, 1)` arrays `du`, `u`, and `g` without any manual reshaping.
+
+## Shape summary
+
+| Expression | Shape | Note |
+|---|---|---|
+| `u` | `(N, 1)` | network output |
+| `u.d(x)` | `(N, 1)` | pointwise derivative |
+| `u.integrate()` | scalar | integral over all mesh points |
+| `g` | `(N, 1)` | forcing term |
+| `residual` | `(N, 1)` | broadcast scalar + vectors |
+
+## Step-by-step
+
+**Step 1 — Domain and variable**
+
+```python
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+x, _ = domain.variable("interior")
+```
+
+**Step 2 — Hard-BC ansatz**
+
+```python
+u = net(x) * x   # u(0) = 0 for any net weights
+```
+
+**Step 3 — Compose operators**
+
+```python
+C  = u.integrate()   # scalar: feeds into every row of the residual
+du = u.d(x)          # pointwise: (N, 1)
+```
+
+**Step 4 — Form and solve**
+
+```python
+residual = du + u - g - C
+crux = jno.core([residual.mse], domain)
+crux.solve(30_000)
+```
+
+## What to notice
+
+- **`.integrate()` returns a scalar** here — no `var=` argument, because there is no outer collocation variable to hold fixed.  The result is a single number representing $\int_0^1 u(t)\,dt$.
+- **`.d(x)` and `.integrate()` compose** — both produce `Placeholder` objects that participate in the same expression graph.
+- **Gradients flow through both operators** — the loss is differentiable with respect to the network weights simultaneously through the derivative term and the integral term.
+- **Relative L2 error < 10%** is achieved with 21 interior points and 30 000 steps.
+
+## Contrast with the Fredholm tutorials
+
+| Feature | Fredholm separable | Fredholm non-separable | IDE (this example) |
+|---|---|---|---|
+| Integral result | scalar | `(N, 1)` | scalar |
+| `.integrate(var=...)` | no | yes | no |
+| Derivative in residual | no | no | yes |
+| Boundary condition | none | none | hard BC ansatz |
+
+## Script
+
+```python
+--8<-- "tutorial_examples/06_integration/integro_differential.py"
+```
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO_docs/tutorial_examples/06_integration/integro_differential.py" download>Download full script</a>
+<a class="md-button" href="/jNO_docs/tutorials/06-integration/">Back to 06 Integration</a>
+</div>

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -14,12 +14,14 @@ from .architectures.models import nn, parameter
 from .core import core
 from .differential_operators import DifferentialOperators
 from .domain import PolygonDomain, domain
+from .integration_operators import IntegrationOperators
 from .trace import (
     Assembly,
     FemLinearSystem,
     FemResidualOperator,
     GroupedAssembly,
     Hessian,
+    Integral,
     Jacobian,
     Model,
     OperationCall,
@@ -86,6 +88,8 @@ __all__ = [
     "TraceEvaluator",
     "TraceCompiler",
     "DifferentialOperators",
+    "IntegrationOperators",
+    "Integral",
     "iree",
     "save",
     "load",

--- a/jno/architectures/lora.py
+++ b/jno/architectures/lora.py
@@ -263,6 +263,7 @@ def apply_lora(
     target: Optional[str] = None,
     specs: Sequence[LoRASpec] | None = None,
     wrappers: type[LoRAWrapper] | Sequence[type[LoRAWrapper]] | None = None,
+    param_mask=None,
 ) -> eqx.Module:
     """Apply LoRA adapters to matching layers in *model*.
 
@@ -277,6 +278,13 @@ def apply_lora(
        Each spec ``{"target": regex, "rank": int, "alpha": float}`` may
        also carry an optional ``"wrapper"`` key to use a different adapter
        class for that group.  The first matching spec wins.
+
+    Args:
+        param_mask: Optional boolean pytree mirroring the model structure.
+            When provided, only modules whose corresponding sub-tree contains
+            at least one ``True`` leaf are wrapped with LoRA adapters.
+            Produced by ``mask(M).lora()``; pass ``None`` to wrap all
+            matching layers (default behaviour).
 
     Returns:
         A new model with ``LoRAWrapper`` replacements at the matched leaves.
@@ -314,6 +322,16 @@ def apply_lora(
     all_wrappers: set[type[LoRAWrapper]] = {w for s in spec_list for w in s.wrappers}
     is_leaf = lambda x: any(w.applies_to(x) for w in all_wrappers)
 
+    # Build set of path strings with a True mask leaf — used to restrict wrapping
+    # to user-selected modules when mask(M).lora() is called.
+    if param_mask is not None:
+        flat_mask_with_path = jax.tree_util.tree_flatten_with_path(param_mask)[0]
+        mask_true_paths: set[str] | None = {
+            _path_str(mp) for mp, val in flat_mask_with_path if val is True or (isinstance(val, bool) and val)
+        }
+    else:
+        mask_true_paths = None
+
     flat_with_path, treedef = jax.tree_util.tree_flatten_with_path(model, is_leaf=is_leaf)
 
     new_leaves: list[Any] = []
@@ -323,6 +341,15 @@ def apply_lora(
             continue
 
         pstr = _path_str(path_keys)
+
+        # Honour param_mask: skip modules not covered by any True leaf.
+        # Use `pstr + "/"` prefix to avoid "layer1" matching "layer10/weight".
+        if mask_true_paths is not None:
+            module_selected = any(tp == pstr or tp.startswith(pstr + "/") for tp in mask_true_paths)
+            if not module_selected:
+                new_leaves.append(leaf)
+                continue
+
         new_leaf = leaf
         for spec in spec_list:
             if spec.pat is None or spec.pat.search(pstr):
@@ -361,6 +388,45 @@ def lora_trainable_filter(model: eqx.Module) -> object:
 
     flat, treedef = jax.tree_util.tree_flatten(model)
     specs = [eqx.is_array(leaf) and id(leaf) in adapter_ids for leaf in flat]
+    return jax.tree_util.tree_unflatten(treedef, specs)
+
+
+def partial_lora_trainable_filter(model: eqx.Module) -> object:
+    """Return a filter-spec for partial LoRA (mask(M).lora() without freeze()).
+
+    Three-bucket logic:
+    - LoRA adapter arrays (b, d, lora_A, lora_B, …)  → ``True``  (trained)
+    - Base arrays inside LoRA wrappers                 → ``False`` (frozen)
+    - Arrays outside any LoRA wrapper                  → ``True``  (trained)
+
+    Use this when the user says ``mask(M).lora()`` without a prior ``freeze()``:
+    selected layers get LoRA with frozen bases; everything else stays trainable.
+    """
+    adapter_ids: set[int] = set()
+    wrapped_base_ids: set[int] = set()
+
+    is_lora = lambda x: isinstance(x, LoRAWrapper)
+    for node in jax.tree_util.tree_leaves(model, is_leaf=is_lora):
+        if isinstance(node, LoRAWrapper):
+            for fname in node.adapter_fields:
+                arr = getattr(node, fname, None)
+                if eqx.is_array(arr):
+                    adapter_ids.add(id(arr))
+            for base_arr in jax.tree_util.tree_leaves(node.base):
+                if eqx.is_array(base_arr):
+                    wrapped_base_ids.add(id(base_arr))
+
+    flat, treedef = jax.tree_util.tree_flatten(model)
+    specs = []
+    for leaf in flat:
+        if not eqx.is_inexact_array(leaf):
+            specs.append(False)
+        elif id(leaf) in adapter_ids:
+            specs.append(True)
+        elif id(leaf) in wrapped_base_ids:
+            specs.append(False)
+        else:
+            specs.append(True)  # unwrapped param — stays trainable
     return jax.tree_util.tree_unflatten(treedef, specs)
 
 

--- a/jno/architectures/lora.py
+++ b/jno/architectures/lora.py
@@ -6,9 +6,9 @@ weights are frozen and only the adapter arrays are trained.
 During forward (LoRALinear):  ``y = base(x) + (x @ A.T) @ B.T * (alpha / rank)``
 After merging               :  ``y = merged_linear(x)``  (no runtime overhead)
 
-LoRA Zoo
-~~~~~~~~
-Several ``LoRAWrapper`` subclasses are provided out of the box:
+LoRA Zoo — Linear
+~~~~~~~~~~~~~~~~~
+Several ``LoRAWrapper`` subclasses are provided out of the box for linear layers:
 
 - ``LoRALinear``   — vanilla LoRA (trainable A and B)
 - ``rsLoRALinear`` — rank-stabilized: scales by ``alpha/sqrt(rank)``
@@ -22,11 +22,27 @@ Several ``LoRAWrapper`` subclasses are provided out of the box:
 - ``LoKrLinear``   — Kronecker product adapter: delta_W = kron(kron_A, kron_B)
 - ``OFTLinear``    — block-diagonal orthogonal fine-tuning via Cayley map
 
+LoRA Zoo — Conv
+~~~~~~~~~~~~~~~
+Matching conv variants for ``eqx.nn.Conv1d/2d/3d`` (ConvTranspose excluded):
+
+- ``LoRAConv``   — vanilla LoRA on flattened conv weight
+- ``rsLoRAConv`` — rank-stabilized conv LoRA
+- ``LoRAFAConv`` — frozen-A conv LoRA
+- ``DoRAConv``   — weight-decomposed conv LoRA
+- ``PiSSAConv``  — SVD-initialised conv LoRA (principal components)
+- ``LoRAXSConv`` — extra-small conv LoRA with trainable r×r core
+- ``VeRAConv``   — seed-based frozen A,B; only b,d vectors trained
+- ``MiLoRAConv`` — SVD minor-component conv LoRA
+- ``IA3Conv``    — per-output-channel scale vector
+- ``LoKrConv``   — Kronecker product conv adapter
+- ``OFTConv``    — block-diagonal orthogonal fine-tuning for conv
+
 Custom adapters
 ~~~~~~~~~~~~~~~
 Subclass ``LoRAWrapper`` to support any layer type::
 
-    class LoRAConv(LoRAWrapper):
+    class MyConvAdapter(LoRAWrapper):
         adapter_fields = ("delta_w",)
 
         @classmethod
@@ -37,10 +53,10 @@ Subclass ``LoRAWrapper`` to support any layer type::
         def __call__(self, x): ...
         def merge(self): ...
 
-    net.lora(rank=4, wrapper=LoRAConv)
+    net.lora(rank=4, wrapper=MyConvAdapter)
     net.lora(specs=[
         {"target": "linear", "rank": 4, "alpha": 1.0},
-        {"target": "conv",   "rank": 8, "alpha": 2.0, "wrapper": LoRAConv},
+        {"target": "conv",   "rank": 8, "alpha": 2.0, "wrapper": MyConvAdapter},
     ])
 """
 
@@ -68,6 +84,27 @@ class LinearLike(Protocol):
     out_features: int
 
     def __call__(self, x: jax.Array) -> jax.Array: ...
+
+
+@runtime_checkable
+class ConvLike(Protocol):
+    """Structural type for any conv module LoRA can wrap (excludes ConvTranspose)."""
+
+    weight: jax.Array
+    in_channels: int
+    out_channels: int
+
+    def __call__(self, x: jax.Array) -> jax.Array: ...
+
+
+try:
+    _CONV_TRANSPOSE_TYPES: tuple[type, ...] = (
+        eqx.nn.ConvTranspose1d,
+        eqx.nn.ConvTranspose2d,
+        eqx.nn.ConvTranspose3d,
+    )
+except AttributeError:
+    _CONV_TRANSPOSE_TYPES = ()
 
 
 # =====================================================================
@@ -184,9 +221,14 @@ class _Spec:
 def _normalize_wrappers(
     wrapper: type[LoRAWrapper] | Sequence[type[LoRAWrapper]] | None,
 ) -> tuple[type[LoRAWrapper], ...]:
-    """Coerce the user-facing ``wrapper`` argument to a tuple of wrapper classes."""
+    """Coerce the user-facing ``wrapper`` argument to a tuple of wrapper classes.
+
+    When ``wrapper`` is ``None``, returns ``(LoRALinear, LoRAConv)`` — both linear
+    and conv layers are wrapped by default.  ``LoRAConv`` is resolved at call time
+    (Python late binding), so the forward reference is safe.
+    """
     if wrapper is None:
-        return (LoRALinear,)
+        return (LoRALinear, LoRAConv)  # LoRAConv defined later in this module
     if isinstance(wrapper, type):
         return (wrapper,)
     return tuple(wrapper)
@@ -330,6 +372,16 @@ def lora_trainable_filter(model: eqx.Module) -> object:
 def _linear_applies_to(leaf: Any) -> bool:
     """Shared predicate: any unwrapped LinearLike eqx.Module."""
     return isinstance(leaf, eqx.Module) and not isinstance(leaf, LoRAWrapper) and isinstance(leaf, LinearLike)
+
+
+def _conv_applies_to(leaf: Any) -> bool:
+    """Shared predicate: any unwrapped ConvLike eqx.Module (ConvTranspose excluded)."""
+    return (
+        isinstance(leaf, eqx.Module)
+        and not isinstance(leaf, LoRAWrapper)
+        and isinstance(leaf, ConvLike)
+        and not isinstance(leaf, _CONV_TRANSPOSE_TYPES)
+    )
 
 
 class rsLoRALinear(LoRALinear):
@@ -796,4 +848,541 @@ class OFTLinear(LoRAWrapper):
 
     def merge(self) -> eqx.Module:
         W_new = self._R() @ self.base.weight
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+# =====================================================================
+# LoRA Zoo — Conv variants (LoRAConv through OFTConv)
+#
+# All conv adapters:
+#   - target ``eqx.nn.Conv1d/2d/3d`` (ConvTranspose excluded)
+#   - flatten weight to (out_channels, flat_in) for linear-algebra ops
+#   - reconstruct via ``eqx.tree_at(lambda m: m.weight, base, W_new)(x)``
+#     so XLA fuses the weight substitution into a single conv kernel call
+#   - store ``weight_shape`` as a static field for shape-safe reshaping
+# =====================================================================
+
+
+class LoRAConv(LoRAWrapper):
+    """Standard LoRA for convolutional layers.
+
+    Flattens the weight tensor to ``(out_channels, flat_in)`` and applies
+    a low-rank update identical to ``LoRALinear``:
+
+        W' = W + (alpha/rank) * lora_B @ lora_A    (in flattened space)
+
+    The updated weight is reshaped back and passed to the base conv via
+    ``eqx.tree_at``, which XLA fuses into a single conv kernel call.
+
+    ``flat_in = in_channels // groups * prod(kernel_size)``
+    """
+
+    adapter_fields = ("lora_A", "lora_B")
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in)
+    lora_B: jax.Array  # (out_channels, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.base = base
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        self.rank = min(rank, min(out_ch, flat_in))
+        self.alpha = alpha
+        k1, _ = jax.random.split(key)
+        std = 1.0 / jnp.sqrt(flat_in)
+        self.lora_A = jax.random.normal(k1, (self.rank, flat_in)) * std
+        self.lora_B = jnp.zeros((out_ch, self.rank))
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class rsLoRAConv(LoRAConv):
+    """Rank-Stabilized LoRA for conv layers.  Scales by ``alpha/sqrt(rank)``.
+
+    Reference: https://arxiv.org/abs/2312.03732
+    """
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / jnp.sqrt(self.rank))
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / jnp.sqrt(self.rank))
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class LoRAFAConv(LoRAConv):
+    """Frozen-A LoRA for conv layers.  Only ``lora_B`` is trained.
+
+    Reference: https://arxiv.org/abs/2308.03303
+    """
+
+    adapter_fields = ("lora_B",)  # lora_A stays in pytree but is frozen
+
+
+class DoRAConv(LoRAWrapper):
+    """Weight-Decomposed Low-Rank Adaptation for conv layers.
+
+    Operates on the flattened weight ``(out_channels, flat_in)`` exactly
+    as ``DoRALinear`` does on a 2-D linear weight.
+
+    Reference: https://arxiv.org/abs/2402.09353
+    """
+
+    adapter_fields = ("magnitude", "lora_A", "lora_B")
+
+    base: ConvLike
+    magnitude: jax.Array  # (out_channels,) — learned per-output-channel scale
+    lora_A: jax.Array  # (rank, flat_in)
+    lora_B: jax.Array  # (out_channels, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        self.rank = min(rank, min(out_ch, flat_in))
+        self.alpha = alpha
+        self.base = base
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        self.magnitude = jnp.linalg.norm(W_flat, axis=1)
+        k1, _ = jax.random.split(key)
+        std = 1.0 / jnp.sqrt(flat_in)
+        self.lora_A = jax.random.normal(k1, (self.rank, flat_in)) * std
+        self.lora_B = jnp.zeros((out_ch, self.rank))
+
+    def _dora_weight_flat(self) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_flat = W_flat + (self.alpha / self.rank) * (self.lora_B @ self.lora_A)
+        row_norms = jnp.linalg.norm(W_flat, axis=1, keepdims=True)
+        return self.magnitude[:, None] * W_flat / row_norms
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        W_new = self._dora_weight_flat().reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        W_new = self._dora_weight_flat().reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class PiSSAConv(LoRAWrapper):
+    """Principal Singular Values and Singular Vectors Adaptation for conv layers.
+
+    SVD is computed on the flattened weight ``(out_channels, flat_in)``.
+    Adapters start from the top-r singular components; base holds the residual.
+
+    Reference: https://arxiv.org/abs/2404.02948
+    """
+
+    adapter_fields = ("lora_A", "lora_B")
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in)
+    lora_B: jax.Array  # (out_channels, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        U, S, Vt = jnp.linalg.svd(W_flat, full_matrices=False)
+        U_r, S_r, Vt_r = U[:, :r], S[:r], Vt[:r, :]
+
+        scale = jnp.sqrt(S_r * r / alpha)
+        self.lora_B = U_r * scale[None, :]
+        self.lora_A = Vt_r * scale[:, None]
+
+        W_residual = (W_flat - (alpha / r) * (self.lora_B @ self.lora_A)).reshape(self.weight_shape)
+        self.base = eqx.tree_at(lambda m: m.weight, base, W_residual)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class LoRAXSConv(LoRAWrapper):
+    """LoRA-XS extra-small adapter for conv layers.
+
+    ``lora_A`` and ``lora_B`` are frozen (from SVD of flattened weight).
+    Only the small ``R`` (rank × rank) matrix is trained.
+
+    Reference: https://arxiv.org/abs/2405.17604
+    """
+
+    adapter_fields = ("R",)
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in) — frozen, from SVD
+    lora_B: jax.Array  # (out_channels, rank) — frozen, from SVD
+    R: jax.Array  # (rank, rank) — the only trainable parameter
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+        self.base = base
+
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        U, _, Vt = jnp.linalg.svd(W_flat, full_matrices=False)
+        self.lora_A = Vt[:r, :]
+        self.lora_B = U[:, :r]
+        self.R = jnp.zeros((r, r))
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.R @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.R @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class VeRAConv(LoRAWrapper):
+    """Vector-based Random Matrix Adaptation for conv layers.
+
+    A and B are generated on-the-fly from a stored seed (XLA constants).
+    Only per-channel ``b`` (out_channels,) and ``d`` (rank,) are trained.
+
+    Reference: https://arxiv.org/abs/2310.11454
+    """
+
+    adapter_fields = ("b", "d")
+
+    base: ConvLike
+    b: jax.Array  # (out_channels,) — trainable output-channel scale
+    d: jax.Array  # (rank,)         — trainable row scale for A
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    seed: int = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.base = base
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        self.rank = rank
+        self.alpha = alpha
+        self.seed = int(jax.random.randint(key, shape=(), minval=0, maxval=2**30))
+        self.b = jnp.zeros(out_ch)
+        self.d = jnp.ones(rank)
+
+    def _frozen_AB(self) -> tuple[jax.Array, jax.Array]:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        A = jax.random.normal(jax.random.PRNGKey(self.seed), (self.rank, flat_in)) / jnp.sqrt(flat_in)
+        B = jax.random.normal(jax.random.PRNGKey(self.seed + 1), (out_ch, self.rank))
+        return A, B
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        A, B = self._frozen_AB()
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = (self.b[:, None] * B) @ (self.d[:, None] * A) * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        A, B = self._frozen_AB()
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = (self.b[:, None] * B) @ (self.d[:, None] * A) * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class MiLoRAConv(LoRAWrapper):
+    """Minor Singular Values and Singular Vectors Adaptation for conv layers.
+
+    Like ``PiSSAConv`` but adapts the minor (least-significant) singular
+    components; base retains the principal directions.
+
+    Reference: https://arxiv.org/abs/2405.09913
+    """
+
+    adapter_fields = ("lora_A", "lora_B")
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in) — minor right singular vectors
+    lora_B: jax.Array  # (out_channels, rank) — minor left singular vectors
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        U, S, Vt = jnp.linalg.svd(W_flat, full_matrices=False)
+        U_r, S_r, Vt_r = U[:, -r:], S[-r:], Vt[-r:, :]
+
+        scale = jnp.sqrt(S_r * r / alpha)
+        self.lora_B = U_r * scale[None, :]
+        self.lora_A = Vt_r * scale[:, None]
+
+        W_residual = (W_flat - (alpha / r) * (self.lora_B @ self.lora_A)).reshape(self.weight_shape)
+        self.base = eqx.tree_at(lambda m: m.weight, base, W_residual)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class IA3Conv(LoRAWrapper):
+    """IA³ output-scaling adapter for conv layers.
+
+    Applies a learned per-output-channel scale to the conv weight before
+    the convolution.  No low-rank matrices — trainable params = ``out_channels``.
+
+    Reference: https://arxiv.org/abs/2205.05638
+    """
+
+    adapter_fields = ("scale",)
+
+    base: ConvLike
+    scale: jax.Array  # (out_channels,) — learned per-channel multiplier
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.base = base
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        self.rank = rank
+        self.alpha = alpha
+        self.scale = jnp.ones(out_ch)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        # Broadcast scale over all non-output axes: (out_ch, 1, 1, ...)
+        scale_shape = (self.weight_shape[0],) + (1,) * (len(self.weight_shape) - 1)
+        W_new = self.base.weight * self.scale.reshape(scale_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        scale_shape = (self.weight_shape[0],) + (1,) * (len(self.weight_shape) - 1)
+        W_new = self.base.weight * self.scale.reshape(scale_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class LoKrConv(LoRAWrapper):
+    """Kronecker-product adapter for conv layers.
+
+    The weight delta is a Kronecker product of two small matrices, cropped to
+    ``(out_channels, flat_in)`` and reshaped to the original weight shape.
+
+    Reference: https://arxiv.org/abs/2212.10650
+    """
+
+    adapter_fields = ("kron_A", "kron_B")
+
+    base: ConvLike
+    kron_A: jax.Array  # (rank, rank)
+    kron_B: jax.Array  # (ceil(out_ch/rank), ceil(flat_in/rank))
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+        self.base = base
+
+        m2 = _math.ceil(out_ch / r)
+        n2 = _math.ceil(flat_in / r)
+        self.kron_A = jax.random.normal(key, (r, r)) / jnp.sqrt(r)
+        self.kron_B = jnp.zeros((m2, n2))
+
+    def _delta_W_flat(self) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        return jnp.kron(self.kron_A, self.kron_B)[:out_ch, :flat_in]
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self._delta_W_flat() * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self._delta_W_flat() * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class OFTConv(LoRAWrapper):
+    """Orthogonal Fine-Tuning for conv layers.
+
+    The block-diagonal Cayley map is applied to the output-channel axis of
+    the flattened weight ``(out_channels, flat_in)``, identical to
+    ``OFTLinear`` on a 2-D weight.
+
+    Reference: https://arxiv.org/abs/2306.07280
+    """
+
+    adapter_fields = ("Q_blocks",)
+
+    base: ConvLike
+    Q_blocks: jax.Array  # (n_blocks, rank, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    n_blocks: int = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        r = min(rank, out_ch)
+        self.rank = r
+        self.alpha = alpha
+        self.n_blocks = _math.ceil(out_ch / r)
+        self.base = base
+        self.Q_blocks = jnp.zeros((self.n_blocks, r, r))
+
+    def _R(self) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        eye = jnp.eye(self.rank)
+
+        def cayley(Q: jax.Array) -> jax.Array:
+            Qs = (Q - Q.T) / 2
+            return (eye - Qs) @ jnp.linalg.inv(eye + Qs)
+
+        blocks = jax.vmap(cayley)(self.Q_blocks)
+        R_padded = jax.scipy.linalg.block_diag(*[blocks[i] for i in range(self.n_blocks)])
+        return R_padded[:out_ch, :out_ch]
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (self._R() @ W_flat).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (self._R() @ W_flat).reshape(self.weight_shape)
         return eqx.tree_at(lambda m: m.weight, self.base, W_new)

--- a/jno/core.py
+++ b/jno/core.py
@@ -24,6 +24,9 @@ from .architectures.lora import (
 from .architectures.lora import (
     merge_lora as _merge_lora,
 )
+from .architectures.lora import (
+    partial_lora_trainable_filter as _partial_lora_trainable_filter,
+)
 from .domain import DomainData, domain
 from .trace import (
     BinaryOp,
@@ -1126,7 +1129,12 @@ class core:
                 self.rng, key = jax.random.split(self.rng)
                 n_params_before = sum(param.size for param in jax.tree_util.tree_leaves(models[lid]) if eqx.is_array(param))
 
-                models[lid] = _apply_lora(models[lid], key=key, specs=fm._lora_config)
+                models[lid] = _apply_lora(
+                    models[lid],
+                    key=key,
+                    specs=fm._lora_config,
+                    param_mask=getattr(fm, "_lora_param_mask", None),
+                )
 
                 model_after = models[lid]
                 n_params_after = sum(param.size for param in jax.tree_util.tree_leaves(model_after) if eqx.is_array(param))
@@ -1171,16 +1179,15 @@ class core:
             fm = flax_mods.get(lid)
             if fm is not None and fm._lora_config is not None:
                 # LoRA modes:
-                # 1) fm._frozen=True  -> freeze all base params, train LoRA only
-                # 2) fm._trainable_param_mask -> custom base trainability mask,
-                #                        train non-target base + LoRA params
-                # 3) otherwise        -> default LoRA behaviour (freeze all base)
+                # 1) fm._frozen=True  -> freeze everything; only LoRA adapters trainable.
+                #    (freeze().lora() or freeze().mask(M).lora() both land here — base
+                #    params outside LoRA-wrapped layers are frozen too.)
+                # 2) otherwise        -> partial LoRA: adapters trainable, wrapped bases
+                #    frozen, every other param stays trainable (mask(M).lora() case).
                 if fm._frozen:
                     filter_spec[lid] = _lora_trainable_filter(model)
-                elif fm._trainable_param_mask is not None:
-                    filter_spec[lid] = _lora_trainable_filter(model)
                 else:
-                    filter_spec[lid] = _lora_trainable_filter(model)
+                    filter_spec[lid] = _partial_lora_trainable_filter(model)
             elif fm is not None and fm._frozen:
                 # Whole model frozen – no arrays trainable
                 filter_spec[lid] = jax.tree_util.tree_map(lambda leaf: False, model)

--- a/jno/domain/mesh_utils.py
+++ b/jno/domain/mesh_utils.py
@@ -106,6 +106,7 @@ class MeshUtils:
         msg = f"Preprocessed mesh connectivity: {n_points} points, {len(elements)} {element_type}"
 
         mesh_connectivity["nodal_ds"] = MeshUtils.compute_nodal_ds(mesh_connectivity)
+        mesh_connectivity["nodal_volumes"] = MeshUtils.compute_nodal_volumes(mesh_connectivity)
         mesh_connectivity["boundary_indices"] = boundary_indices
 
         bp = points[boundary_indices]
@@ -243,6 +244,50 @@ class MeshUtils:
             return ds[boundary_indices]
 
         return ds
+
+    @staticmethod
+    def compute_nodal_volumes(mesh_connectivity: dict) -> np.ndarray:
+        """Per-node volume weights for interior integration.
+
+        Mirrors ``compute_nodal_ds`` for boundary, but distributes element
+        volume/area/length to all interior nodes:
+
+        - 1D: ½ of adjacent segment lengths (trapezoidal rule)
+        - 2D: ⅓ of incident triangle areas
+        - 3D: ¼ of incident tetrahedron volumes
+
+        Called once during mesh preprocessing and stored as
+        ``mesh_connectivity["nodal_volumes"]``.
+        """
+        dimension = mesh_connectivity["dimension"]
+        points = mesh_connectivity["points"]
+        n_points = mesh_connectivity["n_points"]
+        vols = np.zeros(n_points)
+
+        if dimension == 1:
+            for seg in mesh_connectivity["lines"]:
+                L = np.linalg.norm(points[seg[1]] - points[seg[0]])
+                vols[seg[0]] += 0.5 * L
+                vols[seg[1]] += 0.5 * L
+
+        elif dimension == 2:
+            for tri in mesh_connectivity["triangles"]:
+                a, b, c = points[tri[0]], points[tri[1]], points[tri[2]]
+                area = 0.5 * abs(float(np.cross(b - a, c - a)))
+                for n in tri:
+                    vols[n] += area / 3.0
+
+        elif dimension == 3:
+            for tet in mesh_connectivity["tetrahedra"]:
+                a, b, c, d = (points[tet[i]] for i in range(4))
+                vol = abs(float(np.dot(b - a, np.cross(c - a, d - a)))) / 6.0
+                for n in tet:
+                    vols[n] += vol / 4.0
+
+        else:
+            raise ValueError(f"Unsupported dimension: {dimension}")
+
+        return vols
 
     @staticmethod
     def get_boundary_normals(mesh, k=8):

--- a/jno/integration_operators.py
+++ b/jno/integration_operators.py
@@ -1,0 +1,77 @@
+"""Mesh-based numerical integration operators.
+
+Mirrors :class:`DifferentialOperators` but for integration rather than
+differentiation.  All methods are static and work on plain NumPy arrays
+derived from ``mesh_connectivity`` — no domain object dependency.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class IntegrationOperators:
+    """Static namespace for mesh-based numerical integration.
+
+    Works on the ``mesh_connectivity`` dict produced by the domain class.
+    Boundary weights (``nodal_ds``) are already stored there; this class
+    adds volume weights (``nodal_volumes``) computed on the fly.
+    """
+
+    @staticmethod
+    def nodal_volumes(mesh_connectivity: dict) -> np.ndarray:
+        """Per-node volume weights for interior integration.
+
+        Returns ``mesh_connectivity["nodal_volumes"]`` if it was precomputed
+        during domain setup (the normal path).  Otherwise computes on the fly
+        (fallback for manually constructed mesh_connectivity dicts).
+
+        Each node receives a share of surrounding element volumes:
+
+        - 1-D: ½ × sum of adjacent segment lengths (trapezoidal rule)
+        - 2-D: ⅓ × sum of incident triangle areas
+        - 3-D: ¼ × sum of incident tetrahedron volumes
+
+        Parameters
+        ----------
+        mesh_connectivity : dict
+            Preprocessed mesh connectivity from the domain class.
+
+        Returns
+        -------
+        vols : ndarray of shape (n_points,)
+        """
+        if "nodal_volumes" in mesh_connectivity:
+            return np.asarray(mesh_connectivity["nodal_volumes"])
+
+        dim = mesh_connectivity["dimension"]
+        points = mesh_connectivity["points"]
+        N = mesh_connectivity["n_points"]
+        vols = np.zeros(N)
+
+        if dim == 1:
+            for seg in mesh_connectivity["lines"]:
+                L = np.linalg.norm(points[seg[1]] - points[seg[0]])
+                vols[seg[0]] += 0.5 * L
+                vols[seg[1]] += 0.5 * L
+
+        elif dim == 2:
+            for tri in mesh_connectivity["triangles"]:
+                a = points[tri[0]]
+                b = points[tri[1]]
+                c = points[tri[2]]
+                area = 0.5 * abs(float(np.cross(b - a, c - a)))
+                for n in tri:
+                    vols[n] += area / 3.0
+
+        elif dim == 3:
+            for tet in mesh_connectivity["tetrahedra"]:
+                a, b, c, d = (points[tet[i]] for i in range(4))
+                vol = abs(float(np.dot(b - a, np.cross(c - a, d - a)))) / 6.0
+                for n in tet:
+                    vols[n] += vol / 4.0
+
+        else:
+            raise ValueError(f"Unsupported dimension: {dim}")
+
+        return vols

--- a/jno/jnp_ops.py
+++ b/jno/jnp_ops.py
@@ -7,11 +7,13 @@ import jax.numpy as jnp
 from .architectures.models import nn, parameter  # noqa: F401
 
 # Keep import so people can use jno.numpy as jno -> jno.model, jno.tune
+from .integration_operators import IntegrationOperators  # noqa: F401
 from .trace import (
     Choice,
     ConstantNamespace,
     FunctionCall,
     Hessian,
+    Integral,
     Jacobian,
     Placeholder,
     TestFunction,
@@ -732,6 +734,29 @@ def curl_3d(
     curl_y = Jacobian(Fx, [z]) - Jacobian(Fz, [x])
     curl_z = Jacobian(Fy, [x]) - Jacobian(Fx, [y])
     return stack([curl_x, curl_y, curl_z], axis=-1)
+
+
+def integrate(expr: Placeholder) -> "Integral":
+    """Integrate a scalar expression over its mesh domain region.
+
+    Shorthand for ``expr.integrate()``.  The region (boundary vs volume) is
+    auto-detected from the Variable tags inside ``expr`` via
+    ``domain._boundary_registry``.
+
+    The expression is evaluated at **all** mesh nodes of that region and
+    reduced to a scalar via a weighted sum using nodal measures.
+    For flux integrals, compute F·n explicitly first::
+
+        (Fx(x_b, y_b) * nx + Fy(x_b, y_b) * ny).integrate()
+        integrate(Fx(x_b, y_b) * nx + Fy(x_b, y_b) * ny)  # equivalent
+
+    Args:
+        expr: Scalar-valued Placeholder expression.
+
+    Returns:
+        Integral node that evaluates to a scalar.
+    """
+    return Integral(expr)
 
 
 def test(name: str = "phi") -> TestFunction:

--- a/jno/lora.py
+++ b/jno/lora.py
@@ -7,29 +7,46 @@ Import via::
 
 or::
 
-    from jno.lora import rsLoRALinear, DoRALinear
+    from jno.lora import rsLoRALinear, DoRALinear, LoRAConv
 """
 
 from .architectures.lora import (
+    ConvLike,
+    DoRAConv,
     DoRALinear,
+    IA3Conv,
     IA3Linear,
+    LinearLike,
+    LoKrConv,
     LoKrLinear,
+    LoRAConv,
+    LoRAFAConv,
     LoRAFALinear,
     LoRALinear,
     LoRAWrapper,
+    LoRAXSConv,
     LoRAXSLinear,
+    MiLoRAConv,
     MiLoRALinear,
+    OFTConv,
     OFTLinear,
+    PiSSAConv,
     PiSSALinear,
+    VeRAConv,
     VeRALinear,
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    rsLoRAConv,
     rsLoRALinear,
 )
 
 __all__ = [
+    # Base
     "LoRAWrapper",
+    "LinearLike",
+    "ConvLike",
+    # Linear zoo
     "LoRALinear",
     "rsLoRALinear",
     "LoRAFALinear",
@@ -41,6 +58,19 @@ __all__ = [
     "IA3Linear",
     "LoKrLinear",
     "OFTLinear",
+    # Conv zoo
+    "LoRAConv",
+    "rsLoRAConv",
+    "LoRAFAConv",
+    "DoRAConv",
+    "PiSSAConv",
+    "LoRAXSConv",
+    "VeRAConv",
+    "MiLoRAConv",
+    "IA3Conv",
+    "LoKrConv",
+    "OFTConv",
+    # Utilities
     "apply_lora",
     "merge_lora",
     "lora_trainable_filter",

--- a/jno/lora.py
+++ b/jno/lora.py
@@ -37,6 +37,7 @@ from .architectures.lora import (
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    partial_lora_trainable_filter,
     rsLoRAConv,
     rsLoRALinear,
 )
@@ -74,4 +75,5 @@ __all__ = [
     "apply_lora",
     "merge_lora",
     "lora_trainable_filter",
+    "partial_lora_trainable_filter",
 ]

--- a/jno/trace.py
+++ b/jno/trace.py
@@ -444,6 +444,29 @@ class Placeholder:
         """
         return Hessian(self, list(variables), scheme, trace=False)
 
+    # ------------------------------------------------------------------
+    # Integration — method-style API
+    # ------------------------------------------------------------------
+
+    def integrate(self) -> "Integral":
+        """Integrate this expression over its mesh domain region.
+
+        The region (boundary vs volume) is auto-detected from the Variable
+        tags inside the expression: if the tag is registered in
+        ``domain._boundary_registry`` it is treated as a boundary integral
+        (∫_∂Ω f ds), otherwise as a volume integral (∫_Ω f dV).
+
+        The expression is evaluated at **all** mesh nodes of the region,
+        weighted by the nodal measures from ``mesh_connectivity``, and
+        reduced to a scalar.  The user is responsible for computing any
+        desired F·n dot-product before calling ``.integrate()``::
+
+            (Fx(x_b, y_b) * nx + Fy(x_b, y_b) * ny).integrate()  # flux
+            (u(x_b, y_b) - ref).square().integrate()               # boundary loss
+            u(x, y).integrate()                                    # volume integral
+        """
+        return Integral(self)
+
 
 class Literal(Placeholder):
     """Concrete scalar/array embedded in the trace (no trainable params)."""
@@ -1825,6 +1848,22 @@ class Jacobian(Placeholder):
     def __repr__(self):
         var_names = ", ".join(str(v) for v in self.variables)
         return f"Jacobian({self.target}, [{var_names}])"
+
+
+class Integral(Placeholder):
+    """Mesh-based integral reduction of an expression over its domain region.
+
+    Created by :meth:`Placeholder.integrate`.  The region (boundary vs volume)
+    is auto-detected at evaluation time from the Variable tags inside
+    ``target`` via ``domain._boundary_registry``.  Reduces to a scalar.
+    """
+
+    def __init__(self, target: "Placeholder"):
+        self.target = target
+        _propagate_weak(self, target)
+
+    def __repr__(self):
+        return f"Integral({self.target})"
 
 
 class FemLinearSystem:

--- a/jno/trace.py
+++ b/jno/trace.py
@@ -977,6 +977,7 @@ class Model(Placeholder):
         self._dtype = None  # target dtype (e.g. jnp.bfloat16) or None
         self._param_mask = None  # current mask scope for grouped optimizer/lr calls
         self._trainable_param_mask = None  # persistent trainability mask used by mask(...).freeze()
+        self._lora_param_mask = None  # param mask passed to mask().lora() → restricts which modules get LoRA
         self._mask_scope_pending: bool = False  # transient flag for mask(...).optimizer()/lr() group scoping
         self._param_groups: list = []  # [{target, mask, opt_fn, lr}] for per-group optimizer config
         self._weight_tree = None  # pretrained weights as a pytree (alternative to weight_path file)
@@ -1040,6 +1041,7 @@ class Model(Placeholder):
             "-" * 60,
             f"mask_active:          {self._param_mask is not None}",
             f"trainable_mask_set:   {self._trainable_param_mask is not None}",
+            f"lora_mask_set:        {self._lora_param_mask is not None}",
             "",
             "Parameter Groups",
             "-" * 60,
@@ -1201,30 +1203,35 @@ class Model(Placeholder):
            The first matching spec wins.
 
         By default only the low-rank adapters are trained; base weights are
-        frozen.  Call ``freeze()`` before ``lora()`` to also freeze any
-        base parameters that are outside LoRA-wrapped layers::
+        frozen.  Layers that are NOT wrapped by LoRA remain fully trainable.
+        Call ``freeze()`` before ``lora()`` to also freeze any parameters
+        outside LoRA-wrapped layers::
 
             NN.freeze().lora(rank=8, alpha=16)
+
+        Use ``mask(M)`` to restrict which layers receive LoRA adapters::
+
+            NN.mask(M).lora(rank=8, alpha=16)  # only M-selected layers are wrapped
 
         Args:
             rank:    LoRA rank (uniform mode).
             alpha:   LoRA scaling factor (uniform mode).
-            target:  Regex to restrict which layers are wrapped (uniform mode).
+            target:  Regex to restrict *which layers get LoRA adapters* (uniform
+                     mode only).  Layers whose pytree path does not match are left
+                     completely untouched.  Use ``specs=`` for per-group targeting.
             wrapper: Adapter class or list of classes to try in order.
-                     Defaults to ``LoRALinear`` (wraps ``LinearLike`` layers).
-                     Pass a custom ``LoRAWrapper`` subclass to support other
-                     layer types (e.g. convolutions).
+                     Defaults to ``(LoRALinear, LoRAConv)`` — wraps both linear
+                     and conv layers.  Pass a single class or list to override.
             specs:   Per-target specs (per-target mode).  Each dict has keys
                      ``target`` (str regex), ``rank`` (int), ``alpha`` (float),
                      and optionally ``wrapper``.
         """
         if self._mask_scope_pending and self._param_mask is not None:
-            self._trainable_param_mask = jax.tree_util.tree_map(
-                lambda x: (not x) if isinstance(x, bool) else False,
-                self._param_mask,
-            )
+            self._lora_param_mask = self._param_mask
         else:
-            self._trainable_param_mask = None
+            self._lora_param_mask = None
+        # lora() always clears any stale freeze mask — it overrides mask().freeze() semantics.
+        self._trainable_param_mask = None
         self._mask_scope_pending = False
 
         default_wrappers = _normalize_wrappers(wrapper)
@@ -1465,6 +1472,7 @@ class Model(Placeholder):
         self._dtype = None
         self._param_mask = None
         self._trainable_param_mask = None
+        self._lora_param_mask = None
         self._mask_scope_pending = False
         self._weight_tree = None
         self._initialize_mask = None

--- a/jno/trace.py
+++ b/jno/trace.py
@@ -448,24 +448,28 @@ class Placeholder:
     # Integration — method-style API
     # ------------------------------------------------------------------
 
-    def integrate(self) -> "Integral":
+    def integrate(self, var: "Variable | None" = None) -> "Integral":
         """Integrate this expression over its mesh domain region.
 
+        **Scalar integral** (``var=None``, default):
         The region (boundary vs volume) is auto-detected from the Variable
-        tags inside the expression: if the tag is registered in
-        ``domain._boundary_registry`` it is treated as a boundary integral
-        (∫_∂Ω f ds), otherwise as a volume integral (∫_Ω f dV).
+        tags inside the expression.  The expression is evaluated at all mesh
+        nodes and reduced to a scalar via a weighted sum.
 
-        The expression is evaluated at **all** mesh nodes of the region,
-        weighted by the nodal measures from ``mesh_connectivity``, and
-        reduced to a scalar.  The user is responsible for computing any
-        desired F·n dot-product before calling ``.integrate()``::
+        **Vectorized integral** (``var=x`` — the outer/collocation variable):
+        When the expression contains two distinct Variable objects from the
+        same mesh (e.g. an outer collocation variable ``x`` and an inner
+        dummy ``t``), pass the outer one as ``var``.  The integral is then
+        evaluated for every collocation point via ``jax.vmap``, returning an
+        ``(N, 1)`` array — a function of the outer variable.  This enables
+        non-separable Fredholm-type kernels without any special flag on
+        ``domain.variable()``::
 
-            (Fx(x_b, y_b) * nx + Fy(x_b, y_b) * ny).integrate()  # flux
-            (u(x_b, y_b) - ref).square().integrate()               # boundary loss
-            u(x, y).integrate()                                    # volume integral
+            x, _ = domain.variable("interior")   # outer (collocation)
+            t, _ = domain.variable("interior")   # inner (dummy) — no flag needed
+            integral = (K(x, t) * net(t)).integrate(var=x)
         """
-        return Integral(self)
+        return Integral(self, integration_var=var)
 
 
 class Literal(Placeholder):
@@ -1855,14 +1859,21 @@ class Integral(Placeholder):
 
     Created by :meth:`Placeholder.integrate`.  The region (boundary vs volume)
     is auto-detected at evaluation time from the Variable tags inside
-    ``target`` via ``domain._boundary_registry``.  Reduces to a scalar.
+    ``target`` via ``domain._boundary_registry``.
+
+    When ``integration_var`` is set (the outer/collocation Variable), the
+    evaluator uses ``jax.vmap`` to return an ``(N, 1)`` array instead of a
+    scalar, enabling non-separable Fredholm kernels.
     """
 
-    def __init__(self, target: "Placeholder"):
+    def __init__(self, target: "Placeholder", integration_var: "Variable | None" = None):
         self.target = target
+        self.integration_var = integration_var
         _propagate_weak(self, target)
 
     def __repr__(self):
+        if self.integration_var is not None:
+            return f"Integral({self.target}, outer={self.integration_var})"
         return f"Integral({self.target})"
 
 

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -1271,13 +1271,27 @@ class TraceEvaluator:
                 return jax.vmap(hess_single)(points)
 
     def _eval_integral(self, expr: "Integral", ctx):
-        """Evaluate a mesh-based integral reduction to a scalar.
+        """Evaluate a mesh-based integral reduction.
 
-        Walks the expression tree to find the first spatial Variable, looks up
-        its domain and tag, then evaluates the inner expression at **all** mesh
-        nodes of that region (boundary or volume) and returns a weighted sum.
+        **Scalar path** (``expr.integration_var is None``): walks the tree for
+        the first spatial Variable, evaluates the integrand at all mesh nodes of
+        that region, and returns a weighted sum (scalar).
+
+        **Vectorized path** (``expr.integration_var = x``): ``x`` is the outer
+        collocation Variable.  All other spatial Variables in the expression are
+        aliased to a fresh integration mesh via ``var_bindings``, then
+        ``jax.vmap`` evaluates the weighted sum for every outer point, returning
+        ``(N, 1)`` — a function of ``x``.  No special flag on
+        ``domain.variable()`` is needed; just call it twice::
+
+            x, _ = domain.variable("interior")
+            t, _ = domain.variable("interior")
+            integral = (K(x, t) * net(t)).integrate(var=x)
         """
-        # 1. Find first spatial Variable in the expression tree.
+        if expr.integration_var is not None:
+            return self._eval_integral_vectorized(expr, ctx)
+
+        # ── Scalar path ────────────────────────────────────────────────────────
         first_spatial_var = None
 
         def _find_spatial(node):
@@ -1287,7 +1301,6 @@ class TraceEvaluator:
             if isinstance(node, Variable) and getattr(node, "axis", "spatial") == "spatial":
                 bound = ctx.var_bindings.get(id(node), node)
                 b_tag = getattr(bound, "tag", "")
-                # Skip derived normal variables (tag = "n_{spatial_tag}").
                 if getattr(bound, "_domain", None) is not None and not b_tag.startswith("n_"):
                     first_spatial_var = bound
                     return
@@ -1303,8 +1316,7 @@ class TraceEvaluator:
         _find_spatial(expr.target)
 
         if first_spatial_var is None:
-            # Fall back: try any spatial var, including normal vars (e.g. nx.integrate()).
-            # Strip the "n_" prefix to recover the spatial tag.
+            # Fall back: accept normal vars too (e.g. nx.integrate())
             def _find_any_spatial(node):
                 nonlocal first_spatial_var
                 if first_spatial_var is not None:
@@ -1332,8 +1344,6 @@ class TraceEvaluator:
             )
 
         raw_tag = first_spatial_var.tag
-        # If we landed on a normal variable (tag = "n_{spatial}"), strip the prefix
-        # to get the actual spatial region tag.
         tag = raw_tag[2:] if raw_tag.startswith("n_") else raw_tag
         domain = first_spatial_var._domain
         mc = domain.mesh_connectivity
@@ -1344,16 +1354,46 @@ class TraceEvaluator:
                 "Mesh-based integration requires an unstructured mesh domain."
             )
 
-        # 2. Lazy per-tag cache on the domain object.
-        #    Populated on first call (first JIT trace); only fast dict lookups
-        #    + jnp.array() conversions happen on subsequent traces.
+        cached = self._get_integral_cache(domain, tag, mc)
+        is_boundary = cached["is_boundary"]
+        all_region_pts = jnp.array(cached["region_pts"])
+        weights = jnp.array(cached["weights"])
+
+        normal_tag = f"n_{tag}"
+        new_ctx_dict = dict(ctx.context)
+        new_ctx_dict[tag] = all_region_pts
+        if raw_tag != tag:
+            new_ctx_dict[raw_tag] = new_ctx_dict.get(raw_tag, all_region_pts)
+        if normal_tag in ctx.context and is_boundary and cached["normals"] is not None:
+            new_ctx_dict[normal_tag] = jnp.array(cached["normals"])
+
+        new_ctx = self._EvalCtx(
+            new_ctx_dict,
+            ctx.var_bindings,
+            ctx.key,
+            active_region=ctx.active_region,
+        )
+
+        u_full = self._dispatch(expr.target, new_ctx)
+
+        if u_full.ndim > 1 and u_full.shape[-1] == 1:
+            u_full = u_full.squeeze(-1)
+
+        if u_full.ndim != 1:
+            raise ValueError(
+                f"Integral: inner expression must be scalar-valued (shape (N,)) after squeezing, "
+                f"got shape {u_full.shape}. Compute F·n explicitly before calling .integrate()."
+            )
+
+        return jnp.sum(u_full * weights)
+
+    @staticmethod
+    def _get_integral_cache(domain, tag: str, mc: dict) -> dict:
+        """Populate and return the per-tag integration region cache on *domain*."""
         if not hasattr(domain, "_integral_region_cache"):
             domain._integral_region_cache = {}
 
         if tag not in domain._integral_region_cache:
-            # Boundary detection: a tag is a true boundary if it lives in
-            # _boundary_registry AND >50 % of its points are on the global
-            # mesh boundary (guards against interior gmsh physical groups).
             global_bi = np.asarray(mc["boundary_indices"])
             is_boundary = False
             if tag in domain._boundary_registry:
@@ -1382,45 +1422,95 @@ class TraceEvaluator:
                 "normals": normals_np,
             }
 
-        cached = domain._integral_region_cache[tag]
-        is_boundary = cached["is_boundary"]
-        all_region_pts = jnp.array(cached["region_pts"])
-        weights = jnp.array(cached["weights"])
+        return domain._integral_region_cache[tag]
 
-        # 3. Build updated context: feed all region coordinates under this tag.
-        #    Also update the corresponding normal tag if present (e.g. 'n_wall').
-        normal_tag = f"n_{tag}"
-        coord_tag = tag
-        new_ctx_dict = dict(ctx.context)
-        new_ctx_dict[coord_tag] = all_region_pts
-        if raw_tag != coord_tag:
-            # Expression used the normal tag directly; keep that context key too
-            new_ctx_dict[raw_tag] = new_ctx_dict.get(raw_tag, all_region_pts)
-        if normal_tag in ctx.context and is_boundary and cached["normals"] is not None:
-            new_ctx_dict[normal_tag] = jnp.array(cached["normals"])
+    def _eval_integral_vectorized(self, expr, ctx):
+        """Vectorized integral — result is (N_outer, 1), a function of the outer variable.
 
-        new_ctx = self._EvalCtx(
-            new_ctx_dict,
-            ctx.var_bindings,
-            ctx.key,
-            active_region=ctx.active_region,
-        )
+        ``expr.integration_var`` is the outer (collocation) Variable.  All
+        other spatial Variables in the expression are aliased to the full
+        integration mesh via ``var_bindings`` so the two sets of points live in
+        separate context slots, even when they share the same tag.
+        ``jax.vmap`` then evaluates the weighted sum for every outer point.
+        """
+        import types
 
-        # 4. Evaluate the inner expression at all region points.
-        u_full = self._dispatch(expr.target, new_ctx)
+        outer_var = expr.integration_var
+        outer_tag = outer_var.tag
+        outer_id = id(outer_var)
 
-        # Squeeze trailing size-1 dim that some models add.
-        if u_full.ndim > 1 and u_full.shape[-1] == 1:
-            u_full = u_full.squeeze(-1)
+        # Walk the expression tree, collect (node, bound_var) for all spatial vars.
+        seen: list[tuple] = []  # (node, bound_var)
 
-        if u_full.ndim != 1:
+        def _collect(node):
+            if isinstance(node, Variable) and getattr(node, "axis", "spatial") == "spatial":
+                bound = ctx.var_bindings.get(id(node), node)
+                b_tag = getattr(bound, "tag", "")
+                if getattr(bound, "_domain", None) is not None and not b_tag.startswith("n_"):
+                    seen.append((node, bound))
+            for attr in ("target", "left", "right"):
+                child = getattr(node, attr, None)
+                if isinstance(child, Placeholder):
+                    _collect(child)
+            for attr in ("args", "variables"):
+                for child in getattr(node, attr, []):
+                    if isinstance(child, Placeholder):
+                        _collect(child)
+
+        _collect(expr.target)
+
+        # Split into outer entries (matching integration_var by id) and inner.
+        inner_entries = [(node, bound) for node, bound in seen if id(bound) != outer_id]
+
+        if not inner_entries:
             raise ValueError(
-                f"Integral: inner expression must be scalar-valued (shape (N,)) after squeezing, "
-                f"got shape {u_full.shape}. Compute F·n explicitly before calling .integrate()."
+                "integrate(var=x): no inner variable found in the expression. "
+                "Call domain.variable(tag) a second time to create the dummy integration "
+                "variable and use it in the integrand."
             )
 
-        # 5. Weighted sum → scalar.
-        return jnp.sum(u_full * weights)
+        # Determine the integration region from the first inner variable.
+        _, inner_var = inner_entries[0]
+        inner_tag = inner_var.tag
+        domain = inner_var._domain
+        mc = domain.mesh_connectivity
+
+        if mc is None:
+            raise ValueError(f"integrate(var=x): domain for inner tag '{inner_tag}' has no mesh_connectivity.")
+
+        cached = self._get_integral_cache(domain, inner_tag, mc)
+        all_iv_pts = jnp.array(cached["region_pts"])  # (N_iv, D)
+        weights = jnp.array(cached["weights"])  # (N_iv,)
+
+        # Create a lightweight alias that redirects inner Variable reads to the
+        # integration mesh (alias_tag), leaving the outer tag free for vmap.
+        alias_tag = f"__jno_iv_{inner_tag}__"
+        alias_bindings: dict = {}
+        for node, bound in inner_entries:
+            alias = types.SimpleNamespace(tag=alias_tag, dim=bound.dim, axis="spatial")
+            alias_bindings[id(node)] = alias  # keyed by node id, as _eval_variable expects
+
+        outer_pts = jnp.array(ctx.context[outer_tag])  # (N_outer, D)
+        evaluator_self = self
+
+        def integral_at(outer_pt):
+            new_ctx_dict = dict(ctx.context)
+            new_ctx_dict[outer_tag] = outer_pt[None, :]  # (1, D) — single outer point
+            new_ctx_dict[alias_tag] = all_iv_pts  # (N_iv, D) — full integration mesh
+            new_bindings = {**ctx.var_bindings, **alias_bindings}
+            new_ctx = evaluator_self._EvalCtx(
+                new_ctx_dict,
+                new_bindings,
+                ctx.key,
+                active_region=ctx.active_region,
+            )
+            u_full = evaluator_self._dispatch(expr.target, new_ctx)
+            if u_full.ndim > 1 and u_full.shape[-1] == 1:
+                u_full = u_full.squeeze(-1)
+            return jnp.sum(u_full * weights)
+
+        result = jax.vmap(integral_at)(outer_pts)  # (N_outer,)
+        return result[:, None]  # (N_outer, 1) — matches standard jno shape
 
     def _eval_operation_def(self, expr, ctx):
         return self._dispatch(expr.expr, ctx)

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -15,6 +15,7 @@ from .trace import (
     FunctionCall,
     GroupedAssembly,
     Hessian,
+    Integral,
     Jacobian,
     Literal,
     ModelCall,
@@ -36,6 +37,7 @@ def _default_float_dtype():
 
 
 from .differential_operators import DifferentialOperators
+from .integration_operators import IntegrationOperators
 from .utils import get_logger
 
 
@@ -292,6 +294,7 @@ class TraceEvaluator:
         (Choice, "_eval_choice"),
         (Jacobian, "_eval_jacobian"),
         (Hessian, "_eval_hessian"),
+        (Integral, "_eval_integral"),
         (OperationDef, "_eval_operation_def"),
         (TestFunction, "_eval_test_function"),
         (Assembly, "_eval_assembly"),
@@ -1266,6 +1269,158 @@ class TraceEvaluator:
                     return result
 
                 return jax.vmap(hess_single)(points)
+
+    def _eval_integral(self, expr: "Integral", ctx):
+        """Evaluate a mesh-based integral reduction to a scalar.
+
+        Walks the expression tree to find the first spatial Variable, looks up
+        its domain and tag, then evaluates the inner expression at **all** mesh
+        nodes of that region (boundary or volume) and returns a weighted sum.
+        """
+        # 1. Find first spatial Variable in the expression tree.
+        first_spatial_var = None
+
+        def _find_spatial(node):
+            nonlocal first_spatial_var
+            if first_spatial_var is not None:
+                return
+            if isinstance(node, Variable) and getattr(node, "axis", "spatial") == "spatial":
+                bound = ctx.var_bindings.get(id(node), node)
+                b_tag = getattr(bound, "tag", "")
+                # Skip derived normal variables (tag = "n_{spatial_tag}").
+                if getattr(bound, "_domain", None) is not None and not b_tag.startswith("n_"):
+                    first_spatial_var = bound
+                    return
+            for attr in ("target", "left", "right"):
+                child = getattr(node, attr, None)
+                if isinstance(child, Placeholder):
+                    _find_spatial(child)
+            for attr in ("args", "variables"):
+                for child in getattr(node, attr, []):
+                    if isinstance(child, Placeholder):
+                        _find_spatial(child)
+
+        _find_spatial(expr.target)
+
+        if first_spatial_var is None:
+            # Fall back: try any spatial var, including normal vars (e.g. nx.integrate()).
+            # Strip the "n_" prefix to recover the spatial tag.
+            def _find_any_spatial(node):
+                nonlocal first_spatial_var
+                if first_spatial_var is not None:
+                    return
+                if isinstance(node, Variable) and getattr(node, "axis", "spatial") == "spatial":
+                    bound = ctx.var_bindings.get(id(node), node)
+                    if getattr(bound, "_domain", None) is not None:
+                        first_spatial_var = bound
+                        return
+                for attr in ("target", "left", "right"):
+                    child = getattr(node, attr, None)
+                    if isinstance(child, Placeholder):
+                        _find_any_spatial(child)
+                for attr in ("args", "variables"):
+                    for child in getattr(node, attr, []):
+                        if isinstance(child, Placeholder):
+                            _find_any_spatial(child)
+
+            _find_any_spatial(expr.target)
+
+        if first_spatial_var is None:
+            raise ValueError(
+                "Integral: no spatial Variable with a domain found in expression. "
+                "Make sure to call .integrate() on an expression containing spatial variables."
+            )
+
+        raw_tag = first_spatial_var.tag
+        # If we landed on a normal variable (tag = "n_{spatial}"), strip the prefix
+        # to get the actual spatial region tag.
+        tag = raw_tag[2:] if raw_tag.startswith("n_") else raw_tag
+        domain = first_spatial_var._domain
+        mc = domain.mesh_connectivity
+
+        if mc is None:
+            raise ValueError(
+                f"Integral: domain for tag '{tag}' has no mesh_connectivity. "
+                "Mesh-based integration requires an unstructured mesh domain."
+            )
+
+        # 2. Lazy per-tag cache on the domain object.
+        #    Populated on first call (first JIT trace); only fast dict lookups
+        #    + jnp.array() conversions happen on subsequent traces.
+        if not hasattr(domain, "_integral_region_cache"):
+            domain._integral_region_cache = {}
+
+        if tag not in domain._integral_region_cache:
+            # Boundary detection: a tag is a true boundary if it lives in
+            # _boundary_registry AND >50 % of its points are on the global
+            # mesh boundary (guards against interior gmsh physical groups).
+            global_bi = np.asarray(mc["boundary_indices"])
+            is_boundary = False
+            if tag in domain._boundary_registry:
+                reg_pts_idx = np.asarray(domain._boundary_registry[tag]["point_indices"])
+                if len(reg_pts_idx) > 0:
+                    n_on_bnd = int(np.sum(np.isin(reg_pts_idx, global_bi)))
+                    is_boundary = n_on_bnd / len(reg_pts_idx) > 0.5
+
+            if is_boundary:
+                reg_indices = np.asarray(domain._boundary_registry[tag]["point_indices"])
+                region_pts_np = np.asarray(mc["points"])[reg_indices]
+                weights_np = np.asarray(mc["nodal_ds"])[reg_indices]
+                normals_np = None
+                stored = getattr(domain, "normals_by_tag", {}).get(tag)
+                if stored is not None:
+                    normals_np = np.asarray(stored)
+            else:
+                region_pts_np = np.asarray(mc["points"])
+                weights_np = IntegrationOperators.nodal_volumes(mc)
+                normals_np = None
+
+            domain._integral_region_cache[tag] = {
+                "is_boundary": is_boundary,
+                "region_pts": region_pts_np,
+                "weights": weights_np,
+                "normals": normals_np,
+            }
+
+        cached = domain._integral_region_cache[tag]
+        is_boundary = cached["is_boundary"]
+        all_region_pts = jnp.array(cached["region_pts"])
+        weights = jnp.array(cached["weights"])
+
+        # 3. Build updated context: feed all region coordinates under this tag.
+        #    Also update the corresponding normal tag if present (e.g. 'n_wall').
+        normal_tag = f"n_{tag}"
+        coord_tag = tag
+        new_ctx_dict = dict(ctx.context)
+        new_ctx_dict[coord_tag] = all_region_pts
+        if raw_tag != coord_tag:
+            # Expression used the normal tag directly; keep that context key too
+            new_ctx_dict[raw_tag] = new_ctx_dict.get(raw_tag, all_region_pts)
+        if normal_tag in ctx.context and is_boundary and cached["normals"] is not None:
+            new_ctx_dict[normal_tag] = jnp.array(cached["normals"])
+
+        new_ctx = self._EvalCtx(
+            new_ctx_dict,
+            ctx.var_bindings,
+            ctx.key,
+            active_region=ctx.active_region,
+        )
+
+        # 4. Evaluate the inner expression at all region points.
+        u_full = self._dispatch(expr.target, new_ctx)
+
+        # Squeeze trailing size-1 dim that some models add.
+        if u_full.ndim > 1 and u_full.shape[-1] == 1:
+            u_full = u_full.squeeze(-1)
+
+        if u_full.ndim != 1:
+            raise ValueError(
+                f"Integral: inner expression must be scalar-valued (shape (N,)) after squeezing, "
+                f"got shape {u_full.shape}. Compute F·n explicitly before calling .integrate()."
+            )
+
+        # 5. Weighted sum → scalar.
+        return jnp.sum(u_full * weights)
 
     def _eval_operation_def(self, expr, ctx):
         return self._dispatch(expr.expr, ctx)

--- a/tests/test_integration_operators.py
+++ b/tests/test_integration_operators.py
@@ -20,9 +20,8 @@ import numpy as np
 import pytest
 
 import jno
-from jno.trace import Model, Integral, Placeholder
-from jno.trace_evaluator import TraceEvaluator, IntegrationOperators
-
+from jno.trace import Integral, Model, Placeholder
+from jno.trace_evaluator import IntegrationOperators, TraceEvaluator
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -495,3 +494,207 @@ class TestFluxIntegral:
         expr = (x_b * nx + y_b * ny).integrate()
         result = float(_eval_integral_expr(expr, dom))
         assert abs(result - 2.0) < 0.15
+
+
+# ---------------------------------------------------------------------------
+# Vectorized integral via integration_variable=True
+#
+# Analytic reference (1-D domain [0, 1], kernel K(x,t) = x + t):
+#
+#   ∫₀¹ (x + t) · t dt = x · ∫₀¹ t dt + ∫₀¹ t² dt = 0.5x + 1/3
+#
+# Result is an (N_outer, 1) array — a function of the outer variable x.
+# ---------------------------------------------------------------------------
+
+
+class TestVectorizedIntegral:
+    """Non-separable Fredholm kernel via ``.integrate(var=x)``.
+
+    Uses kernel K(x,t) = x + t and integrand u(t) = t so that the analytic
+    result is 0.5·x + 1/3, verifiable pointwise.
+
+    API: call ``domain.variable(tag)`` twice — no special flag needed.
+    Pass the outer (collocation) variable to ``.integrate(var=x)``; the
+    evaluator aliases everything else to the integration mesh automatically.
+    """
+
+    @pytest.fixture(scope="class")
+    def dom(self):
+        return jno.domain(constructor=jno.domain.line(mesh_size=0.02))
+
+    def test_two_calls_produce_distinct_objects(self, dom):
+        """Two domain.variable() calls return distinct Python objects (different id)."""
+        x, _ = dom.variable("interior")
+        t, _ = dom.variable("interior")
+        assert x is not t
+        assert id(x) != id(t)
+
+    def test_vectorized_integral_shape(self, dom):
+        """(x + t)·t integrated with var=x gives (N_outer, 1), not a scalar."""
+        x, _ = dom.variable("interior")
+        t, _ = dom.variable("interior")
+        expr = ((x + t) * t).integrate(var=x)
+        result = _eval_integral_expr(expr, dom)
+        ctx = _build_context(dom)
+        N_outer = ctx["interior"].shape[0]
+        assert result.shape == (N_outer, 1), f"Expected ({N_outer}, 1), got {result.shape}"
+
+    def test_vectorized_integral_values(self, dom):
+        """Pointwise values match 0.5·x + 1/3 within mesh discretisation error."""
+        x, _ = dom.variable("interior")
+        t, _ = dom.variable("interior")
+        expr = ((x + t) * t).integrate(var=x)
+        result = _eval_integral_expr(expr, dom)  # (N, 1)
+
+        ctx = _build_context(dom)
+        x_vals = np.asarray(ctx["interior"])[:, 0]  # (N,)
+        analytic = 0.5 * x_vals + 1.0 / 3.0
+
+        max_err = float(np.max(np.abs(np.asarray(result[:, 0]) - analytic)))
+        assert max_err < 0.01, f"Max pointwise error {max_err:.4f} exceeds tolerance"
+
+    def test_vectorized_integral_is_jit_compatible(self, dom):
+        """jax.jit over the vectorized integral compiles and two calls agree."""
+        x, _ = dom.variable("interior")
+        t, _ = dom.variable("interior")
+        expr = ((x + t) * t).integrate(var=x)
+        ctx = _build_context(dom)
+
+        ev = TraceEvaluator(params={})
+
+        @jax.jit
+        def run():
+            return ev.evaluate(expr, context=ctx, var_bindings={})
+
+        r1 = run()
+        r2 = run()
+        assert jnp.allclose(r1, r2)
+
+    def test_no_inner_var_raises(self, dom):
+        """integrate(var=x) with no second variable raises a clear error."""
+        x, _ = dom.variable("interior")
+        expr = (x * x).integrate(var=x)
+        with pytest.raises(ValueError, match="no inner variable"):
+            _eval_integral_expr(expr, dom)
+
+    def test_nonseparable_kernel_analytic_values(self, dom):
+        """∫₀¹ (x+t)·sin(πt) dt = 2x/π + 1/π at every collocation point.
+
+        This is the integral term in the non-separable Fredholm tutorial.
+        """
+        x, _ = dom.variable("interior")
+        t, _ = dom.variable("interior")
+        π = jno.np.pi
+        expr = ((x + t) * jno.np.sin(π * t)).integrate(var=x)
+        result = _eval_integral_expr(expr, dom)  # (N, 1)
+
+        ctx = _build_context(dom)
+        x_vals = np.asarray(ctx["interior"])[:, 0]
+        analytic = 2.0 * x_vals / float(jnp.pi) + 1.0 / float(jnp.pi)
+
+        max_err = float(np.max(np.abs(np.asarray(result[:, 0]) - analytic)))
+        assert max_err < 0.01, f"Max pointwise error {max_err:.4f}"
+
+    def test_chained_double_integral(self, dom):
+        """∫₀¹ ∫₀¹ (x+t) dt dx = 1.0  via chained .integrate() calls."""
+        x, _ = dom.variable("interior")
+        t, _ = dom.variable("interior")
+        inner = (x + t).integrate(var=x)  # (N,1): g(x) = x + 0.5
+        result = float(_eval_integral_expr(inner.integrate(), dom))  # scalar
+        assert abs(result - 1.0) < 0.01, f"∫∫(x+t)dt dx = {result:.6f}, expected 1.0"
+
+    def test_chained_double_integral_separable(self, dom):
+        """∫₀¹ ∫₀¹ x·t dt dx = 0.25  (separable kernel, chained)."""
+        x, _ = dom.variable("interior")
+        t, _ = dom.variable("interior")
+        inner = (x * t).integrate(var=x)  # (N,1): g(x) = 0.5·x
+        result = float(_eval_integral_expr(inner.integrate(), dom))  # scalar
+        assert abs(result - 0.25) < 0.01, f"∫∫ x·t dt dx = {result:.6f}, expected 0.25"
+
+
+# ---------------------------------------------------------------------------
+# Integro-differential equation: .d(x) and .integrate() in the same residual
+#
+# IDE:  u'(x) + u(x) = g(x) + ∫₀¹ u(t) dt,   u(0) = 0
+# Exact: u*(x) = sin(πx)
+#
+# Two pure-operator checks (no training):
+#
+# 1. u = x²:
+#       u'(x) = 2x
+#       ∫₀¹ x² dt = 1/3
+#       u'(x) + ∫₀¹ u(t) dt = 2x + 1/3
+#
+# 2. IDE residual at exact solution sin(πx) should be near zero (within
+#    discretisation error).  g(x) = π cos(πx) + sin(πx) − 2/π.
+# ---------------------------------------------------------------------------
+
+
+class TestIntegroDifferential:
+    """Composition of .d(x) and .integrate() in an IDE residual.
+
+    No training — uses the identity model u=x² (via multiplication) and the
+    exact solution sin(πx) to verify operator composition analytically.
+    """
+
+    @pytest.fixture
+    def dom(self):
+        return jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+
+    def test_derivative_plus_integral_composition(self, dom):
+        """u=x²: u'(x) + ∫₀¹ u(t) dt = 2x + 1/3 at every collocation point."""
+        x, _ = dom.variable("interior")
+
+        # u = x²  via placeholder arithmetic (no network)
+        u = x * x
+
+        du = u.d(x)  # (N, 1): 2x
+        C = u.integrate()  # scalar: ∫₀¹ t² dt = 1/3
+
+        combined = du + C  # (N, 1): 2x + 1/3
+
+        ctx = _build_context(dom)
+        ev = TraceEvaluator(params={})
+        result = np.asarray(ev.evaluate(combined, context=ctx, var_bindings={}))  # (N, 1)
+
+        x_vals = np.asarray(ctx["interior"])[:, 0]  # (N,)
+        analytic = 2.0 * x_vals + 1.0 / 3.0
+
+        max_err = float(np.max(np.abs(result[:, 0] - analytic)))
+        assert max_err < 0.01, f"Max pointwise error {max_err:.2e}, expected < 0.01"
+
+    def test_ide_residual_at_exact_solution_is_near_zero(self, dom):
+        """IDE residual vanishes at u*(x) = sin(πx) (within discretisation error)."""
+        x, _ = dom.variable("interior")
+        π = jno.np.pi
+
+        u = jno.np.sin(π * x)
+
+        pi_val = float(jnp.pi)
+        g = π * jno.np.cos(π * x) + jno.np.sin(π * x) - 2.0 / pi_val
+
+        C = u.integrate()  # should evaluate to ≈ 2/π
+        du = u.d(x)  # π cos(πx)
+
+        residual = du + u - g - C  # should be ≈ 0
+
+        ctx = _build_context(dom)
+        ev = TraceEvaluator(params={})
+        res = np.asarray(ev.evaluate(residual, context=ctx, var_bindings={}))
+
+        max_abs = float(np.max(np.abs(res)))
+        assert max_abs < 5e-3, f"IDE residual at exact solution: max|R| = {max_abs:.2e}"
+
+    def test_scalar_integral_has_no_outer_dimension(self, dom):
+        """C = u.integrate() (no var=) returns a true scalar, not (N, 1)."""
+        x, _ = dom.variable("interior")
+        u = jno.np.sin(jno.np.pi * x)
+        C = u.integrate()
+
+        ctx = _build_context(dom)
+        ev = TraceEvaluator(params={})
+        result = ev.evaluate(C, context=ctx, var_bindings={})
+
+        assert result.ndim == 0 or result.size == 1, f"Expected scalar, got shape {result.shape}"
+        val = float(jnp.squeeze(result))
+        assert abs(val - 2.0 / float(jnp.pi)) < 0.01, f"∫₀¹ sin(πt) dt = {val:.4f}, expected ≈ {2.0 / float(jnp.pi):.4f}"

--- a/tests/test_integration_operators.py
+++ b/tests/test_integration_operators.py
@@ -1,0 +1,497 @@
+"""Comprehensive tests for mesh-based numerical integration in the jno workflow.
+
+Two tests cover the full story:
+
+1. ``TestJitCompatibleIntegrals`` — boundary and volume integrals evaluated
+   under ``jax.jit`` on 1-D and 2-D domains.  Checks concrete numerical
+   values (perimeter, area, moments, divergence-theorem flux) and verifies
+   that a second JIT call hits the cache without recomputing weights.
+
+2. ``TestGradientThroughIntegralLoss`` — ``eqx.filter_jit`` + ``eqx.filter_grad``
+   through an integral-based loss using a trainable linear model.  Verifies
+   analytically known gradients and that a gradient step moves the loss in
+   the correct direction.
+"""
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import jno
+from jno.trace import Model, Integral, Placeholder
+from jno.trace_evaluator import TraceEvaluator, IntegrationOperators
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_context(domain):
+    """Strip leading singleton axes from domain.context (simulate post-vmap)."""
+    ctx = {}
+    for k, v in domain.context.items():
+        arr = np.asarray(v)
+        while arr.ndim > 2 and arr.shape[0] == 1:
+            arr = arr[0]
+        ctx[k] = jnp.array(arr)
+    return ctx
+
+
+def _eval(expr, domain):
+    """Evaluate *expr* against *domain* via TraceEvaluator (no JIT)."""
+    ev = TraceEvaluator(params={})
+    return ev.evaluate(expr, context=_build_context(domain), var_bindings={})
+
+
+# ---------------------------------------------------------------------------
+# Test 1: JIT-compatible integrals — 1-D and 2-D, concrete values
+# ---------------------------------------------------------------------------
+
+
+class TestJitCompatibleIntegrals:
+    """Boundary and volume integrals evaluated under jax.jit.
+
+    Unit-square (mesh_size=0.04) and unit-line (mesh_size=0.05) domains.
+
+    Analytic targets
+    ----------------
+    1-D line [0, 1]:
+        ∫₀¹ 1 dx  = 1.0
+        ∫₀¹ x dx  = 0.5
+
+    2-D unit square:
+        ∫_∂Ω  1 ds              = 4.0   (perimeter)
+        ∫_∂Ω  x·nₓ + y·nᵧ ds   = 2.0   (divergence theorem, F=(x,y))
+        ∫_Ω   1 dA              = 1.0   (area)
+        ∫_Ω   x + y dA          = 1.0   (∫∫ x+y dxdy = 0.5+0.5)
+    """
+
+    @pytest.fixture(scope="class")
+    def dom_2d(self):
+        return jno.domain(constructor=jno.domain.rect(mesh_size=0.04))
+
+    @pytest.fixture(scope="class")
+    def dom_1d(self):
+        return jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+
+    def test_1d_volume_integrals_under_jit(self, dom_1d):
+        """∫₀¹ 1 dx = 1.0 and ∫₀¹ x dx ≈ 0.5, both JIT-compiled."""
+        x, _ = dom_1d.variable("interior")
+        const_expr = (x * 0.0 + 1.0).integrate()
+        identity_expr = x.integrate()
+
+        ctx = _build_context(dom_1d)
+        ev = TraceEvaluator(params={})
+
+        @jax.jit
+        def compute(c):
+            return (
+                ev.evaluate(const_expr, context=c, var_bindings={}),
+                ev.evaluate(identity_expr, context=c, var_bindings={}),
+            )
+
+        length, half = compute(ctx)
+        assert abs(float(length) - 1.0) < 0.05, f"∫1 dx = {float(length):.4f}, expected ≈ 1.0"
+        assert abs(float(half) - 0.5) < 0.05, f"∫x dx = {float(half):.4f}, expected ≈ 0.5"
+
+        # Second call: verify JIT cache (no recompilation, same values).
+        length2, half2 = compute(ctx)
+        assert jnp.allclose(length, length2), "JIT cache returned different value for ∫1 dx"
+        assert jnp.allclose(half, half2), "JIT cache returned different value for ∫x dx"
+
+    def test_2d_volume_integrals_under_jit(self, dom_2d):
+        """∫_Ω 1 dA = 1.0 and ∫_Ω (x+y) dA = 1.0, both JIT-compiled."""
+        x, y, _ = dom_2d.variable("interior")
+        area_expr = (x * 0.0 + 1.0).integrate()
+        moment_expr = (x + y).integrate()
+
+        ctx = _build_context(dom_2d)
+        ev = TraceEvaluator(params={})
+
+        @jax.jit
+        def compute(c):
+            return (
+                ev.evaluate(area_expr, context=c, var_bindings={}),
+                ev.evaluate(moment_expr, context=c, var_bindings={}),
+            )
+
+        area, moment = compute(ctx)
+        assert abs(float(area) - 1.0) < 0.05, f"∫1 dA = {float(area):.4f}, expected ≈ 1.0"
+        assert abs(float(moment) - 1.0) < 0.05, f"∫(x+y) dA = {float(moment):.4f}, expected ≈ 1.0"
+
+        # Second call: values identical (JIT cache, not numpy recomputation).
+        area2, moment2 = compute(ctx)
+        assert jnp.allclose(area, area2)
+        assert jnp.allclose(moment, moment2)
+
+    def test_2d_boundary_integrals_and_divergence_theorem_under_jit(self, dom_2d):
+        """∫_∂Ω 1 ds = 4 (perimeter), ∫_∂Ω x·nₓ + y·nᵧ ds = 2 (div thm), both JIT."""
+        x_b, y_b, _, nx, ny = dom_2d.variable("boundary", normals=True)
+        perimeter_expr = (x_b * 0.0 + 1.0).integrate()
+        flux_expr = (x_b * nx + y_b * ny).integrate()
+
+        ctx = _build_context(dom_2d)
+        ev = TraceEvaluator(params={})
+
+        @jax.jit
+        def compute(c):
+            return (
+                ev.evaluate(perimeter_expr, context=c, var_bindings={}),
+                ev.evaluate(flux_expr, context=c, var_bindings={}),
+            )
+
+        perimeter, flux = compute(ctx)
+        assert abs(float(perimeter) - 4.0) < 0.15, f"∫_∂Ω 1 ds = {float(perimeter):.4f}, expected ≈ 4.0"
+        assert abs(float(flux) - 2.0) < 0.2, f"∫_∂Ω F·n ds = {float(flux):.4f}, expected ≈ 2.0 (divergence theorem)"
+
+        # Second call from JIT cache.
+        perimeter2, flux2 = compute(ctx)
+        assert jnp.allclose(perimeter, perimeter2)
+        assert jnp.allclose(flux, flux2)
+
+    def test_jno_np_integrate_alias(self, dom_2d):
+        """``jno.np.integrate(expr)`` is a valid alias for ``expr.integrate()``."""
+        x, y, _ = dom_2d.variable("interior")
+        via_method = (x * 0.0 + 1.0).integrate()
+        via_alias = jno.np.integrate(x * 0.0 + 1.0)
+
+        ctx = _build_context(dom_2d)
+        ev = TraceEvaluator(params={})
+
+        r1 = float(ev.evaluate(via_method, context=ctx, var_bindings={}))
+        r2 = float(ev.evaluate(via_alias, context=ctx, var_bindings={}))
+        assert abs(r1 - r2) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Gradient through integral loss with a trainable linear model
+# ---------------------------------------------------------------------------
+
+
+class _LinearXY(eqx.Module):
+    """Minimal linear model: u(x, y) = w0*x + w1*y + b.
+
+    Weights are equinox arrays → differentiable via eqx.filter_grad.
+    Accepts two separate (N, 1) arrays so it works with ``fm(x, y)``.
+    """
+
+    w0: jax.Array
+    w1: jax.Array
+    b: jax.Array
+
+    def __init__(self, w0: float = 0.3, w1: float = 0.7, b: float = 0.5):
+        self.w0 = jnp.array([w0])
+        self.w1 = jnp.array([w1])
+        self.b = jnp.array([b])
+
+    def __call__(self, x, y):
+        return self.w0 * x + self.w1 * y + self.b
+
+
+class TestGradientThroughIntegralLoss:
+    """eqx.filter_grad through integral-based loss with a trainable model.
+
+    Model: u(x, y; w0, w1, b) = w0·x + w1·y + b
+
+    Loss:  L = ∫_Ω u dA  (unit square, area = 1)
+
+    Analytic values (∫_Ω x dA = 0.5, ∫_Ω y dA = 0.5, ∫_Ω 1 dA = 1):
+
+        L     = 0.5·w0 + 0.5·w1 + b
+        ∂L/∂w0 = 0.5
+        ∂L/∂w1 = 0.5
+        ∂L/∂b  = 1.0
+
+    The test verifies these gradients numerically and confirms that one
+    gradient-descent step moves the loss in the correct direction.
+    """
+
+    @pytest.fixture(scope="class")
+    def dom(self):
+        return jno.domain(constructor=jno.domain.rect(mesh_size=0.04))
+
+    @pytest.fixture(scope="class")
+    def setup(self, dom):
+        """Build model, expression, and context once for the whole class."""
+        model = _LinearXY(w0=0.3, w1=0.7, b=0.5)
+        fm = Model(model, name="u")
+
+        x, y, _ = dom.variable("interior")
+        loss_expr = fm(x, y).integrate()
+
+        ctx = _build_context(dom)
+        params = {fm.layer_id: model}
+
+        return {"model": model, "fm": fm, "loss_expr": loss_expr, "ctx": ctx, "params": params}
+
+    def test_integral_loss_value_matches_analytic(self, setup):
+        """L = 0.5*w0 + 0.5*w1 + b (analytic) matches evaluator output."""
+        model = setup["model"]
+        ev = TraceEvaluator(params={setup["fm"].layer_id: model})
+        result = float(ev.evaluate(setup["loss_expr"], context=setup["ctx"], var_bindings={}))
+
+        expected = 0.5 * float(model.w0[0]) + 0.5 * float(model.w1[0]) + float(model.b[0])
+        assert abs(result - expected) < 0.05, f"L = {result:.4f}, analytic = {expected:.4f}"
+
+    def test_gradients_match_analytic_values(self, setup):
+        """∂L/∂w0 ≈ 0.5, ∂L/∂w1 ≈ 0.5, ∂L/∂b ≈ 1.0 (analytic)."""
+        fm = setup["fm"]
+        loss_expr = setup["loss_expr"]
+        ctx = setup["ctx"]
+
+        def loss_fn(m):
+            ev = TraceEvaluator(params={fm.layer_id: m})
+            return ev.evaluate(loss_expr, context=ctx, var_bindings={})
+
+        grad_fn = eqx.filter_jit(eqx.filter_grad(loss_fn))
+        grads = grad_fn(setup["model"])
+
+        dL_dw0 = float(grads.w0[0])
+        dL_dw1 = float(grads.w1[0])
+        dL_db = float(grads.b[0])
+
+        assert abs(dL_dw0 - 0.5) < 0.05, f"∂L/∂w0 = {dL_dw0:.4f}, expected ≈ 0.5"
+        assert abs(dL_dw1 - 0.5) < 0.05, f"∂L/∂w1 = {dL_dw1:.4f}, expected ≈ 0.5"
+        assert abs(dL_db - 1.0) < 0.05, f"∂L/∂b = {dL_db:.4f}, expected ≈ 1.0"
+
+    def test_gradient_step_decreases_loss(self, setup):
+        """One gradient descent step on L reduces it in the expected direction.
+
+        Loss = ∫u dA is minimized by driving w0, w1, b → -∞.
+        After one step with lr=0.1, loss must strictly decrease.
+        """
+        fm = setup["fm"]
+        loss_expr = setup["loss_expr"]
+        ctx = setup["ctx"]
+
+        def loss_fn(m):
+            ev = TraceEvaluator(params={fm.layer_id: m})
+            return ev.evaluate(loss_expr, context=ctx, var_bindings={})
+
+        grad_fn = eqx.filter_jit(eqx.filter_grad(loss_fn))
+        model = setup["model"]
+        L0 = float(loss_fn(model))
+
+        grads = grad_fn(model)
+        lr = 0.1
+        model_updated = jax.tree_util.tree_map(
+            lambda p, g: p - lr * g if isinstance(g, jax.Array) else p,
+            model,
+            grads,
+        )
+        L1 = float(loss_fn(model_updated))
+
+        assert L1 < L0, f"Loss did not decrease: L0={L0:.4f}, L1={L1:.4f}"
+
+    def test_second_grad_call_uses_jit_cache(self, setup):
+        """Calling the jitted grad function twice returns identical results."""
+        fm = setup["fm"]
+        loss_expr = setup["loss_expr"]
+        ctx = setup["ctx"]
+
+        def loss_fn(m):
+            ev = TraceEvaluator(params={fm.layer_id: m})
+            return ev.evaluate(loss_expr, context=ctx, var_bindings={})
+
+        grad_fn = eqx.filter_jit(eqx.filter_grad(loss_fn))
+        model = setup["model"]
+
+        grads1 = grad_fn(model)
+        grads2 = grad_fn(model)
+
+        assert jnp.allclose(grads1.w0, grads2.w0)
+        assert jnp.allclose(grads1.w1, grads2.w1)
+        assert jnp.allclose(grads1.b, grads2.b)
+
+
+"""Tests for mesh-based numerical integration operators.
+
+Covers:
+- IntegrationOperators.nodal_volumes (pure numpy backend)
+- Integral trace node creation via .integrate()
+- _eval_integral via TraceEvaluator (boundary and volume, 1D and 2D)
+- Divergence-theorem flux check (user computes F·n, then integrates)
+"""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_2d_rect_domain(mesh_size=0.05):
+    return jno.domain(constructor=jno.domain.rect(mesh_size=mesh_size))
+
+
+def _eval_integral_expr(expr, domain):
+    """Evaluate an Integral node directly, simulating the post-vmap context."""
+    evaluator = TraceEvaluator(params={})
+    # Peel the leading (B, T) singleton axes — evaluator runs after outer vmaps.
+    context = {}
+    for k, v in domain.context.items():
+        arr = np.asarray(v)
+        while arr.ndim > 2 and arr.shape[0] == 1:
+            arr = arr[0]
+        context[k] = jnp.array(arr)
+    return evaluator.evaluate(expr, context=context, var_bindings={})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: IntegrationOperators.nodal_volumes
+# ---------------------------------------------------------------------------
+
+
+class TestNodalVolumes:
+    def test_1d_sums_to_length(self):
+        dom = jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+        vols = IntegrationOperators.nodal_volumes(dom.mesh_connectivity)
+        assert abs(float(np.sum(vols)) - 1.0) < 0.01
+
+    def test_2d_sums_to_area(self):
+        dom = _make_2d_rect_domain(mesh_size=0.05)
+        vols = IntegrationOperators.nodal_volumes(dom.mesh_connectivity)
+        assert abs(float(np.sum(vols)) - 1.0) < 0.02  # unit square area = 1
+
+    def test_all_non_negative(self):
+        dom = _make_2d_rect_domain(mesh_size=0.1)
+        vols = IntegrationOperators.nodal_volumes(dom.mesh_connectivity)
+        assert np.all(vols >= 0)
+
+    def test_shape_matches_n_points(self):
+        dom = _make_2d_rect_domain(mesh_size=0.1)
+        mc = dom.mesh_connectivity
+        vols = IntegrationOperators.nodal_volumes(mc)
+        assert vols.shape == (mc["n_points"],)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: boundary weights (nodal_ds pre-stored in mesh_connectivity)
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryWeights:
+    def test_2d_nodal_ds_sums_to_perimeter(self):
+        dom = _make_2d_rect_domain(mesh_size=0.05)
+        mc = dom.mesh_connectivity
+        b_idx = mc["boundary_indices"]
+        perimeter = float(np.sum(mc["nodal_ds"][b_idx]))
+        assert abs(perimeter - 4.0) < 0.05  # unit square perimeter = 4
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Integral trace node
+# ---------------------------------------------------------------------------
+
+
+class TestIntegralNode:
+    def test_integrate_returns_integral_instance(self):
+        dom = _make_2d_rect_domain(mesh_size=0.1)
+        x_b, y_b, _ = dom.variable("boundary")
+        node = (x_b * 0.0 + 1.0).integrate()
+        assert isinstance(node, Integral)
+
+    def test_integrate_repr(self):
+        dom = _make_2d_rect_domain(mesh_size=0.1)
+        x_b, _, _ = dom.variable("boundary")
+        node = x_b.integrate()
+        assert "Integral" in repr(node)
+
+    def test_integrate_is_placeholder(self):
+        dom = _make_2d_rect_domain(mesh_size=0.1)
+        x_b, _, _ = dom.variable("boundary")
+        node = x_b.integrate()
+        assert isinstance(node, Placeholder)
+
+    def test_jno_np_integrate_alias(self):
+        dom = _make_2d_rect_domain(mesh_size=0.1)
+        x_b, _, _ = dom.variable("boundary")
+        node = jno.np.integrate(x_b * 0.0 + 1.0)
+        assert isinstance(node, Integral)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: evaluator — 1D
+# ---------------------------------------------------------------------------
+
+
+class TestEvalIntegral1D:
+    # Function-scoped: each test gets a fresh domain to avoid tag collisions
+    # from multiple dom.variable("interior") calls.
+    @pytest.fixture
+    def dom(self):
+        return jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+
+    def test_volume_constant_one_equals_length(self, dom):
+        x, _ = dom.variable("interior")
+        expr = (x * 0.0 + 1.0).integrate()
+        result = float(_eval_integral_expr(expr, dom))
+        assert abs(result - 1.0) < 0.05
+
+    def test_volume_identity_equals_half(self, dom):
+        """∫_0^1 x dx = 0.5"""
+        x, _ = dom.variable("interior")
+        result = float(_eval_integral_expr(x.integrate(), dom))
+        assert abs(result - 0.5) < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: evaluator — 2D unit square
+# ---------------------------------------------------------------------------
+
+
+class TestEvalIntegral2D:
+    @pytest.fixture
+    def dom(self):
+        return _make_2d_rect_domain(mesh_size=0.04)
+
+    def test_boundary_constant_one_equals_perimeter(self, dom):
+        x_b, y_b, _ = dom.variable("boundary")
+        expr = (x_b * 0.0 + 1.0).integrate()
+        result = float(_eval_integral_expr(expr, dom))
+        assert abs(result - 4.0) < 0.1  # perimeter of unit square
+
+    def test_volume_constant_one_equals_area(self, dom):
+        x, y, _ = dom.variable("interior")
+        expr = (x * 0.0 + 1.0).integrate()
+        result = float(_eval_integral_expr(expr, dom))
+        assert abs(result - 1.0) < 0.05  # area of unit square
+
+    def test_boundary_region_detected_not_volume(self, dom):
+        """Boundary tag gives result near 4 (perimeter), not near 1 (area)."""
+        x_b, y_b, _ = dom.variable("boundary")
+        result = float(_eval_integral_expr((x_b * 0.0 + 1.0).integrate(), dom))
+        assert result > 3.5
+
+    def test_volume_region_detected_not_boundary(self, dom):
+        """Interior tag gives result near 1 (area), not near 4 (perimeter)."""
+        x, y, _ = dom.variable("interior")
+        result = float(_eval_integral_expr((x * 0.0 + 1.0).integrate(), dom))
+        assert result < 1.5
+
+
+# ---------------------------------------------------------------------------
+# Flux / divergence theorem: user computes F·n manually, then integrates
+# ---------------------------------------------------------------------------
+
+
+class TestFluxIntegral:
+    """∫_∂Ω F·n ds checked via the divergence theorem on the unit square."""
+
+    @pytest.fixture
+    def dom(self):
+        return _make_2d_rect_domain(mesh_size=0.04)
+
+    def test_constant_flux_net_zero(self, dom):
+        """F = (1, 0): net flux through closed boundary = 0."""
+        x_b, y_b, _, nx, ny = dom.variable("boundary", normals=True)
+        result = float(_eval_integral_expr(nx.integrate(), dom))
+        assert abs(result) < 0.1
+
+    def test_linear_flux_divergence_theorem(self, dom):
+        """F = (x, y): ∫_∂Ω F·n ds = ∫_Ω ∇·F dV = 2 × area = 2."""
+        x_b, y_b, _, nx, ny = dom.variable("boundary", normals=True)
+        expr = (x_b * nx + y_b * ny).integrate()
+        result = float(_eval_integral_expr(expr, dom))
+        assert abs(result - 2.0) < 0.15

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -57,6 +57,7 @@ from jno.lora import (
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    partial_lora_trainable_filter,
     rsLoRAConv,
     rsLoRALinear,
 )
@@ -228,6 +229,58 @@ class TestApplyLora:
         leaves = jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper))
         assert all(isinstance(leaf, rsLoRALinear) for leaf in leaves if isinstance(leaf, LoRAWrapper))
 
+    def test_param_mask_restricts_wrapping(self):
+        """param_mask restricts apply_lora to only mask-selected modules."""
+        mlp = _mlp()
+        n_all = _count_wrappers(apply_lora(mlp, rank=2, alpha=1.0, key=KEY))
+        assert n_all > 1, "need more than one layer for this test to be meaningful"
+
+        # Build a mask selecting only the first hidden layer's weight and bias.
+        all_false = jax.tree_util.tree_map(lambda _: False, mlp)
+        first_layer_mask = eqx.tree_at(
+            lambda m: (m.hidden_layers[0].weight, m.hidden_layers[0].bias),
+            all_false,
+            (True, True),
+        )
+        adapted = apply_lora(mlp, rank=2, alpha=1.0, key=KEY, param_mask=first_layer_mask)
+        n_masked = _count_wrappers(adapted)
+        assert n_masked == 1, f"expected 1 wrapped layer, got {n_masked}"
+
+    def test_param_mask_all_false_wraps_nothing(self):
+        """param_mask with all False → no layers are wrapped."""
+        mlp = _mlp()
+        all_false = jax.tree_util.tree_map(lambda _: False, mlp)
+        adapted = apply_lora(mlp, rank=2, alpha=1.0, key=KEY, param_mask=all_false)
+        assert _count_wrappers(adapted) == 0
+
+    def test_param_mask_prefix_safety(self):
+        """Mask on 'layer1' must not accidentally wrap 'layer10' (prefix-overlap safety)."""
+
+        class TwinNet(eqx.Module):
+            layer1: eqx.nn.Linear
+            layer10: eqx.nn.Linear
+
+            def __call__(self, x):
+                return self.layer10(jax.nn.relu(self.layer1(x)))
+
+        net = TwinNet(
+            layer1=eqx.nn.Linear(4, 4, key=KEY),
+            layer10=eqx.nn.Linear(4, 2, key=KEY),
+        )
+        all_false = jax.tree_util.tree_map(lambda _: False, net)
+        # Select only layer1.weight
+        mask = eqx.tree_at(lambda m: m.layer1.weight, all_false, True)
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, param_mask=mask)
+        lora_leaves = [
+            leaf
+            for leaf in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper))
+            if isinstance(leaf, LoRAWrapper)
+        ]
+        assert len(lora_leaves) == 1
+        assert isinstance(lora_leaves[0].base, eqx.nn.Linear)
+        # Verify it's layer1, not layer10 — layer1 has out_features=4, layer10=2
+        assert lora_leaves[0].base.out_features == 4
+
     def test_custom_wrapper(self):
         """A user-defined LoRAWrapper subclass plugs in and its adapter fields are counted."""
         from jno.architectures.lora import LinearLike
@@ -353,6 +406,89 @@ class TestTrainableFilter:
         adapted = apply_lora(_mlp(), rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
         n_true = _count_adapter_leaves(adapted)
         assert n_true == _ADAPTER_LEAVES[cls]
+
+
+# ---------------------------------------------------------------------------
+# 5b. partial_lora_trainable_filter
+# ---------------------------------------------------------------------------
+
+
+class TestPartialLoraTrainableFilter:
+    """Tests for partial_lora_trainable_filter (used by mask(M).lora() without freeze())."""
+
+    def _adapted_first_only(self):
+        """MLP with only the first hidden layer LoRA-wrapped."""
+        mlp = _mlp()
+        all_false = jax.tree_util.tree_map(lambda _: False, mlp)
+        mask = eqx.tree_at(
+            lambda m: (m.hidden_layers[0].weight, m.hidden_layers[0].bias),
+            all_false,
+            (True, True),
+        )
+        return apply_lora(mlp, rank=2, alpha=1.0, key=KEY, param_mask=mask)
+
+    def test_adapter_arrays_are_trainable(self):
+        """Adapter arrays inside LoRA wrappers must be True in the filter."""
+        adapted = self._adapted_first_only()
+        filt = partial_lora_trainable_filter(adapted)
+        flat_arrays = jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_inexact_array))
+        flat_filt = jax.tree_util.tree_leaves(filt)
+        # collect (trainable, array) pairs for just adapter arrays
+        from jno.lora import LoRAWrapper
+
+        adapter_ids = set()
+        for node in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper)):
+            if isinstance(node, LoRAWrapper):
+                for fname in node.adapter_fields:
+                    arr = getattr(node, fname, None)
+                    if eqx.is_array(arr):
+                        adapter_ids.add(id(arr))
+        for arr, f in zip(flat_arrays, flat_filt):
+            if id(arr) in adapter_ids:
+                assert f is True, "adapter array must be trainable"
+
+    def test_wrapped_base_frozen(self):
+        """Base arrays inside LoRA wrappers must be False."""
+        adapted = self._adapted_first_only()
+        filt = partial_lora_trainable_filter(adapted)
+        from jno.lora import LoRAWrapper
+
+        wrapped_base_ids = set()
+        for node in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper)):
+            if isinstance(node, LoRAWrapper):
+                for arr in jax.tree_util.tree_leaves(node.base):
+                    if eqx.is_array(arr):
+                        wrapped_base_ids.add(id(arr))
+        flat_arrays = jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_array))
+        flat_filt = jax.tree_util.tree_leaves(filt)
+        for arr, f in zip(flat_arrays, flat_filt):
+            if id(arr) in wrapped_base_ids:
+                assert f is False, "base array inside wrapper must be frozen"
+
+    def test_unwrapped_params_trainable(self):
+        """Arrays outside any LoRA wrapper must be True (they stay trainable)."""
+        adapted = self._adapted_first_only()
+        filt = partial_lora_trainable_filter(adapted)
+        from jno.lora import LoRAWrapper
+
+        all_lora_ids = set()
+        for node in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper)):
+            if isinstance(node, LoRAWrapper):
+                for arr in jax.tree_util.tree_leaves(node):
+                    if eqx.is_array(arr):
+                        all_lora_ids.add(id(arr))
+        flat_arrays = jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_inexact_array))
+        flat_filt = jax.tree_util.tree_leaves(filt)
+        for arr, f in zip(flat_arrays, flat_filt):
+            if id(arr) not in all_lora_ids:
+                assert f is True, "unwrapped param must remain trainable"
+
+    def test_more_trainable_than_lora_filter(self):
+        """partial filter marks more params True than lora_trainable_filter (unwrapped layers)."""
+        adapted = self._adapted_first_only()
+        n_partial = sum(1 for v in jax.tree_util.tree_leaves(partial_lora_trainable_filter(adapted)) if v)
+        n_lora = sum(1 for v in jax.tree_util.tree_leaves(lora_trainable_filter(adapted)) if v)
+        assert n_partial > n_lora, "partial filter should train more params than lora-only filter"
 
 
 # ---------------------------------------------------------------------------
@@ -801,33 +937,33 @@ class TestModelControlStateCombinations:
         assert net._frozen is True
         assert net._trainable_param_mask is None
 
-    def test_mask_lora_sets_both_trainable_mask_and_config(self):
-        """mask(m).lora() stores _trainable_param_mask and _lora_config simultaneously."""
+    def test_mask_lora_sets_lora_param_mask_and_config(self):
+        """mask(m).lora() stores _lora_param_mask (as-is) and _lora_config; clears trainable mask."""
         net = self._net()
-        net.mask(self._all_true_mask()).lora(rank=4, alpha=1.0)
-        assert net._trainable_param_mask is not None
+        mask = self._all_true_mask()
+        net.mask(mask).lora(rank=4, alpha=1.0)
+        assert net._lora_param_mask is mask
         assert net._lora_config is not None
+        assert net._trainable_param_mask is None
 
     def test_freeze_then_lora_leaves_no_trainable_mask(self):
-        """freeze().lora() produces _frozen=True, _lora_config set, _trainable_param_mask=None.
-
-        freeze() consumes the (absent) mask scope and leaves _mask_scope_pending=False,
-        so the subsequent lora() call sees no pending mask.
-        """
+        """freeze().lora() produces _frozen=True, _lora_config set, no masks."""
         net = self._net()
         net.freeze().lora(rank=4, alpha=1.0)
         assert net._frozen is True
         assert net._lora_config is not None
         assert net._trainable_param_mask is None
+        assert net._lora_param_mask is None
 
     def test_mask_freeze_then_lora_mask_already_consumed(self):
-        """mask(m).freeze() followed by .lora() — mask scope consumed by freeze."""
+        """mask(m).freeze() followed by .lora() — mask scope consumed by freeze, lora clears lora_mask."""
         net = self._net()
         net.mask(self._all_true_mask()).freeze()  # mask scope consumed here
         net.lora(rank=4, alpha=1.0)  # no pending mask
         assert net._frozen is False  # mask.freeze(), not global
         assert net._lora_config is not None
-        assert net._trainable_param_mask is None  # lora() cleared it (no pending mask)
+        assert net._trainable_param_mask is None  # not set by lora()
+        assert net._lora_param_mask is None  # no pending mask → cleared
 
     def test_mask_scope_consumed_after_freeze(self):
         """_mask_scope_pending is False after freeze() regardless of preceding mask()."""
@@ -841,13 +977,14 @@ class TestModelControlStateCombinations:
         """reset() zeroes every training-time control field."""
         net = self._net()
         net.mask(self._all_true_mask()).freeze()
-        net.lora(rank=4, alpha=1.0)
+        net.mask(self._all_true_mask()).lora(rank=4, alpha=1.0)
         net.optimizer(optax.adam, lr=lrs(1e-3))
         net.dtype(jnp.bfloat16)
         net.reset()
         assert net._frozen is False
         assert net._lora_config is None
         assert net._trainable_param_mask is None
+        assert net._lora_param_mask is None
         assert net._opt_fn is None
         assert net._lr is None
         assert net._dtype is None
@@ -1009,14 +1146,31 @@ class TestIntegrationCombinations:
 
     # ── mask(m).lora(): adapters train, no crash ──────────────────────────────
 
-    def test_mask_lora_no_crash_adapters_train(self):
-        """mask(m).lora() stores _trainable_param_mask but core uses lora_trainable_filter;
-        only adapter arrays train regardless of the mask — must not crash."""
+    def test_mask_lora_restricts_wrapped_layers(self):
+        """mask(M).lora() wraps only M-selected modules; unwrapped params stay trainable."""
+        import equinox as eqx
+
         m = foundax.mlp(1, output_dim=1, hidden_dims=16, num_layers=2, key=KEY)
         net = nn.wrap(m)
-        leaves, treedef = jax.tree_util.tree_flatten(eqx.filter(m, eqx.is_array))
-        half_mask = jax.tree_util.tree_unflatten(treedef, [i < len(leaves) // 2 for i in range(len(leaves))])
-        net.mask(half_mask).lora(rank=4, alpha=1.0).optimizer(optax.adam, lr=lrs(1e-3))
+
+        # Build a mask that selects ONLY the first layer's weight.
+        all_false = jax.tree_util.tree_map(lambda _: False, m)
+        first_layer_mask = eqx.tree_at(lambda mod: mod.hidden_layers[0].weight, all_false, True)
+
+        net.mask(first_layer_mask).lora(rank=4, alpha=1.0).optimizer(optax.adam, lr=lrs(1e-3))
+        assert jnp.isfinite(self._solve_single(net))
+
+    def test_mask_all_false_lora_wraps_nothing(self):
+        """mask(all_false).lora() wraps no layers — model trains all params normally."""
+
+        m = foundax.mlp(1, output_dim=1, hidden_dims=16, num_layers=2, key=KEY)
+        net = nn.wrap(m)
+        all_false = jax.tree_util.tree_map(lambda _: False, m)
+        net.mask(all_false).lora(rank=4, alpha=1.0).optimizer(optax.adam, lr=lrs(1e-3))
+
+        # _lora_param_mask is all-False so no modules should be wrapped after solve
+        # We verify via the state check (lora_config set, but mask was all-False)
+        assert net._lora_param_mask is all_false
         assert jnp.isfinite(self._solve_single(net))
 
     # ── dtype(bfloat16) + freeze + lora ─────────────────────────────────────

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -3,8 +3,10 @@
 Covers:
   - Public namespace: jno.lora.<class>
   - Core utilities: apply_lora, merge_lora, lora_trainable_filter
-  - LoRA Zoo: LoRALinear, rsLoRALinear, LoRAFALinear, DoRALinear, PiSSALinear, LoRAXSLinear,
-              VeRALinear, MiLoRALinear, IA3Linear, LoKrLinear, OFTLinear
+  - LoRA Zoo (linear): LoRALinear, rsLoRALinear, LoRAFALinear, DoRALinear, PiSSALinear,
+                        LoRAXSLinear, VeRALinear, MiLoRALinear, IA3Linear, LoKrLinear, OFTLinear
+  - LoRA Zoo (conv):   LoRAConv, rsLoRAConv, LoRAFAConv, DoRAConv, PiSSAConv, LoRAXSConv,
+                        VeRAConv, MiLoRAConv, IA3Conv, LoKrConv, OFTConv
   - apply_lora options: target regex, per-spec routing, list-of-wrappers, custom wrapper
   - Initialisation invariant: all adapters are no-ops at init (output == base)
   - Merge: merged output == adapted output; no LoRAWrapper nodes remain
@@ -16,6 +18,7 @@ Covers:
   - Model.lora() API: config structure, wrapper=, specs=
   - Model control state combinations: mask/freeze/lora/reset chaining
   - Integration: end-to-end training through jno.core, including complex combinations
+  - Conv zoo: apply, init invariant, merge, trainable filter for all 11 conv adapters
 """
 
 import equinox as eqx
@@ -30,20 +33,31 @@ import jno.jnp_ops as jnn
 from jno import LearningRateSchedule as lrs
 from jno.architectures.models import nn
 from jno.lora import (
+    DoRAConv,
     DoRALinear,
+    IA3Conv,
     IA3Linear,
+    LoKrConv,
     LoKrLinear,
+    LoRAConv,
+    LoRAFAConv,
     LoRAFALinear,
     LoRALinear,
     LoRAWrapper,
+    LoRAXSConv,
     LoRAXSLinear,
+    MiLoRAConv,
     MiLoRALinear,
+    OFTConv,
     OFTLinear,
+    PiSSAConv,
     PiSSALinear,
+    VeRAConv,
     VeRALinear,
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    rsLoRAConv,
     rsLoRALinear,
 )
 
@@ -69,6 +83,23 @@ _ADAPTER_LEAVES: dict[type[LoRAWrapper], int] = {
 
 ZOO = list(_ADAPTER_LEAVES.keys())
 
+# Expected adapter leaf count for the 2-layer conv net with rank=2
+_CONV_ADAPTER_LEAVES: dict[type[LoRAWrapper], int] = {
+    LoRAConv: 4,  # 2 × (lora_A, lora_B)
+    rsLoRAConv: 4,
+    LoRAFAConv: 2,  # 2 × (lora_B,)
+    DoRAConv: 6,  # 2 × (magnitude, lora_A, lora_B)
+    PiSSAConv: 4,
+    LoRAXSConv: 2,  # 2 × (R,)
+    VeRAConv: 4,  # 2 × (b, d)
+    MiLoRAConv: 4,
+    IA3Conv: 2,  # 2 × (scale,)
+    LoKrConv: 4,  # 2 × (kron_A, kron_B)
+    OFTConv: 2,  # 2 × (Q_blocks,)
+}
+
+CONV_ZOO = list(_CONV_ADAPTER_LEAVES.keys())
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -77,6 +108,25 @@ ZOO = list(_ADAPTER_LEAVES.keys())
 
 def _mlp(key=KEY):
     return foundax.mlp(**_MLP_KW, key=key)
+
+
+class _TinyConvNet(eqx.Module):
+    """Two-layer Conv1d net for conv LoRA tests."""
+
+    conv1: eqx.nn.Conv1d
+    conv2: eqx.nn.Conv1d
+
+    def __call__(self, x):
+        return self.conv2(jax.nn.relu(self.conv1(x)))
+
+
+def _conv_net(key=KEY) -> _TinyConvNet:
+    """Conv1d(2→4, k=3) → relu → Conv1d(4→2, k=3); input shape (2, 8)."""
+    k1, k2 = jax.random.split(key)
+    return _TinyConvNet(
+        conv1=eqx.nn.Conv1d(2, 4, kernel_size=3, key=k1, padding=1),
+        conv2=eqx.nn.Conv1d(4, 2, kernel_size=3, key=k2, padding=1),
+    )
 
 
 def _count_wrappers(model) -> int:
@@ -225,6 +275,16 @@ def test_output_equals_base_at_init(cls):
     # float32 rounding even when Q=0, so use a slightly looser tolerance.
     atol = 1e-4 if cls is OFTLinear else 1e-5
     assert jnp.allclose(mlp(x), adapted(x), atol=atol), f"{cls.__name__}: output differs from base at init"
+
+
+@pytest.mark.parametrize("cls", CONV_ZOO)
+def test_conv_output_equals_base_at_init(cls):
+    """Adapted conv model output must equal base at initialisation."""
+    net = _conv_net()
+    adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+    x = jnp.ones((2, 8))
+    atol = 1e-4 if cls is OFTConv else 1e-5
+    assert jnp.allclose(net(x), adapted(x), atol=atol), f"{cls.__name__}: conv output differs from base at init"
 
 
 # ---------------------------------------------------------------------------
@@ -553,7 +613,7 @@ class TestModelLoraAPI:
     def test_default_config(self):
         net = self._net()
         net.lora(rank=4, alpha=1.0)
-        assert net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear,)}]
+        assert net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
 
     def test_wrapper_param_single(self):
         net = self._net()
@@ -577,10 +637,10 @@ class TestModelLoraAPI:
         assert net._lora_config[0]["rank"] == 4
         assert net._lora_config[1]["rank"] == 16
 
-    def test_specs_default_wrapper_is_lora_linear(self):
+    def test_specs_default_wrapper_is_lora_linear_and_conv(self):
         net = self._net()
         net.lora(specs=[{"target": ".*", "rank": 4, "alpha": 1.0}])
-        assert net._lora_config[0]["wrappers"] == (LoRALinear,)
+        assert net._lora_config[0]["wrappers"] == (LoRALinear, LoRAConv)
 
     def test_specs_per_spec_wrapper(self):
         net = self._net()
@@ -1023,3 +1083,183 @@ class TestIntegrationCombinations:
         loss = (u - jnn.sin(jnn.pi * x)).mse
         stats = jno.core([loss], domain).solve(3)
         assert jnp.isfinite(stats.training_logs[-1]["total_loss"][-1])
+
+
+# ---------------------------------------------------------------------------
+# 12. Conv zoo tests
+# ---------------------------------------------------------------------------
+
+
+class TestConvApplyLora:
+    def test_wraps_conv1d(self):
+        """apply_lora must wrap eqx.nn.Conv1d layers by default."""
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY)
+        assert _count_wrappers(adapted) == 2, "Conv1d layers were not wrapped"
+
+    def test_does_not_wrap_linear_with_conv_wrapper(self):
+        """LoRAConv must not wrap LinearLike layers."""
+        mlp = _mlp()
+        adapted = apply_lora(mlp, rank=2, alpha=1.0, key=KEY, wrappers=(LoRAConv,))
+        assert _count_wrappers(adapted) == 0, "LoRAConv incorrectly wrapped a linear layer"
+
+    @pytest.mark.parametrize("cls", CONV_ZOO)
+    def test_conv_adapter_leaf_count(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        assert _count_adapter_leaves(adapted) == _CONV_ADAPTER_LEAVES[cls]
+
+    def test_no_double_wrap_conv(self):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(LoRAConv,))
+        adapted2 = apply_lora(adapted, rank=2, alpha=1.0, key=KEY, wrappers=(LoRAConv,))
+        assert _count_wrappers(adapted) == _count_wrappers(adapted2)
+
+
+@pytest.mark.parametrize("cls", CONV_ZOO)
+class TestConvMergeLora:
+    @staticmethod
+    def _perturb(model):
+        leaves, treedef = jax.tree_util.tree_flatten(model)
+        leaves = [v + 0.01 * jnp.ones_like(v) if eqx.is_array(v) else v for v in leaves]
+        return jax.tree_util.tree_unflatten(treedef, leaves)
+
+    def test_merged_output_equals_adapted(self, cls):
+        net = _conv_net()
+        adapted = self._perturb(apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,)))
+        merged = merge_lora(adapted)
+        x = jax.random.normal(KEY, (2, 8))
+        assert jnp.allclose(adapted(x), merged(x), atol=1e-5), f"{cls.__name__}: merge_lora output differs from adapted"
+
+    def test_no_wrapper_nodes_after_merge(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        merged = merge_lora(adapted)
+        assert _count_wrappers(merged) == 0, f"{cls.__name__}: wrapper nodes remain after merge"
+
+
+@pytest.mark.parametrize("cls", CONV_ZOO)
+class TestConvTrainableFilter:
+    def test_correct_adapter_count(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        n_true = _count_adapter_leaves(adapted)
+        assert n_true == _CONV_ADAPTER_LEAVES[cls], (
+            f"{cls.__name__}: expected {_CONV_ADAPTER_LEAVES[cls]} adapter leaves, got {n_true}"
+        )
+
+    def test_base_arrays_not_marked(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        n_true = _count_adapter_leaves(adapted)
+        assert n_true == _CONV_ADAPTER_LEAVES[cls]
+
+
+class TestConvRankClamping:
+    @pytest.mark.parametrize("cls", [PiSSAConv, DoRAConv, LoRAXSConv, MiLoRAConv])
+    def test_conv_rank_clamped_to_min_dim(self, cls):
+        # Conv1d(2, 4, kernel_size=3): out_ch=4, flat_in=2*3=6; min is 4
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = cls(conv, rank=32, alpha=1.0, key=KEY)
+        assert adapted.rank <= min(4, 6)
+
+    def test_oft_conv_rank_clamped_to_out_ch(self):
+        conv = eqx.nn.Conv1d(2, 3, kernel_size=3, key=KEY)
+        adapted = OFTConv(conv, rank=8, alpha=1.0, key=KEY)
+        assert adapted.rank == 3
+
+
+class TestConvPerClassInvariants:
+    def test_lora_conv_lora_b_zero_at_init(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = LoRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.lora_B == 0)
+
+    def test_rs_lora_conv_scaling(self):
+        """rsLoRAConv uses alpha/sqrt(rank); output must differ from LoRAConv for same non-zero B."""
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        x = jax.random.normal(KEY, (2, 8))
+        a = LoRAConv(conv, rank=4, alpha=1.0, key=KEY)
+        r = rsLoRAConv(conv, rank=4, alpha=1.0, key=KEY)
+        delta_B = jax.random.normal(KEY, a.lora_B.shape)
+        a = eqx.tree_at(lambda m: m.lora_B, a, delta_B)
+        r = eqx.tree_at(lambda m: m.lora_B, r, delta_B)
+        assert not jnp.allclose(a(x), r(x), atol=1e-6)
+
+    def test_lora_fa_conv_only_b_trainable(self):
+        assert LoRAFAConv.adapter_fields == ("lora_B",)
+
+    def test_dora_conv_magnitude_init(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = DoRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        W_flat = conv.weight.reshape(4, -1)
+        expected = jnp.linalg.norm(W_flat, axis=1)
+        assert jnp.allclose(adapted.magnitude, expected, atol=1e-6)
+
+    def test_pissa_conv_residual(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        r, alpha = 2, 4.0
+        adapted = PiSSAConv(conv, rank=r, alpha=alpha, key=KEY)
+        out_ch, flat_in = conv.weight.shape[0], conv.weight.reshape(4, -1).shape[1]
+        W_reconstructed = adapted.base.weight.reshape(out_ch, flat_in) + (alpha / r) * (adapted.lora_B @ adapted.lora_A)
+        assert jnp.allclose(W_reconstructed, conv.weight.reshape(out_ch, flat_in), atol=1e-5)
+
+    def test_lora_xs_conv_r_zero(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = LoRAXSConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.R == 0)
+
+    def test_vera_conv_b_zero_d_ones(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = VeRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.b == 0)
+        assert jnp.all(adapted.d == 1)
+
+    def test_vera_conv_no_AB_in_pytree(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = VeRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        shapes = {leaf.shape for leaf in jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_array))}
+        flat_in = conv.weight.reshape(4, -1).shape[1]
+        assert (2, flat_in) not in shapes, "A-shaped array found in pytree"
+        assert (4, 2) not in shapes, "B-shaped array found in pytree"
+
+    def test_milora_conv_residual(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        r, alpha = 2, 4.0
+        adapted = MiLoRAConv(conv, rank=r, alpha=alpha, key=KEY)
+        out_ch, flat_in = conv.weight.shape[0], conv.weight.reshape(4, -1).shape[1]
+        W_reconstructed = adapted.base.weight.reshape(out_ch, flat_in) + (alpha / r) * (adapted.lora_B @ adapted.lora_A)
+        assert jnp.allclose(W_reconstructed, conv.weight.reshape(out_ch, flat_in), atol=1e-5)
+
+    def test_ia3_conv_scale_ones(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = IA3Conv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.scale == 1.0)
+        assert adapted.scale.shape == (4,)
+
+    def test_lokr_conv_kron_b_zero(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = LoKrConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.kron_B == 0)
+
+    def test_oft_conv_q_zero_r_identity(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = OFTConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.Q_blocks == 0)
+        R = adapted._R()
+        assert jnp.allclose(R, jnp.eye(4), atol=1e-6)
+
+    def test_default_apply_lora_wraps_both_linear_and_conv(self):
+        """Default _normalize_wrappers wraps both Linear and Conv layers."""
+
+        class MixedNet(eqx.Module):
+            linear: eqx.nn.Linear
+            conv: eqx.nn.Conv1d
+
+            def __call__(self, x_lin, x_conv):
+                return self.linear(x_lin) + self.conv(x_conv).sum()
+
+        k1, k2 = jax.random.split(KEY)
+        net = MixedNet(linear=eqx.nn.Linear(4, 8, key=k1), conv=eqx.nn.Conv1d(2, 4, kernel_size=3, key=k2))
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY)
+        assert _count_wrappers(adapted) == 2, "Expected both linear and conv layers to be wrapped by default"

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -345,12 +345,12 @@ class TestModelMask:
         """mask().lora() sets _lora_config as a list of dicts and consumes the mask scope."""
         import jax
 
-        from jno.lora import LoRALinear
+        from jno.lora import LoRAConv, LoRALinear
 
         u_net = self._make_eqx_model()
         all_true = jax.tree_util.tree_map(lambda _: True, u_net.module)
         u_net.mask(all_true).lora(rank=4, alpha=1.0)
-        assert u_net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear,)}]
+        assert u_net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
         assert u_net._mask_scope_pending is False
 
     def test_manual_mask_optimizer_creates_group_and_keeps_global_fallback(self):
@@ -443,9 +443,9 @@ class TestModelMask:
 
         u_net.mask(all_false).lora(rank=2, alpha=1.0)
 
-        from jno.lora import LoRALinear
+        from jno.lora import LoRAConv, LoRALinear
 
-        assert u_net._lora_config == [{"target": None, "rank": 2, "alpha": 1.0, "wrappers": (LoRALinear,)}]
+        assert u_net._lora_config == [{"target": None, "rank": 2, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
         assert u_net._mask_scope_pending is False
         leaves = jax.tree_util.tree_leaves(u_net._trainable_param_mask)
         assert all(v is True for v in leaves if isinstance(v, bool))

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -435,7 +435,7 @@ class TestModelMask:
         assert u_net._frozen is True
 
     def test_mask_scope_is_one_shot_for_lora(self):
-        """mask().lora() consumes mask scope and stores base trainability mask."""
+        """mask().lora() consumes mask scope and stores mask in _lora_param_mask (not inverted)."""
         import jax
 
         u_net = self._make_eqx_model()
@@ -447,23 +447,25 @@ class TestModelMask:
 
         assert u_net._lora_config == [{"target": None, "rank": 2, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
         assert u_net._mask_scope_pending is False
-        leaves = jax.tree_util.tree_leaves(u_net._trainable_param_mask)
-        assert all(v is True for v in leaves if isinstance(v, bool))
+        # Mask stored as-is (not inverted) — all_false means no module is selected for LoRA
+        assert u_net._lora_param_mask is all_false
+        # _trainable_param_mask is no longer used by mask().lora()
+        assert u_net._trainable_param_mask is None
 
-    def test_plain_lora_clears_stale_trainable_mask(self):
-        """A plain lora() call should reset stale base trainability overrides."""
+    def test_plain_lora_clears_stale_lora_mask(self):
+        """A plain lora() call should clear any previously set _lora_param_mask."""
         import jax
 
         u_net = self._make_eqx_model()
         all_false = jax.tree_util.tree_map(lambda _: False, u_net.module)
 
-        # First set a custom base trainability mask via masked LoRA.
+        # First set a lora param mask via masked LoRA.
         u_net.mask(all_false).lora(rank=2, alpha=1.0)
-        assert u_net._trainable_param_mask is not None
+        assert u_net._lora_param_mask is not None
 
-        # A later plain lora() should restore default LoRA semantics.
+        # A later plain lora() should restore default LoRA semantics (no mask restriction).
         u_net.lora(rank=4, alpha=1.0)
-        assert u_net._trainable_param_mask is None
+        assert u_net._lora_param_mask is None
 
     def test_mask_reset_clears_param_mask(self):
         """reset() clears _param_mask back to None."""
@@ -475,6 +477,17 @@ class TestModelMask:
         assert u_net._param_mask is not None
         u_net.reset()
         assert u_net._param_mask is None
+
+    def test_mask_reset_clears_lora_param_mask(self):
+        """reset() clears _lora_param_mask back to None."""
+        import jax
+
+        u_net = self._make_eqx_model()
+        all_true = jax.tree_util.tree_map(lambda _: True, u_net.module)
+        u_net.mask(all_true).lora(rank=2, alpha=1.0)
+        assert u_net._lora_param_mask is not None
+        u_net.reset()
+        assert u_net._lora_param_mask is None
 
     def test_mask_via_model_call_proxies_to_model(self):
         """ModelCall.mask() delegates to the underlying Model."""

--- a/tests/test_trace_evaluator.py
+++ b/tests/test_trace_evaluator.py
@@ -50,7 +50,7 @@ class TestEvalCtx:
 # ======================================================================
 class TestDispatchTable:
     def test_handlers_count(self):
-        assert len(TraceEvaluator._HANDLERS) == 18  # Update this if we add more node types
+        assert len(TraceEvaluator._HANDLERS) == 19  # Update this if we add more node types
 
     def test_handlers_are_strings(self):
         for node_type, method_name in TraceEvaluator._HANDLERS:

--- a/tests/tutorial_examples_tests/06_integration/fredholm_integral_equation.py
+++ b/tests/tutorial_examples_tests/06_integration/fredholm_integral_equation.py
@@ -1,0 +1,77 @@
+"""06 — Fredholm integral equation of the second kind
+
+Equation
+--------
+    u(x) = f(x) + ∫₀¹ x·t · u(t) dt,   x ∈ [0, 1]
+
+with forcing term chosen so that the exact solution is
+
+    u*(x) = sin(πx)
+
+Derivation of f
+---------------
+    ∫₀¹ t · sin(πt) dt = 1/π   (integration by parts)
+    f(x) = sin(πx) − x/π
+
+Network residual
+----------------
+    R(x) = u(x) − f(x) − x · ∫₀¹ t · u(t) dt = 0
+
+The integral ∫₀¹ t · u(t) dt is a scalar C computed once via .integrate().
+"""
+
+import foundax
+import jax
+import jax.numpy as jnp
+import optax
+
+import jno
+
+π = jno.np.pi
+
+# ── Domain ─────────────────────────────────────────────────────────────────────
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.01))
+x, _ = domain.variable("interior")
+
+# ── Forcing term  f(x) = sin(πx) − x/π ───────────────────────────────────────
+pi_val = float(jnp.pi)
+f = jno.np.sin(π * x) - x / pi_val
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+net = jno.nn.wrap(
+    foundax.mlp(
+        in_features=1,
+        hidden_dims=64,
+        num_layers=4,
+        activation=jax.nn.tanh,
+        key=jax.random.PRNGKey(0),
+    )
+)
+net.optimizer(
+    optax.adam(
+        optax.exponential_decay(
+            init_value=1e-3,
+            transition_steps=5_000,
+            decay_rate=0.5,
+            end_value=1e-5,
+        )
+    )
+)
+
+u = net(x)
+
+# ── Fredholm residual ──────────────────────────────────────────────────────────
+C = (x * u).integrate()
+residual = u - f - x * C
+
+# ── Solve ──────────────────────────────────────────────────────────────────────
+EPOCHS = 50_000
+crux = jno.core([residual.mse], domain)
+_history = crux.solve(EPOCHS)
+
+# ── Evaluate ───────────────────────────────────────────────────────────────────
+u_exact = jno.np.sin(π * x)
+u_pred, u_ref = crux.eval([u, u_exact])
+
+rel_l2 = float(jnp.linalg.norm(u_pred - u_ref) / (jnp.linalg.norm(u_ref) + 1e-8))
+assert rel_l2 < 0.05, f"Relative L2 error too large: {rel_l2:.3e}"

--- a/tests/tutorial_examples_tests/06_integration/fredholm_nonseparable.py
+++ b/tests/tutorial_examples_tests/06_integration/fredholm_nonseparable.py
@@ -1,0 +1,67 @@
+"""06 — Fredholm integral equation with non-separable kernel
+
+Equation:  u(x) = f(x) + ∫₀¹ (x + t) · u(t) dt
+Exact:     u*(x) = sin(πx)
+Forcing:   f(x) = sin(πx) − 2x/π − 1/π
+
+Demonstrates .integrate(var=x) for a kernel that depends on both the
+outer collocation variable x and the inner dummy t.
+"""
+
+import foundax
+import jax
+import jax.numpy as jnp
+import optax
+
+import jno
+
+π = jno.np.pi
+
+# ── Domain ─────────────────────────────────────────────────────────────────────
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+
+x, _ = domain.variable("interior")  # outer collocation variable
+t, _ = domain.variable("interior")  # inner integration dummy
+
+# ── Forcing term ───────────────────────────────────────────────────────────────
+pi_val = float(jnp.pi)
+f = jno.np.sin(π * x) - 2.0 * x / pi_val - 1.0 / pi_val
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+net = jno.nn.wrap(
+    foundax.mlp(
+        in_features=1,
+        hidden_dims=32,
+        num_layers=3,
+        activation=jax.nn.tanh,
+        key=jax.random.PRNGKey(0),
+    )
+)
+net.optimizer(
+    optax.adam(
+        optax.exponential_decay(
+            init_value=1e-3,
+            transition_steps=5_000,
+            decay_rate=0.5,
+            end_value=1e-5,
+        )
+    )
+)
+
+u_x = net(x)
+u_t = net(t)
+
+integral_term = ((x + t) * u_t).integrate(var=x)
+residual = u_x - f - integral_term
+
+# ── Solve ──────────────────────────────────────────────────────────────────────
+EPOCHS = 30_000
+crux = jno.core([residual.mse], domain)
+_history = crux.solve(EPOCHS)
+
+# ── Evaluate ───────────────────────────────────────────────────────────────────
+u_exact = jno.np.sin(π * x)
+u_pred, u_ref = crux.eval([u_x, u_exact])
+
+rel_l2 = float(jnp.linalg.norm(u_pred - u_ref) / (jnp.linalg.norm(u_ref) + 1e-8))
+assert rel_l2 < 0.10, f"Relative L2 error too large: {rel_l2:.3e}"

--- a/tests/tutorial_examples_tests/06_integration/integro_differential.py
+++ b/tests/tutorial_examples_tests/06_integration/integro_differential.py
@@ -1,0 +1,66 @@
+"""06 — Integro-Differential Equation
+
+Equation:  u'(x) + u(x) = g(x) + ∫₀¹ u(t) dt,   u(0) = 0
+Exact:     u*(x) = sin(πx)
+Forcing:   g(x) = π cos(πx) + sin(πx) − 2/π
+
+Hard BC ansatz: u = net(x) · x  ensures u(0) = 0.
+Combines .d(x) and .integrate() in the same residual.
+"""
+
+import foundax
+import jax
+import jax.numpy as jnp
+import optax
+
+import jno
+
+π = jno.np.pi
+
+# ── Domain ─────────────────────────────────────────────────────────────────────
+domain = jno.domain(constructor=jno.domain.line(mesh_size=0.005))
+
+x, _ = domain.variable("interior")
+
+# ── Forcing term ───────────────────────────────────────────────────────────────
+pi_val = float(jnp.pi)
+g = π * jno.np.cos(π * x) + jno.np.sin(π * x) - 2.0 / pi_val
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+net = jno.nn.wrap(
+    foundax.mlp(
+        in_features=1,
+        hidden_dims=32,
+        num_layers=3,
+        activation=jax.nn.tanh,
+        key=jax.random.PRNGKey(0),
+    )
+)
+net.optimizer(
+    optax.adam(
+        optax.exponential_decay(
+            init_value=1e-3,
+            transition_steps=5_000,
+            decay_rate=0.5,
+            end_value=1e-5,
+        )
+    )
+)
+
+u = net(x) * x  # hard BC: u(0) = 0
+
+C = u.integrate()
+du = u.d(x)
+residual = du + u - g - C
+
+# ── Solve ──────────────────────────────────────────────────────────────────────
+EPOCHS = 30_000
+crux = jno.core([residual.mse], domain)
+_history = crux.solve(EPOCHS)
+
+# ── Evaluate ───────────────────────────────────────────────────────────────────
+u_exact = jno.np.sin(π * x)
+u_pred, u_ref = crux.eval([u, u_exact])
+
+rel_l2 = float(jnp.linalg.norm(u_pred - u_ref) / (jnp.linalg.norm(u_ref) + 1e-8))
+assert rel_l2 < 1e-3, f"Relative L2 error too large: {rel_l2:.3e}"


### PR DESCRIPTION
## Summary

- **`Integral` placeholder** added to `jno/trace.py` — the integration counterpart to `Jacobian`, participating in the same expression graph and supporting full gradient flow
- **Scalar path** (`expr.integrate()`): auto-detects boundary vs volume from the variable tag, evaluates the integrand at all region mesh nodes, and returns a weighted sum using nodal measures from `mesh_connectivity` — JIT-compatible via a lazy per-tag cache on the domain object
- **Vectorized path** (`expr.integrate(var=x)`): enables non-separable kernels K(x,t) where the result depends on both the outer collocation variable and the inner dummy; aliases inner Variable objects to a separate context slot and evaluates via `jax.vmap`, returning `(N, 1)` — no special flag on `domain.variable()` needed, just call it twice
- **Chained double integrals**: `inner.integrate(var=x).integrate()` verified correct for `∫∫(x+t)dt dx = 1.0`
- **Integro-differential equations**: `.d(x)` and `.integrate()` compose in the same residual with correct gradient flow

## New tutorials (06 Integration chapter)

| Tutorial | Equation | Key API |
|---|---|---|
| Fredholm Integral Equation | `u = f + C·∫K(x)u dx` (separable) | `.integrate()` scalar |
| Fredholm Non-Separable Kernel | `u = f + ∫(x+t)u(t)dt` | `.integrate(var=x)` |
| Flux Conservation 2D | Poisson + integral tracking | `.integrate()` on boundary |
| Integro-Differential Equation | `u' + u = g + ∫u dt` | `.d(x)` + `.integrate()` |

## Test plan

- [x] 36 unit tests in `tests/test_integration_operators.py` covering: nodal volumes, boundary weights, JIT compatibility, gradient flow through integral loss (analytic gradient check), vectorized integrals, chained double integrals, and IDE operator composition
- [x] Tutorial smoke tests in `tests/tutorial_examples_tests/06_integration/` for all four scripts
- [x] All 36 integration tests pass; full suite passes (one transient GPU cuSolver OOM in `test_lora.py` during the back-to-back run, passes cleanly in isolation — pre-existing flakiness unrelated to this PR)