### PR TITLE
fix(domain): per-edge boundary sub-tags for from_regions + dom.summary() boundary section

### DIFF
--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -671,6 +671,33 @@ class domain(MeshIOMixin):
             for tag, pts in self._mesh_pool.items():
                 lines.append(f"    • {tag:20s}  shape {pts.shape}")
 
+        if self._boundary_registry:
+            lines.append(f"  Boundary tags ({len(self._boundary_registry)}):")
+            coord_labels = self.spatial if self.spatial else [f"x{i}" for i in range(self.dimension)]
+            for tag in sorted(self._boundary_registry):
+                pts = self._boundary_registry[tag].get("points")
+                parts: list = [f"    • {tag}"]
+                if pts is not None and len(pts) > 0:
+                    pts_xy = np.asarray(pts)[:, : self.dimension]
+                    extents = []
+                    for axis, label in enumerate(coord_labels):
+                        lo, hi = float(pts_xy[:, axis].min()), float(pts_xy[:, axis].max())
+                        if hi - lo < 1e-10:
+                            extents.append(f"{label}={lo:.3g}")
+                        else:
+                            extents.append(f"{label}=[{lo:.3g},{hi:.3g}]")
+                    parts.append("  " + "  ".join(extents))
+                normals = self.normals_by_tag.get(tag)
+                if normals is None:
+                    ctx_n = self.context.get(f"n_{tag}")
+                    if ctx_n is not None:
+                        normals = np.asarray(ctx_n).reshape(-1, self.dimension)
+                if normals is not None and len(normals) > 0:
+                    mean_n = np.asarray(normals).mean(axis=0)[: self.dimension]
+                    n_str = "(" + ", ".join(f"{v:+.2f}" for v in mean_n) + ")"
+                    parts.append(f"  n={n_str}")
+                lines.append("".join(parts))
+
         if self._param_tags:
             lines.append(f"  Tensor tags ({len(self._param_tags)}):")
             for tag in sorted(self._param_tags):

--- a/jno/domain/polygon_domain.py
+++ b/jno/domain/polygon_domain.py
@@ -192,7 +192,15 @@ def _segments_from_line_geometry(geom: BaseGeometry) -> np.ndarray:
 
 
 def _edge_geometries_from_region(geom: BaseGeometry) -> List[BaseGeometry]:
-    return [_as_line_geometry(line) for line in _line_parts(geom.boundary)]
+    # Decompose each ring into individual LineString segments so that
+    # from_regions / geometry-based paths produce per-edge sub-tags
+    # (boundary_{name}_0, _1, …) matching the _polygon_from_vertices path.
+    edges: List[BaseGeometry] = []
+    for ring in _line_parts(geom.boundary):
+        coords = list(ring.coords)
+        for i in range(len(coords) - 1):
+            edges.append(LineString([coords[i], coords[i + 1]]))
+    return edges if edges else [_as_line_geometry(geom.boundary)]
 
 
 def _unique_segment_points(segments: np.ndarray) -> np.ndarray:

--- a/tests/test_polygon_domain_csg.py
+++ b/tests/test_polygon_domain_csg.py
@@ -269,3 +269,65 @@ def test_visibility_filter_requires_positive_cosines_at_both_endpoints():
     filtered_perpendicular = dom._filter_visibility_by_normals(points, perpendicular_normals, visible)
     assert filtered_perpendicular[0, 1] == pytest.approx(0.0)
     assert filtered_perpendicular[1, 0] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Numbered boundary sub-tag existence and geometry
+# ---------------------------------------------------------------------------
+
+
+def test_from_regions_produces_per_edge_subtags():
+    """from_regions must decompose each polygon into per-edge sub-tags, not one combined tag."""
+    from shapely.geometry import Polygon
+
+    dom = jno.domain.csg.from_regions({"WallO": Polygon(SQUARE_A)})
+    tags = dom.boundary_tags()
+
+    for i in range(4):
+        assert f"boundary_WallO_{i}" in tags, f"boundary_WallO_{i} missing — from_regions returned only: " + str(
+            [t for t in tags if "WallO" in t]
+        )
+
+
+def test_all_numbered_boundary_subtags_present_for_square():
+    """A 4-sided polygon must expose boundary_{name}_0 … _3 and the combined tag."""
+    dom = jno.domain.csg(SQUARE_A, name="wall")
+    tags = dom.boundary_tags()
+
+    for i in range(4):
+        assert f"boundary_wall_{i}" in tags, f"boundary_wall_{i} missing from {tags}"
+    assert "boundary_wall" in tags
+
+
+def test_numbered_boundary_subtags_are_geometrically_distinct():
+    """Each boundary_{name}_{i} sub-tag must sample from a different edge of the square.
+
+    For an axis-aligned unit square every edge has one coordinate that is constant
+    (either x=0, x=1, y=0, or y=1).  The four sub-tags must cover four distinct
+    constant-coordinate values, confirming they are separate faces.
+    """
+    np.random.seed(42)
+    dom = jno.domain.csg(SQUARE_A, name="wall")
+
+    constant_coords = set()
+    for i in range(4):
+        tag = f"boundary_wall_{i}"
+        xb, yb, _ = dom.variable(tag, sample=(64, None))
+        pts = dom.context[tag][0, 0]  # (64, 2)
+
+        x_spread = pts[:, 0].max() - pts[:, 0].min()
+        y_spread = pts[:, 1].max() - pts[:, 1].min()
+
+        # One coordinate must be (near-)constant — it's an axis-aligned edge
+        assert min(x_spread, y_spread) < 1e-10, (
+            f"{tag}: neither x_spread={x_spread:.2e} nor y_spread={y_spread:.2e} is constant — not an axis-aligned edge"
+        )
+
+        # Record which (axis, value) this edge sits on
+        if x_spread < 1e-10:
+            constant_coords.add(("x", round(float(pts[0, 0]), 6)))
+        else:
+            constant_coords.add(("y", round(float(pts[0, 1]), 6)))
+
+    # Four distinct faces ↔ four distinct (axis, value) pairs
+    assert len(constant_coords) == 4, f"Expected 4 distinct edges, got {len(constant_coords)}: {constant_coords}"


### PR DESCRIPTION
## Summary

- **Bug fix**: `_edge_geometries_from_region` was returning one `LineString` per boundary ring instead of one per edge. This meant `from_regions()` and geometry-based CSG paths only ever produced a single `boundary_{name}_0` tag covering the full polygon perimeter, rather than individual per-edge sub-tags. Fixed by decomposing each `LinearRing` into consecutive `LineString` segments — matching what `_polygon_from_vertices` already did explicitly.

- **`dom.summary()` improvement**: Added a **Boundary tags** section that prints the spatial extent and mean outward normal for every registered boundary tag. Before this change, users had to sample each sub-tag and inspect coordinates to figure out which `boundary_{name}_{i}` corresponds to which face. Now `dom.summary()` shows it directly, e.g.:

```
Boundary tags (6):
  • boundary_WallO_0  x=[0,1]  y=0    n=(+0.00, -1.00)
  • boundary_WallO_1  x=1      y=[0,1]  n=(+1.00, +0.00)
  • boundary_WallO_2  x=[0,1]  y=1    n=(+0.00, +1.00)
  • boundary_WallO_3  x=0      y=[0,1]  n=(-1.00, +0.00)
```

Normals appear once the tag has been sampled with `normals=True`; the extent alone is enough to identify the face.

## Test plan

- [x] `test_from_regions_produces_per_edge_subtags` — regression for the `from_regions` bug
- [x] `test_all_numbered_boundary_subtags_present_for_square` — all 4 sub-tags exist for single-polygon CSG
- [x] `test_numbered_boundary_subtags_are_geometrically_distinct` — each sub-tag covers a distinct axis-aligned face
- [x] Full polygon domain suite: `pixi run test tests/test_polygon_domain_csg.py tests/test_polygon_domain_build_mesh.py tests/test_domain_geometries.py` (111 passed)