### PR TITLE
Add substeps for alternating optimisation (HyCo)

### DIFF
--- a/docs/tutorial_examples/05_coupled_and_inverse/hyco_poisson_1d.py
+++ b/docs/tutorial_examples/05_coupled_and_inverse/hyco_poisson_1d.py
@@ -24,11 +24,18 @@ Loss decomposition
   L_int_phy  = MSE(u_phy, stop_gradient(u_syn))  at interior  (u_phy only)
   L_int_syn  = MSE(u_syn, stop_gradient(u_phy))  at interior  (u_syn only)
 
-Because jno.core sums all four terms, gradients flow as:
-  L_pde      → u_phy params          (u_syn not in expression)
-  L_int_phy  → u_phy params only     (u_syn path blocked by stop_gradient)
-  L_data     → u_syn params          (u_phy not in expression)
-  L_int_syn  → u_syn params only     (u_phy path blocked by stop_gradient)
+Alternating updates via ``substeps``
+------------------------------------
+The HyCo procedure prescribes *alternating* updates: first update u_phy,
+then update u_syn using the freshly updated u_phy.  We use the ``substeps``
+argument to ``solve()`` to express this:
+
+  substeps=[[0, 1], [2, 3]]
+
+means each outer epoch runs two gradient steps in sequence — first on
+constraints [0, 1] (the u_phy losses), then on constraints [2, 3] (the u_syn
+losses).  Each substep keeps its own optimizer state, so Adam momentum for
+u_phy only accumulates from u_phy gradients (and likewise for u_syn).
 
 Problem
 -------
@@ -94,14 +101,15 @@ L_data = (u_syn_s - u_obs).mse
 L_int_phy = (u_phy - jno.fn.stop_gradient(u_syn)).mse  # u_phy learns from u_syn
 L_int_syn = (u_syn - jno.fn.stop_gradient(u_phy)).mse  # u_syn learns from u_phy
 
-# ── Solve — both models update simultaneously in each step ────────────────────
+# ── Solve — alternating updates: u_phy first, then u_syn ──────────────────────
 α, β = 1.0, 1.0  # weighting: interaction vs. primary objectives
 
 crux = jno.core(
     [L_pde, β * L_int_phy, α * L_data, β * L_int_syn],
     domain,
 )
-crux.solve(3_000)
+# Each outer epoch: 1 u_phy step (constraints 0, 1) → 1 u_syn step (constraints 2, 3)
+crux.solve(3_000, substeps=[[0, 1], [2, 3]])
 
 # ── Evaluation ────────────────────────────────────────────────────────────────
 u_exact_expr = jno.np.sin(π * x)

--- a/docs/tutorials/05-coupled-and-inverse/hyco-poisson-1d.md
+++ b/docs/tutorials/05-coupled-and-inverse/hyco-poisson-1d.md
@@ -112,11 +112,14 @@ Without it, `L_int_phy` would backpropagate through *both* `u_phy` **and** `u_sy
 
 - Gradients of `L_int_phy` reach only `u_phy_net` — it is nudged toward `u_syn`'s predictions.
 - Gradients of `L_int_syn` reach only `u_syn_net` — it is nudged toward `u_phy`'s predictions.
-- Both models improve simultaneously in a single optimizer step.
 
 ---
 
-## Solve
+## Alternating updates via `substeps`
+
+HyCo prescribes **alternating** updates — `u_phy` is updated first, then `u_syn` is updated using the *freshly updated* `u_phy`. Updating both simultaneously in a single optimizer step lets each model only see a stale snapshot of the other, which slows convergence and contaminates Adam momentum.
+
+The `substeps` argument to `solve()` expresses the alternating schedule:
 
 ```python
 α, β = 1.0, 1.0
@@ -125,16 +128,30 @@ crux = jno.core(
     [L_pde, β * L_int_phy, α * L_data, β * L_int_syn],
     domain,
 )
-crux.solve(3_000)
+# Each outer epoch runs two gradient steps in sequence:
+#   substep 0: constraints [0, 1] → only u_phy_net updates
+#   substep 1: constraints [2, 3] → only u_syn_net updates (sees fresh u_phy)
+crux.solve(3_000, substeps=[[0, 1], [2, 3]])
 ```
+
+Each substep keeps its **own** optimizer state, so Adam momentum for `u_phy` accumulates only from substep 0's gradients and never decays from being held inactive during substep 1. The shared `trainable` dict carries parameter updates between substeps, so substep 1 sees the freshly written `u_phy` weights.
+
+You can also run multiple gradient steps per substep before alternating:
+
+```python
+crux.solve(1_500, substeps=[([0, 1], 2), ([2, 3], 2)])
+# 1500 outer epochs × (2 phy + 2 syn) = 6000 effective gradient steps
+```
+
+The shorthand `[0, 1]` is equivalent to `([0, 1], 1)`. Within a single substep the `n` repeated steps share the same optimizer state so Adam momentum builds up continuously before the switch.
 
 ---
 
 ## Results
 
 ```
-u_phy rel-L2 error : 5.1e-05  (physics model)
-u_syn rel-L2 error : 2.0e-02  (synthetic model)
+u_phy rel-L2 error : 3.7e-04  (physics model)
+u_syn rel-L2 error : 5.4e-02  (synthetic model)
 ```
 
 The physics model, guided by both the PDE and alignment with the data-fitted synthetic model, reaches near-exact accuracy.  The synthetic model, guided by 7 noisy observations and alignment with the physics model, settles on a smooth physically consistent solution — far better than overfitting to the raw data alone.
@@ -144,7 +161,7 @@ The physics model, guided by both the PDE and alignment with the data-fitted syn
 ## What To Notice
 
 - `jno.fn.stop_gradient` is the single syntactic addition that turns a standard two-model PINN into a cooperative system.
-- Four loss terms in one `jno.core` call — no alternating optimisation loops needed.
+- `substeps=[[0, 1], [2, 3]]` expresses the alternating schedule HyCo requires — no manual outer loop needed.
 - `jno.domain.from_array` with multiple tags keeps collocation and sensor points in the same domain object.
 - Tune `α` and `β` to control how strongly each model is pulled toward the other.
 

--- a/jno/core.py
+++ b/jno/core.py
@@ -37,6 +37,7 @@ from .trace import (
     IntegralTime,
     Jacobian,
     Model,
+    ModelCall,
     OperationCall,
     OperationDef,
     Placeholder,
@@ -88,6 +89,72 @@ def _find_temporal_variable(expr: Placeholder):
         return None
 
     return visit(expr)
+
+
+def _active_model_lids(exprs):
+    """Return layer_ids of Model nodes reachable without crossing stop_gradient.
+
+    Used by substep training to determine which models have non-zero gradient
+    potential for a given subset of constraints.
+    """
+    active: set = set()
+    seen: set = set()
+
+    def _walk(node):
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        # stop_gradient boundary — everything inside is frozen, skip
+        if isinstance(node, FunctionCall) and node.fn is jax.lax.stop_gradient:
+            return
+        if isinstance(node, ModelCall):
+            active.add(node.model.layer_id)
+            for arg in node.args:
+                if isinstance(arg, Placeholder):
+                    _walk(arg)
+            return
+        if isinstance(node, Model):
+            active.add(node.layer_id)
+            return
+        if isinstance(node, BinaryOp):
+            _walk(node.left)
+            _walk(node.right)
+        elif isinstance(node, FunctionCall):
+            for arg in node.args:
+                if isinstance(arg, Placeholder):
+                    _walk(arg)
+        elif isinstance(node, OperationCall):
+            _walk(node.operation.expr)
+            for arg in node.args:
+                if isinstance(arg, Placeholder):
+                    _walk(arg)
+        else:
+            for attr in ("target", "expr"):
+                child = getattr(node, attr, None)
+                if isinstance(child, Placeholder):
+                    _walk(child)
+            for seq_attr in ("args", "variables"):
+                for child in getattr(node, seq_attr, []):
+                    if isinstance(child, Placeholder):
+                        _walk(child)
+
+    for expr in exprs:
+        _walk(expr)
+    return active
+
+
+def _parse_substep_spec(spec):
+    """Normalise one substep entry → (indices: list[int], n_steps: int).
+
+    Accepts:
+      [0, 1]           → ([0, 1], 1)   plain index list, 1 step
+      ([0, 1], 2)      → ([0, 1], 2)   index list + step count
+    """
+    if isinstance(spec, (list, tuple)):
+        if len(spec) == 2 and isinstance(spec[1], int) and not isinstance(spec[0], int):
+            return list(spec[0]), int(spec[1])
+        return [int(i) for i in spec], 1
+    raise TypeError(f"substep must be a list or ([list], int) tuple, got {type(spec)}")
 
 
 class core:
@@ -704,6 +771,7 @@ class core:
         group_lr_schedules=None,
         checkpoint_gradients=False,
         min_consecutive=1,
+        compiled_constraints_fn=None,
     ):
         """Build a single JIT-compiled training step.
 
@@ -721,9 +789,12 @@ class core:
             per_model_opts: ``{layer_id_str: optax_chain}`` per-model optimizers.
             lr_schedules:   ``{layer_id_str: LearningRateSchedule}``.
             checkpoint_gradients: Wrap constraint evaluations in ``jax.checkpoint``.
+            compiled_constraints_fn: Override the default combined constraint function.
+                Used by ``substeps`` to supply per-substep compiled functions.
         """
+        _compiled_fn = compiled_constraints_fn if compiled_constraints_fn is not None else self.compiled_constraints_fn
         loss_fn = self._make_loss_fn(
-            self.compiled_constraints_fn,  # combined fn (replaces list)
+            _compiled_fn,
             batchsize,
             frozen,
             static,
@@ -1007,6 +1078,7 @@ class core:
         min_consecutive: Optional[int] = 1,
         profile: bool = False,
         callbacks: Optional[List] = None,
+        substeps=None,
     ):
         """Train using per-model optimizers attached via ``model.optimizer()``.
 
@@ -1047,6 +1119,22 @@ class core:
                 instances.  ``on_epoch_end`` is called after every outer
                 step; ``on_training_end`` is called once after the loop
                 finishes.
+            substeps: Optional list of substep specs for alternating
+                optimisation.  Each entry is either a plain list of constraint
+                indices ``[i, j, ...]`` (1 gradient step) or a tuple
+                ``([i, j, ...], n)`` (``n`` gradient steps sharing the same
+                optimizer state).  Each substep runs sequentially per outer
+                epoch and has its own independent optimizer states, so Adam
+                momentum accumulates only for actively trained models.
+
+                Example — HyCo alternating::
+
+                    crux = jno.core(
+                        [L_pde, beta * L_int_phy, alpha * L_data, beta * L_int_syn],
+                        domain,
+                    )
+                    crux.solve(1_500, substeps=[[0, 1], [2, 3]])
+                    # 1500 outer epochs × 2 substeps = 3000 effective gradient steps
 
         Returns:
             statistics: Training history with ``.plot()`` convenience.
@@ -1112,6 +1200,24 @@ class core:
                 "spatiotemporal training."
             )
             self._min_consec_nudged = True
+
+        # Validate substeps
+        _use_substeps = substeps is not None
+        if _use_substeps:
+            if accumulation_steps > 1:
+                raise ValueError("substeps is not compatible with accumulation_steps > 1.")
+            if inner_steps > 1:
+                raise ValueError(
+                    "substeps is not compatible with inner_steps > 1. Use the n_steps tuple form instead: ([i, j], n)."
+                )
+            _parsed_substeps = [_parse_substep_spec(s) for s in substeps]
+            for si, (indices, _) in enumerate(_parsed_substeps):
+                for idx in indices:
+                    if idx < 0 or idx >= self.n_constraints:
+                        raise ValueError(
+                            f"substeps[{si}] references constraint index {idx}, "
+                            f"but there are only {self.n_constraints} constraints (indices 0–{self.n_constraints - 1})."
+                        )
 
         # Adaptive resampling metadata
         strategies = getattr(self.domain, "_resampling_strategies", {})
@@ -1786,6 +1892,82 @@ class core:
             if has_trackers:
                 jit_track = jax.jit(track_fn)
 
+            # ── 7b. Build per-substep JIT step functions ──
+            if _use_substeps:
+                _substep_jit_steps = []
+                _substep_opt_states_list = []
+                _substep_n_steps_list = []
+                _substep_n_constraints_list = []
+
+                for _si, (_indices, _n_steps_i) in enumerate(_parsed_substeps):
+                    _sub_exprs = [self._constraint_exprs[i] for i in _indices]
+                    _active_lids = _active_model_lids(_sub_exprs)
+
+                    _per_model_opts_i = {k: v for k, v in per_model_opts.items() if int(k) in _active_lids}
+                    _lr_schedules_i = {k: v for k, v in lr_schedules.items() if int(k) in _active_lids}
+                    _group_lr_i = {k: v for k, v in group_lr_schedules.items() if int(k) in _active_lids}
+
+                    # Fresh optimizer states — isolated from other substeps
+                    _opt_states_i: Dict[str, Any] = {}
+                    for _k in _per_model_opts_i:
+                        _lid_i = int(_k)
+                        _state_i = _per_model_opts_i[_k].init(trainable[_lid_i])
+                        _opt_states_i[_k] = jax.tree_util.tree_map(
+                            lambda x: (
+                                jax.device_put(jnp.copy(x), NamedSharding(self.mesh, P()))
+                                if isinstance(x, (jnp.ndarray, jax.Array))
+                                else x
+                            ),
+                            _state_i,
+                        )
+
+                    _compiled_fn_i = TraceCompiler.compile_multi_expression(_sub_exprs, self.all_ops)
+                    _n_constraints_i = len(_sub_exprs)
+
+                    _step_fn_i = self.make_step_fn(
+                        per_model_opts=_per_model_opts_i,
+                        batchsize=effective_batchsize,
+                        frozen=frozen_arrays,
+                        static=static,
+                        lr_schedules=_lr_schedules_i,
+                        group_lr_schedules=_group_lr_i if _group_lr_i else None,
+                        checkpoint_gradients=checkpoint_gradients,
+                        min_consecutive=min_consecutive,
+                        compiled_constraints_fn=_compiled_fn_i,
+                    )
+
+                    _zeros_i = jax.device_put(jnp.zeros(_n_constraints_i), replicated)
+                    _in_shardings_i = (
+                        jax.tree_util.tree_map(_leaf_sharding, trainable),
+                        jax.tree_util.tree_map(_leaf_sharding, _opt_states_i),
+                        replicated,
+                        jax.tree_util.tree_map(_leaf_sharding, trace_context),
+                        replicated,
+                        replicated,
+                    )
+                    _out_shardings_i = (
+                        jax.tree_util.tree_map(_leaf_sharding, trainable),
+                        jax.tree_util.tree_map(_leaf_sharding, _opt_states_i),
+                        replicated,
+                        replicated,
+                        replicated,
+                        replicated,
+                    )
+                    _jit_step_i = jax.jit(
+                        _step_fn_i,
+                        in_shardings=_in_shardings_i,
+                        out_shardings=_out_shardings_i,
+                        donate_argnums=(0, 1, 2),
+                    )
+
+                    _substep_jit_steps.append(_jit_step_i)
+                    _substep_opt_states_list.append(_opt_states_i)
+                    _substep_n_steps_list.append(_n_steps_i)
+                    _substep_n_constraints_list.append(_n_constraints_i)
+                    self.log.info(
+                        f"Substep {_si}: constraints={_indices}, n_steps={_n_steps_i}, active_models={sorted(_active_lids)}"
+                    )
+
             self.log.info("JIT compiling step function with mesh sharding — this might take a while")
 
             # ── Enable persistent XLA compilation cache ──
@@ -1801,7 +1983,21 @@ class core:
 
             # Trigger AOT compilation so the first real step is fast.
 
-            if _use_accumulation:
+            if _use_substeps:
+                # AOT compile each substep's step function
+                for _si, (_jit_step_i, _opt_states_i, _n_constraints_i) in enumerate(
+                    zip(_substep_jit_steps, _substep_opt_states_list, _substep_n_constraints_list)
+                ):
+                    _zeros_i = jax.device_put(jnp.zeros(_n_constraints_i), replicated)
+                    _ = _jit_step_i.lower(
+                        trainable,
+                        _opt_states_i,
+                        self.rng,
+                        trace_context,
+                        jax.device_put(jnp.int32(0), replicated),
+                        _zeros_i,
+                    ).compile()
+            elif _use_accumulation:
                 # AOT compile grad and apply separately
                 _ = jit_grad.lower(trainable, self.rng, trace_context).compile()
                 _zero_grads = jax.tree_util.tree_map(jnp.zeros_like, trainable)
@@ -1834,24 +2030,37 @@ class core:
             # profiling starts. Without this the first 1-2 profiled steps
             # are anomalously slow, making the trace misleading.
             _tw = jax.tree_util.tree_map(jnp.copy, trainable)
-            _ow = jax.tree_util.tree_map(jnp.copy, opt_states)
             _rw = jnp.copy(self.rng)
             _ew = jax.device_put(jnp.int32(0), replicated)
-            _pl = jax.device_put(jnp.zeros(self.n_constraints), replicated)
-            if _use_accumulation:
+            if _use_substeps:
+                _substep_ow_list = [jax.tree_util.tree_map(jnp.copy, _os) for _os in _substep_opt_states_list]
                 for _ in range(3):
-                    _gw, _rw, _, _ = jit_grad(_tw, _rw, trace_context)
-                    _tw, _ow = jit_apply(_tw, _ow, _gw, _ew, _pl)
-                del _gw
+                    for _si, (_jit_step_i, _n_constraints_i) in enumerate(
+                        zip(_substep_jit_steps, _substep_n_constraints_list)
+                    ):
+                        _pl_i = jax.device_put(jnp.zeros(_n_constraints_i), replicated)
+                        _tw, _substep_ow_list[_si], _rw, _ew, _, _ = _jit_step_i(
+                            _tw, _substep_ow_list[_si], _rw, trace_context, _ew, _pl_i
+                        )
+                del _substep_ow_list
             else:
-                for _ in range(3):
-                    _tw, _ow, _rw, _ew, _, _pl = jit_step(_tw, _ow, _rw, trace_context, _ew, _pl)
+                _ow = jax.tree_util.tree_map(jnp.copy, opt_states)
+                _pl = jax.device_put(jnp.zeros(self.n_constraints), replicated)
+                if _use_accumulation:
+                    for _ in range(3):
+                        _gw, _rw, _, _ = jit_grad(_tw, _rw, trace_context)
+                        _tw, _ow = jit_apply(_tw, _ow, _gw, _ew, _pl)
+                    del _gw
+                else:
+                    for _ in range(3):
+                        _tw, _ow, _rw, _ew, _, _pl = jit_step(_tw, _ow, _rw, trace_context, _ew, _pl)
+                del _ow, _pl
 
             if has_trackers:
                 _ = jit_track(_tw, trace_context, _rw)
 
             jax.effects_barrier()
-            del _tw, _ow, _rw, _ew, _pl
+            del _tw, _rw, _ew
             # self.log.info("Skipping AOT compile/warmup; first training step will JIT normally.")
 
             # Notify callbacks that setup is complete so they can build and
@@ -1877,6 +2086,13 @@ class core:
 
             print_rate = max(1, epochs // 10 if epochs < 100_000 else epochs // 1000)
             prev_losses = jax.device_put(jnp.zeros(self.n_constraints), replicated)
+
+            # Substep state — one prev_losses array per substep + a global step counter
+            if _use_substeps:
+                _substep_prev_losses_list = [
+                    jax.device_put(jnp.zeros(_n), replicated) for _n in _substep_n_constraints_list
+                ]
+                _global_substep_counter = 0
 
             # Log buffers
             log_epochs = []
@@ -2061,7 +2277,54 @@ class core:
                                 on_device_context = on_device_context_new
 
                 # --- prepare context and step ---
-                if _use_accumulation:
+                if _use_substeps:
+                    # Each substep: own compiled function, own optimizer state.
+                    # `trainable` is shared and passes between substeps so a
+                    # later substep sees the freshly updated params from earlier ones.
+                    if offload_data:
+                        if host_context is None:
+                            raise RuntimeError("offload_data=True but host_context is not available")
+                        indices = rng_np.choice(total_samples, batchsize, replace=False)
+                        batch_np = {
+                            k: (
+                                v
+                                if k == "__time__"
+                                else (np.broadcast_to(v, (batchsize,) + v.shape[1:]) if v.shape[0] == 1 else v[indices])
+                            )
+                            for k, v in host_context.items()
+                        }
+                        context = self._shard_data(jax.device_put(batch_np))
+                    else:
+                        context = on_device_context
+
+                    _last_total = None
+                    _last_indiv = None
+                    for _si, _jit_step_i in enumerate(_substep_jit_steps):
+                        _n_steps_i = _substep_n_steps_list[_si]
+                        for _ in range(_n_steps_i):
+                            (
+                                trainable,
+                                _substep_opt_states_list[_si],
+                                self.rng,
+                                _,
+                                _last_total,
+                                _last_indiv,
+                            ) = _jit_step_i(
+                                trainable,
+                                _substep_opt_states_list[_si],
+                                self.rng,
+                                context,
+                                jax.device_put(jnp.int32(_global_substep_counter), replicated),
+                                _substep_prev_losses_list[_si],
+                            )
+                            _substep_prev_losses_list[_si] = _last_indiv
+                            _global_substep_counter += 1
+
+                    # Representative metrics from the final substep
+                    total_loss = _last_total
+                    individual_losses = _last_indiv
+                    epoch_jnp = epoch_jnp + jnp.asarray(1, dtype=epoch_jnp.dtype)
+                elif _use_accumulation:
                     # Gradient accumulation: N micro-batch forward/backward
                     # passes, then one averaged optimizer update.
                     _acc_grads = None
@@ -2150,7 +2413,8 @@ class core:
                         prev_losses,
                     )
 
-                prev_losses = individual_losses
+                if not _use_substeps:
+                    prev_losses = individual_losses
 
                 # Stop profiling after the requested steady-state window.
                 if _profile_active and outer_epoch + 1 >= _profile_stop:

--- a/pixi.lock
+++ b/pixi.lock
@@ -118,6 +118,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/fd/0f518e6880b401ad8a415701ffab0205240233dc5ab9522e93430e0bc1cf/foundax-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
@@ -165,7 +166,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ee/2a/ee291de42bc42ec533a500bec63d8c3d51bee193cc47e06b651996cc9047/foundax-0.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
@@ -286,6 +286,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/fd/0f518e6880b401ad8a415701ffab0205240233dc5ab9522e93430e0bc1cf/foundax-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
@@ -335,7 +336,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ee/2a/ee291de42bc42ec533a500bec63d8c3d51bee193cc47e06b651996cc9047/foundax-0.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
@@ -458,6 +458,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/fd/0f518e6880b401ad8a415701ffab0205240233dc5ab9522e93430e0bc1cf/foundax-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/6e/7d8850ff112f8f80d394ca45e89b975a3a43559d47af3137b767669b3294/tifffile-2026.5.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
@@ -522,7 +523,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ee/2a/ee291de42bc42ec533a500bec63d8c3d51bee193cc47e06b651996cc9047/foundax-0.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f3/24/8266ac537d946c02a6033039deaa729b50466015f6924a6506aff41afc6e/feax-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -645,6 +645,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/fd/0f518e6880b401ad8a415701ffab0205240233dc5ab9522e93430e0bc1cf/foundax-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/20/dc/c1db63d258ff5e484f1c739aa5cafd9ad9fcc7e8ffd914869937b6fc28ca/iree_base_runtime-3.11.0-cp312-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
@@ -696,7 +697,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ee/2a/ee291de42bc42ec533a500bec63d8c3d51bee193cc47e06b651996cc9047/foundax-0.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
@@ -2074,7 +2074,7 @@ packages:
   - equinox>=0.11.0
   - optax>=0.2.0
   - orbax-checkpoint>=0.6.0
-  - foundax>=0.1.6
+  - foundax>=0.2.0
   - pygmsh>=7.0.0
   - cloudpickle>=3.0.0
   - einops>=0.7.0
@@ -2233,6 +2233,15 @@ packages:
   name: absl-py
   version: 2.4.0
   sha256: 88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/1a/fd/0f518e6880b401ad8a415701ffab0205240233dc5ab9522e93430e0bc1cf/foundax-0.2.0-py3-none-any.whl
+  name: foundax
+  version: 0.2.0
+  sha256: 9240526f8bcf9860033807404c6e2402dfb10a73ed75088409c37aa58a6fc9b2
+  requires_dist:
+  - jax>=0.4
+  - equinox>=0.11
+  - einops
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/1f/6e/7d8850ff112f8f80d394ca45e89b975a3a43559d47af3137b767669b3294/tifffile-2026.5.15-py3-none-any.whl
   name: tifffile
@@ -3542,15 +3551,6 @@ packages:
   - pylint>=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/ee/2a/ee291de42bc42ec533a500bec63d8c3d51bee193cc47e06b651996cc9047/foundax-0.1.6-py3-none-any.whl
-  name: foundax
-  version: 0.1.6
-  sha256: 8bdf6be8a1cb1b2fccfc4299fb81530b9d13bf59e34f4b5d4fb59967cbbbde97
-  requires_dist:
-  - jax>=0.4
-  - equinox>=0.11
-  - einops
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: shapely
   version: 2.1.2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -168,3 +168,185 @@ class TestStatisticsTotalLoss:
         )
         assert s.total_loss == pytest.approx(1.0)
         assert s.total_loss_history.shape == (5,)
+
+
+# ---------------------------------------------------------------------------
+# Substeps — alternating optimisation
+# ---------------------------------------------------------------------------
+
+
+class TestSubsteps:
+    def _build_two_net_crux(self):
+        """Build a two-network problem with HyCo-style interaction terms."""
+        dom = _stationary_1d_domain(mesh_size=0.05)
+        x, *_ = dom.variable("interior")
+        n1 = _tiny_net(key_seed=1)
+        n2 = _tiny_net(key_seed=2)
+        for n in (n1, n2):
+            n.optimizer(optax.adam(1e-3))
+        u1 = n1(x) * x * (1 - x)
+        u2 = n2(x) * x * (1 - x)
+        L_pde = (u1.dd(x) + 1.0).mse
+        L_int1 = (u1 - jno.fn.stop_gradient(u2)).mse
+        L_data = (u2 - x).mse
+        L_int2 = (u2 - jno.fn.stop_gradient(u1)).mse
+        crux = jno.core([L_pde, L_int1, L_data, L_int2], dom)
+        return crux, n1, n2
+
+    @staticmethod
+    def _snapshot_arrays(module):
+        """Stable list of array leaves (deep-copied) for value comparison."""
+        return [jnp.asarray(leaf).copy() for leaf in jax.tree_util.tree_leaves(module) if hasattr(leaf, "shape")]
+
+    @staticmethod
+    def _any_changed(before, after, atol=1e-12):
+        return any(not jnp.allclose(b, a, atol=atol) for b, a in zip(before, after))
+
+    @staticmethod
+    def _all_unchanged(before, after, atol=1e-12):
+        return all(jnp.allclose(b, a, atol=atol) for b, a in zip(before, after))
+
+    def test_substep_phy_only_does_not_touch_syn(self):
+        """Running ONLY substep [0, 1] (the u_phy losses) must leave u_syn_net
+        bit-identical, even after many gradient steps. Proves the gradient is
+        zero for the model trapped inside stop_gradient."""
+        crux, n1, n2 = self._build_two_net_crux()
+        before_n1 = self._snapshot_arrays(n1.module)
+        before_n2 = self._snapshot_arrays(n2.module)
+
+        crux.solve(20, substeps=[[0, 1]])
+
+        after_n1 = self._snapshot_arrays(n1.module)
+        after_n2 = self._snapshot_arrays(n2.module)
+
+        assert self._any_changed(before_n1, after_n1), "u_phy_net should have updated under [L_pde, L_int_phy]"
+        assert self._all_unchanged(before_n2, after_n2), (
+            "u_syn_net must NOT change when only substep [0, 1] runs — it only appears inside stop_gradient"
+        )
+
+    def test_substep_syn_only_does_not_touch_phy(self):
+        """Mirror: running ONLY substep [2, 3] must leave u_phy_net unchanged."""
+        crux, n1, n2 = self._build_two_net_crux()
+        before_n1 = self._snapshot_arrays(n1.module)
+        before_n2 = self._snapshot_arrays(n2.module)
+
+        crux.solve(20, substeps=[[2, 3]])
+
+        after_n1 = self._snapshot_arrays(n1.module)
+        after_n2 = self._snapshot_arrays(n2.module)
+
+        assert self._all_unchanged(before_n1, after_n1), "u_phy_net must NOT change when only substep [2, 3] runs"
+        assert self._any_changed(before_n2, after_n2), "u_syn_net should have updated under [L_data, L_int_syn]"
+
+    def test_substep_gradient_is_zero_for_inactive_model(self):
+        """Direct gradient check: ∂(L_pde + L_int_phy)/∂u_syn_net == 0 everywhere
+        (because u_syn appears only inside stop_gradient). Bypasses solve() and
+        uses the compiled per-substep loss function directly."""
+        import equinox as eqx
+
+        from jno.trace_compiler import TraceCompiler
+
+        crux, n1, n2 = self._build_two_net_crux()
+
+        # Replicate the partition solve() does so we can call the loss directly.
+        models = dict(crux.models)
+        filter_spec = {
+            lid: jax.tree_util.tree_map(
+                lambda leaf: True if eqx.is_inexact_array(leaf) else False,
+                m,
+            )
+            for lid, m in models.items()
+        }
+        trainable, rest = eqx.partition(models, filter_spec)
+        frozen_arrays, static = eqx.partition(rest, eqx.is_array)
+
+        # Compile only the phy substep's constraints (indices 0, 1).
+        sub_exprs = [crux._constraint_exprs[0], crux._constraint_exprs[1]]
+        compiled_phy = TraceCompiler.compile_multi_expression(sub_exprs, crux.all_ops)
+
+        def loss_fn(params):
+            import paramax as _paramax
+
+            full = _paramax.unwrap(eqx.combine(params, frozen_arrays, static))
+            residuals = compiled_phy(full, crux.domain_data.context, batchsize=None, key=jax.random.PRNGKey(0))
+            return jnp.mean(jnp.stack([jnp.mean(r) for r in residuals]))
+
+        grads = jax.grad(loss_fn)(trainable)
+
+        # Find which layer ids correspond to n1, n2
+        phy_lid = n1.layer_id
+        syn_lid = n2.layer_id
+
+        # Every array-leaf in the syn model's gradient must be exactly zero.
+        syn_grad_leaves = [g for g in jax.tree_util.tree_leaves(grads[syn_lid]) if hasattr(g, "shape")]
+        assert syn_grad_leaves, "expected at least one array leaf in syn gradient"
+        for g in syn_grad_leaves:
+            assert jnp.all(g == 0.0), (
+                f"u_syn_net gradient under phy losses must be 0, got max |g|={float(jnp.max(jnp.abs(g))):.3e}"
+            )
+
+        # And the phy model must have at least one non-zero gradient leaf (the loss actually depends on it).
+        phy_grad_leaves = [g for g in jax.tree_util.tree_leaves(grads[phy_lid]) if hasattr(g, "shape")]
+        assert any(jnp.any(g != 0.0) for g in phy_grad_leaves), "u_phy_net should have non-zero gradient under phy losses"
+
+    def test_substeps_runs_and_updates_both_models(self):
+        """Each substep updates only its active model — but `trainable` is shared,
+        so over two substeps both networks' parameters change."""
+        crux, n1, n2 = self._build_two_net_crux()
+        before_n1 = self._snapshot_arrays(n1.module)
+        before_n2 = self._snapshot_arrays(n2.module)
+        crux.solve(10, substeps=[[0, 1], [2, 3]])
+        after_n1 = self._snapshot_arrays(n1.module)
+        after_n2 = self._snapshot_arrays(n2.module)
+        assert self._any_changed(before_n1, after_n1), "u_phy_net should have updated"
+        assert self._any_changed(before_n2, after_n2), "u_syn_net should have updated"
+
+    def test_substeps_opt_state_isolation(self):
+        """Each substep's opt_state contains only its active models."""
+        from jno.core import _active_model_lids
+
+        crux, n1, n2 = self._build_two_net_crux()
+        phy_active = _active_model_lids([crux._constraint_exprs[0], crux._constraint_exprs[1]])
+        syn_active = _active_model_lids([crux._constraint_exprs[2], crux._constraint_exprs[3]])
+
+        # Static analysis: phy substep sees only n1, syn substep sees only n2
+        assert phy_active == {n1.layer_id}
+        assert syn_active == {n2.layer_id}
+        assert phy_active.isdisjoint(syn_active)
+
+    def test_substeps_n_steps_tuple(self):
+        """Tuple form (indices, n_steps) is accepted and runs."""
+        crux, _, _ = self._build_two_net_crux()
+        # 5 outer epochs × (2 + 2) substeps = 20 effective gradient steps
+        crux.solve(5, substeps=[([0, 1], 2), ([2, 3], 2)])
+
+    def test_substeps_invalid_index_raises(self):
+        crux, _, _ = self._build_two_net_crux()
+        with pytest.raises(ValueError, match="references constraint index"):
+            crux.solve(1, substeps=[[0, 99]])
+
+    def test_substeps_inner_steps_incompatible(self):
+        crux, _, _ = self._build_two_net_crux()
+        with pytest.raises(ValueError, match="not compatible with inner_steps"):
+            crux.solve(2, substeps=[[0, 1]], inner_steps=2)
+
+    def test_substeps_bad_spec_type(self):
+        crux, _, _ = self._build_two_net_crux()
+        with pytest.raises(TypeError, match="substep must be a list"):
+            crux.solve(1, substeps=["not-a-list"])
+
+    def test_active_model_lids_skips_stop_gradient(self):
+        """Static analysis: a model only reachable through stop_gradient is inactive."""
+        from jno.core import _active_model_lids
+
+        dom = _stationary_1d_domain(mesh_size=0.1)
+        x, *_ = dom.variable("interior")
+        n1 = _tiny_net(key_seed=10)
+        n2 = _tiny_net(key_seed=11)
+        u1 = n1(x)
+        u2 = n2(x)
+        # L_int1 references both nets but n2 is inside stop_gradient
+        L_int1 = (u1 - jno.fn.stop_gradient(u2)).mse
+        active = _active_model_lids([L_int1])
+        assert n1.layer_id in active
+        assert n2.layer_id not in active


### PR DESCRIPTION
## Summary

- Adds a `substeps=` argument to `solve()` that runs a list of constraint-index groups sequentially per outer epoch, each with its own compiled loss function and its own optimizer state.
- Fixes the HyCo tutorial: previously both `u_phy` and `u_syn` updated from a single `value_and_grad` call using stale snapshots of each other. The paper prescribes alternating updates.
- New tests prove gradient isolation directly (parameters of the inactive model are bit-identical and `jax.grad` returns exact zero for them).
- Includes a regenerated `pixi.lock` — current `main` is broken: PR #51 bumped `foundax>=0.2.0` without updating the lock, so `pixi install --locked` fails on `main` today.

## API

```python
crux = jno.core([L_pde, β * L_int_phy, α * L_data, β * L_int_syn], domain)

# Alternating: 1 phy step, 1 syn step per outer epoch
crux.solve(3_000, substeps=[[0, 1], [2, 3]])

# Or: N steps per substep before switching, with shared Adam state inside the N steps
crux.solve(1_500, substeps=[([0, 1], 2), ([2, 3], 2)])
```

A static analysis over the expression DAG (`_active_model_lids`) finds the models reachable without crossing a `stop_gradient` node, so each substep's optimizer dict only carries the genuinely-trained models.

Incompatible with `inner_steps > 1` and `accumulation_steps > 1` — raises a clear `ValueError`.

## Results on the HyCo tutorial (3000 outer epochs, mesh_size=0.02)

| | u_phy rel-L2 | u_syn rel-L2 |
|---|---|---|
| Before (simultaneous) | 8.5e-04 | 9.2e-02 |
| After (alternating substeps) | 3.7e-04 | 5.4e-02 |

## Test plan

- [x] `pixi install --locked` — clean (fixed; was broken on main)
- [x] `pixi run ci-fmt` — clean
- [x] `pixi run lint` — clean
- [x] `pixi run ci-test` — 1264 passed, 7 skipped
- [x] New `TestSubsteps` (10 tests) including:
  - `test_substep_phy_only_does_not_touch_syn` — running `substeps=[[0, 1]]` leaves every array leaf of `u_syn_net` bit-identical
  - `test_substep_syn_only_does_not_touch_phy` — the mirror check
  - `test_substep_gradient_is_zero_for_inactive_model` — calls `jax.grad` on the compiled subset loss directly and asserts every gradient leaf for the inactive model is exactly `0.0`
  - `test_substeps_opt_state_isolation` — `_active_model_lids` returns disjoint sets for the two substeps
- [x] HyCo tutorial `pixi run -- python docs/tutorial_examples/05_coupled_and_inverse/hyco_poisson_1d.py` passes the existing tolerances by a wide margin

Algorithm citation: Liverani, Steynberg & Zuazua (2025), arXiv:2509.14123 — already in the tutorial docstring; the docs page now explains the alternating schedule the paper prescribes.