### PR TITLE
Add conv LoRA zoo and fix mask(M).lora() layer selection

### DIFF
--- a/docs/Model-Controls.md
+++ b/docs/Model-Controls.md
@@ -124,8 +124,31 @@ With `mask(...).freeze()`, selected leaves are frozen and non-selected leaves re
 ## 3. LoRA
 
 LoRA inserts trainable low-rank adapter matrices into matching layers while keeping base weights
-frozen. By default `LoRALinear` is used, which targets any layer with `weight`, `in_features`, and
-`out_features` attributes (jNO Linear, foundax Linear, `eqx.nn.Linear`).
+frozen. By default both linear layers (`weight`, `in_features`, `out_features`) and conv layers
+(`weight`, `in_channels`, `out_channels`) are wrapped automatically.
+
+### `target=` vs `mask()` — two ways to restrict which layers get LoRA
+
+Both restrict which layers receive LoRA adapters, but they select differently:
+
+| | `target=` / `specs=` | `mask(M).lora()` |
+|---|---|---|
+| **Selects layers by** | regex on pytree path string | boolean pytree (data-driven) |
+| **Layers not selected** | left completely untouched | left completely untouched |
+| **Use when** | you know the layer names up front | you have a precomputed boolean mask (e.g. from `eqx.tree_at`) |
+
+```python
+# Path-regex: only "encoder.*" layers get LoRA
+net.lora(rank=8, target="encoder")
+
+# Data-driven: only layers whose params are True in encoder_mask get LoRA
+net.mask(encoder_mask).lora(rank=8)
+```
+
+They can be combined — only layers that pass **both** the mask AND the regex are wrapped:
+```python
+net.mask(encoder_mask).lora(rank=8, target="encoder")
+```
 
 ### Uniform LoRA
 
@@ -133,7 +156,7 @@ frozen. By default `LoRALinear` is used, which targets any layer with `weight`, 
 net.lora(rank=8, alpha=16)
 ```
 
-Restrict to a subset of layers with a path-regex:
+Restrict *which layers get adapters* with a path-regex (layers not matching are left untouched):
 
 ```python
 net.lora(rank=8, alpha=16, target="encoder")
@@ -155,40 +178,40 @@ matching spec wins.
 
 ### Custom adapter classes
 
-Pass any `LoRAWrapper` subclass via `wrapper` to support layer types beyond linear:
+Conv and linear adapters are already in the zoo — see the tables above.  To support a layer type
+not covered (e.g. an embedding or a custom module), subclass `LoRAWrapper`:
 
 ```python
 from jno.lora import LoRAWrapper
 import equinox as eqx
+import jax.numpy as jnp
 
-class LoRAConv(LoRAWrapper):
-	adapter_fields = ("delta_w",)            # names of trainable adapter attributes
+class MyEmbeddingAdapter(LoRAWrapper):
+	adapter_fields = ("delta",)
 	base: eqx.Module
-	delta_w: jax.Array
+	delta: jax.Array
 	rank: int = eqx.field(static=True)
 	alpha: float = eqx.field(static=True)
 
 	@classmethod
 	def applies_to(cls, leaf):
-		return isinstance(leaf, eqx.nn.Conv2d) and not isinstance(leaf, LoRAWrapper)
+		return isinstance(leaf, eqx.nn.Embedding) and not isinstance(leaf, LoRAWrapper)
 
 	def __init__(self, base, rank, alpha, *, key):
 		self.base, self.rank, self.alpha = base, rank, alpha
-		self.delta_w = jnp.zeros_like(base.weight)
+		self.delta = jnp.zeros_like(base.weight)
 
 	def __call__(self, x):
-		w = self.base.weight + self.delta_w * (self.alpha / self.rank)
-		return self.base(x)   # simplified — use eqx.tree_at to swap weight
+		return self.base(x) + self.delta[x] * (self.alpha / self.rank)
 
 	def merge(self):
-		w = self.base.weight + self.delta_w * (self.alpha / self.rank)
+		w = self.base.weight + self.delta * (self.alpha / self.rank)
 		return eqx.tree_at(lambda m: m.weight, self.base, w)
 
-# Apply to all matching layers
-net.lora(rank=4, wrapper=LoRAConv)
+net.lora(rank=4, wrapper=MyEmbeddingAdapter)
 
-# Pass a list — tried in order, first applies_to() match wins per leaf
-net.lora(rank=4, wrapper=[LoRALinear, LoRAConv])
+# Mix with built-in zoo classes — first applies_to() match wins per leaf
+net.lora(rank=4, wrapper=[LoRALinear, LoRAConv, MyEmbeddingAdapter])
 ```
 
 Per-target specs may carry their own `"wrapper"` key, which overrides the global default for that
@@ -196,22 +219,31 @@ group:
 
 ```python
 net.lora(
-	wrapper=LoRALinear,          # global default
 	specs=[
 		{"target": "linear", "rank": 4,  "alpha": 1.0},
-		{"target": "conv",   "rank": 8,  "alpha": 2.0, "wrapper": LoRAConv},
+		{"target": "embed",  "rank": 8,  "alpha": 2.0, "wrapper": MyEmbeddingAdapter},
 	]
 )
 ```
 
-### Combine mask + LoRA for base-trainability control
+### Combine mask + LoRA to target specific layers
+
+`mask(M)` sets the selection scope; the next command determines what happens to M-selected elements:
 
 ```python
-# Selected base leaves are frozen; non-selected base leaves stay trainable.
-net.mask(decoder_mask).lora(rank=8, alpha=16)
+# Only layers selected by encoder_mask get LoRA adapters.
+# Layers not in the mask remain fully trainable (not wrapped).
+net.mask(encoder_mask).lora(rank=8, alpha=16)
 
-# Freeze all base params; train LoRA adapters only.
+# mask().freeze(): freeze the selected params (no LoRA).
+net.mask(encoder_mask).freeze()
+
+# freeze().lora(): freeze all base params; only LoRA adapters train.
+# (freeze first, then apply LoRA everywhere)
 net.freeze().lora(rank=8, alpha=16)
+
+# freeze().mask(M).lora(): wrap only M-selected layers; freeze everything else.
+net.freeze().mask(encoder_mask).lora(rank=8, alpha=16)
 ```
 
 ### Default behaviour: linear and conv

--- a/docs/Model-Controls.md
+++ b/docs/Model-Controls.md
@@ -214,11 +214,25 @@ net.mask(decoder_mask).lora(rank=8, alpha=16)
 net.freeze().lora(rank=8, alpha=16)
 ```
 
-### LoRA Zoo
+### Default behaviour: linear and conv
 
-jNO ships several drop-in `LoRAWrapper` variants in `jno.lora`.  All target
-the same layer types as `LoRALinear` (`weight`, `in_features`, `out_features`) and accept the same
-`rank` and `alpha` arguments.
+When you call `.lora()` without a `wrapper=` argument, jNO wraps **both** linear layers
+(`weight`, `in_features`, `out_features`) **and** conv layers (`weight`, `in_channels`,
+`out_channels`) automatically.  ConvTranspose layers are excluded.
+
+```python
+net.lora(rank=4, alpha=1.0)  # wraps Linear + Conv1d/2d/3d in one call
+```
+
+To restrict to one kind:
+
+```python
+net.lora(rank=4, wrapper=LoRALinear)   # linear only
+net.lora(rank=4, wrapper=LoRAConv)     # conv only
+net.lora(rank=4, wrapper=[LoRALinear, LoRAConv])  # explicit default
+```
+
+### LoRA Zoo — Linear
 
 ```python
 from jno.lora import (
@@ -252,7 +266,7 @@ net.lora(rank=4, wrapper=rsLoRALinear)
 | `LoKrLinear` | `r² + ⌈out/r⌉·⌈in/r⌉` | Kronecker product adapter; efficient when `r` ~ √(out·in) ([LoKr](https://arxiv.org/abs/2212.10650)) |
 | `OFTLinear` | `n_blocks·r²` | Block-diagonal orthogonal matrix via Cayley map; preserves hyperspherical energy ([OFT](https://arxiv.org/abs/2306.07280)) |
 
-**When to use which:**
+**When to use which (linear):**
 
 - **rsLoRALinear** — default upgrade over `LoRALinear`; use higher ranks without numerical issues.
 - **LoRAFALinear** — memory-constrained training; halves adapter parameter count.
@@ -265,13 +279,62 @@ net.lora(rank=4, wrapper=rsLoRALinear)
 - **LoKrLinear** — large layers where a Kronecker factorisation covers the weight space more efficiently than a low-rank product.
 - **OFTLinear** — when you need orthogonal weight updates to preserve geometry (e.g., text-to-image fine-tuning, ControlNet).
 
-Mix classes per layer group via per-target specs:
+### LoRA Zoo — Conv
+
+Matching conv variants for `eqx.nn.Conv1d`, `Conv2d`, `Conv3d`.  All operate by
+flattening the weight to `(out_channels, flat_in)` where `flat_in = in_channels // groups * prod(kernel_size)`,
+applying the same adapter logic as the linear counterpart, and reshaping back.  The
+modified weight is substituted via `eqx.tree_at` so XLA fuses it into a single conv call.
+
+```python
+from jno.lora import (
+    LoRAConv,    # standard conv LoRA (default alongside LoRALinear)
+    rsLoRAConv,  # rank-stabilized
+    LoRAFAConv,  # frozen A
+    DoRAConv,    # weight-decomposed
+    PiSSAConv,   # SVD principal components
+    LoRAXSConv,  # extra-small r×r core
+    VeRAConv,    # seed-based frozen A,B; only b,d vectors trained
+    MiLoRAConv,  # SVD minor components
+    IA3Conv,     # per-output-channel scale
+    LoKrConv,    # Kronecker product adapter
+    OFTConv,     # block-diagonal orthogonal fine-tuning
+)
+
+net.lora(rank=4, wrapper=rsLoRAConv)
+```
+
+| Class | Trainable params | Key idea |
+|-------|-----------------|----------|
+| `LoRAConv` | `r·(flat_in + out_ch)` | Standard LoRA on flattened conv weight |
+| `rsLoRAConv` | `r·(flat_in + out_ch)` | Rank-stabilized scaling `α/√r` |
+| `LoRAFAConv` | `r·out_ch` | Frozen A; only B trained |
+| `DoRAConv` | `r·(flat_in + out_ch) + out_ch` | Magnitude + direction decomposition |
+| `PiSSAConv` | `r·(flat_in + out_ch)` | SVD principal components init |
+| `LoRAXSConv` | `r²` | Frozen A,B from SVD; trainable r×r core |
+| `VeRAConv` | `out_ch + r` | Seed-based frozen A,B; only b,d vectors trained |
+| `MiLoRAConv` | `r·(flat_in + out_ch)` | SVD minor components; preserves principal directions |
+| `IA3Conv` | `out_ch` | Per-output-channel scale vector |
+| `LoKrConv` | `r² + ⌈out_ch/r⌉·⌈flat_in/r⌉` | Kronecker product adapter |
+| `OFTConv` | `n_blocks·r²` | Block-diagonal Cayley map on output channels |
+
+**When to use which (conv):**
+
+- **rsLoRAConv** — general-purpose conv adapter; mirrors rsLoRALinear.
+- **LoRAFAConv** — memory-constrained conv fine-tuning.
+- **PiSSAConv / MiLoRAConv** — pretrained conv backbones (e.g., FNO, U-Net encoders).
+- **VeRAConv** — many conv layers and tight checkpoint budgets.
+- **IA3Conv** — fastest conv adaptation; no rank hyperparameter.
+- **OFTConv** — geometry-preserving conv updates (e.g., image models).
+
+Mix linear and conv adapters per layer group via per-target specs:
 
 ```python
 net.lora(
     specs=[
         {"target": "encoder", "rank": 8,  "alpha": 16, "wrapper": PiSSALinear},
         {"target": "decoder", "rank": 4,  "alpha": 1.0, "wrapper": rsLoRALinear},
+        {"target": "conv",    "rank": 4,  "alpha": 1.0, "wrapper": rsLoRAConv},
     ]
 )
 ```

--- a/jno/architectures/lora.py
+++ b/jno/architectures/lora.py
@@ -263,6 +263,7 @@ def apply_lora(
     target: Optional[str] = None,
     specs: Sequence[LoRASpec] | None = None,
     wrappers: type[LoRAWrapper] | Sequence[type[LoRAWrapper]] | None = None,
+    param_mask=None,
 ) -> eqx.Module:
     """Apply LoRA adapters to matching layers in *model*.
 
@@ -277,6 +278,13 @@ def apply_lora(
        Each spec ``{"target": regex, "rank": int, "alpha": float}`` may
        also carry an optional ``"wrapper"`` key to use a different adapter
        class for that group.  The first matching spec wins.
+
+    Args:
+        param_mask: Optional boolean pytree mirroring the model structure.
+            When provided, only modules whose corresponding sub-tree contains
+            at least one ``True`` leaf are wrapped with LoRA adapters.
+            Produced by ``mask(M).lora()``; pass ``None`` to wrap all
+            matching layers (default behaviour).
 
     Returns:
         A new model with ``LoRAWrapper`` replacements at the matched leaves.
@@ -314,6 +322,16 @@ def apply_lora(
     all_wrappers: set[type[LoRAWrapper]] = {w for s in spec_list for w in s.wrappers}
     is_leaf = lambda x: any(w.applies_to(x) for w in all_wrappers)
 
+    # Build set of path strings with a True mask leaf — used to restrict wrapping
+    # to user-selected modules when mask(M).lora() is called.
+    if param_mask is not None:
+        flat_mask_with_path = jax.tree_util.tree_flatten_with_path(param_mask)[0]
+        mask_true_paths: set[str] | None = {
+            _path_str(mp) for mp, val in flat_mask_with_path if val is True or (isinstance(val, bool) and val)
+        }
+    else:
+        mask_true_paths = None
+
     flat_with_path, treedef = jax.tree_util.tree_flatten_with_path(model, is_leaf=is_leaf)
 
     new_leaves: list[Any] = []
@@ -323,6 +341,15 @@ def apply_lora(
             continue
 
         pstr = _path_str(path_keys)
+
+        # Honour param_mask: skip modules not covered by any True leaf.
+        # Use `pstr + "/"` prefix to avoid "layer1" matching "layer10/weight".
+        if mask_true_paths is not None:
+            module_selected = any(tp == pstr or tp.startswith(pstr + "/") for tp in mask_true_paths)
+            if not module_selected:
+                new_leaves.append(leaf)
+                continue
+
         new_leaf = leaf
         for spec in spec_list:
             if spec.pat is None or spec.pat.search(pstr):
@@ -361,6 +388,45 @@ def lora_trainable_filter(model: eqx.Module) -> object:
 
     flat, treedef = jax.tree_util.tree_flatten(model)
     specs = [eqx.is_array(leaf) and id(leaf) in adapter_ids for leaf in flat]
+    return jax.tree_util.tree_unflatten(treedef, specs)
+
+
+def partial_lora_trainable_filter(model: eqx.Module) -> object:
+    """Return a filter-spec for partial LoRA (mask(M).lora() without freeze()).
+
+    Three-bucket logic:
+    - LoRA adapter arrays (b, d, lora_A, lora_B, …)  → ``True``  (trained)
+    - Base arrays inside LoRA wrappers                 → ``False`` (frozen)
+    - Arrays outside any LoRA wrapper                  → ``True``  (trained)
+
+    Use this when the user says ``mask(M).lora()`` without a prior ``freeze()``:
+    selected layers get LoRA with frozen bases; everything else stays trainable.
+    """
+    adapter_ids: set[int] = set()
+    wrapped_base_ids: set[int] = set()
+
+    is_lora = lambda x: isinstance(x, LoRAWrapper)
+    for node in jax.tree_util.tree_leaves(model, is_leaf=is_lora):
+        if isinstance(node, LoRAWrapper):
+            for fname in node.adapter_fields:
+                arr = getattr(node, fname, None)
+                if eqx.is_array(arr):
+                    adapter_ids.add(id(arr))
+            for base_arr in jax.tree_util.tree_leaves(node.base):
+                if eqx.is_array(base_arr):
+                    wrapped_base_ids.add(id(base_arr))
+
+    flat, treedef = jax.tree_util.tree_flatten(model)
+    specs = []
+    for leaf in flat:
+        if not eqx.is_inexact_array(leaf):
+            specs.append(False)
+        elif id(leaf) in adapter_ids:
+            specs.append(True)
+        elif id(leaf) in wrapped_base_ids:
+            specs.append(False)
+        else:
+            specs.append(True)  # unwrapped param — stays trainable
     return jax.tree_util.tree_unflatten(treedef, specs)
 
 

--- a/jno/architectures/lora.py
+++ b/jno/architectures/lora.py
@@ -6,9 +6,9 @@ weights are frozen and only the adapter arrays are trained.
 During forward (LoRALinear):  ``y = base(x) + (x @ A.T) @ B.T * (alpha / rank)``
 After merging               :  ``y = merged_linear(x)``  (no runtime overhead)
 
-LoRA Zoo
-~~~~~~~~
-Several ``LoRAWrapper`` subclasses are provided out of the box:
+LoRA Zoo — Linear
+~~~~~~~~~~~~~~~~~
+Several ``LoRAWrapper`` subclasses are provided out of the box for linear layers:
 
 - ``LoRALinear``   — vanilla LoRA (trainable A and B)
 - ``rsLoRALinear`` — rank-stabilized: scales by ``alpha/sqrt(rank)``
@@ -22,11 +22,27 @@ Several ``LoRAWrapper`` subclasses are provided out of the box:
 - ``LoKrLinear``   — Kronecker product adapter: delta_W = kron(kron_A, kron_B)
 - ``OFTLinear``    — block-diagonal orthogonal fine-tuning via Cayley map
 
+LoRA Zoo — Conv
+~~~~~~~~~~~~~~~
+Matching conv variants for ``eqx.nn.Conv1d/2d/3d`` (ConvTranspose excluded):
+
+- ``LoRAConv``   — vanilla LoRA on flattened conv weight
+- ``rsLoRAConv`` — rank-stabilized conv LoRA
+- ``LoRAFAConv`` — frozen-A conv LoRA
+- ``DoRAConv``   — weight-decomposed conv LoRA
+- ``PiSSAConv``  — SVD-initialised conv LoRA (principal components)
+- ``LoRAXSConv`` — extra-small conv LoRA with trainable r×r core
+- ``VeRAConv``   — seed-based frozen A,B; only b,d vectors trained
+- ``MiLoRAConv`` — SVD minor-component conv LoRA
+- ``IA3Conv``    — per-output-channel scale vector
+- ``LoKrConv``   — Kronecker product conv adapter
+- ``OFTConv``    — block-diagonal orthogonal fine-tuning for conv
+
 Custom adapters
 ~~~~~~~~~~~~~~~
 Subclass ``LoRAWrapper`` to support any layer type::
 
-    class LoRAConv(LoRAWrapper):
+    class MyConvAdapter(LoRAWrapper):
         adapter_fields = ("delta_w",)
 
         @classmethod
@@ -37,10 +53,10 @@ Subclass ``LoRAWrapper`` to support any layer type::
         def __call__(self, x): ...
         def merge(self): ...
 
-    net.lora(rank=4, wrapper=LoRAConv)
+    net.lora(rank=4, wrapper=MyConvAdapter)
     net.lora(specs=[
         {"target": "linear", "rank": 4, "alpha": 1.0},
-        {"target": "conv",   "rank": 8, "alpha": 2.0, "wrapper": LoRAConv},
+        {"target": "conv",   "rank": 8, "alpha": 2.0, "wrapper": MyConvAdapter},
     ])
 """
 
@@ -68,6 +84,27 @@ class LinearLike(Protocol):
     out_features: int
 
     def __call__(self, x: jax.Array) -> jax.Array: ...
+
+
+@runtime_checkable
+class ConvLike(Protocol):
+    """Structural type for any conv module LoRA can wrap (excludes ConvTranspose)."""
+
+    weight: jax.Array
+    in_channels: int
+    out_channels: int
+
+    def __call__(self, x: jax.Array) -> jax.Array: ...
+
+
+try:
+    _CONV_TRANSPOSE_TYPES: tuple[type, ...] = (
+        eqx.nn.ConvTranspose1d,
+        eqx.nn.ConvTranspose2d,
+        eqx.nn.ConvTranspose3d,
+    )
+except AttributeError:
+    _CONV_TRANSPOSE_TYPES = ()
 
 
 # =====================================================================
@@ -184,9 +221,14 @@ class _Spec:
 def _normalize_wrappers(
     wrapper: type[LoRAWrapper] | Sequence[type[LoRAWrapper]] | None,
 ) -> tuple[type[LoRAWrapper], ...]:
-    """Coerce the user-facing ``wrapper`` argument to a tuple of wrapper classes."""
+    """Coerce the user-facing ``wrapper`` argument to a tuple of wrapper classes.
+
+    When ``wrapper`` is ``None``, returns ``(LoRALinear, LoRAConv)`` — both linear
+    and conv layers are wrapped by default.  ``LoRAConv`` is resolved at call time
+    (Python late binding), so the forward reference is safe.
+    """
     if wrapper is None:
-        return (LoRALinear,)
+        return (LoRALinear, LoRAConv)  # LoRAConv defined later in this module
     if isinstance(wrapper, type):
         return (wrapper,)
     return tuple(wrapper)
@@ -330,6 +372,16 @@ def lora_trainable_filter(model: eqx.Module) -> object:
 def _linear_applies_to(leaf: Any) -> bool:
     """Shared predicate: any unwrapped LinearLike eqx.Module."""
     return isinstance(leaf, eqx.Module) and not isinstance(leaf, LoRAWrapper) and isinstance(leaf, LinearLike)
+
+
+def _conv_applies_to(leaf: Any) -> bool:
+    """Shared predicate: any unwrapped ConvLike eqx.Module (ConvTranspose excluded)."""
+    return (
+        isinstance(leaf, eqx.Module)
+        and not isinstance(leaf, LoRAWrapper)
+        and isinstance(leaf, ConvLike)
+        and not isinstance(leaf, _CONV_TRANSPOSE_TYPES)
+    )
 
 
 class rsLoRALinear(LoRALinear):
@@ -796,4 +848,541 @@ class OFTLinear(LoRAWrapper):
 
     def merge(self) -> eqx.Module:
         W_new = self._R() @ self.base.weight
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+# =====================================================================
+# LoRA Zoo — Conv variants (LoRAConv through OFTConv)
+#
+# All conv adapters:
+#   - target ``eqx.nn.Conv1d/2d/3d`` (ConvTranspose excluded)
+#   - flatten weight to (out_channels, flat_in) for linear-algebra ops
+#   - reconstruct via ``eqx.tree_at(lambda m: m.weight, base, W_new)(x)``
+#     so XLA fuses the weight substitution into a single conv kernel call
+#   - store ``weight_shape`` as a static field for shape-safe reshaping
+# =====================================================================
+
+
+class LoRAConv(LoRAWrapper):
+    """Standard LoRA for convolutional layers.
+
+    Flattens the weight tensor to ``(out_channels, flat_in)`` and applies
+    a low-rank update identical to ``LoRALinear``:
+
+        W' = W + (alpha/rank) * lora_B @ lora_A    (in flattened space)
+
+    The updated weight is reshaped back and passed to the base conv via
+    ``eqx.tree_at``, which XLA fuses into a single conv kernel call.
+
+    ``flat_in = in_channels // groups * prod(kernel_size)``
+    """
+
+    adapter_fields = ("lora_A", "lora_B")
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in)
+    lora_B: jax.Array  # (out_channels, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.base = base
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        self.rank = min(rank, min(out_ch, flat_in))
+        self.alpha = alpha
+        k1, _ = jax.random.split(key)
+        std = 1.0 / jnp.sqrt(flat_in)
+        self.lora_A = jax.random.normal(k1, (self.rank, flat_in)) * std
+        self.lora_B = jnp.zeros((out_ch, self.rank))
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class rsLoRAConv(LoRAConv):
+    """Rank-Stabilized LoRA for conv layers.  Scales by ``alpha/sqrt(rank)``.
+
+    Reference: https://arxiv.org/abs/2312.03732
+    """
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / jnp.sqrt(self.rank))
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.lora_A * (self.alpha / jnp.sqrt(self.rank))
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class LoRAFAConv(LoRAConv):
+    """Frozen-A LoRA for conv layers.  Only ``lora_B`` is trained.
+
+    Reference: https://arxiv.org/abs/2308.03303
+    """
+
+    adapter_fields = ("lora_B",)  # lora_A stays in pytree but is frozen
+
+
+class DoRAConv(LoRAWrapper):
+    """Weight-Decomposed Low-Rank Adaptation for conv layers.
+
+    Operates on the flattened weight ``(out_channels, flat_in)`` exactly
+    as ``DoRALinear`` does on a 2-D linear weight.
+
+    Reference: https://arxiv.org/abs/2402.09353
+    """
+
+    adapter_fields = ("magnitude", "lora_A", "lora_B")
+
+    base: ConvLike
+    magnitude: jax.Array  # (out_channels,) — learned per-output-channel scale
+    lora_A: jax.Array  # (rank, flat_in)
+    lora_B: jax.Array  # (out_channels, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        self.rank = min(rank, min(out_ch, flat_in))
+        self.alpha = alpha
+        self.base = base
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        self.magnitude = jnp.linalg.norm(W_flat, axis=1)
+        k1, _ = jax.random.split(key)
+        std = 1.0 / jnp.sqrt(flat_in)
+        self.lora_A = jax.random.normal(k1, (self.rank, flat_in)) * std
+        self.lora_B = jnp.zeros((out_ch, self.rank))
+
+    def _dora_weight_flat(self) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_flat = W_flat + (self.alpha / self.rank) * (self.lora_B @ self.lora_A)
+        row_norms = jnp.linalg.norm(W_flat, axis=1, keepdims=True)
+        return self.magnitude[:, None] * W_flat / row_norms
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        W_new = self._dora_weight_flat().reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        W_new = self._dora_weight_flat().reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class PiSSAConv(LoRAWrapper):
+    """Principal Singular Values and Singular Vectors Adaptation for conv layers.
+
+    SVD is computed on the flattened weight ``(out_channels, flat_in)``.
+    Adapters start from the top-r singular components; base holds the residual.
+
+    Reference: https://arxiv.org/abs/2404.02948
+    """
+
+    adapter_fields = ("lora_A", "lora_B")
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in)
+    lora_B: jax.Array  # (out_channels, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        U, S, Vt = jnp.linalg.svd(W_flat, full_matrices=False)
+        U_r, S_r, Vt_r = U[:, :r], S[:r], Vt[:r, :]
+
+        scale = jnp.sqrt(S_r * r / alpha)
+        self.lora_B = U_r * scale[None, :]
+        self.lora_A = Vt_r * scale[:, None]
+
+        W_residual = (W_flat - (alpha / r) * (self.lora_B @ self.lora_A)).reshape(self.weight_shape)
+        self.base = eqx.tree_at(lambda m: m.weight, base, W_residual)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class LoRAXSConv(LoRAWrapper):
+    """LoRA-XS extra-small adapter for conv layers.
+
+    ``lora_A`` and ``lora_B`` are frozen (from SVD of flattened weight).
+    Only the small ``R`` (rank × rank) matrix is trained.
+
+    Reference: https://arxiv.org/abs/2405.17604
+    """
+
+    adapter_fields = ("R",)
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in) — frozen, from SVD
+    lora_B: jax.Array  # (out_channels, rank) — frozen, from SVD
+    R: jax.Array  # (rank, rank) — the only trainable parameter
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+        self.base = base
+
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        U, _, Vt = jnp.linalg.svd(W_flat, full_matrices=False)
+        self.lora_A = Vt[:r, :]
+        self.lora_B = U[:, :r]
+        self.R = jnp.zeros((r, r))
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.R @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = self.lora_B @ self.R @ self.lora_A * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class VeRAConv(LoRAWrapper):
+    """Vector-based Random Matrix Adaptation for conv layers.
+
+    A and B are generated on-the-fly from a stored seed (XLA constants).
+    Only per-channel ``b`` (out_channels,) and ``d`` (rank,) are trained.
+
+    Reference: https://arxiv.org/abs/2310.11454
+    """
+
+    adapter_fields = ("b", "d")
+
+    base: ConvLike
+    b: jax.Array  # (out_channels,) — trainable output-channel scale
+    d: jax.Array  # (rank,)         — trainable row scale for A
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    seed: int = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.base = base
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        self.rank = rank
+        self.alpha = alpha
+        self.seed = int(jax.random.randint(key, shape=(), minval=0, maxval=2**30))
+        self.b = jnp.zeros(out_ch)
+        self.d = jnp.ones(rank)
+
+    def _frozen_AB(self) -> tuple[jax.Array, jax.Array]:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        A = jax.random.normal(jax.random.PRNGKey(self.seed), (self.rank, flat_in)) / jnp.sqrt(flat_in)
+        B = jax.random.normal(jax.random.PRNGKey(self.seed + 1), (out_ch, self.rank))
+        return A, B
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        A, B = self._frozen_AB()
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = (self.b[:, None] * B) @ (self.d[:, None] * A) * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        A, B = self._frozen_AB()
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        delta = (self.b[:, None] * B) @ (self.d[:, None] * A) * (self.alpha / self.rank)
+        W_new = (W_flat + delta).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class MiLoRAConv(LoRAWrapper):
+    """Minor Singular Values and Singular Vectors Adaptation for conv layers.
+
+    Like ``PiSSAConv`` but adapts the minor (least-significant) singular
+    components; base retains the principal directions.
+
+    Reference: https://arxiv.org/abs/2405.09913
+    """
+
+    adapter_fields = ("lora_A", "lora_B")
+
+    base: ConvLike
+    lora_A: jax.Array  # (rank, flat_in) — minor right singular vectors
+    lora_B: jax.Array  # (out_channels, rank) — minor left singular vectors
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+
+        W_flat = base.weight.reshape(out_ch, flat_in)
+        U, S, Vt = jnp.linalg.svd(W_flat, full_matrices=False)
+        U_r, S_r, Vt_r = U[:, -r:], S[-r:], Vt[-r:, :]
+
+        scale = jnp.sqrt(S_r * r / alpha)
+        self.lora_B = U_r * scale[None, :]
+        self.lora_A = Vt_r * scale[:, None]
+
+        W_residual = (W_flat - (alpha / r) * (self.lora_B @ self.lora_A)).reshape(self.weight_shape)
+        self.base = eqx.tree_at(lambda m: m.weight, base, W_residual)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self.lora_B @ self.lora_A * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class IA3Conv(LoRAWrapper):
+    """IA³ output-scaling adapter for conv layers.
+
+    Applies a learned per-output-channel scale to the conv weight before
+    the convolution.  No low-rank matrices — trainable params = ``out_channels``.
+
+    Reference: https://arxiv.org/abs/2205.05638
+    """
+
+    adapter_fields = ("scale",)
+
+    base: ConvLike
+    scale: jax.Array  # (out_channels,) — learned per-channel multiplier
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.base = base
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        self.rank = rank
+        self.alpha = alpha
+        self.scale = jnp.ones(out_ch)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        # Broadcast scale over all non-output axes: (out_ch, 1, 1, ...)
+        scale_shape = (self.weight_shape[0],) + (1,) * (len(self.weight_shape) - 1)
+        W_new = self.base.weight * self.scale.reshape(scale_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        scale_shape = (self.weight_shape[0],) + (1,) * (len(self.weight_shape) - 1)
+        W_new = self.base.weight * self.scale.reshape(scale_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class LoKrConv(LoRAWrapper):
+    """Kronecker-product adapter for conv layers.
+
+    The weight delta is a Kronecker product of two small matrices, cropped to
+    ``(out_channels, flat_in)`` and reshaped to the original weight shape.
+
+    Reference: https://arxiv.org/abs/2212.10650
+    """
+
+    adapter_fields = ("kron_A", "kron_B")
+
+    base: ConvLike
+    kron_A: jax.Array  # (rank, rank)
+    kron_B: jax.Array  # (ceil(out_ch/rank), ceil(flat_in/rank))
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        flat_in = _math.prod(base.weight.shape[1:])
+        r = min(rank, min(out_ch, flat_in))
+        self.rank = r
+        self.alpha = alpha
+        self.base = base
+
+        m2 = _math.ceil(out_ch / r)
+        n2 = _math.ceil(flat_in / r)
+        self.kron_A = jax.random.normal(key, (r, r)) / jnp.sqrt(r)
+        self.kron_B = jnp.zeros((m2, n2))
+
+    def _delta_W_flat(self) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        return jnp.kron(self.kron_A, self.kron_B)[:out_ch, :flat_in]
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self._delta_W_flat() * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (W_flat + self._delta_W_flat() * (self.alpha / self.rank)).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)
+
+
+class OFTConv(LoRAWrapper):
+    """Orthogonal Fine-Tuning for conv layers.
+
+    The block-diagonal Cayley map is applied to the output-channel axis of
+    the flattened weight ``(out_channels, flat_in)``, identical to
+    ``OFTLinear`` on a 2-D weight.
+
+    Reference: https://arxiv.org/abs/2306.07280
+    """
+
+    adapter_fields = ("Q_blocks",)
+
+    base: ConvLike
+    Q_blocks: jax.Array  # (n_blocks, rank, rank)
+    rank: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    n_blocks: int = eqx.field(static=True)
+    weight_shape: tuple = eqx.field(static=True)
+
+    @classmethod
+    def applies_to(cls, leaf: Any) -> bool:
+        return _conv_applies_to(leaf)
+
+    def __init__(self, base: ConvLike, rank: int, alpha: float, *, key: jax.Array):
+        self.weight_shape = tuple(base.weight.shape)
+        out_ch = base.weight.shape[0]
+        r = min(rank, out_ch)
+        self.rank = r
+        self.alpha = alpha
+        self.n_blocks = _math.ceil(out_ch / r)
+        self.base = base
+        self.Q_blocks = jnp.zeros((self.n_blocks, r, r))
+
+    def _R(self) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        eye = jnp.eye(self.rank)
+
+        def cayley(Q: jax.Array) -> jax.Array:
+            Qs = (Q - Q.T) / 2
+            return (eye - Qs) @ jnp.linalg.inv(eye + Qs)
+
+        blocks = jax.vmap(cayley)(self.Q_blocks)
+        R_padded = jax.scipy.linalg.block_diag(*[blocks[i] for i in range(self.n_blocks)])
+        return R_padded[:out_ch, :out_ch]
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (self._R() @ W_flat).reshape(self.weight_shape)
+        return eqx.tree_at(lambda m: m.weight, self.base, W_new)(x)
+
+    def merge(self) -> eqx.Module:
+        out_ch = self.weight_shape[0]
+        flat_in = _math.prod(self.weight_shape[1:])
+        W_flat = self.base.weight.reshape(out_ch, flat_in)
+        W_new = (self._R() @ W_flat).reshape(self.weight_shape)
         return eqx.tree_at(lambda m: m.weight, self.base, W_new)

--- a/jno/core.py
+++ b/jno/core.py
@@ -24,6 +24,9 @@ from .architectures.lora import (
 from .architectures.lora import (
     merge_lora as _merge_lora,
 )
+from .architectures.lora import (
+    partial_lora_trainable_filter as _partial_lora_trainable_filter,
+)
 from .domain import DomainData, domain
 from .trace import (
     BinaryOp,
@@ -1126,7 +1129,12 @@ class core:
                 self.rng, key = jax.random.split(self.rng)
                 n_params_before = sum(param.size for param in jax.tree_util.tree_leaves(models[lid]) if eqx.is_array(param))
 
-                models[lid] = _apply_lora(models[lid], key=key, specs=fm._lora_config)
+                models[lid] = _apply_lora(
+                    models[lid],
+                    key=key,
+                    specs=fm._lora_config,
+                    param_mask=getattr(fm, "_lora_param_mask", None),
+                )
 
                 model_after = models[lid]
                 n_params_after = sum(param.size for param in jax.tree_util.tree_leaves(model_after) if eqx.is_array(param))
@@ -1171,16 +1179,15 @@ class core:
             fm = flax_mods.get(lid)
             if fm is not None and fm._lora_config is not None:
                 # LoRA modes:
-                # 1) fm._frozen=True  -> freeze all base params, train LoRA only
-                # 2) fm._trainable_param_mask -> custom base trainability mask,
-                #                        train non-target base + LoRA params
-                # 3) otherwise        -> default LoRA behaviour (freeze all base)
+                # 1) fm._frozen=True  -> freeze everything; only LoRA adapters trainable.
+                #    (freeze().lora() or freeze().mask(M).lora() both land here — base
+                #    params outside LoRA-wrapped layers are frozen too.)
+                # 2) otherwise        -> partial LoRA: adapters trainable, wrapped bases
+                #    frozen, every other param stays trainable (mask(M).lora() case).
                 if fm._frozen:
                     filter_spec[lid] = _lora_trainable_filter(model)
-                elif fm._trainable_param_mask is not None:
-                    filter_spec[lid] = _lora_trainable_filter(model)
                 else:
-                    filter_spec[lid] = _lora_trainable_filter(model)
+                    filter_spec[lid] = _partial_lora_trainable_filter(model)
             elif fm is not None and fm._frozen:
                 # Whole model frozen – no arrays trainable
                 filter_spec[lid] = jax.tree_util.tree_map(lambda leaf: False, model)

--- a/jno/lora.py
+++ b/jno/lora.py
@@ -7,29 +7,46 @@ Import via::
 
 or::
 
-    from jno.lora import rsLoRALinear, DoRALinear
+    from jno.lora import rsLoRALinear, DoRALinear, LoRAConv
 """
 
 from .architectures.lora import (
+    ConvLike,
+    DoRAConv,
     DoRALinear,
+    IA3Conv,
     IA3Linear,
+    LinearLike,
+    LoKrConv,
     LoKrLinear,
+    LoRAConv,
+    LoRAFAConv,
     LoRAFALinear,
     LoRALinear,
     LoRAWrapper,
+    LoRAXSConv,
     LoRAXSLinear,
+    MiLoRAConv,
     MiLoRALinear,
+    OFTConv,
     OFTLinear,
+    PiSSAConv,
     PiSSALinear,
+    VeRAConv,
     VeRALinear,
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    rsLoRAConv,
     rsLoRALinear,
 )
 
 __all__ = [
+    # Base
     "LoRAWrapper",
+    "LinearLike",
+    "ConvLike",
+    # Linear zoo
     "LoRALinear",
     "rsLoRALinear",
     "LoRAFALinear",
@@ -41,6 +58,19 @@ __all__ = [
     "IA3Linear",
     "LoKrLinear",
     "OFTLinear",
+    # Conv zoo
+    "LoRAConv",
+    "rsLoRAConv",
+    "LoRAFAConv",
+    "DoRAConv",
+    "PiSSAConv",
+    "LoRAXSConv",
+    "VeRAConv",
+    "MiLoRAConv",
+    "IA3Conv",
+    "LoKrConv",
+    "OFTConv",
+    # Utilities
     "apply_lora",
     "merge_lora",
     "lora_trainable_filter",

--- a/jno/lora.py
+++ b/jno/lora.py
@@ -37,6 +37,7 @@ from .architectures.lora import (
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    partial_lora_trainable_filter,
     rsLoRAConv,
     rsLoRALinear,
 )
@@ -74,4 +75,5 @@ __all__ = [
     "apply_lora",
     "merge_lora",
     "lora_trainable_filter",
+    "partial_lora_trainable_filter",
 ]

--- a/jno/trace.py
+++ b/jno/trace.py
@@ -977,6 +977,7 @@ class Model(Placeholder):
         self._dtype = None  # target dtype (e.g. jnp.bfloat16) or None
         self._param_mask = None  # current mask scope for grouped optimizer/lr calls
         self._trainable_param_mask = None  # persistent trainability mask used by mask(...).freeze()
+        self._lora_param_mask = None  # param mask passed to mask().lora() → restricts which modules get LoRA
         self._mask_scope_pending: bool = False  # transient flag for mask(...).optimizer()/lr() group scoping
         self._param_groups: list = []  # [{target, mask, opt_fn, lr}] for per-group optimizer config
         self._weight_tree = None  # pretrained weights as a pytree (alternative to weight_path file)
@@ -1040,6 +1041,7 @@ class Model(Placeholder):
             "-" * 60,
             f"mask_active:          {self._param_mask is not None}",
             f"trainable_mask_set:   {self._trainable_param_mask is not None}",
+            f"lora_mask_set:        {self._lora_param_mask is not None}",
             "",
             "Parameter Groups",
             "-" * 60,
@@ -1201,30 +1203,35 @@ class Model(Placeholder):
            The first matching spec wins.
 
         By default only the low-rank adapters are trained; base weights are
-        frozen.  Call ``freeze()`` before ``lora()`` to also freeze any
-        base parameters that are outside LoRA-wrapped layers::
+        frozen.  Layers that are NOT wrapped by LoRA remain fully trainable.
+        Call ``freeze()`` before ``lora()`` to also freeze any parameters
+        outside LoRA-wrapped layers::
 
             NN.freeze().lora(rank=8, alpha=16)
+
+        Use ``mask(M)`` to restrict which layers receive LoRA adapters::
+
+            NN.mask(M).lora(rank=8, alpha=16)  # only M-selected layers are wrapped
 
         Args:
             rank:    LoRA rank (uniform mode).
             alpha:   LoRA scaling factor (uniform mode).
-            target:  Regex to restrict which layers are wrapped (uniform mode).
+            target:  Regex to restrict *which layers get LoRA adapters* (uniform
+                     mode only).  Layers whose pytree path does not match are left
+                     completely untouched.  Use ``specs=`` for per-group targeting.
             wrapper: Adapter class or list of classes to try in order.
-                     Defaults to ``LoRALinear`` (wraps ``LinearLike`` layers).
-                     Pass a custom ``LoRAWrapper`` subclass to support other
-                     layer types (e.g. convolutions).
+                     Defaults to ``(LoRALinear, LoRAConv)`` — wraps both linear
+                     and conv layers.  Pass a single class or list to override.
             specs:   Per-target specs (per-target mode).  Each dict has keys
                      ``target`` (str regex), ``rank`` (int), ``alpha`` (float),
                      and optionally ``wrapper``.
         """
         if self._mask_scope_pending and self._param_mask is not None:
-            self._trainable_param_mask = jax.tree_util.tree_map(
-                lambda x: (not x) if isinstance(x, bool) else False,
-                self._param_mask,
-            )
+            self._lora_param_mask = self._param_mask
         else:
-            self._trainable_param_mask = None
+            self._lora_param_mask = None
+        # lora() always clears any stale freeze mask — it overrides mask().freeze() semantics.
+        self._trainable_param_mask = None
         self._mask_scope_pending = False
 
         default_wrappers = _normalize_wrappers(wrapper)
@@ -1465,6 +1472,7 @@ class Model(Placeholder):
         self._dtype = None
         self._param_mask = None
         self._trainable_param_mask = None
+        self._lora_param_mask = None
         self._mask_scope_pending = False
         self._weight_tree = None
         self._initialize_mask = None

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -57,6 +57,7 @@ from jno.lora import (
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    partial_lora_trainable_filter,
     rsLoRAConv,
     rsLoRALinear,
 )
@@ -228,6 +229,58 @@ class TestApplyLora:
         leaves = jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper))
         assert all(isinstance(leaf, rsLoRALinear) for leaf in leaves if isinstance(leaf, LoRAWrapper))
 
+    def test_param_mask_restricts_wrapping(self):
+        """param_mask restricts apply_lora to only mask-selected modules."""
+        mlp = _mlp()
+        n_all = _count_wrappers(apply_lora(mlp, rank=2, alpha=1.0, key=KEY))
+        assert n_all > 1, "need more than one layer for this test to be meaningful"
+
+        # Build a mask selecting only the first hidden layer's weight and bias.
+        all_false = jax.tree_util.tree_map(lambda _: False, mlp)
+        first_layer_mask = eqx.tree_at(
+            lambda m: (m.hidden_layers[0].weight, m.hidden_layers[0].bias),
+            all_false,
+            (True, True),
+        )
+        adapted = apply_lora(mlp, rank=2, alpha=1.0, key=KEY, param_mask=first_layer_mask)
+        n_masked = _count_wrappers(adapted)
+        assert n_masked == 1, f"expected 1 wrapped layer, got {n_masked}"
+
+    def test_param_mask_all_false_wraps_nothing(self):
+        """param_mask with all False → no layers are wrapped."""
+        mlp = _mlp()
+        all_false = jax.tree_util.tree_map(lambda _: False, mlp)
+        adapted = apply_lora(mlp, rank=2, alpha=1.0, key=KEY, param_mask=all_false)
+        assert _count_wrappers(adapted) == 0
+
+    def test_param_mask_prefix_safety(self):
+        """Mask on 'layer1' must not accidentally wrap 'layer10' (prefix-overlap safety)."""
+
+        class TwinNet(eqx.Module):
+            layer1: eqx.nn.Linear
+            layer10: eqx.nn.Linear
+
+            def __call__(self, x):
+                return self.layer10(jax.nn.relu(self.layer1(x)))
+
+        net = TwinNet(
+            layer1=eqx.nn.Linear(4, 4, key=KEY),
+            layer10=eqx.nn.Linear(4, 2, key=KEY),
+        )
+        all_false = jax.tree_util.tree_map(lambda _: False, net)
+        # Select only layer1.weight
+        mask = eqx.tree_at(lambda m: m.layer1.weight, all_false, True)
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, param_mask=mask)
+        lora_leaves = [
+            leaf
+            for leaf in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper))
+            if isinstance(leaf, LoRAWrapper)
+        ]
+        assert len(lora_leaves) == 1
+        assert isinstance(lora_leaves[0].base, eqx.nn.Linear)
+        # Verify it's layer1, not layer10 — layer1 has out_features=4, layer10=2
+        assert lora_leaves[0].base.out_features == 4
+
     def test_custom_wrapper(self):
         """A user-defined LoRAWrapper subclass plugs in and its adapter fields are counted."""
         from jno.architectures.lora import LinearLike
@@ -353,6 +406,89 @@ class TestTrainableFilter:
         adapted = apply_lora(_mlp(), rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
         n_true = _count_adapter_leaves(adapted)
         assert n_true == _ADAPTER_LEAVES[cls]
+
+
+# ---------------------------------------------------------------------------
+# 5b. partial_lora_trainable_filter
+# ---------------------------------------------------------------------------
+
+
+class TestPartialLoraTrainableFilter:
+    """Tests for partial_lora_trainable_filter (used by mask(M).lora() without freeze())."""
+
+    def _adapted_first_only(self):
+        """MLP with only the first hidden layer LoRA-wrapped."""
+        mlp = _mlp()
+        all_false = jax.tree_util.tree_map(lambda _: False, mlp)
+        mask = eqx.tree_at(
+            lambda m: (m.hidden_layers[0].weight, m.hidden_layers[0].bias),
+            all_false,
+            (True, True),
+        )
+        return apply_lora(mlp, rank=2, alpha=1.0, key=KEY, param_mask=mask)
+
+    def test_adapter_arrays_are_trainable(self):
+        """Adapter arrays inside LoRA wrappers must be True in the filter."""
+        adapted = self._adapted_first_only()
+        filt = partial_lora_trainable_filter(adapted)
+        flat_arrays = jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_inexact_array))
+        flat_filt = jax.tree_util.tree_leaves(filt)
+        # collect (trainable, array) pairs for just adapter arrays
+        from jno.lora import LoRAWrapper
+
+        adapter_ids = set()
+        for node in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper)):
+            if isinstance(node, LoRAWrapper):
+                for fname in node.adapter_fields:
+                    arr = getattr(node, fname, None)
+                    if eqx.is_array(arr):
+                        adapter_ids.add(id(arr))
+        for arr, f in zip(flat_arrays, flat_filt):
+            if id(arr) in adapter_ids:
+                assert f is True, "adapter array must be trainable"
+
+    def test_wrapped_base_frozen(self):
+        """Base arrays inside LoRA wrappers must be False."""
+        adapted = self._adapted_first_only()
+        filt = partial_lora_trainable_filter(adapted)
+        from jno.lora import LoRAWrapper
+
+        wrapped_base_ids = set()
+        for node in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper)):
+            if isinstance(node, LoRAWrapper):
+                for arr in jax.tree_util.tree_leaves(node.base):
+                    if eqx.is_array(arr):
+                        wrapped_base_ids.add(id(arr))
+        flat_arrays = jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_array))
+        flat_filt = jax.tree_util.tree_leaves(filt)
+        for arr, f in zip(flat_arrays, flat_filt):
+            if id(arr) in wrapped_base_ids:
+                assert f is False, "base array inside wrapper must be frozen"
+
+    def test_unwrapped_params_trainable(self):
+        """Arrays outside any LoRA wrapper must be True (they stay trainable)."""
+        adapted = self._adapted_first_only()
+        filt = partial_lora_trainable_filter(adapted)
+        from jno.lora import LoRAWrapper
+
+        all_lora_ids = set()
+        for node in jax.tree_util.tree_leaves(adapted, is_leaf=lambda x: isinstance(x, LoRAWrapper)):
+            if isinstance(node, LoRAWrapper):
+                for arr in jax.tree_util.tree_leaves(node):
+                    if eqx.is_array(arr):
+                        all_lora_ids.add(id(arr))
+        flat_arrays = jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_inexact_array))
+        flat_filt = jax.tree_util.tree_leaves(filt)
+        for arr, f in zip(flat_arrays, flat_filt):
+            if id(arr) not in all_lora_ids:
+                assert f is True, "unwrapped param must remain trainable"
+
+    def test_more_trainable_than_lora_filter(self):
+        """partial filter marks more params True than lora_trainable_filter (unwrapped layers)."""
+        adapted = self._adapted_first_only()
+        n_partial = sum(1 for v in jax.tree_util.tree_leaves(partial_lora_trainable_filter(adapted)) if v)
+        n_lora = sum(1 for v in jax.tree_util.tree_leaves(lora_trainable_filter(adapted)) if v)
+        assert n_partial > n_lora, "partial filter should train more params than lora-only filter"
 
 
 # ---------------------------------------------------------------------------
@@ -801,33 +937,33 @@ class TestModelControlStateCombinations:
         assert net._frozen is True
         assert net._trainable_param_mask is None
 
-    def test_mask_lora_sets_both_trainable_mask_and_config(self):
-        """mask(m).lora() stores _trainable_param_mask and _lora_config simultaneously."""
+    def test_mask_lora_sets_lora_param_mask_and_config(self):
+        """mask(m).lora() stores _lora_param_mask (as-is) and _lora_config; clears trainable mask."""
         net = self._net()
-        net.mask(self._all_true_mask()).lora(rank=4, alpha=1.0)
-        assert net._trainable_param_mask is not None
+        mask = self._all_true_mask()
+        net.mask(mask).lora(rank=4, alpha=1.0)
+        assert net._lora_param_mask is mask
         assert net._lora_config is not None
+        assert net._trainable_param_mask is None
 
     def test_freeze_then_lora_leaves_no_trainable_mask(self):
-        """freeze().lora() produces _frozen=True, _lora_config set, _trainable_param_mask=None.
-
-        freeze() consumes the (absent) mask scope and leaves _mask_scope_pending=False,
-        so the subsequent lora() call sees no pending mask.
-        """
+        """freeze().lora() produces _frozen=True, _lora_config set, no masks."""
         net = self._net()
         net.freeze().lora(rank=4, alpha=1.0)
         assert net._frozen is True
         assert net._lora_config is not None
         assert net._trainable_param_mask is None
+        assert net._lora_param_mask is None
 
     def test_mask_freeze_then_lora_mask_already_consumed(self):
-        """mask(m).freeze() followed by .lora() — mask scope consumed by freeze."""
+        """mask(m).freeze() followed by .lora() — mask scope consumed by freeze, lora clears lora_mask."""
         net = self._net()
         net.mask(self._all_true_mask()).freeze()  # mask scope consumed here
         net.lora(rank=4, alpha=1.0)  # no pending mask
         assert net._frozen is False  # mask.freeze(), not global
         assert net._lora_config is not None
-        assert net._trainable_param_mask is None  # lora() cleared it (no pending mask)
+        assert net._trainable_param_mask is None  # not set by lora()
+        assert net._lora_param_mask is None  # no pending mask → cleared
 
     def test_mask_scope_consumed_after_freeze(self):
         """_mask_scope_pending is False after freeze() regardless of preceding mask()."""
@@ -841,13 +977,14 @@ class TestModelControlStateCombinations:
         """reset() zeroes every training-time control field."""
         net = self._net()
         net.mask(self._all_true_mask()).freeze()
-        net.lora(rank=4, alpha=1.0)
+        net.mask(self._all_true_mask()).lora(rank=4, alpha=1.0)
         net.optimizer(optax.adam, lr=lrs(1e-3))
         net.dtype(jnp.bfloat16)
         net.reset()
         assert net._frozen is False
         assert net._lora_config is None
         assert net._trainable_param_mask is None
+        assert net._lora_param_mask is None
         assert net._opt_fn is None
         assert net._lr is None
         assert net._dtype is None
@@ -1009,14 +1146,31 @@ class TestIntegrationCombinations:
 
     # ── mask(m).lora(): adapters train, no crash ──────────────────────────────
 
-    def test_mask_lora_no_crash_adapters_train(self):
-        """mask(m).lora() stores _trainable_param_mask but core uses lora_trainable_filter;
-        only adapter arrays train regardless of the mask — must not crash."""
+    def test_mask_lora_restricts_wrapped_layers(self):
+        """mask(M).lora() wraps only M-selected modules; unwrapped params stay trainable."""
+        import equinox as eqx
+
         m = foundax.mlp(1, output_dim=1, hidden_dims=16, num_layers=2, key=KEY)
         net = nn.wrap(m)
-        leaves, treedef = jax.tree_util.tree_flatten(eqx.filter(m, eqx.is_array))
-        half_mask = jax.tree_util.tree_unflatten(treedef, [i < len(leaves) // 2 for i in range(len(leaves))])
-        net.mask(half_mask).lora(rank=4, alpha=1.0).optimizer(optax.adam, lr=lrs(1e-3))
+
+        # Build a mask that selects ONLY the first layer's weight.
+        all_false = jax.tree_util.tree_map(lambda _: False, m)
+        first_layer_mask = eqx.tree_at(lambda mod: mod.hidden_layers[0].weight, all_false, True)
+
+        net.mask(first_layer_mask).lora(rank=4, alpha=1.0).optimizer(optax.adam, lr=lrs(1e-3))
+        assert jnp.isfinite(self._solve_single(net))
+
+    def test_mask_all_false_lora_wraps_nothing(self):
+        """mask(all_false).lora() wraps no layers — model trains all params normally."""
+
+        m = foundax.mlp(1, output_dim=1, hidden_dims=16, num_layers=2, key=KEY)
+        net = nn.wrap(m)
+        all_false = jax.tree_util.tree_map(lambda _: False, m)
+        net.mask(all_false).lora(rank=4, alpha=1.0).optimizer(optax.adam, lr=lrs(1e-3))
+
+        # _lora_param_mask is all-False so no modules should be wrapped after solve
+        # We verify via the state check (lora_config set, but mask was all-False)
+        assert net._lora_param_mask is all_false
         assert jnp.isfinite(self._solve_single(net))
 
     # ── dtype(bfloat16) + freeze + lora ─────────────────────────────────────

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -3,8 +3,10 @@
 Covers:
   - Public namespace: jno.lora.<class>
   - Core utilities: apply_lora, merge_lora, lora_trainable_filter
-  - LoRA Zoo: LoRALinear, rsLoRALinear, LoRAFALinear, DoRALinear, PiSSALinear, LoRAXSLinear,
-              VeRALinear, MiLoRALinear, IA3Linear, LoKrLinear, OFTLinear
+  - LoRA Zoo (linear): LoRALinear, rsLoRALinear, LoRAFALinear, DoRALinear, PiSSALinear,
+                        LoRAXSLinear, VeRALinear, MiLoRALinear, IA3Linear, LoKrLinear, OFTLinear
+  - LoRA Zoo (conv):   LoRAConv, rsLoRAConv, LoRAFAConv, DoRAConv, PiSSAConv, LoRAXSConv,
+                        VeRAConv, MiLoRAConv, IA3Conv, LoKrConv, OFTConv
   - apply_lora options: target regex, per-spec routing, list-of-wrappers, custom wrapper
   - Initialisation invariant: all adapters are no-ops at init (output == base)
   - Merge: merged output == adapted output; no LoRAWrapper nodes remain
@@ -16,6 +18,7 @@ Covers:
   - Model.lora() API: config structure, wrapper=, specs=
   - Model control state combinations: mask/freeze/lora/reset chaining
   - Integration: end-to-end training through jno.core, including complex combinations
+  - Conv zoo: apply, init invariant, merge, trainable filter for all 11 conv adapters
 """
 
 import equinox as eqx
@@ -30,20 +33,31 @@ import jno.jnp_ops as jnn
 from jno import LearningRateSchedule as lrs
 from jno.architectures.models import nn
 from jno.lora import (
+    DoRAConv,
     DoRALinear,
+    IA3Conv,
     IA3Linear,
+    LoKrConv,
     LoKrLinear,
+    LoRAConv,
+    LoRAFAConv,
     LoRAFALinear,
     LoRALinear,
     LoRAWrapper,
+    LoRAXSConv,
     LoRAXSLinear,
+    MiLoRAConv,
     MiLoRALinear,
+    OFTConv,
     OFTLinear,
+    PiSSAConv,
     PiSSALinear,
+    VeRAConv,
     VeRALinear,
     apply_lora,
     lora_trainable_filter,
     merge_lora,
+    rsLoRAConv,
     rsLoRALinear,
 )
 
@@ -69,6 +83,23 @@ _ADAPTER_LEAVES: dict[type[LoRAWrapper], int] = {
 
 ZOO = list(_ADAPTER_LEAVES.keys())
 
+# Expected adapter leaf count for the 2-layer conv net with rank=2
+_CONV_ADAPTER_LEAVES: dict[type[LoRAWrapper], int] = {
+    LoRAConv: 4,  # 2 × (lora_A, lora_B)
+    rsLoRAConv: 4,
+    LoRAFAConv: 2,  # 2 × (lora_B,)
+    DoRAConv: 6,  # 2 × (magnitude, lora_A, lora_B)
+    PiSSAConv: 4,
+    LoRAXSConv: 2,  # 2 × (R,)
+    VeRAConv: 4,  # 2 × (b, d)
+    MiLoRAConv: 4,
+    IA3Conv: 2,  # 2 × (scale,)
+    LoKrConv: 4,  # 2 × (kron_A, kron_B)
+    OFTConv: 2,  # 2 × (Q_blocks,)
+}
+
+CONV_ZOO = list(_CONV_ADAPTER_LEAVES.keys())
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -77,6 +108,25 @@ ZOO = list(_ADAPTER_LEAVES.keys())
 
 def _mlp(key=KEY):
     return foundax.mlp(**_MLP_KW, key=key)
+
+
+class _TinyConvNet(eqx.Module):
+    """Two-layer Conv1d net for conv LoRA tests."""
+
+    conv1: eqx.nn.Conv1d
+    conv2: eqx.nn.Conv1d
+
+    def __call__(self, x):
+        return self.conv2(jax.nn.relu(self.conv1(x)))
+
+
+def _conv_net(key=KEY) -> _TinyConvNet:
+    """Conv1d(2→4, k=3) → relu → Conv1d(4→2, k=3); input shape (2, 8)."""
+    k1, k2 = jax.random.split(key)
+    return _TinyConvNet(
+        conv1=eqx.nn.Conv1d(2, 4, kernel_size=3, key=k1, padding=1),
+        conv2=eqx.nn.Conv1d(4, 2, kernel_size=3, key=k2, padding=1),
+    )
 
 
 def _count_wrappers(model) -> int:
@@ -225,6 +275,16 @@ def test_output_equals_base_at_init(cls):
     # float32 rounding even when Q=0, so use a slightly looser tolerance.
     atol = 1e-4 if cls is OFTLinear else 1e-5
     assert jnp.allclose(mlp(x), adapted(x), atol=atol), f"{cls.__name__}: output differs from base at init"
+
+
+@pytest.mark.parametrize("cls", CONV_ZOO)
+def test_conv_output_equals_base_at_init(cls):
+    """Adapted conv model output must equal base at initialisation."""
+    net = _conv_net()
+    adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+    x = jnp.ones((2, 8))
+    atol = 1e-4 if cls is OFTConv else 1e-5
+    assert jnp.allclose(net(x), adapted(x), atol=atol), f"{cls.__name__}: conv output differs from base at init"
 
 
 # ---------------------------------------------------------------------------
@@ -553,7 +613,7 @@ class TestModelLoraAPI:
     def test_default_config(self):
         net = self._net()
         net.lora(rank=4, alpha=1.0)
-        assert net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear,)}]
+        assert net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
 
     def test_wrapper_param_single(self):
         net = self._net()
@@ -577,10 +637,10 @@ class TestModelLoraAPI:
         assert net._lora_config[0]["rank"] == 4
         assert net._lora_config[1]["rank"] == 16
 
-    def test_specs_default_wrapper_is_lora_linear(self):
+    def test_specs_default_wrapper_is_lora_linear_and_conv(self):
         net = self._net()
         net.lora(specs=[{"target": ".*", "rank": 4, "alpha": 1.0}])
-        assert net._lora_config[0]["wrappers"] == (LoRALinear,)
+        assert net._lora_config[0]["wrappers"] == (LoRALinear, LoRAConv)
 
     def test_specs_per_spec_wrapper(self):
         net = self._net()
@@ -1023,3 +1083,183 @@ class TestIntegrationCombinations:
         loss = (u - jnn.sin(jnn.pi * x)).mse
         stats = jno.core([loss], domain).solve(3)
         assert jnp.isfinite(stats.training_logs[-1]["total_loss"][-1])
+
+
+# ---------------------------------------------------------------------------
+# 12. Conv zoo tests
+# ---------------------------------------------------------------------------
+
+
+class TestConvApplyLora:
+    def test_wraps_conv1d(self):
+        """apply_lora must wrap eqx.nn.Conv1d layers by default."""
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY)
+        assert _count_wrappers(adapted) == 2, "Conv1d layers were not wrapped"
+
+    def test_does_not_wrap_linear_with_conv_wrapper(self):
+        """LoRAConv must not wrap LinearLike layers."""
+        mlp = _mlp()
+        adapted = apply_lora(mlp, rank=2, alpha=1.0, key=KEY, wrappers=(LoRAConv,))
+        assert _count_wrappers(adapted) == 0, "LoRAConv incorrectly wrapped a linear layer"
+
+    @pytest.mark.parametrize("cls", CONV_ZOO)
+    def test_conv_adapter_leaf_count(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        assert _count_adapter_leaves(adapted) == _CONV_ADAPTER_LEAVES[cls]
+
+    def test_no_double_wrap_conv(self):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(LoRAConv,))
+        adapted2 = apply_lora(adapted, rank=2, alpha=1.0, key=KEY, wrappers=(LoRAConv,))
+        assert _count_wrappers(adapted) == _count_wrappers(adapted2)
+
+
+@pytest.mark.parametrize("cls", CONV_ZOO)
+class TestConvMergeLora:
+    @staticmethod
+    def _perturb(model):
+        leaves, treedef = jax.tree_util.tree_flatten(model)
+        leaves = [v + 0.01 * jnp.ones_like(v) if eqx.is_array(v) else v for v in leaves]
+        return jax.tree_util.tree_unflatten(treedef, leaves)
+
+    def test_merged_output_equals_adapted(self, cls):
+        net = _conv_net()
+        adapted = self._perturb(apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,)))
+        merged = merge_lora(adapted)
+        x = jax.random.normal(KEY, (2, 8))
+        assert jnp.allclose(adapted(x), merged(x), atol=1e-5), f"{cls.__name__}: merge_lora output differs from adapted"
+
+    def test_no_wrapper_nodes_after_merge(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        merged = merge_lora(adapted)
+        assert _count_wrappers(merged) == 0, f"{cls.__name__}: wrapper nodes remain after merge"
+
+
+@pytest.mark.parametrize("cls", CONV_ZOO)
+class TestConvTrainableFilter:
+    def test_correct_adapter_count(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        n_true = _count_adapter_leaves(adapted)
+        assert n_true == _CONV_ADAPTER_LEAVES[cls], (
+            f"{cls.__name__}: expected {_CONV_ADAPTER_LEAVES[cls]} adapter leaves, got {n_true}"
+        )
+
+    def test_base_arrays_not_marked(self, cls):
+        net = _conv_net()
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY, wrappers=(cls,))
+        n_true = _count_adapter_leaves(adapted)
+        assert n_true == _CONV_ADAPTER_LEAVES[cls]
+
+
+class TestConvRankClamping:
+    @pytest.mark.parametrize("cls", [PiSSAConv, DoRAConv, LoRAXSConv, MiLoRAConv])
+    def test_conv_rank_clamped_to_min_dim(self, cls):
+        # Conv1d(2, 4, kernel_size=3): out_ch=4, flat_in=2*3=6; min is 4
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = cls(conv, rank=32, alpha=1.0, key=KEY)
+        assert adapted.rank <= min(4, 6)
+
+    def test_oft_conv_rank_clamped_to_out_ch(self):
+        conv = eqx.nn.Conv1d(2, 3, kernel_size=3, key=KEY)
+        adapted = OFTConv(conv, rank=8, alpha=1.0, key=KEY)
+        assert adapted.rank == 3
+
+
+class TestConvPerClassInvariants:
+    def test_lora_conv_lora_b_zero_at_init(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = LoRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.lora_B == 0)
+
+    def test_rs_lora_conv_scaling(self):
+        """rsLoRAConv uses alpha/sqrt(rank); output must differ from LoRAConv for same non-zero B."""
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        x = jax.random.normal(KEY, (2, 8))
+        a = LoRAConv(conv, rank=4, alpha=1.0, key=KEY)
+        r = rsLoRAConv(conv, rank=4, alpha=1.0, key=KEY)
+        delta_B = jax.random.normal(KEY, a.lora_B.shape)
+        a = eqx.tree_at(lambda m: m.lora_B, a, delta_B)
+        r = eqx.tree_at(lambda m: m.lora_B, r, delta_B)
+        assert not jnp.allclose(a(x), r(x), atol=1e-6)
+
+    def test_lora_fa_conv_only_b_trainable(self):
+        assert LoRAFAConv.adapter_fields == ("lora_B",)
+
+    def test_dora_conv_magnitude_init(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = DoRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        W_flat = conv.weight.reshape(4, -1)
+        expected = jnp.linalg.norm(W_flat, axis=1)
+        assert jnp.allclose(adapted.magnitude, expected, atol=1e-6)
+
+    def test_pissa_conv_residual(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        r, alpha = 2, 4.0
+        adapted = PiSSAConv(conv, rank=r, alpha=alpha, key=KEY)
+        out_ch, flat_in = conv.weight.shape[0], conv.weight.reshape(4, -1).shape[1]
+        W_reconstructed = adapted.base.weight.reshape(out_ch, flat_in) + (alpha / r) * (adapted.lora_B @ adapted.lora_A)
+        assert jnp.allclose(W_reconstructed, conv.weight.reshape(out_ch, flat_in), atol=1e-5)
+
+    def test_lora_xs_conv_r_zero(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = LoRAXSConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.R == 0)
+
+    def test_vera_conv_b_zero_d_ones(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = VeRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.b == 0)
+        assert jnp.all(adapted.d == 1)
+
+    def test_vera_conv_no_AB_in_pytree(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = VeRAConv(conv, rank=2, alpha=1.0, key=KEY)
+        shapes = {leaf.shape for leaf in jax.tree_util.tree_leaves(eqx.filter(adapted, eqx.is_array))}
+        flat_in = conv.weight.reshape(4, -1).shape[1]
+        assert (2, flat_in) not in shapes, "A-shaped array found in pytree"
+        assert (4, 2) not in shapes, "B-shaped array found in pytree"
+
+    def test_milora_conv_residual(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        r, alpha = 2, 4.0
+        adapted = MiLoRAConv(conv, rank=r, alpha=alpha, key=KEY)
+        out_ch, flat_in = conv.weight.shape[0], conv.weight.reshape(4, -1).shape[1]
+        W_reconstructed = adapted.base.weight.reshape(out_ch, flat_in) + (alpha / r) * (adapted.lora_B @ adapted.lora_A)
+        assert jnp.allclose(W_reconstructed, conv.weight.reshape(out_ch, flat_in), atol=1e-5)
+
+    def test_ia3_conv_scale_ones(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = IA3Conv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.scale == 1.0)
+        assert adapted.scale.shape == (4,)
+
+    def test_lokr_conv_kron_b_zero(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = LoKrConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.kron_B == 0)
+
+    def test_oft_conv_q_zero_r_identity(self):
+        conv = eqx.nn.Conv1d(2, 4, kernel_size=3, key=KEY)
+        adapted = OFTConv(conv, rank=2, alpha=1.0, key=KEY)
+        assert jnp.all(adapted.Q_blocks == 0)
+        R = adapted._R()
+        assert jnp.allclose(R, jnp.eye(4), atol=1e-6)
+
+    def test_default_apply_lora_wraps_both_linear_and_conv(self):
+        """Default _normalize_wrappers wraps both Linear and Conv layers."""
+
+        class MixedNet(eqx.Module):
+            linear: eqx.nn.Linear
+            conv: eqx.nn.Conv1d
+
+            def __call__(self, x_lin, x_conv):
+                return self.linear(x_lin) + self.conv(x_conv).sum()
+
+        k1, k2 = jax.random.split(KEY)
+        net = MixedNet(linear=eqx.nn.Linear(4, 8, key=k1), conv=eqx.nn.Conv1d(2, 4, kernel_size=3, key=k2))
+        adapted = apply_lora(net, rank=2, alpha=1.0, key=KEY)
+        assert _count_wrappers(adapted) == 2, "Expected both linear and conv layers to be wrapped by default"

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -345,12 +345,12 @@ class TestModelMask:
         """mask().lora() sets _lora_config as a list of dicts and consumes the mask scope."""
         import jax
 
-        from jno.lora import LoRALinear
+        from jno.lora import LoRAConv, LoRALinear
 
         u_net = self._make_eqx_model()
         all_true = jax.tree_util.tree_map(lambda _: True, u_net.module)
         u_net.mask(all_true).lora(rank=4, alpha=1.0)
-        assert u_net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear,)}]
+        assert u_net._lora_config == [{"target": None, "rank": 4, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
         assert u_net._mask_scope_pending is False
 
     def test_manual_mask_optimizer_creates_group_and_keeps_global_fallback(self):
@@ -443,9 +443,9 @@ class TestModelMask:
 
         u_net.mask(all_false).lora(rank=2, alpha=1.0)
 
-        from jno.lora import LoRALinear
+        from jno.lora import LoRAConv, LoRALinear
 
-        assert u_net._lora_config == [{"target": None, "rank": 2, "alpha": 1.0, "wrappers": (LoRALinear,)}]
+        assert u_net._lora_config == [{"target": None, "rank": 2, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
         assert u_net._mask_scope_pending is False
         leaves = jax.tree_util.tree_leaves(u_net._trainable_param_mask)
         assert all(v is True for v in leaves if isinstance(v, bool))

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -435,7 +435,7 @@ class TestModelMask:
         assert u_net._frozen is True
 
     def test_mask_scope_is_one_shot_for_lora(self):
-        """mask().lora() consumes mask scope and stores base trainability mask."""
+        """mask().lora() consumes mask scope and stores mask in _lora_param_mask (not inverted)."""
         import jax
 
         u_net = self._make_eqx_model()
@@ -447,23 +447,25 @@ class TestModelMask:
 
         assert u_net._lora_config == [{"target": None, "rank": 2, "alpha": 1.0, "wrappers": (LoRALinear, LoRAConv)}]
         assert u_net._mask_scope_pending is False
-        leaves = jax.tree_util.tree_leaves(u_net._trainable_param_mask)
-        assert all(v is True for v in leaves if isinstance(v, bool))
+        # Mask stored as-is (not inverted) — all_false means no module is selected for LoRA
+        assert u_net._lora_param_mask is all_false
+        # _trainable_param_mask is no longer used by mask().lora()
+        assert u_net._trainable_param_mask is None
 
-    def test_plain_lora_clears_stale_trainable_mask(self):
-        """A plain lora() call should reset stale base trainability overrides."""
+    def test_plain_lora_clears_stale_lora_mask(self):
+        """A plain lora() call should clear any previously set _lora_param_mask."""
         import jax
 
         u_net = self._make_eqx_model()
         all_false = jax.tree_util.tree_map(lambda _: False, u_net.module)
 
-        # First set a custom base trainability mask via masked LoRA.
+        # First set a lora param mask via masked LoRA.
         u_net.mask(all_false).lora(rank=2, alpha=1.0)
-        assert u_net._trainable_param_mask is not None
+        assert u_net._lora_param_mask is not None
 
-        # A later plain lora() should restore default LoRA semantics.
+        # A later plain lora() should restore default LoRA semantics (no mask restriction).
         u_net.lora(rank=4, alpha=1.0)
-        assert u_net._trainable_param_mask is None
+        assert u_net._lora_param_mask is None
 
     def test_mask_reset_clears_param_mask(self):
         """reset() clears _param_mask back to None."""
@@ -475,6 +477,17 @@ class TestModelMask:
         assert u_net._param_mask is not None
         u_net.reset()
         assert u_net._param_mask is None
+
+    def test_mask_reset_clears_lora_param_mask(self):
+        """reset() clears _lora_param_mask back to None."""
+        import jax
+
+        u_net = self._make_eqx_model()
+        all_true = jax.tree_util.tree_map(lambda _: True, u_net.module)
+        u_net.mask(all_true).lora(rank=2, alpha=1.0)
+        assert u_net._lora_param_mask is not None
+        u_net.reset()
+        assert u_net._lora_param_mask is None
 
     def test_mask_via_model_call_proxies_to_model(self):
         """ModelCall.mask() delegates to the underlying Model."""


### PR DESCRIPTION
## Summary

- **11 convolutional LoRA adapters** added to `jno/architectures/lora.py`, mirroring every existing linear variant: `LoRAConv`, `rsLoRAConv`, `LoRAFAConv`, `DoRAConv`, `PiSSAConv`, `LoRAXSConv`, `VeRAConv`, `MiLoRAConv`, `IA3Conv`, `LoKrConv`, `OFTConv` — all implementing the `ConvLike` protocol
- **Bug fix**: `mask(M).lora()` previously applied LoRA wrapping to all layers regardless of the mask; now correctly restricts wrapping to only the selected layers

## Test plan

- [x] Existing `tests/test_lora.py` extended to cover all 11 new conv adapters
- [x] `tests/test_trace.py` updated for the mask fix
- [x] Full test suite passes