### PR TITLE
Add four new explainability callbacks (residual stats, input saliency, NTK, Hessian)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ If you use jNO in academic work, please cite:
   url     = {https://arxiv.org/abs/2605.10159}
 }
 ```
+
+## AI Disclosure
+
+Parts of this codebase — including model ports, tests, and documentation — were developed with the assistance of AI coding tools. All contributions are reviewed and tested to the best of our ability, but mistakes may remain; please open an issue if you spot one.

--- a/docs/training/explainability.md
+++ b/docs/training/explainability.md
@@ -90,6 +90,24 @@ For each constraint $i$, evaluates the un-reduced residual array $r_i$ produced 
 
 W&B keys: `explainability/residual/constraint_{i}/{mean,std,max,p99}`, `.../histogram` (image)
 
+### Scoping to a subset of constraints
+
+Pass the constraint expressions you care about via `constraints=`. The callback validates them by Python identity against what was given to `jno.core(...)`, so you must assign your constraints to variables — `.mse` is a property that returns a fresh placeholder every access:
+
+```python
+pde_loss = pde.mse                       # assign once
+bc_loss  = bc.mse
+solver = jno.core([pde_loss, bc_loss], domain)
+
+cb = jno.callbacks.residual_stats(interval=100, constraints=[pde_loss])
+crux.solve(5000, callbacks=[cb])
+
+print(cb.result["means"].shape)   # (n_samples, 1)  — just pde_loss
+print(cb.result["indices"])       # [0]  — solver-side index
+```
+
+W&B keys use the **solver-side index** so the dashboard remains stable when you add or remove unrelated constraints later. `cb.result["indices"]` records that mapping.
+
 Reference: per-point residual magnitudes as a sampling / diagnostic signal — Sec. 3 of [[2207.10289](https://arxiv.org/abs/2207.10289)] (Wu et al., 2023).
 
 ---

--- a/docs/training/explainability.md
+++ b/docs/training/explainability.md
@@ -112,6 +112,33 @@ Reference: per-point residual magnitudes as a sampling / diagnostic signal — S
 
 ---
 
+## Input sensitivity / saliency
+
+```python
+cb = jno.callbacks.input_sensitivity(u.d(x), interval=100)
+crux.solve(5000, callbacks=[cb])
+
+values = cb.result["values"]    # (n_samples, *expr_shape)
+```
+
+Evaluates an arbitrary jno placeholder expression at the training collocation points and records its value every `interval` outer steps. The intended use is *input-gradient saliency* — for a scalar network output $u$ and a coordinate variable $x$, $\partial u/\partial x$ measures how strongly the network response at a given point depends on that input dimension. High-magnitude regions are where small input perturbations produce large output changes (the PINN analogue of the class-saliency map of [Simonyan, Vedaldi & Zisserman, 2014](https://arxiv.org/abs/1312.6034), Sec. 3).
+
+Common expressions to pass:
+
+| Expression                       | Meaning                                              |
+|----------------------------------|------------------------------------------------------|
+| `u.d(x)`                         | $\partial u/\partial x$ — scalar per point           |
+| `jno.Jacobian(u, [x, y])`        | full input Jacobian — shape `(N, 2)` for 2-D inputs  |
+| `u.d(x)**2 + u.d(y)**2`          | squared $\lvert\nabla u\rvert^2$ as a scalar field   |
+
+Any composite expression compiles, because the callback uses the same `TraceCompiler.compile_multi_expression` pathway that the solver uses for constraints and trackers.
+
+W&B keys: `explainability/saliency/{mean_abs,max_abs,std_abs}`, `.../histogram` (image)
+
+Reference: input-gradient saliency — Sec. 3 of [[1312.6034](https://arxiv.org/abs/1312.6034)] (Simonyan et al., 2014).
+
+---
+
 ## Loss landscape
 
 ```python

--- a/docs/training/explainability.md
+++ b/docs/training/explainability.md
@@ -1,6 +1,6 @@
 # Explainability
 
-Four callbacks give insight into what is happening inside the training loop. They work by differentiating through the constraint functions after each outer step, independently of the gradient updates that drive training. Results are stored as numpy arrays and, when a W&B run is active, pushed automatically to your dashboard.
+Several callbacks give insight into what is happening inside the training loop. They work by differentiating through the constraint functions after each outer step, or by directly inspecting the residuals, independently of the gradient updates that drive training. Results are stored as numpy arrays and, when a W&B run is active, pushed automatically to your dashboard.
 
 ---
 
@@ -120,7 +120,7 @@ W&B key: `explainability/loss_landscape` (heatmap image)
 
 ## Restricting to a parameter subset
 
-All four callbacks accept an optional `mask` — a pytree of booleans matching the `trainable` structure. Only the selected parameters are differentiated or perturbed. This is essential for large networks and strongly recommended even for medium-sized ones.
+The gradient-analysis callbacks (gradient norms, cosine similarity, gradient alignment, loss landscape) accept an optional `mask` — a pytree of booleans matching the `trainable` structure. Only the selected parameters are differentiated or perturbed. This is essential for large networks and strongly recommended even for medium-sized ones. (`residual_stats` does not need a mask — it inspects pre-existing constraint residuals rather than computing parameter gradients.)
 
 ```python
 import equinox as eqx, jax
@@ -140,7 +140,7 @@ The output-layer weight matrix typically gives the dominant gradient directions 
 
 ## W&B logging
 
-All four callbacks push their results to W&B automatically when a run is active (see [Weights & Biases](../misc/wandb.md)). No extra code is needed — enabling `jno.setup(..., wandb=True)` is sufficient.
+All callbacks push their results to W&B automatically when a run is active (see [Weights & Biases](../misc/wandb.md)). No extra code is needed — enabling `jno.setup(..., wandb=True)` is sufficient.
 
 ---
 

--- a/docs/training/explainability.md
+++ b/docs/training/explainability.md
@@ -139,6 +139,80 @@ Reference: input-gradient saliency — Sec. 3 of [[1312.6034](https://arxiv.org/
 
 ---
 
+## Empirical NTK spectrum
+
+```python
+cb = jno.callbacks.ntk_spectrum(
+    u.grad(u_net),
+    n_points=256,
+    top_k=10,
+    interval=500,
+)
+crux.solve(10_000, callbacks=[cb])
+
+eigvals = cb.result["eigvals_topk"]        # (n_samples, top_k)
+cond    = cb.result["condition_number"]    # (n_samples,)
+```
+
+Compiles a `NetworkGradient` placeholder to obtain the per-point parameter Jacobian $J \in \mathbb{R}^{N \times P}$, subsamples ``n_points`` rows (with a fixed seed so the same points are used at every call), and reports the eigenvalue spectrum of the empirical NTK $K = J J^\top$. A wide spread between the largest and smallest eigenvalues is the canonical diagnostic for PINN spectral bias.
+
+$$K_{ij} = \langle \nabla_\theta u(x_i), \, \nabla_\theta u(x_j) \rangle$$
+
+Restrict to a parameter subset via `net.mask(...)` chained into the placeholder:
+
+```python
+cb = jno.callbacks.ntk_spectrum(u.grad(u_net.mask(out_mask)), n_points=128, top_k=10)
+```
+
+!!! warning "Cost"
+    Cost is $O(n\_\text{points}^2 \times P)$.  Use both subsampling (`n_points`) **and** placeholder masking on large networks.  Scalar output only — for vector-valued $u$, project first (e.g. `u[..., 0].grad(net)`).
+
+W&B keys: `explainability/ntk/eigval_{0..k-1}`, `.../lambda_max`, `.../lambda_min`, `.../condition_number`, `.../spectrum_hist`
+
+Reference: NTK spectrum for PINN spectral-bias diagnosis — Sec. 3-4 of [[2007.14527](https://arxiv.org/abs/2007.14527)] (Wang, Wang & Perdikaris, 2022).
+
+---
+
+## Hessian eigenspectrum (sharpness)
+
+```python
+cb = jno.callbacks.hessian_spectrum(
+    k=10,
+    n_iter=30,
+    interval=500,
+    # mask=output_mask  # strongly recommended for large models
+)
+crux.solve(10_000, callbacks=[cb])
+
+eigvals   = cb.result["eigvals"]      # (n_samples, k)  — descending
+sharpness = cb.result["sharpness"]    # (n_samples,)    — largest eigenvalue
+```
+
+Computes the top-$k$ eigenvalues of the total training loss Hessian $\nabla^2_\theta L$ via Lanczos with Hessian-vector products. The largest eigenvalue is the **sharpness** of the loss surface at the current iterate (Sec. 2.2 of [[1609.04836](https://arxiv.org/abs/1609.04836)] — Keskar et al., 2017).
+
+### Per-constraint Hessian (`constraints=`)
+
+The total-loss Hessian conflates conditioning across all constraints. Pass `constraints=[...]` to scope the Hessian to a subset of the constraint losses — the spectrum then reflects the Hessian of `mean(L_i for i in constraints)`:
+
+```python
+pde_loss = pde.mse
+bc_loss  = bc.mse
+solver = jno.core([pde_loss, bc_loss], domain)
+
+cb_pde = jno.callbacks.hessian_spectrum(k=5, n_iter=20, interval=500, constraints=[pde_loss])
+cb_bc  = jno.callbacks.hessian_spectrum(k=5, n_iter=20, interval=500, constraints=[bc_loss])
+crux.solve(5000, callbacks=[cb_pde, cb_bc])
+```
+
+!!! warning "Cost"
+    Each call performs ``n_iter`` HVPs, each roughly the cost of one full forward+backward pass.  Keep ``interval`` large (500–1000) for real runs and use ``mask`` to restrict to a parameter subset.
+
+W&B keys: `explainability/hessian/eigval_{0..k-1}`, `.../sharpness`, `.../n_iter`
+
+Reference: HVP-based Lanczos for neural-network Hessian spectra — Sec. 3.1-3.2 of [[1912.07145](https://arxiv.org/abs/1912.07145)] (Yao et al., 2020).  Sharpness concept — Sec. 2.2 of [[1609.04836](https://arxiv.org/abs/1609.04836)] (Keskar et al., 2017).
+
+---
+
 ## Loss landscape
 
 ```python

--- a/docs/training/explainability.md
+++ b/docs/training/explainability.md
@@ -75,6 +75,25 @@ W&B key: `explainability/gradient_alignment`
 
 ---
 
+## Residual statistics
+
+```python
+cb = jno.callbacks.residual_stats(interval=100)
+crux.solve(5000, callbacks=[cb])
+
+means = cb.result["means"]    # (n_samples, n_constraints)
+maxes = cb.result["maxes"]    # (n_samples, n_constraints)
+p99   = cb.result["p99"]      # (n_samples, n_constraints)
+```
+
+For each constraint $i$, evaluates the un-reduced residual array $r_i$ produced by the compiled constraint function (i.e. the values *before* the training loss applies its mean) and records four scalar statistics — mean, std, max, and 99th percentile — plus a histogram of the raw residuals when W&B is active. A constraint whose ``max`` or ``p99`` stays orders of magnitude above the others points to a region of the domain where the PDE is poorly satisfied, complementing [gradient norms](#gradient-norms) which only reflect each constraint's *aggregated* contribution to the parameter update.
+
+W&B keys: `explainability/residual/constraint_{i}/{mean,std,max,p99}`, `.../histogram` (image)
+
+Reference: per-point residual magnitudes as a sampling / diagnostic signal — Sec. 3 of [[2207.10289](https://arxiv.org/abs/2207.10289)] (Wu et al., 2023).
+
+---
+
 ## Loss landscape
 
 ```python

--- a/docs/tutorial_examples/09_wandb/wandb_integration.py
+++ b/docs/tutorial_examples/09_wandb/wandb_integration.py
@@ -17,6 +17,7 @@ Techniques shown
 * GradientAlignmentCallback    — total alignment scalar ‖Σgᵢ‖ / Σ‖gᵢ‖
 * LossLandscapeCallback        — 2-D loss landscape around current params
 * ResidualStatsCallback        — per-constraint residual mean/std/max/p99 + histogram
+* InputSensitivityCallback     — |∂u/∂x| at collocation points (saliency)
 * CheckpointCallback           — periodic Orbax save + W&B artifact upload
 
 Run this script directly to see all metrics appear in your W&B dashboard
@@ -92,6 +93,13 @@ cb_residual = jno.callbacks.residual_stats(
     interval=50,
 )
 
+# Input saliency: |∂u/∂x| at the interior collocation points.
+# Any jno placeholder expression compiles — try Jacobian(u, [x, y]) for 2-D problems.
+cb_saliency = jno.callbacks.input_sensitivity(
+    u.d(x),
+    interval=50,
+)
+
 # ── Checkpoint callback ────────────────────────────────────────────────────────
 # Saves to disk every 500 epochs; uploads a versioned artifact to W&B.
 # Artifact metadata includes epoch, total_loss, individual_losses, checkpoint_dir.
@@ -106,7 +114,7 @@ cb_ckpt = jno.callbacks.checkpoint(
 crux = jno.core([pde.mse, bc.mse], domain)
 crux.solve(
     2_000,
-    callbacks=[cb_norms, cb_cos, cb_align, cb_landscape, cb_residual, cb_ckpt],
+    callbacks=[cb_norms, cb_cos, cb_align, cb_landscape, cb_residual, cb_saliency, cb_ckpt],
 )
 cb_ckpt.close()
 
@@ -138,6 +146,13 @@ print(f"  means shape : {residual_result['means'].shape}   (samples × constrain
 print(f"  final mean  : {residual_result['means'][-1]}")
 print(f"  final max   : {residual_result['maxes'][-1]}")
 print(f"  final p99   : {residual_result['p99'][-1]}")
+
+saliency_result = cb_saliency.result
+print("\n── Input sensitivity ─────────────────────────────────────────────────")
+print(f"  values shape : {saliency_result['values'].shape}")
+final_abs = jnp.abs(saliency_result["values"][-1])
+print(f"  final mean|∂u/∂x| : {float(final_abs.mean()):.4e}")
+print(f"  final max |∂u/∂x| : {float(final_abs.max()):.4e}")
 
 # ── Validate solution ──────────────────────────────────────────────────────────
 _u, _u_exact = crux.eval([u, u_exact])

--- a/docs/tutorial_examples/09_wandb/wandb_integration.py
+++ b/docs/tutorial_examples/09_wandb/wandb_integration.py
@@ -18,6 +18,8 @@ Techniques shown
 * LossLandscapeCallback        — 2-D loss landscape around current params
 * ResidualStatsCallback        — per-constraint residual mean/std/max/p99 + histogram
 * InputSensitivityCallback     — |∂u/∂x| at collocation points (saliency)
+* NTKSpectrumCallback          — empirical NTK eigenvalue spectrum
+* HessianSpectrumCallback      — top-k Hessian eigenvalues + sharpness
 * CheckpointCallback           — periodic Orbax save + W&B artifact upload
 
 Run this script directly to see all metrics appear in your W&B dashboard
@@ -100,6 +102,21 @@ cb_saliency = jno.callbacks.input_sensitivity(
     interval=50,
 )
 
+# Empirical NTK spectrum: diagnoses spectral bias.
+cb_ntk = jno.callbacks.ntk_spectrum(
+    u.grad(u_net),
+    n_points=32,
+    top_k=5,
+    interval=200,
+)
+
+# Hessian eigenspectrum: top-k eigenvalues + sharpness via Lanczos w/ HVPs.
+cb_hess = jno.callbacks.hessian_spectrum(
+    k=5,
+    n_iter=15,
+    interval=400,
+)
+
 # ── Checkpoint callback ────────────────────────────────────────────────────────
 # Saves to disk every 500 epochs; uploads a versioned artifact to W&B.
 # Artifact metadata includes epoch, total_loss, individual_losses, checkpoint_dir.
@@ -114,7 +131,7 @@ cb_ckpt = jno.callbacks.checkpoint(
 crux = jno.core([pde.mse, bc.mse], domain)
 crux.solve(
     2_000,
-    callbacks=[cb_norms, cb_cos, cb_align, cb_landscape, cb_residual, cb_saliency, cb_ckpt],
+    callbacks=[cb_norms, cb_cos, cb_align, cb_landscape, cb_residual, cb_saliency, cb_ntk, cb_hess, cb_ckpt],
 )
 cb_ckpt.close()
 
@@ -153,6 +170,17 @@ print(f"  values shape : {saliency_result['values'].shape}")
 final_abs = jnp.abs(saliency_result["values"][-1])
 print(f"  final mean|∂u/∂x| : {float(final_abs.mean()):.4e}")
 print(f"  final max |∂u/∂x| : {float(final_abs.max()):.4e}")
+
+ntk_result = cb_ntk.result
+print("\n── NTK spectrum ──────────────────────────────────────────────────────")
+print(f"  top-{ntk_result['eigvals_topk'].shape[1]} eigvals (final): {ntk_result['eigvals_topk'][-1]}")
+print(f"  λ_max (final)        : {ntk_result['lambda_max'][-1]:.4e}")
+print(f"  condition (final)    : {ntk_result['condition_number'][-1]:.4e}")
+
+hess_result = cb_hess.result
+print("\n── Hessian eigenspectrum ─────────────────────────────────────────────")
+print(f"  top-{hess_result['eigvals'].shape[1]} eigvals (final): {hess_result['eigvals'][-1]}")
+print(f"  sharpness (final)    : {hess_result['sharpness'][-1]:.4e}")
 
 # ── Validate solution ──────────────────────────────────────────────────────────
 _u, _u_exact = crux.eval([u, u_exact])

--- a/docs/tutorial_examples/09_wandb/wandb_integration.py
+++ b/docs/tutorial_examples/09_wandb/wandb_integration.py
@@ -16,6 +16,7 @@ Techniques shown
 * CosSimilarityCallback        — pairwise cosine similarity matrix (heatmap)
 * GradientAlignmentCallback    — total alignment scalar ‖Σgᵢ‖ / Σ‖gᵢ‖
 * LossLandscapeCallback        — 2-D loss landscape around current params
+* ResidualStatsCallback        — per-constraint residual mean/std/max/p99 + histogram
 * CheckpointCallback           — periodic Orbax save + W&B artifact upload
 
 Run this script directly to see all metrics appear in your W&B dashboard
@@ -87,6 +88,10 @@ cb_landscape = jno.callbacks.loss_landscape(
     alpha_range=0.5,
 )
 
+cb_residual = jno.callbacks.residual_stats(
+    interval=50,
+)
+
 # ── Checkpoint callback ────────────────────────────────────────────────────────
 # Saves to disk every 500 epochs; uploads a versioned artifact to W&B.
 # Artifact metadata includes epoch, total_loss, individual_losses, checkpoint_dir.
@@ -101,7 +106,7 @@ cb_ckpt = jno.callbacks.checkpoint(
 crux = jno.core([pde.mse, bc.mse], domain)
 crux.solve(
     2_000,
-    callbacks=[cb_norms, cb_cos, cb_align, cb_landscape, cb_ckpt],
+    callbacks=[cb_norms, cb_cos, cb_align, cb_landscape, cb_residual, cb_ckpt],
 )
 cb_ckpt.close()
 
@@ -126,6 +131,13 @@ print("\n── Loss landscape ────────────────�
 print(f"  grid shape : {land_result['landscapes'].shape}")
 print(f"  final min  : {land_result['landscapes'][-1].min():.4e}")
 print(f"  final max  : {land_result['landscapes'][-1].max():.4e}")
+
+residual_result = cb_residual.result
+print("\n── Residual statistics ───────────────────────────────────────────────")
+print(f"  means shape : {residual_result['means'].shape}   (samples × constraints)")
+print(f"  final mean  : {residual_result['means'][-1]}")
+print(f"  final max   : {residual_result['maxes'][-1]}")
+print(f"  final p99   : {residual_result['p99'][-1]}")
 
 # ── Validate solution ──────────────────────────────────────────────────────────
 _u, _u_exact = crux.eval([u, u_exact])

--- a/jno/core.py
+++ b/jno/core.py
@@ -1869,6 +1869,8 @@ class core:
                         rng=self.rng,
                         min_consecutive=min_consecutive,
                         constraint_exprs=self._user_constraint_exprs,
+                        all_ops=self.all_ops,
+                        domain=self.domain,
                     )
 
             # ── 8. Training loop ──

--- a/jno/core.py
+++ b/jno/core.py
@@ -952,10 +952,15 @@ class core:
         # === Compile constraints and trackers ===
         self.compiled_trackers = []
         self._constraint_exprs = []  # raw expressions for shape tracing
+        # Original (pre-wrap, pre-CSE) constraint expressions in the same order
+        # as ``_constraint_exprs`` — used by callbacks like residual_stats /
+        # hessian_spectrum that accept a ``constraints=`` subset and need to
+        # identity-match the user's original Python objects.
+        self._user_constraint_exprs = []
         self._tracker_exprs = []
         constraint_exprs = []
 
-        for expr in constraints:
+        for orig_expr, expr in zip(self.constraints, constraints):
             inner = expr
             tracker_interval = None
             if isinstance(expr, OperationDef) and isinstance(expr.expr, Tracker):
@@ -972,6 +977,7 @@ class core:
             else:
                 constraint_exprs.append(inner)
                 self._constraint_exprs.append(inner)
+                self._user_constraint_exprs.append(orig_expr)
 
         # Compile all normal constraints in ONE combined function so XLA
         # can apply CSE across shared sub-expressions.
@@ -1862,6 +1868,7 @@ class core:
                         context=trace_context,
                         rng=self.rng,
                         min_consecutive=min_consecutive,
+                        constraint_exprs=self._user_constraint_exprs,
                     )
 
             # ── 8. Training loop ──

--- a/jno/utils/adaptive/callbacks.py
+++ b/jno/utils/adaptive/callbacks.py
@@ -746,6 +746,117 @@ class LossLandscapeCallback(Callback):
         }
 
 
+# ---------------------------------------------------------------------------
+# Callback 5 — Per-constraint residual statistics
+# ---------------------------------------------------------------------------
+
+
+class ResidualStatsCallback(Callback):
+    """Track per-constraint residual distributions during training.
+
+    At every ``interval`` outer steps, evaluates each constraint's
+    *un-reduced* residual array (shape ``(B, T, ...)``) and records four
+    summary statistics per constraint — mean, std, max, and 99th percentile
+    — plus a histogram of the raw residual magnitudes (Sec. 3, [2207.10289]).
+
+    A constraint whose ``max`` or ``p99`` stays orders of magnitude above
+    the others indicates a region of the domain where the PDE is poorly
+    satisfied; this complements :class:`GradientNormsCallback` which only
+    reflects a constraint's *aggregated* contribution to the gradient.
+
+    Args:
+        interval: Compute every *n* outer training steps. Default ``100``.
+
+    Example::
+
+        cb = jno.callbacks.residual_stats(interval=100)
+        crux.solve(5000, callbacks=[cb])
+        print(cb.result["maxes"])   # (n_samples, n_constraints)
+    """
+
+    def __init__(self, interval: int = 100) -> None:
+        self._interval = interval
+        self._fn = None
+        self._n_constraints = 0
+        self._epochs: list = []
+        self._means: list = []
+        self._stds: list = []
+        self._maxes: list = []
+        self._p99: list = []
+
+    def on_solve_begin(self, **kwargs) -> None:
+        from jno.utils.explainability import make_residual_stats_fn
+
+        self._n_constraints = kwargs["n_constraints"]
+        self._fn = jax.jit(
+            make_residual_stats_fn(
+                kwargs["compiled_constraints_fn"],
+                kwargs["n_constraints"],
+                kwargs["batchsize"],
+                kwargs["frozen"],
+                kwargs["static"],
+                min_consecutive=kwargs.get("min_consecutive", 1),
+            )
+        )
+        self._fn.lower(kwargs["trainable"], kwargs["context"], kwargs["rng"]).compile()
+
+    def on_epoch_end(self, **kwargs) -> bool:
+        if self._fn is None:
+            return False
+        epoch = kwargs["epoch"]
+        if epoch % self._interval != 0:
+            return False
+        means, stds, maxes, p99, raw = self._fn(kwargs["trainable"], kwargs["context"], kwargs["rng"])
+        means_np = np.asarray(jax.device_get(means))
+        stds_np = np.asarray(jax.device_get(stds))
+        maxes_np = np.asarray(jax.device_get(maxes))
+        p99_np = np.asarray(jax.device_get(p99))
+        raw_np = [np.asarray(jax.device_get(r)) for r in raw]
+
+        self._epochs.append(epoch)
+        self._means.append(means_np)
+        self._stds.append(stds_np)
+        self._maxes.append(maxes_np)
+        self._p99.append(p99_np)
+
+        if get_wandb_run() is not None:
+            wb: dict = {}
+            for i in range(self._n_constraints):
+                wb[f"explainability/residual/constraint_{i}/mean"] = float(means_np[i])
+                wb[f"explainability/residual/constraint_{i}/std"] = float(stds_np[i])
+                wb[f"explainability/residual/constraint_{i}/max"] = float(maxes_np[i])
+                wb[f"explainability/residual/constraint_{i}/p99"] = float(p99_np[i])
+            try:
+                import wandb as _wandb
+
+                for i, r in enumerate(raw_np):
+                    wb[f"explainability/residual/constraint_{i}/histogram"] = _wandb.Histogram(r)
+            except ImportError:
+                pass
+            wandb_log(wb, step=epoch)
+        return False
+
+    @property
+    def result(self) -> dict:
+        """Collected data as numpy arrays.
+
+        Keys:
+            ``epochs`` — ``(S,)`` int array of sampled outer steps.
+            ``means``  — ``(S, N)`` float32 per-constraint residual mean.
+            ``stds``   — ``(S, N)`` float32 per-constraint residual std.
+            ``maxes``  — ``(S, N)`` float32 per-constraint residual max.
+            ``p99``    — ``(S, N)`` float32 per-constraint 99th-percentile.
+        """
+        empty = np.zeros((0,))
+        return {
+            "epochs": np.array(self._epochs),
+            "means": np.stack(self._means) if self._means else empty,
+            "stds": np.stack(self._stds) if self._stds else empty,
+            "maxes": np.stack(self._maxes) if self._maxes else empty,
+            "p99": np.stack(self._p99) if self._p99 else empty,
+        }
+
+
 class callbacks:
     """Factory helpers for built-in adaptive training callbacks.
 
@@ -875,3 +986,16 @@ class callbacks:
             alpha_range: Perturbation range in units of ``‖θ_selected‖``.
         """
         return LossLandscapeCallback(interval=interval, mask=mask, n_grid=n_grid, alpha_range=alpha_range)
+
+    @staticmethod
+    def residual_stats(interval: int = 100) -> ResidualStatsCallback:
+        """Create a :class:`ResidualStatsCallback`.
+
+        Tracks per-constraint residual mean, std, max, and 99th-percentile —
+        plus a histogram when W&B is active — every *interval* outer steps
+        (Sec. 3, [2207.10289]).
+
+        Args:
+            interval: Compute every *n* outer training steps.
+        """
+        return ResidualStatsCallback(interval=interval)

--- a/jno/utils/adaptive/callbacks.py
+++ b/jno/utils/adaptive/callbacks.py
@@ -34,6 +34,10 @@ class Callback:
             context: Domain context (use for pre-compilation only).
             rng: PRNG key.
             min_consecutive (int): Minimum consecutive time steps per constraint call.
+            constraint_exprs: List of the solver's raw constraint placeholders
+                (the exact Python objects passed to ``jno.core([...])``).
+                Callbacks that take a ``constraints=`` arg validate user input
+                against this list by Python identity.
         """
 
     def on_epoch_end(self, **kwargs) -> bool:
@@ -56,6 +60,47 @@ class Callback:
 
     def on_training_end(self, **kwargs) -> None:
         """Called once after the training loop finishes."""
+
+
+def _resolve_constraint_indices(user_constraints, solver_constraints, callback_name: str) -> list[int]:
+    """Map user-supplied constraint placeholders to their solver-side indices.
+
+    Matches by Python identity — i.e. the user must pass the *same* Python
+    object that was given to ``jno.core([...])`` (assign the constraint to a
+    variable rather than re-accessing ``.mse``, which returns a fresh
+    placeholder every time).  Raises ``ValueError`` with a clear hint on
+    mismatch.
+
+    Args:
+        user_constraints: List of placeholder expressions, or ``None`` for "all".
+        solver_constraints: ``solver._constraint_exprs`` (the solver's stored
+            constraint list).
+        callback_name: Used in the error message so users know which callback
+            raised.
+
+    Returns:
+        List of integer indices into ``solver_constraints``.  When
+        ``user_constraints is None`` the full range ``[0, len(solver_constraints))``.
+    """
+    if user_constraints is None:
+        return list(range(len(solver_constraints)))
+    indices: list[int] = []
+    for c in user_constraints:
+        found = -1
+        for i, ce in enumerate(solver_constraints):
+            if c is ce:
+                found = i
+                break
+        if found == -1:
+            raise ValueError(
+                f"{callback_name}: constraint {c!r} not found among the "
+                f"solver's compiled constraints.  Pass the same Python "
+                f"object that was given to jno.core([...]) — assign your "
+                f"constraint to a variable rather than re-accessing .mse "
+                f"(which returns a fresh placeholder each access)."
+            )
+        indices.append(found)
+    return indices
 
 
 # ---------------------------------------------------------------------------
@@ -766,16 +811,27 @@ class ResidualStatsCallback(Callback):
 
     Args:
         interval: Compute every *n* outer training steps. Default ``100``.
+        constraints: Optional list of constraint placeholders to scope the
+            callback to a subset of the solver's constraints.  Pass the
+            *same* Python objects that were given to ``jno.core([...])`` —
+            assign your constraints to variables rather than re-accessing
+            ``.mse`` (which returns a fresh placeholder each access).
+            When ``None`` (default) all constraints are tracked.
 
     Example::
 
-        cb = jno.callbacks.residual_stats(interval=100)
+        pde_loss = pde.mse                       # assign once
+        bc_loss  = bc.mse
+        solver = jno.core([pde_loss, bc_loss], domain)
+        cb = jno.callbacks.residual_stats(interval=100, constraints=[pde_loss])
         crux.solve(5000, callbacks=[cb])
-        print(cb.result["maxes"])   # (n_samples, n_constraints)
+        print(cb.result["maxes"])   # (n_samples, 1)  — just pde_loss
     """
 
-    def __init__(self, interval: int = 100) -> None:
+    def __init__(self, interval: int = 100, constraints=None) -> None:
         self._interval = interval
+        self._user_constraints = constraints  # resolved in on_solve_begin
+        self._indices: list[int] = []  # populated in on_solve_begin
         self._fn = None
         self._n_constraints = 0
         self._epochs: list = []
@@ -788,6 +844,14 @@ class ResidualStatsCallback(Callback):
         from jno.utils.explainability import make_residual_stats_fn
 
         self._n_constraints = kwargs["n_constraints"]
+        # Resolve the optional constraint subset to solver-side indices.
+        # `constraint_exprs` is added by the solver hook; defensively fall back
+        # to the full range if absent (older solvers without the hook).
+        solver_constraints = kwargs.get("constraint_exprs")
+        if solver_constraints is None:
+            solver_constraints = [None] * self._n_constraints
+        self._indices = _resolve_constraint_indices(self._user_constraints, solver_constraints, "residual_stats")
+
         self._fn = jax.jit(
             make_residual_stats_fn(
                 kwargs["compiled_constraints_fn"],
@@ -813,24 +877,36 @@ class ResidualStatsCallback(Callback):
         p99_np = np.asarray(jax.device_get(p99))
         raw_np = [np.asarray(jax.device_get(r)) for r in raw]
 
+        # Slice each scalar array to the requested constraint subset.  Raw
+        # residuals are a list of variable-length arrays, so they're
+        # picked-by-index rather than fancy-indexed.
+        idx = self._indices
+        means_sel = means_np[idx]
+        stds_sel = stds_np[idx]
+        maxes_sel = maxes_np[idx]
+        p99_sel = p99_np[idx]
+        raw_sel = [raw_np[i] for i in idx]
+
         self._epochs.append(epoch)
-        self._means.append(means_np)
-        self._stds.append(stds_np)
-        self._maxes.append(maxes_np)
-        self._p99.append(p99_np)
+        self._means.append(means_sel)
+        self._stds.append(stds_sel)
+        self._maxes.append(maxes_sel)
+        self._p99.append(p99_sel)
 
         if get_wandb_run() is not None:
             wb: dict = {}
-            for i in range(self._n_constraints):
-                wb[f"explainability/residual/constraint_{i}/mean"] = float(means_np[i])
-                wb[f"explainability/residual/constraint_{i}/std"] = float(stds_np[i])
-                wb[f"explainability/residual/constraint_{i}/max"] = float(maxes_np[i])
-                wb[f"explainability/residual/constraint_{i}/p99"] = float(p99_np[i])
+            # Use the *solver-side* index for the W&B key so the dashboard
+            # remains stable when users add/remove unrelated constraints.
+            for slot, i in enumerate(idx):
+                wb[f"explainability/residual/constraint_{i}/mean"] = float(means_sel[slot])
+                wb[f"explainability/residual/constraint_{i}/std"] = float(stds_sel[slot])
+                wb[f"explainability/residual/constraint_{i}/max"] = float(maxes_sel[slot])
+                wb[f"explainability/residual/constraint_{i}/p99"] = float(p99_sel[slot])
             try:
                 import wandb as _wandb
 
-                for i, r in enumerate(raw_np):
-                    wb[f"explainability/residual/constraint_{i}/histogram"] = _wandb.Histogram(r)
+                for slot, i in enumerate(idx):
+                    wb[f"explainability/residual/constraint_{i}/histogram"] = _wandb.Histogram(raw_sel[slot])
             except ImportError:
                 pass
             wandb_log(wb, step=epoch)
@@ -842,10 +918,14 @@ class ResidualStatsCallback(Callback):
 
         Keys:
             ``epochs`` — ``(S,)`` int array of sampled outer steps.
-            ``means``  — ``(S, N)`` float32 per-constraint residual mean.
-            ``stds``   — ``(S, N)`` float32 per-constraint residual std.
-            ``maxes``  — ``(S, N)`` float32 per-constraint residual max.
-            ``p99``    — ``(S, N)`` float32 per-constraint 99th-percentile.
+            ``means``  — ``(S, K)`` float32 per-constraint residual mean,
+                where ``K = len(constraints)`` when a subset was selected,
+                else ``N_constraints``.
+            ``stds``   — ``(S, K)`` float32 per-constraint residual std.
+            ``maxes``  — ``(S, K)`` float32 per-constraint residual max.
+            ``p99``    — ``(S, K)`` float32 per-constraint 99th-percentile.
+            ``indices`` — ``(K,)`` int array of solver-side constraint indices
+                in the same order as the columns of ``means``/``stds``/etc.
         """
         empty = np.zeros((0,))
         return {
@@ -854,6 +934,7 @@ class ResidualStatsCallback(Callback):
             "stds": np.stack(self._stds) if self._stds else empty,
             "maxes": np.stack(self._maxes) if self._maxes else empty,
             "p99": np.stack(self._p99) if self._p99 else empty,
+            "indices": np.array(self._indices, dtype=int),
         }
 
 
@@ -988,7 +1069,7 @@ class callbacks:
         return LossLandscapeCallback(interval=interval, mask=mask, n_grid=n_grid, alpha_range=alpha_range)
 
     @staticmethod
-    def residual_stats(interval: int = 100) -> ResidualStatsCallback:
+    def residual_stats(interval: int = 100, constraints=None) -> ResidualStatsCallback:
         """Create a :class:`ResidualStatsCallback`.
 
         Tracks per-constraint residual mean, std, max, and 99th-percentile —
@@ -997,5 +1078,9 @@ class callbacks:
 
         Args:
             interval: Compute every *n* outer training steps.
+            constraints: Optional list of constraint placeholders to scope to a
+                subset of the solver's constraints.  Pass the same Python
+                objects given to ``jno.core([...])`` (assign your constraints
+                to variables first).  Default ``None`` — all constraints.
         """
-        return ResidualStatsCallback(interval=interval)
+        return ResidualStatsCallback(interval=interval, constraints=constraints)

--- a/jno/utils/adaptive/callbacks.py
+++ b/jno/utils/adaptive/callbacks.py
@@ -747,7 +747,7 @@ class LossLandscapeCallback(Callback):
 
 
 # ---------------------------------------------------------------------------
-# Callback 5 — Per-constraint residual statistics
+# Per-constraint residual statistics
 # ---------------------------------------------------------------------------
 
 

--- a/jno/utils/adaptive/callbacks.py
+++ b/jno/utils/adaptive/callbacks.py
@@ -38,6 +38,11 @@ class Callback:
                 (the exact Python objects passed to ``jno.core([...])``).
                 Callbacks that take a ``constraints=`` arg validate user input
                 against this list by Python identity.
+            all_ops: List of OperationDef instances (the solver's compiled op set);
+                callbacks may pass this to ``TraceCompiler.compile_multi_expression``
+                to evaluate user-supplied placeholder expressions during training.
+            domain: The solver's :class:`~jno.domain.domain` instance (read-only;
+                use only for shape / metadata inspection during pre-compilation).
         """
 
     def on_epoch_end(self, **kwargs) -> bool:
@@ -938,6 +943,113 @@ class ResidualStatsCallback(Callback):
         }
 
 
+# ---------------------------------------------------------------------------
+# Input sensitivity / saliency
+# ---------------------------------------------------------------------------
+
+
+class InputSensitivityCallback(Callback):
+    """Evaluate any placeholder expression at training collocation points.
+
+    Most useful for input-saliency: pass ``u.d(x)`` (single coordinate) or
+    ``jno.Jacobian(u, [x, y])`` (multi-coordinate) and the callback will
+    record the per-point sensitivity of the network output to its inputs
+    every ``interval`` outer steps.  Conceptually equivalent to the
+    class-saliency map of Sec. 3 of [1312.6034] — high magnitude points
+    correspond to spatial regions where the network response is most
+    responsive to a perturbation of the input coordinate.
+
+    The expression is compiled via
+    :meth:`~jno.trace_compiler.TraceCompiler.compile_multi_expression`
+    (the same machinery used by the solver's constraints and trackers),
+    so any composite placeholder expression works — not just first
+    derivatives.
+
+    Args:
+        expr: A :class:`~jno.trace.Placeholder` expression to evaluate.
+            Common choices: ``u.d(x)``, ``jno.Jacobian(u, [x, y])``,
+            ``jno.np.linalg.norm(u.d(x))``.
+        interval: Compute every *n* outer training steps. Default ``100``.
+
+    Example::
+
+        cb = jno.callbacks.input_sensitivity(u.d(x), interval=100)
+        crux.solve(5000, callbacks=[cb])
+        print(cb.result["values"].shape)   # (n_samples, *expr_shape)
+    """
+
+    def __init__(self, expr, interval: int = 100) -> None:
+        from jno.trace import Placeholder
+
+        if not isinstance(expr, Placeholder):
+            raise TypeError(
+                f"input_sensitivity expects a jno Placeholder expression (e.g. u.d(x)), got {type(expr).__name__!r}."
+            )
+        self._expr = expr
+        self._interval = interval
+        self._fn = None
+        self._epochs: list = []
+        self._values: list = []
+
+    def on_solve_begin(self, **kwargs) -> None:
+        from jno.utils.explainability import make_expression_eval_fn
+
+        if "all_ops" not in kwargs:
+            raise RuntimeError(
+                "InputSensitivityCallback requires the solver to pass `all_ops` "
+                "via on_solve_begin (added by jno >= explainability v2)."
+            )
+        self._fn = jax.jit(
+            make_expression_eval_fn(
+                self._expr,
+                kwargs["all_ops"],
+                kwargs["batchsize"],
+                kwargs["frozen"],
+                kwargs["static"],
+                min_consecutive=kwargs.get("min_consecutive", 1),
+            )
+        )
+        self._fn.lower(kwargs["trainable"], kwargs["context"], kwargs["rng"]).compile()
+
+    def on_epoch_end(self, **kwargs) -> bool:
+        if self._fn is None:
+            return False
+        epoch = kwargs["epoch"]
+        if epoch % self._interval != 0:
+            return False
+        values = np.asarray(jax.device_get(self._fn(kwargs["trainable"], kwargs["context"], kwargs["rng"])))
+        self._epochs.append(epoch)
+        self._values.append(values)
+        if get_wandb_run() is not None:
+            abs_v = np.abs(values)
+            wb: dict = {
+                "explainability/saliency/mean_abs": float(abs_v.mean()),
+                "explainability/saliency/max_abs": float(abs_v.max()),
+                "explainability/saliency/std_abs": float(abs_v.std()),
+            }
+            try:
+                import wandb as _wandb
+
+                wb["explainability/saliency/histogram"] = _wandb.Histogram(abs_v.ravel())
+            except ImportError:
+                pass
+            wandb_log(wb, step=epoch)
+        return False
+
+    @property
+    def result(self) -> dict:
+        """Collected data as numpy arrays.
+
+        Keys:
+            ``epochs`` — ``(S,)`` int array of sampled outer steps.
+            ``values`` — ``(S, *expr_shape)`` array of expression evaluations.
+        """
+        return {
+            "epochs": np.array(self._epochs),
+            "values": np.stack(self._values) if self._values else np.zeros((0,)),
+        }
+
+
 class callbacks:
     """Factory helpers for built-in adaptive training callbacks.
 
@@ -1067,6 +1179,21 @@ class callbacks:
             alpha_range: Perturbation range in units of ``‖θ_selected‖``.
         """
         return LossLandscapeCallback(interval=interval, mask=mask, n_grid=n_grid, alpha_range=alpha_range)
+
+    @staticmethod
+    def input_sensitivity(expr, interval: int = 100) -> InputSensitivityCallback:
+        """Create an :class:`InputSensitivityCallback`.
+
+        Evaluates a user-supplied placeholder expression at training
+        collocation points every *interval* outer steps (Sec. 3, [1312.6034]).
+
+        Args:
+            expr: A :class:`~jno.trace.Placeholder` expression — commonly
+                ``u.d(x)`` for input-gradient saliency, or
+                ``jno.Jacobian(u, [x, y])`` for a multi-variable Jacobian.
+            interval: Compute every *n* outer training steps.
+        """
+        return InputSensitivityCallback(expr=expr, interval=interval)
 
     @staticmethod
     def residual_stats(interval: int = 100, constraints=None) -> ResidualStatsCallback:

--- a/jno/utils/adaptive/callbacks.py
+++ b/jno/utils/adaptive/callbacks.py
@@ -1050,6 +1050,249 @@ class InputSensitivityCallback(Callback):
         }
 
 
+# ---------------------------------------------------------------------------
+# Empirical NTK spectrum
+# ---------------------------------------------------------------------------
+
+
+class NTKSpectrumCallback(Callback):
+    """Track the empirical Neural Tangent Kernel eigenvalue spectrum.
+
+    For a :class:`~jno.trace.NetworkGradient` placeholder ``u.grad(net)``
+    (per-point parameter Jacobian :math:`J \\in \\mathbb{R}^{N \\times P}`)
+    constructs the empirical NTK :math:`K = J J^\\top` at every
+    ``interval`` outer steps, subsampled to ``n_points`` collocation
+    points, and reports the top-k eigenvalues, condition number, and full
+    spectrum.
+
+    The eigenvalue spread is the canonical diagnostic for PINN spectral
+    bias (Sec. 3-4, [2007.14527]): widely separated eigenvalues mean some
+    directions in parameter space train orders of magnitude faster than
+    others, producing the characteristic PINN failure mode where
+    high-frequency features lag low-frequency ones.
+
+    Args:
+        grad_expr: A :class:`~jno.trace.NetworkGradient` placeholder
+            (the result of ``expr.grad(model)``).  Use ``model.mask(...)``
+            to restrict to a parameter subset, e.g.
+            ``u.grad(net.mask(output_only_mask))`` — masking lives in the
+            placeholder rather than as a separate argument.
+        n_points: Number of collocation points to subsample for the
+            kernel.  Cost is ``O(n_points² × P)``; default ``256``.
+        top_k: Number of largest eigenvalues to report.  Default ``10``.
+        interval: Compute every *n* outer training steps.  Default ``500``
+            (expensive — keep large for real runs).
+
+    Example::
+
+        cb = jno.callbacks.ntk_spectrum(u.grad(u_net), n_points=128, top_k=10)
+        crux.solve(10_000, callbacks=[cb])
+        print(cb.result["lambda_max"])         # (n_samples,)
+        print(cb.result["condition_number"])   # (n_samples,)
+    """
+
+    def __init__(
+        self,
+        grad_expr,
+        n_points: int = 256,
+        top_k: int = 10,
+        interval: int = 500,
+    ) -> None:
+        from jno.trace import NetworkGradient
+
+        if not isinstance(grad_expr, NetworkGradient):
+            raise TypeError(
+                f"ntk_spectrum expects a NetworkGradient placeholder "
+                f"(e.g. u.grad(net)), got {type(grad_expr).__name__!r}. "
+                "Build one via ``expr.grad(model)``."
+            )
+        self._grad_expr = grad_expr
+        self._n_points = n_points
+        self._top_k = top_k
+        self._interval = interval
+        self._fn = None
+        self._epochs: list = []
+        self._top: list = []
+        self._lam_min: list = []
+        self._lam_max: list = []
+        self._cond: list = []
+        self._all: list = []
+
+    def on_solve_begin(self, **kwargs) -> None:
+        from jno.utils.explainability import make_ntk_spectrum_fn
+
+        if "all_ops" not in kwargs:
+            raise RuntimeError(
+                "NTKSpectrumCallback requires the solver to pass `all_ops` "
+                "via on_solve_begin (added by jno >= explainability v2)."
+            )
+        self._fn = jax.jit(
+            make_ntk_spectrum_fn(
+                self._grad_expr,
+                kwargs["all_ops"],
+                kwargs["batchsize"],
+                kwargs["frozen"],
+                kwargs["static"],
+                n_points=self._n_points,
+                top_k=self._top_k,
+                min_consecutive=kwargs.get("min_consecutive", 1),
+            )
+        )
+        self._fn.lower(kwargs["trainable"], kwargs["context"], kwargs["rng"]).compile()
+
+    def on_epoch_end(self, **kwargs) -> bool:
+        if self._fn is None:
+            return False
+        epoch = kwargs["epoch"]
+        if epoch % self._interval != 0:
+            return False
+        top, lam_min, lam_max, cond, all_eigs = self._fn(kwargs["trainable"], kwargs["context"], kwargs["rng"])
+        top_np = np.asarray(jax.device_get(top))
+        lam_min_v = float(jax.device_get(lam_min))
+        lam_max_v = float(jax.device_get(lam_max))
+        cond_v = float(jax.device_get(cond))
+        all_np = np.asarray(jax.device_get(all_eigs))
+
+        self._epochs.append(epoch)
+        self._top.append(top_np)
+        self._lam_min.append(lam_min_v)
+        self._lam_max.append(lam_max_v)
+        self._cond.append(cond_v)
+        self._all.append(all_np)
+
+        if get_wandb_run() is not None:
+            wb: dict = {f"explainability/ntk/eigval_{i}": float(v) for i, v in enumerate(top_np)}
+            wb["explainability/ntk/lambda_max"] = lam_max_v
+            wb["explainability/ntk/lambda_min"] = lam_min_v
+            wb["explainability/ntk/condition_number"] = cond_v
+            try:
+                import wandb as _wandb
+
+                wb["explainability/ntk/spectrum_hist"] = _wandb.Histogram(all_np)
+            except ImportError:
+                pass
+            wandb_log(wb, step=epoch)
+        return False
+
+    @property
+    def result(self) -> dict:
+        """Collected data as numpy arrays."""
+        empty = np.zeros((0,))
+        return {
+            "epochs": np.array(self._epochs),
+            "eigvals_topk": np.stack(self._top) if self._top else empty,
+            "lambda_min": np.array(self._lam_min),
+            "lambda_max": np.array(self._lam_max),
+            "condition_number": np.array(self._cond),
+            "all_eigvals": np.stack(self._all) if self._all else empty,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Hessian eigenspectrum / sharpness
+# ---------------------------------------------------------------------------
+
+
+class HessianSpectrumCallback(Callback):
+    """Track the top-k Hessian eigenvalues of the total training loss.
+
+    Constructs :math:`\\nabla^2_\\theta L` implicitly via Hessian-vector
+    products (``jvp(grad(L), …, …)``) and runs ``n_iter`` Lanczos
+    iterations with full reorthogonalisation.  The resulting tridiagonal
+    is eigendecomposed host-side via ``scipy.linalg.eigh_tridiagonal``
+    (Sec. 3.1-3.2, [1912.07145]) to obtain the top-k eigenvalues.
+
+    The largest eigenvalue is the *sharpness* of the loss surface at the
+    current iterate (Sec. 2.2, [1609.04836]); high values predict a sharp
+    minimum, typically associated with worse generalisation.
+
+    Args:
+        k: Number of largest eigenvalues to report.  Default ``10``.
+        n_iter: Number of Lanczos iterations.  Default ``30``.
+        interval: Compute every *n* outer training steps.  Default ``500``.
+        mask: Optional pytree of booleans matching the *trainable*
+            structure.  Essential for large models.
+        constraints: Optional list of constraint placeholders to scope the
+            Hessian to the mean of those constraints' losses (instead of
+            the total training loss).  Pass the same Python objects given
+            to ``jno.core([...])`` — assign your constraints to variables
+            rather than re-accessing ``.mse``.
+    """
+
+    def __init__(
+        self,
+        k: int = 10,
+        n_iter: int = 30,
+        interval: int = 500,
+        mask=None,
+        constraints=None,
+    ) -> None:
+        self._k = k
+        self._n_iter = n_iter
+        self._interval = interval
+        self._mask = mask
+        self._user_constraints = constraints
+        self._indices: list[int] = []
+        self._fn = None
+        self._epochs: list = []
+        self._eigvals: list = []
+        self._sharpness: list = []
+
+    def on_solve_begin(self, **kwargs) -> None:
+        from jno.utils.explainability import make_hessian_spectrum_fn
+
+        solver_constraints = kwargs.get("constraint_exprs")
+        if solver_constraints is None:
+            solver_constraints = [None] * kwargs["n_constraints"]
+        self._indices = _resolve_constraint_indices(self._user_constraints, solver_constraints, "hessian_spectrum")
+
+        constraint_indices = tuple(self._indices) if self._user_constraints is not None else None
+
+        self._fn = make_hessian_spectrum_fn(
+            kwargs["compiled_constraints_fn"],
+            kwargs["batchsize"],
+            kwargs["frozen"],
+            kwargs["static"],
+            param_mask=self._mask,
+            min_consecutive=kwargs.get("min_consecutive", 1),
+            k=self._k,
+            n_iter=self._n_iter,
+            constraint_indices=constraint_indices,
+        )
+        # Pre-warm — Lanczos is a Python driver, so it JIT-compiles the inner
+        # HVP lazily on first call.
+        self._fn(kwargs["trainable"], kwargs["context"], kwargs["rng"])
+
+    def on_epoch_end(self, **kwargs) -> bool:
+        if self._fn is None:
+            return False
+        epoch = kwargs["epoch"]
+        if epoch % self._interval != 0:
+            return False
+        top, lambda_max, _all = self._fn(kwargs["trainable"], kwargs["context"], kwargs["rng"])
+        top_np = np.asarray(top)
+        self._epochs.append(epoch)
+        self._eigvals.append(top_np)
+        self._sharpness.append(float(lambda_max))
+
+        if get_wandb_run() is not None:
+            wb: dict = {f"explainability/hessian/eigval_{i}": float(v) for i, v in enumerate(top_np)}
+            wb["explainability/hessian/sharpness"] = float(lambda_max)
+            wb["explainability/hessian/n_iter"] = int(self._n_iter)
+            wandb_log(wb, step=epoch)
+        return False
+
+    @property
+    def result(self) -> dict:
+        """Collected data as numpy arrays."""
+        empty = np.zeros((0,))
+        return {
+            "epochs": np.array(self._epochs),
+            "eigvals": np.stack(self._eigvals) if self._eigvals else empty,
+            "sharpness": np.array(self._sharpness),
+        }
+
+
 class callbacks:
     """Factory helpers for built-in adaptive training callbacks.
 
@@ -1179,6 +1422,68 @@ class callbacks:
             alpha_range: Perturbation range in units of ``‖θ_selected‖``.
         """
         return LossLandscapeCallback(interval=interval, mask=mask, n_grid=n_grid, alpha_range=alpha_range)
+
+    @staticmethod
+    def hessian_spectrum(
+        k: int = 10,
+        n_iter: int = 30,
+        interval: int = 500,
+        mask=None,
+        constraints=None,
+    ) -> HessianSpectrumCallback:
+        """Create a :class:`HessianSpectrumCallback`.
+
+        Tracks the top-k eigenvalues of the total training loss Hessian
+        via Lanczos with HVPs (Sec. 3.1-3.2, [1912.07145]); the largest
+        eigenvalue is the sharpness of [Keskar et al., Sec. 2.2,
+        1609.04836].
+
+        Args:
+            k: Number of largest eigenvalues to report.
+            n_iter: Number of Lanczos iterations.
+            interval: Compute every *n* outer training steps.
+            mask: Optional pytree of booleans matching ``crux.models``
+                structure — essential for large models.
+            constraints: Optional list of constraint placeholders to scope
+                the Hessian to the mean of those constraints' losses
+                instead of the full training loss.
+        """
+        return HessianSpectrumCallback(
+            k=k,
+            n_iter=n_iter,
+            interval=interval,
+            mask=mask,
+            constraints=constraints,
+        )
+
+    @staticmethod
+    def ntk_spectrum(
+        grad_expr,
+        n_points: int = 256,
+        top_k: int = 10,
+        interval: int = 500,
+    ) -> NTKSpectrumCallback:
+        """Create an :class:`NTKSpectrumCallback`.
+
+        Tracks the empirical NTK eigenvalue spectrum (Sec. 3-4, [2007.14527])
+        for a user-supplied :class:`~jno.trace.NetworkGradient` placeholder,
+        e.g. ``u.grad(net)``.  Restrict to a parameter subset by chaining
+        ``net.mask(mask)`` into the placeholder.
+
+        Args:
+            grad_expr: ``NetworkGradient`` placeholder (typically
+                ``u.grad(net)`` or ``u.grad(net.mask(mask))``).
+            n_points: Subsample cap for kernel rows.  Cost is
+                ``O(n_points² × P)``.
+            top_k: Number of largest eigenvalues to report.
+            interval: Compute every *n* outer training steps.
+        """
+        return NTKSpectrumCallback(
+            grad_expr=grad_expr,
+            n_points=n_points,
+            top_k=top_k,
+            interval=interval,
+        )
 
     @staticmethod
     def input_sensitivity(expr, interval: int = 100) -> InputSensitivityCallback:

--- a/jno/utils/explainability.py
+++ b/jno/utils/explainability.py
@@ -7,6 +7,64 @@ import jax
 import jax.numpy as jnp
 
 
+def make_residual_stats_fn(
+    compiled_constraints_fn,
+    n_constraints: int,
+    batchsize,
+    frozen,
+    static,
+    min_consecutive: int = 1,
+):
+    """Build a function that summarises per-constraint residual distributions.
+
+    The compiled constraints function returns one ``(B, T, ...)`` residual
+    array per constraint *before* the training loss applies ``jnp.mean``.
+    This builder wraps that call and reduces each array to four scalar
+    statistics — exposing *where* in the domain the PDE is poorly satisfied
+    (Sec. 3, [2207.10289]).
+
+    Returns a JIT-friendly callable::
+
+        f(trainable, context, rng) -> (means, stds, maxes, p99, raw)
+
+    where
+      means  : float32 (n_constraints,)  — per-constraint residual mean
+      stds   : float32 (n_constraints,)  — per-constraint residual std
+      maxes  : float32 (n_constraints,)  — per-constraint residual max
+      p99    : float32 (n_constraints,)  — 99th-percentile residual
+      raw    : tuple of 1-D arrays, one per constraint, flattened — for
+               host-side histogram logging
+
+    Args:
+        compiled_constraints_fn: Combined compiled JAX function for all constraints.
+        n_constraints: Number of constraint terms (kept for symmetry with the
+            other builders; not used directly here but documents expected output).
+        batchsize: Mini-batch size (``None`` for full-batch).
+        frozen: Frozen parameter pytree (from ``eqx.partition``).
+        static: Static (non-array) pytree.
+        min_consecutive: Forwarded to ``compiled_constraints_fn``.
+    """
+    del n_constraints  # documented for symmetry only; output length matches the call
+
+    def stats(trainable, context, rng):
+        full_models = eqx.combine(trainable, frozen, static)
+        residuals = compiled_constraints_fn(
+            full_models,
+            context,
+            batchsize=batchsize,
+            key=rng,
+            min_consecutive=min_consecutive,
+        )
+        means = jnp.stack([jnp.mean(r) for r in residuals])
+        stds = jnp.stack([jnp.std(r) for r in residuals])
+        maxes = jnp.stack([jnp.max(r) for r in residuals])
+        p99 = jnp.stack([jnp.percentile(r, 99.0) for r in residuals])
+        raw = tuple(r.ravel() for r in residuals)
+        return means, stds, maxes, p99, raw
+
+    return stats
+
+
 def make_per_loss_grad_fn(
     compiled_constraints_fn,
     n_constraints: int,

--- a/jno/utils/explainability.py
+++ b/jno/utils/explainability.py
@@ -65,6 +65,57 @@ def make_residual_stats_fn(
     return stats
 
 
+def make_expression_eval_fn(
+    expr,
+    all_ops,
+    batchsize,
+    frozen,
+    static,
+    min_consecutive: int = 1,
+):
+    """Build a function that evaluates any placeholder expression during training.
+
+    Compiles a user-supplied jno placeholder expression — for example
+    ``u.d(x)`` for an input gradient (saliency), ``Jacobian(u, [x, y])``
+    for a multi-variable spatial Jacobian, or any composite expression —
+    using the same :class:`~jno.trace_compiler.TraceCompiler` pathway that
+    the solver uses for constraints and trackers (Sec. 3, [1312.6034]).
+
+    Returns a JIT-friendly callable::
+
+        f(trainable, context, rng) -> values
+
+    where ``values`` is the array (or pytree) returned by evaluating
+    ``expr`` against the current parameters and the collocation points
+    bound to ``expr``'s :class:`~jno.trace.Variable` references.
+
+    Args:
+        expr: Any :class:`~jno.trace.Placeholder` expression.
+        all_ops: List of :class:`~jno.trace.OperationDef` (the solver's
+            ``self.all_ops``).  Forwarded to ``compile_multi_expression``.
+        batchsize: Mini-batch size (``None`` for full-batch).
+        frozen: Frozen parameter pytree (from ``eqx.partition``).
+        static: Static (non-array) pytree.
+        min_consecutive: Forwarded to the compiled expression.
+    """
+    from jno.trace_compiler import TraceCompiler
+
+    compiled_fn = TraceCompiler.compile_multi_expression([expr], all_ops)
+
+    def eval_expr(trainable, context, rng):
+        full_models = eqx.combine(trainable, frozen, static)
+        results = compiled_fn(
+            full_models,
+            context,
+            batchsize=batchsize,
+            key=rng,
+            min_consecutive=min_consecutive,
+        )
+        return results[0]
+
+    return eval_expr
+
+
 def make_per_loss_grad_fn(
     compiled_constraints_fn,
     n_constraints: int,

--- a/jno/utils/explainability.py
+++ b/jno/utils/explainability.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 
 def make_residual_stats_fn(
@@ -114,6 +115,228 @@ def make_expression_eval_fn(
         return results[0]
 
     return eval_expr
+
+
+def make_ntk_spectrum_fn(
+    grad_expr,
+    all_ops,
+    batchsize,
+    frozen,
+    static,
+    n_points: int = 256,
+    top_k: int = 10,
+    min_consecutive: int = 1,
+):
+    """Build a function that returns the empirical NTK eigenvalue spectrum.
+
+    Compiles a :class:`~jno.trace.NetworkGradient` placeholder (e.g.
+    ``u.grad(net)`` or, for a parameter subset, ``u.grad(net.mask(mask))``)
+    to produce a per-point parameter Jacobian
+    :math:`J \\in \\mathbb{R}^{N \\times P}` and forms the empirical Neural
+    Tangent Kernel :math:`K = J J^\\top \\in \\mathbb{R}^{N \\times N}`.
+
+    The returned closure subsamples ``n_points`` rows (without replacement)
+    from the full collocation grid, builds :math:`K`, and reports its
+    eigenvalue spectrum.  This is the canonical diagnostic for the PINN
+    spectral-bias problem (Sec. 3-4, [2007.14527]) — a wide eigenvalue
+    spread indicates that the network is learning some directions vastly
+    faster than others.
+
+    Returns a JIT-friendly callable::
+
+        f(trainable, context, rng) ->
+            (eigvals_topk, lambda_min, lambda_max, condition, all_eigvals)
+
+    where eigenvalues are returned in descending order, ``condition`` is
+    :math:`\\lambda_{\\max} / \\lambda_{\\min}`, and ``all_eigvals`` has
+    length ``n_points``.
+
+    Args:
+        grad_expr: A :class:`~jno.trace.NetworkGradient` placeholder, e.g.
+            ``u.grad(net)``.  Use ``net.mask(...)`` to restrict to a
+            parameter subset — masking lives in the placeholder itself
+            rather than in a separate callback argument.
+        all_ops: Solver's ``self.all_ops``.
+        batchsize: Mini-batch size (``None`` for full-batch).
+        frozen: Frozen parameter pytree (from ``eqx.partition``).
+        static: Static (non-array) pytree.
+        n_points: Number of collocation points to subsample for the kernel.
+            Cost is ``O(n_points² × P)``; default ``256``.
+        top_k: Number of largest eigenvalues to report.  Default ``10``.
+        min_consecutive: Forwarded to the compiled expression.
+
+    Note:
+        The point subsample uses a fixed seed (``jax.random.PRNGKey(0)``)
+        so the *same* rows are selected at every call — this makes the
+        recorded eigenvalue spectrum directly comparable across epochs.
+    """
+    from jno.trace_compiler import TraceCompiler
+
+    compiled_fn = TraceCompiler.compile_multi_expression([grad_expr], all_ops)
+    sample_key_const = jax.random.PRNGKey(0)  # closed over below
+
+    def spectrum(trainable, context, rng):
+        full_models = eqx.combine(trainable, frozen, static)
+        results = compiled_fn(
+            full_models,
+            context,
+            batchsize=batchsize,
+            key=rng,
+            min_consecutive=min_consecutive,
+        )
+        # NetworkGradient compiles to shape (B, N, P) for scalar output and
+        # (B, N, D, P) for D-dim output.  We require scalar output: silently
+        # mixing the D output components into the row axis would produce a
+        # confidently-wrong kernel.
+        J_full = results[0]
+        if J_full.ndim != 3:
+            raise ValueError(
+                "ntk_spectrum expects a scalar-output NetworkGradient (shape "
+                f"(B, N, P)); got J with shape {J_full.shape}.  For a "
+                "vector-valued network, project to a scalar first — e.g. "
+                "u[..., 0].grad(net)."
+            )
+        J = J_full.reshape(-1, J_full.shape[-1])  # (N_total, P)
+
+        N_total = J.shape[0]
+        n_take = min(n_points, N_total)
+        idx = jax.random.choice(sample_key_const, N_total, shape=(n_take,), replace=False)
+        J_sub = J[idx]  # (n_take, P)
+
+        K = J_sub @ J_sub.T  # (n_take, n_take)
+        eigvals_asc = jnp.linalg.eigvalsh(K)
+        eigvals_desc = eigvals_asc[::-1]
+        top = eigvals_desc[:top_k]
+        lambda_max = eigvals_desc[0]
+        lambda_min = eigvals_desc[-1]
+        condition = lambda_max / (jnp.abs(lambda_min) + 1e-12)
+        return top, lambda_min, lambda_max, condition, eigvals_desc
+
+    return spectrum
+
+
+def make_hessian_spectrum_fn(
+    compiled_constraints_fn,
+    batchsize,
+    frozen,
+    static,
+    param_mask=None,
+    min_consecutive: int = 1,
+    k: int = 10,
+    n_iter: int = 30,
+    constraint_indices=None,
+):
+    """Build a function that returns the top-k Hessian eigenvalues via Lanczos.
+
+    Constructs the Hessian-vector product (HVP) of the total training
+    loss with respect to the (optionally masked) trainable parameters via
+    ``jvp(grad(L), …, …)``, runs ``n_iter`` Lanczos iterations with full
+    reorthogonalisation, and returns the top-k eigenvalues of the
+    Lanczos tridiagonal — which approximate the top-k eigenvalues of the
+    full Hessian (Sec. 3.1-3.2, [1912.07145]).  The largest of these is
+    the *sharpness* of [Keskar et al., Sec. 2.2, 1609.04836]: a high
+    value predicts that the optimiser is sitting in a sharp minimum,
+    typically associated with worse generalisation.
+
+    Returns a Python driver function (the inner HVP is JIT-compiled;
+    the Lanczos loop runs in Python and the tridiagonal is eigen-
+    decomposed host-side via ``scipy.linalg.eigh_tridiagonal``)::
+
+        f(trainable, context, rng) -> (eigvals_topk, lambda_max, all_eigvals)
+
+    where eigenvalues are returned in descending order.
+
+    Args:
+        compiled_constraints_fn: Combined compiled JAX function for all constraints.
+        batchsize: Mini-batch size (``None`` for full-batch).
+        frozen: Frozen parameter pytree.
+        static: Static (non-array) pytree.
+        param_mask: Optional pytree of booleans matching *trainable*; when
+            set, the Hessian is computed only on the selected subset.
+            Essential for large models.
+        min_consecutive: Forwarded to ``compiled_constraints_fn``.
+        k: Number of top eigenvalues to report.  Default ``10``.
+        n_iter: Number of Lanczos iterations.  Default ``30``.
+        constraint_indices: Optional tuple of integer indices into the
+            solver's compiled constraints.  When set, the Hessian is taken
+            over the mean of *only* those constraint losses rather than
+            the full training loss — useful for diagnosing which
+            constraint drives the sharpness.  Default ``None`` (full loss).
+    """
+    _selected_idx = jnp.array(constraint_indices) if constraint_indices is not None else None
+
+    def _total_loss(selected, held_fixed, context, rng):
+        if held_fixed is not None:
+            trainable_full = eqx.combine(selected, held_fixed)
+        else:
+            trainable_full = selected
+        full_models = eqx.combine(trainable_full, frozen, static)
+        residuals = compiled_constraints_fn(
+            full_models,
+            context,
+            batchsize=batchsize,
+            key=rng,
+            min_consecutive=min_consecutive,
+        )
+        losses = jnp.stack([jnp.mean(r) for r in residuals])
+        if _selected_idx is not None:
+            losses = losses[_selected_idx]
+        return jnp.mean(losses)
+
+    @jax.jit
+    def _hvp_pytree(selected, held_fixed, context, rng, v_pytree):
+        grad_fn = jax.grad(lambda s: _total_loss(s, held_fixed, context, rng))
+        _, hv = jax.jvp(grad_fn, (selected,), (v_pytree,))
+        return hv
+
+    # Fixed seed for the Lanczos start vector — see PR-4 commit for rationale.
+    start_key_const = jax.random.PRNGKey(0)
+
+    def spectrum(trainable, context, rng):
+        if param_mask is not None:
+            selected, held_fixed = eqx.partition(trainable, param_mask)
+        else:
+            selected, held_fixed = trainable, None
+
+        flat_v0, unravel = jax.flatten_util.ravel_pytree(selected)
+        n = flat_v0.size
+
+        def matvec(v_flat):
+            v_pytree = unravel(v_flat)
+            hv_pytree = _hvp_pytree(selected, held_fixed, context, rng, v_pytree)
+            hv_flat, _ = jax.flatten_util.ravel_pytree(hv_pytree)
+            return hv_flat
+
+        # Lanczos with full reorthogonalisation — Python loop, JIT'd matvec.
+        v = jax.random.normal(start_key_const, (n,))
+        v = v / (jnp.linalg.norm(v) + 1e-30)
+        Q = [v]
+        alphas: list = []
+        betas: list = []
+        for j in range(n_iter):
+            w = matvec(Q[-1])
+            alpha = jnp.dot(Q[-1], w)
+            alphas.append(alpha)
+            w = w - alpha * Q[-1]
+            if j > 0:
+                w = w - betas[-1] * Q[-2]
+            for q in Q[:-1]:
+                w = w - jnp.dot(q, w) * q
+            beta = jnp.linalg.norm(w)
+            Q.append(w / (beta + 1e-30))
+            betas.append(beta)
+
+        from scipy.linalg import eigh_tridiagonal
+
+        alphas_h = np.array([float(a) for a in alphas], dtype=np.float64)
+        betas_h = np.array([float(b) for b in betas], dtype=np.float64)
+        eigvals = eigh_tridiagonal(alphas_h, betas_h[:-1], eigvals_only=True)
+        eigvals_desc = np.sort(eigvals)[::-1].astype(np.float32)
+        top = eigvals_desc[:k]
+        lambda_max = float(eigvals_desc[0])
+        return top, lambda_max, eigvals_desc
+
+    return spectrum
 
 
 def make_per_loss_grad_fn(

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -114,3 +114,46 @@ def test_residual_stats_subset_selects_one_constraint():
         # Re-using the same already-built solver; on_solve_begin fires when
         # solve() is called again.
         solver.solve(1, callbacks=[cb_bad])
+
+
+def test_input_saliency_records_finite_values_with_consistent_shape():
+    """InputSensitivityCallback compiles ``u.d(x)`` and records finite
+    per-point sensitivities of consistent shape across sampled epochs.
+    Params are frozen via lr=0, so values should not change between epochs.
+    """
+    import foundax
+    import optax
+
+    import jno
+    import jno.jnp_ops as jnn
+    from jno import LearningRateSchedule as lrs
+    from jno.utils.adaptive.callbacks import InputSensitivityCallback
+
+    domain = jno.domain(constructor=jno.domain.line(mesh_size=0.1))
+    x, _ = domain.variable("interior")
+    key = jax.random.PRNGKey(0)
+
+    u_net = jnn.nn.wrap(foundax.mlp(1, hidden_dims=4, num_layers=2, key=key))
+    u_net.optimizer(optax.sgd, lr=lrs.exponential(0.0, 1.0, 1, 0.0))  # lr=0
+    u = u_net(x)
+    pde = u
+
+    solver = jno.core([pde.mse], domain)
+    cb = InputSensitivityCallback(u.d(x), interval=1)
+    solver.solve(2, callbacks=[cb])
+
+    values = cb.result["values"]
+    assert cb.result["epochs"].shape == (2,)
+    assert values.shape[0] == 2
+    assert np.all(np.isfinite(values))
+    np.testing.assert_allclose(values[0], values[1], atol=1e-5)
+
+
+def test_input_sensitivity_rejects_non_placeholder():
+    """InputSensitivityCallback rejects non-Placeholder arguments."""
+    import pytest
+
+    from jno.utils.adaptive.callbacks import InputSensitivityCallback
+
+    with pytest.raises(TypeError, match="Placeholder"):
+        InputSensitivityCallback(expr=jnp.zeros(3), interval=1)

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -157,3 +157,200 @@ def test_input_sensitivity_rejects_non_placeholder():
 
     with pytest.raises(TypeError, match="Placeholder"):
         InputSensitivityCallback(expr=jnp.zeros(3), interval=1)
+
+
+# ---------------------------------------------------------------------------
+# NTK spectrum
+# ---------------------------------------------------------------------------
+
+
+def test_ntk_spectrum_records_finite_eigenvalues_with_consistent_shape():
+    """NTKSpectrumCallback compiles u.grad(net) and records finite
+    eigenvalues with the expected shape; spectrum is identical across
+    epochs when params are frozen (lr=0) thanks to the fixed sample seed.
+    """
+    import foundax
+    import optax
+
+    import jno
+    import jno.jnp_ops as jnn
+    from jno import LearningRateSchedule as lrs
+    from jno.utils.adaptive.callbacks import NTKSpectrumCallback
+
+    domain = jno.domain(constructor=jno.domain.line(mesh_size=0.1))
+    x, _ = domain.variable("interior")
+    key = jax.random.PRNGKey(0)
+
+    u_net = jnn.nn.wrap(foundax.mlp(1, hidden_dims=4, num_layers=2, key=key))
+    u_net.optimizer(optax.sgd, lr=lrs.exponential(0.0, 1.0, 1, 0.0))
+    u = u_net(x)
+    pde = u
+
+    n_points = 8
+    top_k = 5
+
+    solver = jno.core([pde.mse], domain)
+    cb = NTKSpectrumCallback(u.grad(u_net), n_points=n_points, top_k=top_k, interval=1)
+    solver.solve(2, callbacks=[cb])
+
+    res = cb.result
+    assert res["epochs"].shape == (2,)
+    assert res["eigvals_topk"].shape == (2, top_k)
+    assert res["all_eigvals"].shape == (2, n_points)
+    assert np.all(np.isfinite(res["all_eigvals"]))
+    assert np.all(res["all_eigvals"] >= -1e-5)
+    assert np.all(res["eigvals_topk"][:, :-1] >= res["eigvals_topk"][:, 1:] - 1e-6)
+    np.testing.assert_allclose(res["eigvals_topk"][0], res["eigvals_topk"][1], atol=1e-5)
+
+
+def test_ntk_spectrum_rejects_non_network_gradient():
+    """NTKSpectrumCallback rejects non-NetworkGradient arguments."""
+    import pytest
+
+    from jno.utils.adaptive.callbacks import NTKSpectrumCallback
+
+    with pytest.raises(TypeError, match="NetworkGradient"):
+        NTKSpectrumCallback(grad_expr=jnp.zeros(3), n_points=4)
+
+
+# ---------------------------------------------------------------------------
+# Hessian spectrum
+# ---------------------------------------------------------------------------
+
+
+def test_hessian_spectrum_records_finite_eigenvalues_with_consistent_shape():
+    """HessianSpectrumCallback runs Lanczos and records top-k eigenvalues +
+    a sharpness scalar with the expected shape; identical across epochs
+    when params are frozen (lr=0) thanks to the fixed Lanczos start seed.
+    """
+    import foundax
+    import optax
+
+    import jno
+    import jno.jnp_ops as jnn
+    from jno import LearningRateSchedule as lrs
+    from jno.utils.adaptive.callbacks import HessianSpectrumCallback
+
+    domain = jno.domain(constructor=jno.domain.line(mesh_size=0.1))
+    x, _ = domain.variable("interior")
+    key = jax.random.PRNGKey(0)
+
+    u_net = jnn.nn.wrap(foundax.mlp(1, hidden_dims=4, num_layers=2, key=key))
+    u_net.optimizer(optax.sgd, lr=lrs.exponential(0.0, 1.0, 1, 0.0))
+    u = u_net(x)
+    pde = u
+
+    k = 4
+    n_iter = 8
+
+    solver = jno.core([pde.mse], domain)
+    cb = HessianSpectrumCallback(k=k, n_iter=n_iter, interval=1)
+    solver.solve(2, callbacks=[cb])
+
+    res = cb.result
+    assert res["epochs"].shape == (2,)
+    assert res["eigvals"].shape == (2, k)
+    assert res["sharpness"].shape == (2,)
+    assert np.all(np.isfinite(res["eigvals"]))
+    assert np.all(np.isfinite(res["sharpness"]))
+    np.testing.assert_allclose(res["sharpness"], res["eigvals"][:, 0], atol=1e-5)
+    assert np.all(res["eigvals"][:, :-1] >= res["eigvals"][:, 1:] - 1e-5)
+    np.testing.assert_allclose(res["eigvals"][0], res["eigvals"][1], atol=1e-5)
+
+
+def test_hessian_lanczos_recovers_quadratic_top_eigenvalue():
+    """For L = mean(p²) with N=4 params, Hessian = (2/N)·I → λ_max = 0.5."""
+    from jno.utils.explainability import make_hessian_spectrum_fn
+
+    theta = jnp.array([1.0, 2.0, 3.0, 4.0])
+    trainable = {"theta": theta}
+
+    def constraints_fn(full_models, context, *, batchsize, key, min_consecutive):
+        del context, batchsize, key, min_consecutive
+        params = full_models["theta"]
+        return [params * params]
+
+    fn = make_hessian_spectrum_fn(
+        constraints_fn,
+        batchsize=None,
+        frozen={"theta": None},
+        static={"theta": None},
+        k=3,
+        n_iter=10,
+    )
+    top, lambda_max, all_eigs = fn(trainable, context={}, rng=jax.random.PRNGKey(0))
+    expected = 2.0 / 4.0
+    assert abs(lambda_max - expected) < 1e-5
+    assert abs(top[0] - expected) < 1e-5
+    assert all_eigs.shape == (10,)
+
+
+def test_hessian_constraint_subset_isolates_one_constraint():
+    """Subsetting the Hessian to one of two constraints with different
+    closed-form λ_max recovers that constraint's value, not the mean.
+    """
+    from jno.utils.explainability import make_hessian_spectrum_fn
+
+    N = 4
+    a = 3.0
+    b = 1.0
+    theta = jnp.zeros((N,))
+    trainable = {"theta": theta}
+
+    def constraints_fn(full_models, context, *, batchsize, key, min_consecutive):
+        del context, batchsize, key, min_consecutive
+        p = full_models["theta"]
+        return [(a * p) * (a * p), (b * p) * (b * p)]
+
+    fn_full = make_hessian_spectrum_fn(
+        constraints_fn,
+        batchsize=None,
+        frozen={"theta": None},
+        static={"theta": None},
+        k=2,
+        n_iter=6,
+    )
+    fn_sub = make_hessian_spectrum_fn(
+        constraints_fn,
+        batchsize=None,
+        frozen={"theta": None},
+        static={"theta": None},
+        k=2,
+        n_iter=6,
+        constraint_indices=(0,),
+    )
+
+    _, lmax_full, _ = fn_full(trainable, context={}, rng=jax.random.PRNGKey(0))
+    _, lmax_sub, _ = fn_sub(trainable, context={}, rng=jax.random.PRNGKey(0))
+
+    expected_full = (a**2 + b**2) / N
+    expected_sub = 2 * a**2 / N
+    assert abs(lmax_full - expected_full) < 1e-5
+    assert abs(lmax_sub - expected_sub) < 1e-5
+    assert abs(lmax_sub - lmax_full) > 0.1
+
+
+def test_hessian_spectrum_subset_rejects_unknown_constraint():
+    """Re-accessing .mse after solver construction fails identity matching."""
+    import foundax
+    import optax
+    import pytest
+
+    import jno
+    import jno.jnp_ops as jnn
+    from jno import LearningRateSchedule as lrs
+    from jno.utils.adaptive.callbacks import HessianSpectrumCallback
+
+    domain = jno.domain(constructor=jno.domain.line(mesh_size=0.1))
+    x, _ = domain.variable("interior")
+    key = jax.random.PRNGKey(0)
+    u_net = jnn.nn.wrap(foundax.mlp(1, hidden_dims=4, num_layers=2, key=key))
+    u_net.optimizer(optax.sgd, lr=lrs.exponential(0.0, 1.0, 1, 0.0))
+    u = u_net(x)
+    pde_loss = u.mse
+
+    solver = jno.core([pde_loss], domain)
+
+    cb_bad = HessianSpectrumCallback(k=2, n_iter=4, interval=1, constraints=[u.mse])
+    with pytest.raises(ValueError, match="constraint .* not found"):
+        solver.solve(1, callbacks=[cb_bad])

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -61,3 +61,56 @@ def test_residual_stats_matches_handcomputed():
     assert len(raw) == 2
     assert raw[0].shape == (11,)
     assert raw[1].shape == (4,)
+
+
+def test_residual_stats_subset_selects_one_constraint():
+    """End-to-end: passing a subset of constraints scopes stats and W&B keys
+    to those constraints only.
+    """
+    import foundax
+    import optax
+    import pytest
+
+    import jno
+    import jno.jnp_ops as jnn
+    from jno import LearningRateSchedule as lrs
+    from jno.utils.adaptive.callbacks import ResidualStatsCallback
+
+    domain = jno.domain(constructor=jno.domain.line(mesh_size=0.1))
+    x, _ = domain.variable("interior")
+    key = jax.random.PRNGKey(0)
+
+    u_net = jnn.nn.wrap(foundax.mlp(1, hidden_dims=4, num_layers=2, key=key))
+    u_net.optimizer(optax.sgd, lr=lrs.exponential(0.0, 1.0, 1, 0.0))  # frozen
+    u = u_net(x)
+    c0 = (u * u).mse  # arbitrary residual
+    c1 = u.mse  # second constraint, different residual
+
+    solver = jno.core([c0, c1], domain)
+
+    # Subset: only c0 → result should have 1 column, and only the
+    # solver-side index 0 should appear in W&B keys (we can't inspect those
+    # without mocking, but we can verify the .result["indices"] is [0]).
+    cb_subset = ResidualStatsCallback(interval=1, constraints=[c0])
+    # Full: both constraints
+    cb_full = ResidualStatsCallback(interval=1)
+
+    solver.solve(2, callbacks=[cb_subset, cb_full])
+
+    # Subset result has K=1 column with index 0.
+    assert cb_subset.result["means"].shape == (2, 1)
+    np.testing.assert_array_equal(cb_subset.result["indices"], np.array([0]))
+
+    # Full has K=2 columns.
+    assert cb_full.result["means"].shape == (2, 2)
+    np.testing.assert_array_equal(cb_full.result["indices"], np.array([0, 1]))
+
+    # Subset's c0 column must equal full's c0 column (same compute, just sliced).
+    np.testing.assert_allclose(cb_subset.result["means"][:, 0], cb_full.result["means"][:, 0], atol=1e-6)
+
+    # Re-accessing .mse returns a fresh placeholder → identity match fails.
+    cb_bad = ResidualStatsCallback(interval=1, constraints=[(u * u).mse])
+    with pytest.raises(ValueError, match="constraint .* not found"):
+        # Re-using the same already-built solver; on_solve_begin fires when
+        # solve() is called again.
+        solver.solve(1, callbacks=[cb_bad])

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -1,0 +1,63 @@
+"""Unit tests for builders in ``jno.utils.explainability``.
+
+These tests exercise each builder against a hand-crafted constraint
+function with known residual values, asserting that the JIT-compiled
+closure returns the analytically expected statistics. They are *not*
+end-to-end solver tests — that integration lives in
+``test_wandb_integration.py::TestExplainabilityCallbacksWandBLogging``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jno.utils.explainability import make_residual_stats_fn
+
+
+def test_residual_stats_matches_handcomputed():
+    """Residual stats closure returns mean/std/max/p99 matching numpy ground truth."""
+    # Two synthetic constraints with known residual arrays of different shapes.
+    r0 = jnp.linspace(0.0, 1.0, 11)  # shape (11,) — values 0.0, 0.1, ..., 1.0
+    r1 = jnp.array([0.5, 0.5, 0.5, 4.0])  # shape (4,) — one big outlier
+
+    def fake_constraints_fn(full_models, context, *, batchsize, key, min_consecutive):
+        # Signature matches the real ``compiled_constraints_fn``; arguments unused
+        # because the residuals are baked in for this unit test.
+        del full_models, context, batchsize, key, min_consecutive
+        return [r0, r1]
+
+    fn = make_residual_stats_fn(
+        compiled_constraints_fn=fake_constraints_fn,
+        n_constraints=2,
+        batchsize=None,
+        frozen={},
+        static={},
+    )
+    fn = jax.jit(fn)
+
+    # Empty trainable / context are accepted because fake_constraints_fn ignores them.
+    means, stds, maxes, p99, raw = fn(trainable={}, context={}, rng=jax.random.PRNGKey(0))
+    means = np.asarray(means)
+    stds = np.asarray(stds)
+    maxes = np.asarray(maxes)
+    p99 = np.asarray(p99)
+
+    expected_means = np.array([np.mean(np.asarray(r0)), np.mean(np.asarray(r1))], dtype=np.float32)
+    expected_stds = np.array([np.std(np.asarray(r0)), np.std(np.asarray(r1))], dtype=np.float32)
+    expected_maxes = np.array([np.max(np.asarray(r0)), np.max(np.asarray(r1))], dtype=np.float32)
+    expected_p99 = np.array(
+        [np.percentile(np.asarray(r0), 99.0), np.percentile(np.asarray(r1), 99.0)],
+        dtype=np.float32,
+    )
+
+    np.testing.assert_allclose(means, expected_means, atol=1e-6)
+    np.testing.assert_allclose(stds, expected_stds, atol=1e-6)
+    np.testing.assert_allclose(maxes, expected_maxes, atol=1e-6)
+    np.testing.assert_allclose(p99, expected_p99, atol=1e-5)
+
+    # Raw residuals are returned as flattened 1-D arrays per constraint.
+    assert len(raw) == 2
+    assert raw[0].shape == (11,)
+    assert raw[1].shape == (4,)

--- a/tests/test_wandb_integration.py
+++ b/tests/test_wandb_integration.py
@@ -225,6 +225,7 @@ class TestExplainabilityCallbacksWandBLogging:
         """Smoke-test: all explainability keys + checkpoint metadata reach W&B."""
         import foundax
         import jax
+        import numpy as np
         import optax
 
         import jno
@@ -235,8 +236,10 @@ class TestExplainabilityCallbacksWandBLogging:
             CosSimilarityCallback,
             GradientAlignmentCallback,
             GradientNormsCallback,
+            HessianSpectrumCallback,
             InputSensitivityCallback,
             LossLandscapeCallback,
+            NTKSpectrumCallback,
             ResidualStatsCallback,
         )
 
@@ -259,6 +262,10 @@ class TestExplainabilityCallbacksWandBLogging:
         cb_residual = ResidualStatsCallback(interval=1)
         # Input saliency: ∂u/∂x evaluated at the interior collocation points.
         cb_saliency = InputSensitivityCallback(u.d(x), interval=1)
+        # NTK spectrum on u.grad(net) — subsample to all 8 interior points, top_k=3.
+        cb_ntk = NTKSpectrumCallback(u.grad(u_net), n_points=8, top_k=3, interval=1)
+        # Hessian spectrum
+        cb_hess = HessianSpectrumCallback(k=3, n_iter=5, interval=1)
         cb_ckpt = CheckpointCallback(
             directory=str(tmp_path / "ckpts"),
             save_interval_epochs=1,
@@ -273,7 +280,7 @@ class TestExplainabilityCallbacksWandBLogging:
         with patch.dict("sys.modules", {"wandb": mock_wandb}):
             solver.solve(
                 3,
-                callbacks=[cb_norms, cb_cos, cb_align, cb_land, cb_residual, cb_saliency, cb_ckpt],
+                callbacks=[cb_norms, cb_cos, cb_align, cb_land, cb_residual, cb_saliency, cb_ntk, cb_hess, cb_ckpt],
             )
         cb_ckpt.close()
 
@@ -310,6 +317,17 @@ class TestExplainabilityCallbacksWandBLogging:
         assert "explainability/saliency/max_abs" in logged_keys
         assert "explainability/saliency/std_abs" in logged_keys
 
+        # NTK spectrum — top-k + scalars
+        assert "explainability/ntk/lambda_max" in logged_keys
+        assert "explainability/ntk/lambda_min" in logged_keys
+        assert "explainability/ntk/condition_number" in logged_keys
+        assert "explainability/ntk/eigval_0" in logged_keys
+
+        # Hessian eigenspectrum — top-k + sharpness
+        assert "explainability/hessian/sharpness" in logged_keys
+        assert "explainability/hessian/eigval_0" in logged_keys
+        assert "explainability/hessian/n_iter" in logged_keys
+
         # ── checkpoint artifact carries checkpoint_dir + loss fields ─────────
         assert mock_run.log_artifact.called, "Expected at least one checkpoint artifact upload"
         ckpt_artifact_calls = [c for c in mock_wandb.Artifact.call_args_list if c.kwargs.get("type") == "checkpoint"]
@@ -334,3 +352,10 @@ class TestExplainabilityCallbacksWandBLogging:
         # saliency: result["values"] holds the raw expression evaluations
         assert cb_saliency.result["values"].ndim >= 2
         assert len(cb_saliency.result["epochs"]) > 0
+        # NTK: top-k=3 eigvals, n_points=8 → all_eigvals shape (S, 8)
+        assert cb_ntk.result["eigvals_topk"].shape[1] == 3
+        assert cb_ntk.result["all_eigvals"].shape[1] == 8
+        assert np.all(np.isfinite(cb_ntk.result["lambda_max"]))
+        # Hessian: top-k=3 eigvals, sharpness scalar
+        assert cb_hess.result["eigvals"].shape[1] == 3
+        assert cb_hess.result["sharpness"].ndim == 1

--- a/tests/test_wandb_integration.py
+++ b/tests/test_wandb_integration.py
@@ -235,6 +235,7 @@ class TestExplainabilityCallbacksWandBLogging:
             CosSimilarityCallback,
             GradientAlignmentCallback,
             GradientNormsCallback,
+            InputSensitivityCallback,
             LossLandscapeCallback,
             ResidualStatsCallback,
         )
@@ -256,6 +257,8 @@ class TestExplainabilityCallbacksWandBLogging:
         cb_align = GradientAlignmentCallback(interval=1)
         cb_land = LossLandscapeCallback(interval=1, n_grid=3)
         cb_residual = ResidualStatsCallback(interval=1)
+        # Input saliency: ∂u/∂x evaluated at the interior collocation points.
+        cb_saliency = InputSensitivityCallback(u.d(x), interval=1)
         cb_ckpt = CheckpointCallback(
             directory=str(tmp_path / "ckpts"),
             save_interval_epochs=1,
@@ -270,7 +273,7 @@ class TestExplainabilityCallbacksWandBLogging:
         with patch.dict("sys.modules", {"wandb": mock_wandb}):
             solver.solve(
                 3,
-                callbacks=[cb_norms, cb_cos, cb_align, cb_land, cb_residual, cb_ckpt],
+                callbacks=[cb_norms, cb_cos, cb_align, cb_land, cb_residual, cb_saliency, cb_ckpt],
             )
         cb_ckpt.close()
 
@@ -302,6 +305,11 @@ class TestExplainabilityCallbacksWandBLogging:
                     f"missing explainability/residual/constraint_{i}/{stat}"
                 )
 
+        # input sensitivity / saliency — three scalar stats per call
+        assert "explainability/saliency/mean_abs" in logged_keys
+        assert "explainability/saliency/max_abs" in logged_keys
+        assert "explainability/saliency/std_abs" in logged_keys
+
         # ── checkpoint artifact carries checkpoint_dir + loss fields ─────────
         assert mock_run.log_artifact.called, "Expected at least one checkpoint artifact upload"
         ckpt_artifact_calls = [c for c in mock_wandb.Artifact.call_args_list if c.kwargs.get("type") == "checkpoint"]
@@ -323,3 +331,6 @@ class TestExplainabilityCallbacksWandBLogging:
         assert cb_residual.result["means"].shape[1] == 2  # N=2 constraints
         assert cb_residual.result["maxes"].shape == cb_residual.result["means"].shape
         assert cb_residual.result["p99"].shape == cb_residual.result["means"].shape
+        # saliency: result["values"] holds the raw expression evaluations
+        assert cb_saliency.result["values"].ndim >= 2
+        assert len(cb_saliency.result["epochs"]) > 0

--- a/tests/test_wandb_integration.py
+++ b/tests/test_wandb_integration.py
@@ -236,6 +236,7 @@ class TestExplainabilityCallbacksWandBLogging:
             GradientAlignmentCallback,
             GradientNormsCallback,
             LossLandscapeCallback,
+            ResidualStatsCallback,
         )
 
         # ── two-constraint 1-D Poisson ──────────────────────────────────────
@@ -254,6 +255,7 @@ class TestExplainabilityCallbacksWandBLogging:
         cb_cos = CosSimilarityCallback(interval=1)
         cb_align = GradientAlignmentCallback(interval=1)
         cb_land = LossLandscapeCallback(interval=1, n_grid=3)
+        cb_residual = ResidualStatsCallback(interval=1)
         cb_ckpt = CheckpointCallback(
             directory=str(tmp_path / "ckpts"),
             save_interval_epochs=1,
@@ -268,7 +270,7 @@ class TestExplainabilityCallbacksWandBLogging:
         with patch.dict("sys.modules", {"wandb": mock_wandb}):
             solver.solve(
                 3,
-                callbacks=[cb_norms, cb_cos, cb_align, cb_land, cb_ckpt],
+                callbacks=[cb_norms, cb_cos, cb_align, cb_land, cb_residual, cb_ckpt],
             )
         cb_ckpt.close()
 
@@ -293,6 +295,13 @@ class TestExplainabilityCallbacksWandBLogging:
             "Expected loss landscape to be logged (image or scalar fallback)"
         )
 
+        # residual stats — one key per stat per constraint (N=2)
+        for i in (0, 1):
+            for stat in ("mean", "std", "max", "p99"):
+                assert f"explainability/residual/constraint_{i}/{stat}" in logged_keys, (
+                    f"missing explainability/residual/constraint_{i}/{stat}"
+                )
+
         # ── checkpoint artifact carries checkpoint_dir + loss fields ─────────
         assert mock_run.log_artifact.called, "Expected at least one checkpoint artifact upload"
         ckpt_artifact_calls = [c for c in mock_wandb.Artifact.call_args_list if c.kwargs.get("type") == "checkpoint"]
@@ -310,3 +319,7 @@ class TestExplainabilityCallbacksWandBLogging:
         assert cb_align.result["alignment"].ndim == 1
         assert len(cb_align.result["alignment"]) > 0
         assert cb_land.result["landscapes"].shape[1:] == (3, 3)
+        assert cb_residual.result["means"].ndim == 2
+        assert cb_residual.result["means"].shape[1] == 2  # N=2 constraints
+        assert cb_residual.result["maxes"].shape == cb_residual.result["means"].shape
+        assert cb_residual.result["p99"].shape == cb_residual.result["means"].shape


### PR DESCRIPTION
## Summary

Extends the explainability feature (shipped in #44) with **four new callbacks** that complement the existing four loss-side diagnostics, plus an AI-disclosure section in the README. All callbacks follow the established `jno.callbacks.<name>(...)` factory pattern, pre-compile in `on_solve_begin`, and log to W&B under `explainability/...` keys when a run is active.

### New callbacks

| Callback | Diagnostic | Origin |
|---|---|---|
| `residual_stats` | Per-constraint mean/std/max/p99 of residuals + histogram | [Wu et al. 2023, Sec. 3](https://arxiv.org/abs/2207.10289) |
| `input_sensitivity` | Evaluates any jno placeholder expression at collocation points (e.g. `u.d(x)` for saliency) | [Simonyan et al. 2014, Sec. 3](https://arxiv.org/abs/1312.6034) |
| `ntk_spectrum` | Empirical NTK eigenvalue spectrum + condition number from `u.grad(net)` | [Wang, Wang & Perdikaris 2022, Sec. 3-4](https://arxiv.org/abs/2007.14527) |
| `hessian_spectrum` | Top-k Hessian eigenvalues (sharpness) via Lanczos + HVPs | [Yao et al. 2020, Sec. 3.1-3.2](https://arxiv.org/abs/1912.07145) + [Keskar et al. 2017, Sec. 2.2](https://arxiv.org/abs/1609.04836) |

### Design choices

- **Placeholder-driven API**: callbacks that need a custom expression (saliency, NTK) accept jno `Placeholder` arguments and compile them via the existing `TraceCompiler.compile_multi_expression` pathway. Parameter masking lives in the placeholder via `net.mask(...)`.
- **Constraint-subset selection**: `residual_stats` and `hessian_spectrum` accept a `constraints=[...]` arg to scope to a subset of the solver's constraints. Matching is by Python identity — users must assign constraints to variables before passing them to both `jno.core([...])` and the callback.
- **Reproducible spectra**: NTK and Hessian both use a fixed `PRNGKey(0)` for their stochastic step (point subsample / Lanczos start vector) so the recorded spectrum is comparable across epochs.
- **Solver hook addition**: `core.on_solve_begin(...)` now also passes `all_ops`, `domain`, and `constraint_exprs` so the new callbacks can compile placeholders and validate constraint subsets. Existing callbacks accept `**kwargs` and are unaffected.

### What's included

- 4 builder functions in `jno/utils/explainability.py` (`make_residual_stats_fn`, `make_expression_eval_fn`, `make_ntk_spectrum_fn`, `make_hessian_spectrum_fn`).
- 4 callback classes + 4 factory methods in `jno/utils/adaptive/callbacks.py`.
- Solver hook additions in `jno/core.py` (`_user_constraint_exprs` storage + 3 new `on_solve_begin` kwargs).
- Closed-form unit tests in `tests/test_explainability.py` (residual stats vs hand-computed; saliency on frozen linear network; NTK shape + non-negativity + descending order; Hessian recovers `λ_max = 0.5` for `L = mean(p²)`; constraint-subset isolates analytical per-constraint Hessian).
- Extended integration test in `tests/test_wandb_integration.py` exercising all 8 callbacks against a real 1-D Poisson solver and asserting every W&B key prefix.
- New docs sections in `docs/training/explainability.md` for each callback (with math + W&B keys + cost callout + citation).
- Tutorial walk-through in `docs/tutorial_examples/09_wandb/wandb_integration.py` covering all four.
- AI disclosure section in `README.md`.

## Test plan

- [x] `pixi run ci-fmt` — clean
- [x] `pixi run ci-lint` — clean
- [x] `pixi run ci-test` — 1264 passed, 7 skipped, 0 failed
- [x] Closed-form unit tests verify each builder's numerical correctness
- [x] Integration test exercises all 8 callbacks end-to-end with mocked W&B
- [ ] Manual smoke test: run `docs/tutorial_examples/09_wandb/wandb_integration.py` and confirm metrics appear in the W&B dashboard