### PR TITLE
fix: W&B real-time syncing, step timing, and eval() device mismatch

### DIFF
--- a/jno/core.py
+++ b/jno/core.py
@@ -4516,6 +4516,15 @@ class core:
         _models = eqx.tree_inference(self._unwrapped_models)
         ctx = domain_data.context
 
+        # After solve(), model weights carry NamedSharding from the training
+        # mesh while context arrays are CPU-pinned by prepare_domain_data.
+        # Passing mixed-device inputs to a plain filter_jit raises
+        # "incompatible devices".  Normalise both to the default device so
+        # the eval JIT sees a consistent, unsharded device set.
+        _eval_dev = jax.devices()[0]
+        _models = jax.device_put(_models, _eval_dev)
+        ctx = jax.device_put(ctx, _eval_dev)
+
         def _point_eval(op):
             op_entry = self._eval_cache.get(op)
             if op_entry is None:

--- a/jno/core.py
+++ b/jno/core.py
@@ -62,7 +62,7 @@ from .utils import (
     get_seed,
     statistics,
 )
-from .utils.config import get_wandb_run, wandb_alert, wandb_log, wandb_log_model
+from .utils.config import get_wandb_run, wandb_alert, wandb_commit, wandb_log, wandb_log_model
 
 
 def _cpu_device():
@@ -3338,7 +3338,7 @@ class core:
                                         _wb[f"posterior/{_name_w}/mean_{_f_w}"] = float(jnp.nanmean(_joined_w))
                         _bay_step = _epoch_counter - 1
                         wandb_log(_wb, step=_bay_step)
-                        _wandb_run.log({}, step=_bay_step, commit=True)
+                        wandb_commit(_bay_step)
                         if (not _wandb_nan_alerted) and not np.isfinite(_total_np):
                             wandb_alert(
                                 "NaN/Inf loss detected",
@@ -3861,8 +3861,7 @@ class core:
                 # higher step is seen.  Without an explicit commit the current
                 # epoch's metrics are invisible until the next epoch starts,
                 # and the very last epoch's metrics are never uploaded at all.
-                if _wandb_run is not None:
-                    _wandb_run.log({}, step=displayed_epoch, commit=True)
+                wandb_commit(displayed_epoch)
 
             if _profile_active:
                 _profile_ctx.__exit__(None, None, None)

--- a/jno/utils/config.py
+++ b/jno/utils/config.py
@@ -430,6 +430,17 @@ def wandb_log(metrics: dict[str, Any], *, step: int | None = None) -> None:
         _WANDB_RUN.log(metrics, step=step)
 
 
+def wandb_commit(step: int) -> None:
+    """Commit the buffered W&B row for *step* (no-op if W&B is not enabled).
+
+    When ``step=`` is passed to :func:`wandb_log`, W&B buffers the row and
+    only flushes it when a higher step is seen.  Call this once after all
+    per-epoch log calls to make the row visible in the UI immediately.
+    """
+    if _WANDB_RUN is not None:
+        _WANDB_RUN.log({}, step=step, commit=True)
+
+
 def wandb_alert(title: str, text: str, level: str = "WARN") -> None:
     """Send a W&B alert if a run is active (no-op otherwise).
 

--- a/tests/test_core_device.py
+++ b/tests/test_core_device.py
@@ -624,3 +624,31 @@ class TestGPUPlacement:
         assert jnp.isfinite(loss), f"GPU solve produced non-finite loss: {loss}"
         # The RNG should now live on a GPU device after the step
         assert all(d.platform == "gpu" for d in s.rng.devices()), f"Expected rng on GPU after solve, got {s.rng.devices()}"
+
+
+# ---------------------------------------------------------------------------
+# eval() after solve() — device compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestEvalAfterSolve:
+    """eval() must work after solve() even though solve() shards model weights
+    onto the training mesh while prepare_domain_data() pins context to CPU."""
+
+    @requires_gpu
+    def test_eval_after_solve_no_device_error(self):
+        """crux.eval(expr) after crux.solve() must not raise incompatible-devices."""
+        import optax
+
+        dom = jno.domain(constructor=jno.domain.line(mesh_size=0.1))
+        x, *_ = dom.variable("interior")
+        net = jnn.nn.wrap(foundax.mlp(1, output_dim=1, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(0)))
+        net.optimizer(optax.adam(1e-3))
+        u = net(x) * x * (1 - x)
+        crux = jno.core([jnn.laplacian(u, [x]).mse], dom)
+        crux.solve(2)
+
+        result = crux.eval(u)
+        arr = jnp.asarray(result)
+        assert arr.shape[-1] == 1
+        assert jnp.all(jnp.isfinite(arr))


### PR DESCRIPTION
## Summary

- **W&B `wandb_commit()` wrapper**: routes the per-epoch `commit=True` flush through a new `config.py` function instead of calling `_wandb_run.log()` directly — fixes `AttributeError` in Bayesian W&B tests whose `_FakeRun` stub had no `.log` method
- **`eval()` after `solve()` device mismatch**: after training, model weights carry `NamedSharding` (GPU) from the training mesh while `prepare_domain_data()` pins context to CPU; `eval()`'s plain `filter_jit` raised `ValueError: incompatible devices`; fix normalises both to `jax.devices()[0]` (unsharded) at the top of `eval()`

## Test plan

- [x] `tests/test_bayesian.py::TestPosteriorDiagnostics::test_wandb_diagnostics_keys` — previously failing with `AttributeError: '_FakeRun' object has no attribute 'log'`
- [x] `tests/test_bayesian.py::TestWandbChainStatsSmoke`
- [x] `tests/test_core_device.py::TestEvalAfterSolve::test_eval_after_solve_no_device_error` — new GPU regression test