### PR TITLE
Bump version to 0.2.3, require foundax>=0.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it."
 title: "jNO: A JAX Library for Neural Operator and Foundation Model Training"
-version: "0.2.2"
+version: "0.2.3"
 date-released: 2026-03-26
 license: EPL-2.0
 repository-code: "https://github.com/FhG-IISB/jno"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jax-neural-operators"
-version = "0.2.2"
+version = "0.2.3"
 description = "Jax Neural Operators"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -31,7 +31,7 @@ dependencies = [
     "equinox>=0.11.0",
     "optax>=0.2.0",
     "orbax-checkpoint>=0.6.0",
-    "foundax>=0.1.6",
+    "foundax>=0.2.0",
 
     "pygmsh>=7.0.0",
     "cloudpickle>=3.0.0",


### PR DESCRIPTION
## Summary

- Bump package version `0.2.2` → `0.2.3` in `pyproject.toml` and `CITATION.cff`
- Raise foundax minimum requirement `>=0.1.6` → `>=0.2.0`

## Test plan

- [x] `pixi run ci-fmt` — clean
- [x] `pixi run ci-lint` — clean
- [x] `pixi run ci-test` — 1254 passed, 7 skipped