### PR TITLE
Add NetworkGradient operator with LoRA-compatible path matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,50 +37,41 @@ Foundation models and other neural operators  are maintained in a separate repos
 ```python
 import jno
 import jax
-import jax.numpy as jnp
 import optax
 import foundax
-import equinox as eqx
-from jno import LearningRateSchedule as lrs
-from jno.numpy import tracker
 
-dir = jno.setup("./runs/poisson2d")
+dir = jno.setup("./runs/test")
 
-# ── Domain — rect with named boundary sides ────────────────────────────────────
-dom        = jno.domain(constructor=jno.domain.rect(mesh_size=0.05, x_range=(0, 1), y_range=(0, 1)))
-x,  y,  _  = dom.variable("interior")
-xl, yl, _  = dom.variable("left")    # x = 0  →  soft Dirichlet
+# Domain
+dom = 500 * jno.domain.rect(mesh_size=0.05, x_range=(0, 2), y_range=(0, 1))
+x, y, _ = dom.variable("interior")
+xb, yb, _ = dom.variable("boundary")
 
-# ── Network — LoRA adapters on hidden layers ────────────────────────────────────
-net = jno.nn.wrap(
-    foundax.mlp(in_features=2, hidden_dims=64, num_layers=4,
-                activation=jnp.tanh, key=jax.random.PRNGKey(0))
-)
-net.lora(rank=4, alpha=1.0, target="hidden_layers")  # parameter-efficient training
-net.optimizer(optax.adam(1), lr=lrs.exponential(1e-3, 0.5, 5_000, 1e-5))
+random_k = jax.random.uniform(jax.random.PRNGKey(0), shape=(500, 1, 1), minval=0.5, maxval=1.5)
+k = dom.variable("k", random_k)
 
-# ── Forward pass — hard BCs on right (x=1), bottom (y=0), top (y=1) ───────────
-π  = jno.np.pi
-u  = net(jno.np.concat([x,  y ], axis=-1)) * (1 - x)  * y  * (1 - y)
-ul = net(jno.np.concat([xl, yl], axis=-1)) * (1 - xl) * yl * (1 - yl)
+# Neural Network
+fx = foundax.deeponet(n_sensors=1, coord_dim=2, basis_functions=32, hidden_dim=128, activation=jax.numpy.tanh)
+net = jno.nn.wrap(fx)
+net.optimizer(optax.adam(learning_rate=optax.schedules.cosine_decay_schedule(init_value=1e-3, decay_steps=20_000, alpha=1e-5)))
 
-# ── PDE: −∇²u = 2π²sin(πx)sin(πy),  exact u* = sin(πx)sin(πy) ───────────────
-pde     = -(u.dd(x) + u.dd(y)) - 2 * π**2 * jno.np.sin(π * x) * jno.np.sin(π * y)
-bc_left = ul                                          # soft: u(0, y) = 0
+# Forward pass and hard enforcement of BCs via output transformation
+u = net(k, jno.np.concat([x, y], axis=-1)) * x * (2 - x) * y * (1 - y)
+pde = k * (u.dd(x) + u.dd(y)) + 1.0  # PDE Loss
 
-# ── Integral: ∫u dΩ → 4/π² ≈ 0.405 for the exact solution ────────────────────
-vol_tracker = tracker(u.integrate(), interval=500)
+# Checkpointing (saves every 5000 epochs, keeps best 3)
+cb = jno.callbacks.checkpoint(save_interval_epochs=5000, best_fn=lambda m: m["total_loss"])
 
-# ── Gradient alignment — PDE vs. left-BC loss, output-layer params only ───────
-all_false  = jax.tree_util.tree_map(lambda _: False, net.module)
-out_mask   = eqx.tree_at(lambda m: m.output_layer.weight, all_false, True)
-J_pde      = pde.mse.grad(net.mask(out_mask))         # ∂L_pde / ∂θ_out
-J_bc       = bc_left.mse.grad(net.mask(out_mask))     # ∂L_bc  / ∂θ_out
-grad_align = tracker(jno.np.dot(J_pde, J_bc), interval=500)
-
-# ── Solve ──────────────────────────────────────────────────────────────────────
-crux = jno.core([pde.mse, bc_left.mse, vol_tracker, grad_align], domain=dom)
-crux.solve(20_000).plot(f"{dir}/training.png")
+# Create -> Train -> Save
+crux = jno.core(constraints=[pde.mse], domain=dom).print_shapes()
+crux.solve(epochs=20_000, batchsize=32, callbacks=[cb]).plot(f"{dir}/training.png")
 jno.save(crux, f"{dir}/model.pkl")
+
+# Inference via test domain on a finer mesh
+tst_dom = 16 * jno.domain.rect(mesh_size=0.01, x_range=(0, 2), y_range=(0, 1))
+tst_dom.variable("k", jax.random.uniform(jax.random.PRNGKey(0), shape=(16, 1, 1), minval=0.1, maxval=1.9))
+
+pred, x, y, k = crux.eval([u, x, y, k], domain=tst_dom)
+print(pred.shape, x.shape, y.shape, k.shape)
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,17 +51,13 @@ dom        = jno.domain(constructor=jno.domain.rect(mesh_size=0.05, x_range=(0, 
 x,  y,  _  = dom.variable("interior")
 xl, yl, _  = dom.variable("left")    # x = 0  →  soft Dirichlet
 
-# ── Network — LoRA adapters on hidden layers, 10× LR on output layer ───────────
+# ── Network — LoRA adapters on hidden layers ────────────────────────────────────
 net = jno.nn.wrap(
     foundax.mlp(in_features=2, hidden_dims=64, num_layers=4,
                 activation=jnp.tanh, key=jax.random.PRNGKey(0))
 )
-net.lora(rank=4, alpha=1.0)                                            # parameter-efficient training
+net.lora(rank=4, alpha=1.0, target="hidden_layers")  # parameter-efficient training
 net.optimizer(optax.adam(1), lr=lrs.exponential(1e-3, 0.5, 5_000, 1e-5))
-
-all_false = jax.tree_util.tree_map(lambda _: False, net.module)
-out_mask  = eqx.tree_at(lambda m: m.output_layer.weight, all_false, True)
-net.mask(out_mask).lr(lrs.exponential(1e-2, 0.5, 5_000, 1e-4))       # output layer at 10× LR
 
 # ── Forward pass — hard BCs on right (x=1), bottom (y=0), top (y=1) ───────────
 π  = jno.np.pi
@@ -76,6 +72,8 @@ bc_left = ul                                          # soft: u(0, y) = 0
 vol_tracker = tracker(u.integrate(), interval=500)
 
 # ── Gradient alignment — PDE vs. left-BC loss, output-layer params only ───────
+all_false  = jax.tree_util.tree_map(lambda _: False, net.module)
+out_mask   = eqx.tree_at(lambda m: m.output_layer.weight, all_false, True)
 J_pde      = pde.mse.grad(net.mask(out_mask))         # ∂L_pde / ∂θ_out
 J_bc       = bc_left.mse.grad(net.mask(out_mask))     # ∂L_bc  / ∂θ_out
 grad_align = tracker(jno.np.dot(J_pde, J_bc), interval=500)

--- a/docs/tutorial_examples/07_stochastic/fokker_planck_2d.py
+++ b/docs/tutorial_examples/07_stochastic/fokker_planck_2d.py
@@ -42,15 +42,13 @@ from jno import LearningRateSchedule as lrs
 π = jno.np.pi
 
 # ── Domain (centred at origin so the stationary Gaussian is symmetric) ────────
-domain = jno.domain(
-    constructor=jno.domain.rect(x_range=(-3.0, 3.0), y_range=(-3.0, 3.0), mesh_size=0.15)
-)
-x,  y,  _ = domain.variable("interior")
+domain = jno.domain(constructor=jno.domain.rect(x_range=(-3.0, 3.0), y_range=(-3.0, 3.0), mesh_size=0.15))
+x, y, _ = domain.variable("interior")
 xb, yb, _ = domain.variable("boundary")
 
 # ── Analytical steady-state distribution ─────────────────────────────────────
-p_exact    = jno.np.exp(-(x**2  + y**2))  / π
-p_exact_bc = jno.np.exp(-(xb**2 + yb**2)) / π   # ≈ 4e-5 at the corners
+p_exact = jno.np.exp(-(x**2 + y**2)) / π
+p_exact_bc = jno.np.exp(-(xb**2 + yb**2)) / π  # ≈ 4e-5 at the corners
 
 # ── Network ───────────────────────────────────────────────────────────────────
 net = jno.nn.wrap(
@@ -64,14 +62,14 @@ net = jno.nn.wrap(
 )
 net.optimizer(optax.adam(1), lr=lrs.exponential(1e-3, 0.5, 10, 1e-5))
 
-p = net(x, y)   # probability density field
+p = net(x, y)  # probability density field
 
 # ── Fokker-Planck residual ─────────────────────────────────────────────────────
 # drift term:  ∂(xp)/∂x + ∂(yp)/∂y
 drift = jno.np.grad(x * p, x) + jno.np.grad(y * p, y)
 # diffusion term:  ½ ∆p
-diff  = 0.5 * jno.np.laplacian(p, [x, y])
-fp    = drift + diff                               # residual = 0
+diff = 0.5 * jno.np.laplacian(p, [x, y])
+fp = drift + diff  # residual = 0
 
 # ── Normalization constraint:  ∫∫_Ω p dx dy = 1 ──────────────────────────────
 norm = p.integrate() - 1.0

--- a/docs/tutorial_examples/07_stochastic/stochastic_forcing_2d.py
+++ b/docs/tutorial_examples/07_stochastic/stochastic_forcing_2d.py
@@ -50,14 +50,14 @@ import jno
 from jno import LearningRateSchedule as lrs
 
 π = jno.np.pi
-σ = 0.5   # noise amplitude on the forcing
+σ = 0.5  # noise amplitude on the forcing
 
 # ── Domain ─────────────────────────────────────────────────────────────────────
 domain = jno.domain(constructor=jno.domain.rect(mesh_size=0.05))
 x, y, _ = domain.variable("interior")
 
 # ── Deterministic forcing and exact solution ───────────────────────────────────
-f       = 2 * π**2 * jno.np.sin(π * x) * jno.np.sin(π * y)
+f = 2 * π**2 * jno.np.sin(π * x) * jno.np.sin(π * y)
 u_exact = jno.np.sin(π * x) * jno.np.sin(π * y)
 
 # ── Network (hard BCs via ansatz) ──────────────────────────────────────────────
@@ -72,16 +72,16 @@ net = jno.nn.wrap(
 )
 net.optimizer(optax.adam(1), lr=lrs.exponential(1e-3, 0.5, 10, 1e-5))
 
-u = net(x, y) * x * (1 - x) * y * (1 - y)   # u = 0 on ∂Ω by construction
+u = net(x, y) * x * (1 - x) * y * (1 - y)  # u = 0 on ∂Ω by construction
 
 # ── Stochastic PDE residual ────────────────────────────────────────────────────
 # The noise term is resampled every training step.  Its expectation is zero,
 # so E[loss] is minimised by the deterministic solution u*(x,y) = sin(πx)sin(πy).
-noise   = jno.noise.gaussian(std=σ)
-pde     = -jno.np.laplacian(u, [x, y]) - f - noise
+noise = jno.noise.gaussian(std=σ)
+pde = -jno.np.laplacian(u, [x, y]) - f - noise
 
 # ── Solve ──────────────────────────────────────────────────────────────────────
-crux    = jno.core([pde.mse], domain)
+crux = jno.core([pde.mse], domain)
 history = crux.solve(40_000)
 
 # ── Evaluate ───────────────────────────────────────────────────────────────────
@@ -94,8 +94,6 @@ print(f"Relative L2 error: {rel_l2:.4e}")
 # ── Record ─────────────────────────────────────────────────────────────────────
 results_file = Path(__file__).parent.parent.parent / "tutorial_results.txt"
 with open(results_file, "a") as f_out:
-    f_out.write(
-        f"07_stochastic/stochastic_forcing_2d.py | epochs=40000 | sigma={σ} | rel_L2={rel_l2:.6e}\n"
-    )
+    f_out.write(f"07_stochastic/stochastic_forcing_2d.py | epochs=40000 | sigma={σ} | rel_L2={rel_l2:.6e}\n")
 
 assert rel_l2 < 1e-1, f"relative L2 error too large: {rel_l2:.3e}"

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -10,12 +10,12 @@ import sys
 
 from . import fn, lora
 from . import jnp_ops as np
-from .noise import noise
 from .architectures.models import nn, parameter
 from .core import core
 from .differential_operators import DifferentialOperators
 from .domain import PolygonDomain, domain
 from .integration_operators import IntegrationOperators
+from .noise import noise
 from .trace import (
     Assembly,
     FemLinearSystem,

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -755,7 +755,8 @@ class TraceEvaluator:
             return jax.random.normal(subkey, shape) * expr.params.get("std", 1.0)
         elif dist == "uniform":
             return jax.random.uniform(
-                subkey, shape,
+                subkey,
+                shape,
                 minval=expr.params.get("low", -1.0),
                 maxval=expr.params.get("high", 1.0),
             )
@@ -766,8 +767,7 @@ class TraceEvaluator:
             return -jnp.sign(u) * jnp.log(1.0 - 2.0 * jnp.abs(u)) * std / jnp.sqrt(2.0)
         else:
             raise ValueError(
-                f"Unknown noise distribution {expr.distribution!r}. "
-                "Choose from: 'gaussian', 'uniform', 'laplace'."
+                f"Unknown noise distribution {expr.distribution!r}. Choose from: 'gaussian', 'uniform', 'laplace'."
             )
 
     def _eval_tunable_module_call(self, expr, ctx):

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -620,6 +620,40 @@ class TraceEvaluator:
     def _eval_state_field(self, expr, ctx):
         return self._dispatch(expr.expr, ctx)
 
+    @staticmethod
+    def _partition_by_path_match(model, selector):
+        """Partition model using path-matching when LoRA changed the tree structure.
+
+        Falls back to this when eqx.partition(model, selector) fails due to a
+        structural mismatch between the selector (built on the pre-LoRA model) and
+        the current model (with LoRALinear layers).  Selects model leaves whose
+        pytree path exactly matches a True-valued path in the selector.
+        """
+
+        def _path_str(path):
+            parts = []
+            for k in path:
+                if hasattr(k, "key"):
+                    parts.append(str(k.key))
+                elif hasattr(k, "idx"):
+                    parts.append(str(k.idx))
+                elif hasattr(k, "name"):
+                    parts.append(k.name)
+                else:
+                    parts.append(str(k))
+            return "/".join(parts)
+
+        sel_flat, _ = jax.tree_util.tree_flatten_with_path(selector)
+        true_paths = {_path_str(path) for path, val in sel_flat if val is True or (isinstance(val, bool) and val)}
+
+        bool_tree = jax.tree_util.tree_map_with_path(
+            lambda path, leaf: _path_str(path) in true_paths and isinstance(leaf, jax.Array),
+            model,
+        )
+        import equinox as eqx
+
+        return eqx.partition(model, bool_tree)
+
     def _eval_network_gradient(self, expr, ctx):
         """Compute ∂target/∂params using jax.jacrev over eqx.partition'd weights.
 
@@ -648,7 +682,13 @@ class TraceEvaluator:
         # selector is either None (all params) or a boolean pytree built by the
         # caller via eqx.tree_at and stored on the model with net.mask(mask).
         if expr.selector is not None:
-            trainable, static = eqx.partition(current_model, expr.selector)
+            try:
+                trainable, static = eqx.partition(current_model, expr.selector)
+            except ValueError:
+                # Structural mismatch — model was transformed (e.g. LoRA applied to
+                # hidden layers) after the selector was built on the original model.
+                # Fall back to selecting leaves by pytree path.
+                trainable, static = self._partition_by_path_match(current_model, expr.selector)
         else:
             trainable, static = eqx.partition(current_model, eqx.is_array)
 

--- a/tests/test_trace_evaluator.py
+++ b/tests/test_trace_evaluator.py
@@ -52,7 +52,7 @@ class TestEvalCtx:
 # ======================================================================
 class TestDispatchTable:
     def test_handlers_count(self):
-        assert len(TraceEvaluator._HANDLERS) == 20  # Update this if we add more node types
+        assert len(TraceEvaluator._HANDLERS) == 21  # Update this if we add more node types
 
     def test_handlers_are_strings(self):
         for node_type, method_name in TraceEvaluator._HANDLERS:

--- a/tests/tutorial_examples_tests/07_operator_architectures/fno2d_poisson.py
+++ b/tests/tutorial_examples_tests/07_operator_architectures/fno2d_poisson.py
@@ -17,9 +17,9 @@ Reference: Li et al. "Fourier Neural Operator for Parametric PDEs" (2020)
 import foundax
 import jax
 import optax
+from create_domain import build_domain_from_arrays, generate_poisson_data
 
 import jno
-from create_domain import build_domain_from_arrays, generate_poisson_data
 
 KEY = jax.random.PRNGKey(0)
 GRID = 16

--- a/tests/tutorial_examples_tests/07_operator_architectures/pit_poisson.py
+++ b/tests/tutorial_examples_tests/07_operator_architectures/pit_poisson.py
@@ -18,9 +18,9 @@ Reference: Zhao et al. "Position-induced Transformer" (2023)
 import foundax
 import jax
 import optax
+from create_domain import build_domain_from_arrays, generate_poisson_data
 
 import jno
-from create_domain import build_domain_from_arrays, generate_poisson_data
 
 KEY = jax.random.PRNGKey(0)
 GRID = 16

--- a/tests/tutorial_examples_tests/07_operator_architectures/unet2d_poisson.py
+++ b/tests/tutorial_examples_tests/07_operator_architectures/unet2d_poisson.py
@@ -15,9 +15,9 @@ Architecture: (B, H, W, C) → Encoder (skip connections) → Decoder → (B, H,
 import foundax
 import jax
 import optax
+from create_domain import build_domain_from_arrays, generate_poisson_data
 
 import jno
-from create_domain import build_domain_from_arrays, generate_poisson_data
 
 KEY = jax.random.PRNGKey(0)
 GRID = 16


### PR DESCRIPTION
## Summary

- Adds `NetworkGradient` — symbolic `∂loss/∂θ` operator usable inside the training loss or via `crux.eval()`; supports full-parameter and masked-subset Jacobians
- Adds `Noise` — stochastic noise operator for SDE/stochastic PINN training
- Fixes `NetworkGradient` selector mismatch when LoRA is applied: the fallback `_partition_by_path_match` now normalises LoRA-inserted `base/` levels (e.g. `output_layer/base/weight` → `output_layer/weight`) so pre-LoRA selectors still resolve correctly
- Updates `test_handlers_count` to reflect the two new dispatch entries

## Test plan

- [x] `pixi run ci-test` passes (975 passed, 1 fixed handler-count assertion)
- [x] `trial.py` smoke-test: LoRA + gradient alignment tracker runs to completion without `ValueError: Custom node type mismatch` or `Too few leaves`