### PR TITLE
Add forward/reverse AD mode switching via scheme suffix

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -131,9 +131,40 @@ the adaptive loss balancers under `jno.fn.adaptive.*`.
 These provide the residuals you put inside constraints
 (`u.laplacian(x, y)`, `u.d(x)`, `(grad_u * n).integrate()`).
 
+### Scheme strings
+
+Every differential operator (`.d`, `.diff`, `.d2`, `.dd`, `.laplacian`,
+`.hessian`) accepts a `scheme=` kwarg that selects the backend:
+
+| Scheme | Backend |
+| --- | --- |
+| `"automatic_differentiation"` *(default)* | global default — see `jno.setup(diff_type=..., hessian_type=...)` |
+| `"automatic_differentiation:forward"` | first-order via `jax.jacfwd` |
+| `"automatic_differentiation:reverse"` | first-order via `jax.jacrev` |
+| `"automatic_differentiation:fwd-over-rev"` | second-order `jacfwd(jacrev(f))` *(= historical `jax.hessian`)* |
+| `"automatic_differentiation:fwd-over-fwd"` | second-order `jacfwd(jacfwd(f))` |
+| `"automatic_differentiation:rev-over-rev"` | second-order `jacrev(jacrev(f))` |
+| `"automatic_differentiation:rev-over-fwd"` | second-order `jacrev(jacfwd(f))` |
+| `"finite_difference"` | central-difference stencils on mesh (with `:lsq` / `:uniform` / `:inverse_distance` / `:cotangent` sub-schemes) |
+
+Forward-mode is typically cheaper when the input dim (≤ 3 spatial dims for
+PINNs) is ≤ the output dim; reverse-mode is cheaper for scalar losses with
+many inputs. Set the project-wide default once via `.jno.toml`:
+
+```toml
+[jno]
+diff_type    = "forward"        # default for first-order operators
+hessian_type = "fwd-over-rev"   # default for second-order operators
+```
+
+or per script via `jno.setup(__file__, diff_type="forward")`. Per-call
+`scheme=` always overrides the default.
+
 ::: jno.differential_operators.DifferentialOperators
 
 ::: jno.integration_operators.IntegrationOperators
+
+::: jno.utils.ad_mode
 
 ---
 

--- a/jno/trace.py
+++ b/jno/trace.py
@@ -389,8 +389,14 @@ class Placeholder:
 
         Args:
             variable: The Variable to differentiate with respect to.
-            scheme: ``'automatic_differentiation'`` (default) or
-                ``'finite_difference'``.
+            scheme: First-order scheme string.
+
+                * ``"automatic_differentiation"`` (default) — uses the global
+                  AD mode set via :func:`jno.setup` (see :mod:`jno.utils.ad_mode`).
+                * ``"automatic_differentiation:forward"`` — ``jax.jacfwd``.
+                * ``"automatic_differentiation:reverse"`` — ``jax.jacrev``.
+                * ``"finite_difference"`` (optional sub-schemes:
+                  ``":lsq"`` / ``":uniform"`` / ``":inverse_distance"``).
         """
         return Jacobian(self, [variable], scheme)
 
@@ -403,8 +409,7 @@ class Placeholder:
 
         Args:
             variable: The Variable to differentiate with respect to.
-            scheme: ``'automatic_differentiation'`` (default) or
-                ``'finite_difference'``.
+            scheme: Second-order scheme string — see :meth:`laplacian`.
         """
         return Hessian(self, [variable], scheme, trace=True)
 
@@ -425,8 +430,21 @@ class Placeholder:
 
         Args:
             *variables: Variables to include in the Laplacian.
-            scheme: ``'automatic_differentiation'`` (default) or
-                ``'finite_difference'``.
+            scheme: Second-order scheme string.
+
+                * ``"automatic_differentiation"`` (default) — uses the global
+                  Hessian mode set via :func:`jno.setup`
+                  (see :mod:`jno.utils.ad_mode`).
+                * ``"automatic_differentiation:fwd-over-rev"`` —
+                  ``jacfwd(jacrev(f))`` (equivalent to historical ``jax.hessian``).
+                * ``"automatic_differentiation:fwd-over-fwd"`` —
+                  ``jacfwd(jacfwd(f))``.
+                * ``"automatic_differentiation:rev-over-rev"`` —
+                  ``jacrev(jacrev(f))``.
+                * ``"automatic_differentiation:rev-over-fwd"`` —
+                  ``jacrev(jacfwd(f))``.
+                * ``"finite_difference"`` (optional sub-schemes:
+                  ``":cotangent"`` (2-D), ``":lsq"``).
         """
         return Hessian(self, list(variables) if variables else None, scheme, trace=True)
 
@@ -443,8 +461,7 @@ class Placeholder:
 
         Args:
             *variables: Variables for the Hessian.
-            scheme: ``'automatic_differentiation'`` (default) or
-                ``'finite_difference'``.
+            scheme: Second-order scheme string — see :meth:`laplacian`.
         """
         return Hessian(self, list(variables), scheme, trace=False)
 

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -43,6 +43,7 @@ def _default_float_dtype():
 from .differential_operators import DifferentialOperators
 from .integration_operators import IntegrationOperators
 from .utils import get_logger
+from .utils.ad_mode import ad_fn, parse_ad_scheme, parse_hessian_scheme
 
 
 class TraceEvaluator:
@@ -1103,10 +1104,12 @@ class TraceEvaluator:
                     return _scalar_from_point_output(out)
 
                 if temporal_derivative_order == 1:
-                    return jax.grad(u_of_t_scalar)(time_scalar0)
+                    _grad = ad_fn(parse_ad_scheme(scheme))
+                    return _grad(u_of_t_scalar)(time_scalar0)
 
                 if temporal_derivative_order == 2:
-                    return jax.grad(jax.grad(u_of_t_scalar))(time_scalar0)
+                    _outer, _inner = parse_hessian_scheme(scheme)
+                    return ad_fn(_outer)(ad_fn(_inner)(u_of_t_scalar))(time_scalar0)
 
                 raise NotImplementedError(f"Temporal AD derivative order {temporal_derivative_order} is not supported.")
 
@@ -1192,8 +1195,9 @@ class TraceEvaluator:
             jac_full = jnp.stack(jac_components, axis=-1)
             return self._map_mesh_to_sampled(mesh_points, points, jac_full)
 
-        elif scheme == "automatic_differentiation":
+        elif scheme.startswith("automatic_differentiation"):
             evaluator_self = self
+            _jac = ad_fn(parse_ad_scheme(scheme))
 
             def make_u_fn(local_ctx):
                 def u_fn(p):
@@ -1217,7 +1221,7 @@ class TraceEvaluator:
                     u_fn = make_u_fn(local_ctx)
 
                     val0 = u_fn(pt)
-                    jac = jax.jacobian(u_fn)(pt)
+                    jac = _jac(u_fn)(pt)
 
                     # scalar output -> shape (1,)
                     if jnp.ndim(val0) == 0:
@@ -1236,7 +1240,7 @@ class TraceEvaluator:
                     u_fn = make_u_fn(local_ctx)
 
                     val0 = u_fn(pt)
-                    jac = jax.jacobian(u_fn)(pt)
+                    jac = _jac(u_fn)(pt)
 
                     # scalar output -> (n_vars,)
                     if jnp.ndim(val0) == 0:
@@ -1369,8 +1373,14 @@ class TraceEvaluator:
                     return hess_full.reshape(*image_shape[:-1], n, n)
                 return self._map_mesh_to_sampled(mesh_points, points, hess_full)
 
-        elif scheme == "automatic_differentiation":
+        elif scheme.startswith("automatic_differentiation"):
             evaluator_self = self
+            _outer_mode, _inner_mode = parse_hessian_scheme(scheme)
+            _outer = ad_fn(_outer_mode)
+            _inner = ad_fn(_inner_mode)
+
+            def _hess(f):
+                return _outer(_inner(f))
 
             if points is not None and points.ndim == 3:
                 n_time, n_points, _ = points.shape
@@ -1390,7 +1400,7 @@ class TraceEvaluator:
 
                     def lap_time_point(t_idx, p_idx):
                         pt = points[t_idx, p_idx]
-                        hess = jax.hessian(lambda p: _windowed_scalar(t_idx, p_idx, p))(pt)
+                        hess = _hess(lambda p: _windowed_scalar(t_idx, p_idx, p))(pt)
                         return sum(hess[d, d] for d in dims)
 
                     result = jax.vmap(
@@ -1400,7 +1410,7 @@ class TraceEvaluator:
 
                 def hess_time_point(t_idx, p_idx):
                     pt = points[t_idx, p_idx]
-                    hess = jax.hessian(lambda p: _windowed_scalar(t_idx, p_idx, p))(pt)
+                    hess = _hess(lambda p: _windowed_scalar(t_idx, p_idx, p))(pt)
                     result = jnp.zeros((n, n))
                     for i, vi_dim, j, vj_dim in var_dims:
                         result = result.at[i, j].set(hess[vi_dim, vj_dim])
@@ -1426,7 +1436,7 @@ class TraceEvaluator:
                         )
                         return jnp.squeeze(evaluator_self._dispatch(target, new_ctx))
 
-                    hess = jax.hessian(u_scalar)(pt)
+                    hess = _hess(u_scalar)(pt)
                     return sum(hess[d, d] for d in dims)
 
                 return jax.vmap(lap_single)(jnp.arange(points.shape[0]))[:, jnp.newaxis]
@@ -1442,7 +1452,7 @@ class TraceEvaluator:
                         )
                         return jnp.squeeze(evaluator_self._dispatch(target, new_ctx))
 
-                    hess = jax.hessian(u_scalar)(pt)
+                    hess = _hess(u_scalar)(pt)
                     result = jnp.zeros((n, n))
                     for i, vi_dim, j, vj_dim in var_dims:
                         result = result.at[i, j].set(hess[vi_dim, vj_dim])

--- a/jno/utils/ad_mode.py
+++ b/jno/utils/ad_mode.py
@@ -1,0 +1,136 @@
+"""AD mode (forward / reverse) selection for jNO operators.
+
+Two layers, in order of precedence:
+
+1. Per-call scheme suffix on the operator:
+
+   - First-order   (``.d``, ``.diff``, ``d/dt``)::
+
+       u.d(x, scheme="automatic_differentiation:forward")
+       u.d(x, scheme="automatic_differentiation:reverse")
+
+   - Second-order  (``.laplacian``, ``.hessian``, ``.d2``, ``.dd``)::
+
+       u.laplacian(x, y, scheme="automatic_differentiation:fwd-over-rev")
+       u.laplacian(x, y, scheme="automatic_differentiation:fwd-over-fwd")
+       u.laplacian(x, y, scheme="automatic_differentiation:rev-over-rev")
+       u.laplacian(x, y, scheme="automatic_differentiation:rev-over-fwd")
+
+2. Global default — set via :func:`jno.setup` or via ``.jno.toml``::
+
+       jno.setup(__file__, diff_type="forward", hessian_type="fwd-over-fwd")
+
+   .. code-block:: toml
+
+       [jno]
+       diff_type    = "forward"        # first-order default
+       hessian_type = "fwd-over-rev"   # second-order default
+
+The plain string ``"automatic_differentiation"`` (no suffix) resolves to the
+current global default. Defaults match historical behaviour: first-order
+``reverse`` (was ``jax.jacobian`` = ``jacrev``); second-order ``fwd-over-rev``
+(was ``jax.hessian`` = ``jacfwd ∘ jacrev``).
+"""
+
+from __future__ import annotations
+
+import jax
+
+_VALID_FIRST_ORDER = ("forward", "reverse")
+_VALID_HESSIAN = ("fwd-over-rev", "fwd-over-fwd", "rev-over-rev", "rev-over-fwd")
+
+_AD_MODE: str = "reverse"
+_HESSIAN_MODE: str = "fwd-over-rev"
+
+
+def set_ad_mode(mode: str) -> None:
+    """Set the global default for first-order AD."""
+    global _AD_MODE
+    if mode not in _VALID_FIRST_ORDER:
+        raise ValueError(f"Invalid AD mode {mode!r}; expected one of {_VALID_FIRST_ORDER}.")
+    _AD_MODE = mode
+
+
+def get_ad_mode() -> str:
+    """Return the global default for first-order AD."""
+    return _AD_MODE
+
+
+def set_hessian_mode(mode: str) -> None:
+    """Set the global default for second-order AD."""
+    global _HESSIAN_MODE
+    if mode not in _VALID_HESSIAN:
+        raise ValueError(f"Invalid Hessian mode {mode!r}; expected one of {_VALID_HESSIAN}.")
+    _HESSIAN_MODE = mode
+
+
+def get_hessian_mode() -> str:
+    """Return the global default for second-order AD."""
+    return _HESSIAN_MODE
+
+
+def parse_ad_scheme(scheme: str) -> str:
+    """Resolve a first-order scheme string to ``"forward"`` or ``"reverse"``.
+
+    Supported::
+
+        "automatic_differentiation"          → global default (get_ad_mode())
+        "automatic_differentiation:forward"  → "forward"
+        "automatic_differentiation:reverse"  → "reverse"
+    """
+    if ":" not in scheme:
+        return get_ad_mode()
+    _, sub = scheme.split(":", 1)
+    sub = sub.strip()
+    if sub in _VALID_FIRST_ORDER:
+        return sub
+    raise ValueError(f"Unknown AD scheme suffix {sub!r}; expected one of {_VALID_FIRST_ORDER}.")
+
+
+def parse_hessian_scheme(scheme: str) -> tuple[str, str]:
+    """Resolve a second-order scheme string to ``(outer, inner)`` AD modes.
+
+    The result composes as ``outer(inner(f))``. E.g. ``("forward", "reverse")``
+    means ``jax.jacfwd(jax.jacrev(f))`` — the historical ``jax.hessian`` path.
+
+    Supported::
+
+        "automatic_differentiation"                → global default (get_hessian_mode())
+        "automatic_differentiation:fwd-over-rev"   → ("forward", "reverse")
+        "automatic_differentiation:fwd-over-fwd"   → ("forward", "forward")
+        "automatic_differentiation:rev-over-rev"   → ("reverse", "reverse")
+        "automatic_differentiation:rev-over-fwd"   → ("reverse", "forward")
+
+    First-order suffixes ``forward``/``reverse`` are accepted as shorthand for
+    the matching same-mode composition (``forward`` → ``fwd-over-fwd``).
+    """
+    if ":" not in scheme:
+        return _hessian_to_outer_inner(get_hessian_mode())
+    _, sub = scheme.split(":", 1)
+    sub = sub.strip()
+    if sub in _VALID_HESSIAN:
+        return _hessian_to_outer_inner(sub)
+    if sub in _VALID_FIRST_ORDER:
+        return (sub, sub)
+    raise ValueError(f"Unknown Hessian scheme suffix {sub!r}; expected one of {_VALID_HESSIAN}.")
+
+
+def _hessian_to_outer_inner(mode: str) -> tuple[str, str]:
+    mapping = {
+        "fwd-over-rev": ("forward", "reverse"),
+        "fwd-over-fwd": ("forward", "forward"),
+        "rev-over-rev": ("reverse", "reverse"),
+        "rev-over-fwd": ("reverse", "forward"),
+    }
+    if mode not in mapping:
+        raise ValueError(mode)
+    return mapping[mode]
+
+
+def ad_fn(mode: str):
+    """Return ``jax.jacfwd`` or ``jax.jacrev`` for the given mode."""
+    if mode == "forward":
+        return jax.jacfwd
+    if mode == "reverse":
+        return jax.jacrev
+    raise ValueError(f"Invalid AD mode {mode!r}.")

--- a/jno/utils/config.py
+++ b/jno/utils/config.py
@@ -169,7 +169,30 @@ def get_seed() -> int:
 # ---------------------------------------------------------------------------
 
 
-def setup(script_file: str, name: str | None = None, wandb: bool | dict = False) -> str:
+def apply_ad_mode_defaults(diff_type: str | None = None, hessian_type: str | None = None) -> None:
+    """Apply AD mode globals from explicit kwargs, falling back to ``[jno]`` TOML.
+
+    Precedence: explicit kwarg > ``[jno] diff_type`` / ``[jno] hessian_type`` >
+    historical defaults already set in :mod:`jno.utils.ad_mode`.
+    """
+    from . import ad_mode as _ad_mode
+
+    cfg = get_config().get("jno", {})
+    diff = diff_type if diff_type is not None else cfg.get("diff_type")
+    hess = hessian_type if hessian_type is not None else cfg.get("hessian_type")
+    if diff is not None:
+        _ad_mode.set_ad_mode(diff)
+    if hess is not None:
+        _ad_mode.set_hessian_mode(hess)
+
+
+def setup(
+    script_file: str,
+    name: str | None = None,
+    wandb: bool | dict = False,
+    diff_type: str | None = None,
+    hessian_type: str | None = None,
+) -> str:
     """Initialise logging and return the run directory for *script_file*.
 
     Replaces the two-line boilerplate at the top of every example::
@@ -188,11 +211,14 @@ def setup(script_file: str, name: str | None = None, wandb: bool | dict = False)
     directory so output paths are stable regardless of current shell cwd.
     Pass an explicit *name* to override the stem.
 
-    A global RNG seed can be set in ``.jno.toml`` under ``[jno] seed`` so that
-    all ``jno.core(...)`` instances use it automatically::
+    A global RNG seed and the default AD modes can be set in ``.jno.toml``
+    under ``[jno]`` so that all ``jno.core(...)`` instances use them
+    automatically::
 
         [jno]
-        seed = 42
+        seed         = 42
+        diff_type    = "forward"        # first-order AD default
+        hessian_type = "fwd-over-rev"   # second-order AD default
 
     Args:
         script_file: Pass ``__file__`` from the calling script.
@@ -207,6 +233,15 @@ def setup(script_file: str, name: str | None = None, wandb: bool | dict = False)
             Requires the ``wandb`` package to be installed. When the
             import fails and *wandb* is not ``False``, a warning is
             printed and training continues without W&B logging.
+        diff_type: Global default for first-order AD on ``.d`` / ``.diff`` /
+            ``d/dt``. One of ``"forward"`` / ``"reverse"``. ``None`` reads
+            ``[jno] diff_type`` from the TOML config, or keeps the historical
+            default (``"reverse"``).
+        hessian_type: Global default for second-order AD on ``.laplacian`` /
+            ``.hessian`` / ``.d2`` / ``.dd``. One of ``"fwd-over-rev"``,
+            ``"fwd-over-fwd"``, ``"rev-over-rev"``, ``"rev-over-fwd"``.
+            ``None`` reads ``[jno] hessian_type`` from the TOML config, or
+            keeps the historical default (``"fwd-over-rev"``).
 
     Returns:
         The path of the run directory (created if absent).
@@ -243,6 +278,10 @@ def setup(script_file: str, name: str | None = None, wandb: bool | dict = False)
     except Exception:
         # Keep setup robust even if architecture modules are unavailable.
         pass
+
+    # Apply AD mode defaults — explicit kwargs win over TOML, which wins
+    # over the historical defaults already in ad_mode.py.
+    apply_ad_mode_defaults(diff_type, hessian_type)
 
     # --- Optional Weights & Biases ---
     _init_wandb(wandb, stem, str(dire))

--- a/tests/test_ad_mode.py
+++ b/tests/test_ad_mode.py
@@ -1,0 +1,365 @@
+"""Tests for AD mode switching (forward vs reverse) on derivative operators.
+
+Covers:
+  - parse_ad_scheme / parse_hessian_scheme — pure scheme-string parsing.
+  - Numerical agreement of all four first-order modes (default,
+    :forward, :reverse) against analytic results.
+  - Numerical agreement of all four second-order compositions
+    (:fwd-over-rev, :fwd-over-fwd, :rev-over-rev, :rev-over-fwd) on
+    .laplacian and .hessian.
+  - Dispatch routing: monkeypatched ad_fn spy proves the requested mode
+    reaches trace_evaluator for first- and second-order operators.
+  - Global default via jno.setup (and ad_mode.set_ad_mode) plus per-call
+    suffix override.
+
+A module-level fixture restores the global mode after each test so the
+tests are order-independent.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from jno.trace import FunctionCall, Literal
+from jno.trace_evaluator import TraceEvaluator
+from jno.utils.ad_mode import (
+    ad_fn,
+    get_ad_mode,
+    get_hessian_mode,
+    parse_ad_scheme,
+    parse_hessian_scheme,
+    set_ad_mode,
+    set_hessian_mode,
+)
+from jno.utils.config import apply_ad_mode_defaults
+from tests.conftest import make_var
+
+FIRST_ORDER_SCHEMES = (
+    "automatic_differentiation",
+    "automatic_differentiation:forward",
+    "automatic_differentiation:reverse",
+)
+HESSIAN_SCHEMES = (
+    "automatic_differentiation",
+    "automatic_differentiation:fwd-over-rev",
+    "automatic_differentiation:fwd-over-fwd",
+    "automatic_differentiation:rev-over-rev",
+    "automatic_differentiation:rev-over-fwd",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_ad_mode():
+    """Restore module-level AD defaults after every test."""
+    prev_first = get_ad_mode()
+    prev_second = get_hessian_mode()
+    yield
+    set_ad_mode(prev_first)
+    set_hessian_mode(prev_second)
+
+
+def _eval(expr, context):
+    ev = TraceEvaluator({})
+    return ev.evaluate(expr, context, {}, key=jax.random.PRNGKey(0))
+
+
+def _pts_1d(n=16):
+    return jnp.linspace(0.1, 0.9, n).reshape(n, 1)
+
+
+def _make_2d_vars():
+    """(x, y) sharing tag 'xy' on a 2-D mock domain."""
+    from tests.conftest import MockDomain
+
+    d = MockDomain(tags=["xy"], dim=2)
+    from jno.trace import Variable
+
+    x = Variable("xy", [0, 1], domain=d)
+    y = Variable("xy", [1, 2], domain=d)
+    return x, y
+
+
+def _pts_2d(n=6):
+    xs = jnp.linspace(0.1, 0.9, n)
+    ys = jnp.linspace(0.1, 0.9, n)
+    gx, gy = jnp.meshgrid(xs, ys)
+    return jnp.stack([gx.ravel(), gy.ravel()], axis=-1)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# 1. Pure-parser tests
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestParseAdScheme:
+    def test_no_suffix_uses_global_default(self):
+        set_ad_mode("forward")
+        assert parse_ad_scheme("automatic_differentiation") == "forward"
+        set_ad_mode("reverse")
+        assert parse_ad_scheme("automatic_differentiation") == "reverse"
+
+    def test_explicit_suffix_overrides_default(self):
+        set_ad_mode("forward")
+        assert parse_ad_scheme("automatic_differentiation:reverse") == "reverse"
+
+    def test_unknown_suffix_raises(self):
+        with pytest.raises(ValueError):
+            parse_ad_scheme("automatic_differentiation:bogus")
+
+    def test_set_ad_mode_validates(self):
+        with pytest.raises(ValueError):
+            set_ad_mode("sideways")
+
+
+class TestParseHessianScheme:
+    def test_no_suffix_uses_global_default(self):
+        set_hessian_mode("fwd-over-fwd")
+        assert parse_hessian_scheme("automatic_differentiation") == ("forward", "forward")
+        set_hessian_mode("rev-over-fwd")
+        assert parse_hessian_scheme("automatic_differentiation") == ("reverse", "forward")
+
+    @pytest.mark.parametrize(
+        "suffix,expected",
+        [
+            ("fwd-over-rev", ("forward", "reverse")),
+            ("fwd-over-fwd", ("forward", "forward")),
+            ("rev-over-rev", ("reverse", "reverse")),
+            ("rev-over-fwd", ("reverse", "forward")),
+        ],
+    )
+    def test_explicit_composition(self, suffix, expected):
+        assert parse_hessian_scheme(f"automatic_differentiation:{suffix}") == expected
+
+    def test_first_order_suffix_is_same_mode_for_both_layers(self):
+        assert parse_hessian_scheme("automatic_differentiation:forward") == ("forward", "forward")
+        assert parse_hessian_scheme("automatic_differentiation:reverse") == ("reverse", "reverse")
+
+    def test_unknown_suffix_raises(self):
+        with pytest.raises(ValueError):
+            parse_hessian_scheme("automatic_differentiation:fwd-rev")
+
+
+# ────────────────────────────────────────────────────────────────────────
+# 2. ad_fn dispatch
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestAdFn:
+    def test_forward_returns_jacfwd(self):
+        assert ad_fn("forward") is jax.jacfwd
+
+    def test_reverse_returns_jacrev(self):
+        assert ad_fn("reverse") is jax.jacrev
+
+    def test_unknown_raises(self):
+        with pytest.raises(ValueError):
+            ad_fn("middle")
+
+
+# ────────────────────────────────────────────────────────────────────────
+# 3. Numerical correctness across all schemes
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestFirstOrderNumerical:
+    """d/dx(x³) = 3x² must hold for every first-order scheme."""
+
+    @pytest.mark.parametrize("scheme", FIRST_ORDER_SCHEMES)
+    def test_d_cubic(self, scheme):
+        x = make_var("x")
+        u = x ** Literal(3.0)
+        pts = _pts_1d()
+        result = jnp.ravel(_eval(u.d(x, scheme=scheme), {"x": pts}))
+        expected = 3.0 * pts[:, 0] ** 2
+        assert jnp.allclose(result, expected, atol=1e-4)
+
+    @pytest.mark.parametrize("scheme", FIRST_ORDER_SCHEMES)
+    def test_d_sin(self, scheme):
+        x = make_var("x")
+        u = FunctionCall(jnp.sin, [x], "sin")
+        pts = _pts_1d()
+        result = jnp.ravel(_eval(u.d(x, scheme=scheme), {"x": pts}))
+        expected = jnp.cos(pts[:, 0])
+        assert jnp.allclose(result, expected, atol=1e-4)
+
+    @pytest.mark.parametrize("scheme", FIRST_ORDER_SCHEMES)
+    def test_d_2d_partial(self, scheme):
+        """∂/∂x(x² + y³) = 2x at (x, y)."""
+        x, y = _make_2d_vars()
+        u = x ** Literal(2.0) + y ** Literal(3.0)
+        pts = _pts_2d()
+        result = jnp.ravel(_eval(u.d(x, scheme=scheme), {"xy": pts}))
+        expected = 2.0 * pts[:, 0]
+        assert jnp.allclose(result, expected, atol=1e-4)
+
+
+class TestSecondOrderNumerical:
+    @pytest.mark.parametrize("scheme", HESSIAN_SCHEMES)
+    def test_laplacian_2d_quadratic(self, scheme):
+        """Δ(x² + y²) = 4."""
+        x, y = _make_2d_vars()
+        u = x ** Literal(2.0) + y ** Literal(2.0)
+        pts = _pts_2d()
+        result = jnp.ravel(_eval(u.laplacian(x, y, scheme=scheme), {"xy": pts}))
+        assert jnp.allclose(result, 4.0, atol=1e-4)
+
+    @pytest.mark.parametrize("scheme", HESSIAN_SCHEMES)
+    def test_hessian_2d_quadratic(self, scheme):
+        """H(x² + xy + y²) = [[2, 1], [1, 2]]."""
+        x, y = _make_2d_vars()
+        u = x ** Literal(2.0) + x * y + y ** Literal(2.0)
+        pts = _pts_2d()
+        H = _eval(u.hessian(x, y, scheme=scheme), {"xy": pts})
+        expected = jnp.array([[2.0, 1.0], [1.0, 2.0]])
+        assert jnp.allclose(H, expected[None, ...], atol=1e-4)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# 4. Dispatch verification — spy on ad_fn to prove the routed mode reaches
+# the trace evaluator.
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestDispatchRouting:
+    def test_scheme_forward_routes_to_jacfwd(self, monkeypatch):
+        calls = []
+        original = ad_fn
+
+        def spy(mode):
+            calls.append(mode)
+            return original(mode)
+
+        monkeypatch.setattr("jno.trace_evaluator.ad_fn", spy)
+        x = make_var("x")
+        u = x ** Literal(3.0)
+        _eval(u.d(x, scheme="automatic_differentiation:forward"), {"x": _pts_1d()})
+        assert "forward" in calls and "reverse" not in calls
+
+    def test_scheme_reverse_routes_to_jacrev(self, monkeypatch):
+        calls = []
+        original = ad_fn
+
+        def spy(mode):
+            calls.append(mode)
+            return original(mode)
+
+        monkeypatch.setattr("jno.trace_evaluator.ad_fn", spy)
+        x = make_var("x")
+        u = x ** Literal(3.0)
+        _eval(u.d(x, scheme="automatic_differentiation:reverse"), {"x": _pts_1d()})
+        assert "reverse" in calls and "forward" not in calls
+
+    def test_hessian_scheme_fwd_over_fwd_routes_to_both_jacfwd(self, monkeypatch):
+        calls = []
+        original = ad_fn
+
+        def spy(mode):
+            calls.append(mode)
+            return original(mode)
+
+        monkeypatch.setattr("jno.trace_evaluator.ad_fn", spy)
+        x, y = _make_2d_vars()
+        u = x ** Literal(2.0) + y ** Literal(2.0)
+        _eval(
+            u.laplacian(x, y, scheme="automatic_differentiation:fwd-over-fwd"),
+            {"xy": _pts_2d()},
+        )
+        assert calls.count("forward") == 2 and "reverse" not in calls
+
+    def test_hessian_scheme_rev_over_fwd_routes_mixed(self, monkeypatch):
+        calls = []
+        original = ad_fn
+
+        def spy(mode):
+            calls.append(mode)
+            return original(mode)
+
+        monkeypatch.setattr("jno.trace_evaluator.ad_fn", spy)
+        x, y = _make_2d_vars()
+        u = x * y + x ** Literal(2.0)
+        _eval(
+            u.laplacian(x, y, scheme="automatic_differentiation:rev-over-fwd"),
+            {"xy": _pts_2d()},
+        )
+        assert "forward" in calls and "reverse" in calls
+
+
+# ────────────────────────────────────────────────────────────────────────
+# 5. Global default + per-call override
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestGlobalDefaultAndOverride:
+    def test_set_ad_mode_changes_unscoped_scheme(self):
+        """A bare 'automatic_differentiation' resolves at parse time."""
+        set_ad_mode("forward")
+        assert parse_ad_scheme("automatic_differentiation") == "forward"
+        set_ad_mode("reverse")
+        assert parse_ad_scheme("automatic_differentiation") == "reverse"
+
+    def test_per_call_overrides_global(self):
+        set_ad_mode("forward")
+        # Explicit suffix beats the global default.
+        assert parse_ad_scheme("automatic_differentiation:reverse") == "reverse"
+
+    def test_numerical_default_matches_explicit_after_set(self):
+        """After set_ad_mode('forward'), a bare-scheme call must produce
+        the same numbers as an explicit ':forward' call."""
+        x = make_var("x")
+        u = x ** Literal(3.0)
+        pts = _pts_1d()
+
+        set_ad_mode("forward")
+        r_default = jnp.ravel(_eval(u.d(x), {"x": pts}))
+        r_explicit = jnp.ravel(_eval(u.d(x, scheme="automatic_differentiation:forward"), {"x": pts}))
+        assert jnp.allclose(r_default, r_explicit, atol=1e-6)
+
+    def test_apply_ad_mode_defaults_sets_modes(self):
+        """jno.setup(diff_type=...) routes through apply_ad_mode_defaults."""
+        set_ad_mode("reverse")
+        set_hessian_mode("fwd-over-rev")
+        apply_ad_mode_defaults(diff_type="forward", hessian_type="rev-over-rev")
+        assert get_ad_mode() == "forward"
+        assert get_hessian_mode() == "rev-over-rev"
+
+    def test_apply_ad_mode_defaults_no_kwargs_does_not_clobber(self):
+        """Omitting kwargs must not reset state already set, when TOML has no override."""
+        set_ad_mode("forward")
+        set_hessian_mode("fwd-over-fwd")
+        from jno.utils.config import load_config
+
+        cfg = load_config(force=True).get("jno", {})
+        apply_ad_mode_defaults()
+        if "diff_type" not in cfg:
+            assert get_ad_mode() == "forward"
+        if "hessian_type" not in cfg:
+            assert get_hessian_mode() == "fwd-over-fwd"
+
+
+# ────────────────────────────────────────────────────────────────────────
+# 6. Cross-mode agreement on a vector-valued network output
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestCrossModeAgreement:
+    """All four Hessian compositions must produce the same H within tolerance."""
+
+    def test_hessian_matches_across_modes(self):
+        x, y = _make_2d_vars()
+        u = (x ** Literal(2.0)) * y + y ** Literal(3.0)
+        pts = _pts_2d()
+        results = {scheme: _eval(u.hessian(x, y, scheme=scheme), {"xy": pts}) for scheme in HESSIAN_SCHEMES}
+        ref = results[HESSIAN_SCHEMES[1]]  # fwd-over-rev
+        for scheme, H in results.items():
+            assert jnp.allclose(H, ref, atol=1e-4), f"Hessian disagrees for scheme {scheme}"
+
+    def test_first_order_matches_across_modes(self):
+        x, y = _make_2d_vars()
+        u = FunctionCall(jnp.sin, [x], "sin") * y
+        pts = _pts_2d()
+        results = {scheme: _eval(u.d(x, scheme=scheme), {"xy": pts}) for scheme in FIRST_ORDER_SCHEMES}
+        ref = results[FIRST_ORDER_SCHEMES[1]]  # forward
+        for scheme, val in results.items():
+            assert jnp.allclose(val, ref, atol=1e-5), f"d disagrees for scheme {scheme}"


### PR DESCRIPTION
## Summary

Adds a way to pick the AD mode (forward vs reverse) per operator via a scheme
suffix, without changing call sites. Adds the supporting plumbing in
`jno/utils/ad_mode.py`, threads it through `jno.trace` and the trace evaluator,
and surfaces the new knob in `jno/utils/config.py` and `docs/API.md`.

- New `jno/utils/ad_mode.py` with the scheme-suffix resolver.
- `jno/trace.py` and `jno/trace_evaluator.py` consume the resolved mode.
- `jno/utils/config.py` exposes the configuration entry.
- `tests/test_ad_mode.py` covers both modes end-to-end (365 LOC).
- `docs/API.md` documents the suffix convention.

## Test plan

- [x] `pixi run ci-fmt` — format clean
- [x] `pixi run ci-lint` — lint clean
- [x] `JAX_PLATFORMS=cuda,cpu pixi run ci-test` — 1591 passed, 8 skipped, 58 deselected (slow), 14m22s on GPU