### PR TITLE
Fold: tensor-tag inlining + pinn-gaps resampling fix & Monte-Carlo default

### DIFF
--- a/jno/core.py
+++ b/jno/core.py
@@ -3453,13 +3453,45 @@ class core:
                         full_models = eqx.combine(trainable, frozen_arrays, static)
                         full_models = _paramax.unwrap(full_models)
 
-                        residuals_all = self.compiled_resample_constraints_fn(
-                            full_models,
-                            full_context,
-                            batchsize=None,
-                            key=self.rng,
-                            min_consecutive=min_consecutive,
-                        )
+                        # Only compute residuals when at least one due strategy
+                        # actually consumes them. Skipping avoids an expensive
+                        # un-jit'd forward pass for residual-agnostic strategies
+                        # (e.g. RandomResampling) where the residuals would be
+                        # ignored anyway.
+                        if any(s.needs_residuals for _, s in due):
+                            # Pin both operands to the default device (the GPU
+                            # under JAX_PLATFORMS=cuda,cpu) so the residual
+                            # forward pass has consistent device placement.
+                            #
+                            # Why: ``compiled_resample_constraints_fn`` is not
+                            # ``jax.jit``'d with explicit ``in_shardings``, so
+                            # JAX can't reconcile mesh-sharded model params
+                            # (NamedSharding from the training-step jit setup,
+                            # which becomes ARG_SHARDING inside the resample
+                            # function's internal vmap) with the CPU-resident
+                            # context arrays — the MLP matmul errors out.
+                            #
+                            # Cost: the model ``device_put`` is a metadata-only
+                            # resharding (NamedSharding→SingleDeviceSharding)
+                            # when the mesh is a single device; the context
+                            # ``device_put`` moves CPU→GPU but only fires on
+                            # resample epochs, and the transferred slice is
+                            # small (one (B, T, N, D) per resample-relevant
+                            # tag). For the Monte-Carlo auto-default path
+                            # (RandomResampling, needs_residuals=False) this
+                            # branch is skipped entirely.
+                            _resample_dev = jax.devices()[0]
+                            _models_local = jax.device_put(full_models, _resample_dev)
+                            _ctx_local = jax.device_put(full_context, _resample_dev)
+                            residuals_all = self.compiled_resample_constraints_fn(
+                                _models_local,
+                                _ctx_local,
+                                batchsize=None,
+                                key=self.rng,
+                                min_consecutive=min_consecutive,
+                            )
+                        else:
+                            residuals_all = None
 
                         updated = False
                         for tag, strategy in due:
@@ -3480,31 +3512,46 @@ class core:
                             points_bn = jnp.asarray(tag_points[:, 0, :, :])
                             n_batch, n_points = points_bn.shape[0], points_bn.shape[1]
 
-                            idxs = tag_to_constraint_indices.get(tag, [])
-                            if not idxs:
-                                self.log.warning(
-                                    f"Resampling skipped for tag '{tag}': no constraints associated with this tag"
-                                )
-                                continue
+                            if strategy.needs_residuals:
+                                idxs = tag_to_constraint_indices.get(tag, [])
+                                if not idxs:
+                                    self.log.warning(
+                                        f"Resampling skipped for tag '{tag}': no constraints associated with this tag"
+                                    )
+                                    continue
 
-                            scored = []
-                            for idx in idxs:
-                                collapsed = _collapse_residual_for_tag(residuals_all[idx], n_points, n_batch)
-                                if collapsed is not None:
-                                    scored.append(collapsed)
+                                scored = []
+                                for idx in idxs:
+                                    collapsed = _collapse_residual_for_tag(residuals_all[idx], n_points, n_batch)
+                                    if collapsed is not None:
+                                        scored.append(collapsed)
 
-                            if not scored:
-                                self.log.warning(f"Resampling skipped for tag '{tag}': no compatible pointwise residuals")
-                                continue
+                                if not scored:
+                                    self.log.warning(
+                                        f"Resampling skipped for tag '{tag}': no compatible pointwise residuals"
+                                    )
+                                    continue
 
-                            # Normalize each constraint to [0, 1] then take per-point max.
-                            stacked = jnp.stack(scored, axis=0)  # (C, B, N)
-                            per_max = jnp.max(stacked, axis=-1, keepdims=True)  # (C, B, 1)
-                            normalized = stacked / (per_max + 1e-12)
-                            combined = jnp.max(normalized, axis=0)  # (B, N)
+                                # Normalize each constraint to [0, 1] then take per-point max.
+                                stacked = jnp.stack(scored, axis=0)  # (C, B, N)
+                                per_max = jnp.max(stacked, axis=-1, keepdims=True)  # (C, B, 1)
+                                normalized = stacked / (per_max + 1e-12)
+                                combined = jnp.max(normalized, axis=0)  # (B, N)
+                            else:
+                                # Strategy ignores residuals — pass a zero placeholder.
+                                combined = jnp.zeros((n_batch, n_points))
 
                             # Draw candidates once — reused by every batch and for normals.
                             candidates_pts, candidates_nrms = self.domain.draw_candidates(tag)
+
+                            # Resampling mixes host-side context arrays (potentially
+                            # on CPU under JAX_PLATFORMS=cuda,cpu) with JAX-random
+                            # outputs that land on the default device. Co-locate
+                            # them so primitives like scatter don't error on the
+                            # device mismatch.
+                            _default_device = jax.devices()[0]
+                            points_bn = jax.device_put(points_bn, _default_device)
+                            combined = jax.device_put(combined, _default_device)
 
                             new_batches = []
                             for b in range(n_batch):

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -1978,42 +1978,6 @@ class domain(MeshIOMixin):
 
         return None
 
-    def add_tensor_tag(self, name: str, tensor: Union[np.ndarray, jnp.ndarray]) -> "domain":
-        """Attach a tensor to this domain for parametric PDEs.
-
-        Tensor tags allow parameters to vary across batched domains.
-        The first dimension is the batch dimension and must match the
-        domain's batch count exactly.
-
-        Args:
-            name: Name for this tensor (used in vars(name))
-            tensor: Array with shape (B, ...) where B equals the domain's batch count.
-
-        Returns:
-            Self for method chaining.
-
-        Example:
-            domain = 2 * domain.from_mesh(...)
-            domain.add_tensor_tag('diffusivity', jnp.array([[1.0], [2.0]]))  # shape (2, 1)
-            a = domain.variable('diffusivity')  # Returns TensorTag
-        """
-        tensor = jnp.asarray(tensor)
-        if tensor.ndim < 1:
-            tensor = tensor.reshape(1, 1)
-
-        # Validate batch dimension - must match exactly
-        batch_count = self._effective_batch_count()
-        tensor_batch = tensor.shape[0]
-        if tensor_batch != batch_count:
-            self.log.warning(
-                f"Tensor '{name}' has batch dimension {tensor_batch}, but domain has "
-                f"effective batch count {batch_count}. Was this intended?"
-            )
-
-        self.context[name] = tensor
-        self._param_tags.add(name)
-        return self
-
     # The dominant call ``x, y, _ = dom.variable("interior")`` returns a tuple of
     # coordinate ``Variable``s; typing it (rather than ``Any``) is what makes the
     # whole traced-DSL chain — ``x.d(x)``, ``u.scalar``, … — discoverable in an
@@ -2047,7 +2011,6 @@ class domain(MeshIOMixin):
         return_indices: bool = False,
         time_value: Optional[float] = None,
     ) -> Any: ...
-
     def variable(
         self,
         tag: str,
@@ -2068,7 +2031,18 @@ class domain(MeshIOMixin):
                  or tensor tag (e.g., 'diffusivity')
             sample: Optional sampling specification for this tag:
                     - (n_samples, sampler) tuple to trigger sampling
-                    - jax.numpy array to register a tensor tag
+                    - np.ndarray / jnp.ndarray to register a tensor tag
+
+                When ``sample`` is an array, the leading dimension determines
+                how the tensor is routed by the compiler:
+
+                  * ``shape[0] == B`` (the domain's effective batch count) —
+                    vmapped over the batch axis, one row per sample.
+                  * ``shape[0] == 1`` — broadcast across the batch.
+                  * ``shape[0]`` anything else — *shared*: the full array is
+                    exposed at every step (use this for labeled supervised
+                    data, lookup tables, or gather indices that are not
+                    aligned with the physics batch).
 
             resampling_strategy: Optional ResamplingStrategy for adaptive point selection
             normals: If True, also compute and return normal vectors for this tag
@@ -2084,11 +2058,18 @@ class domain(MeshIOMixin):
         # Optional sampling / tensor-tag attachment
         if sample is not None:
             if isinstance(sample, jnp.ndarray) or isinstance(sample, np.ndarray):
-                # Attach as tensor tag (parameter field) or point data
+                # Attach as tensor tag (parameter field) or point data.
+                # Three shape conventions for tensor tags are documented above
+                # and routed in jno/trace_compiler.py at attach time; we do
+                # not validate the leading dim here.
                 if point_data:
                     self.context[tag] = sample
                 else:
-                    self.add_tensor_tag(tag, sample)
+                    tensor = jnp.asarray(sample)
+                    if tensor.ndim < 1:
+                        tensor = tensor.reshape(1, 1)
+                    self.context[tag] = tensor
+                    self._param_tags.add(tag)
 
         # ------------------------------------------------------------------
         # Clean API for initial condition:

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -19,6 +19,7 @@ from ..utils.logger import get_logger
 from .boundary_region import BoundaryRegion
 from .geometries import Geometries
 from .meshio_mixin import MeshIOMixin
+from .simplex_pool import SimplexPool
 
 
 def _scalar_float(value: Any) -> float:
@@ -571,6 +572,10 @@ class domain(MeshIOMixin):
         self._tag_edges: Dict[str, np.ndarray] = {}
         self._tag_triangles: Dict[str, np.ndarray] = {}
         self._boundary_regions: Dict[str, BoundaryRegion] = {}
+        # Precomputed simplex pools (segments / triangles + optional normals)
+        # for in-JIT collocation sampling — populated by ``_build_simplex_pools``
+        # after each ``_apply_mesh``.
+        self._simplex_pools: Dict[str, SimplexPool] = {}
         # self._boundary_predicates: Dict[str, Callable] = {}
 
         # Neural operator storage
@@ -1735,10 +1740,72 @@ class domain(MeshIOMixin):
         else:
             self.mesh = mesh
             boundary_indices = self._extract_points_from_mesh(mesh)
+            self._build_simplex_pools()
 
         if mesh is not None and self.compute_mesh_connectivity:
             self.mesh_connectivity, msg = self._preprocess_mesh_connectivity(mesh, self.dimension, boundary_indices)
             self.log.info(msg)
+
+    def _build_simplex_pools(self) -> None:
+        """Populate ``self._simplex_pools`` from ``_tag_edges`` / ``_tag_triangles``.
+
+        Runs after ``_extract_points_from_mesh`` so the per-tag cell-membership
+        tables are filled in.  For each mesh tag we materialise a
+        ``SimplexPool``:
+
+        * ``_tag_triangles[tag]`` (dim-2 interior) → V=3 barycentric pool.
+        * ``_tag_edges[tag]`` (1-D interior or 2-D boundary) → V=2 lerp pool;
+          if the tag has a per-point normal in ``normals_by_tag`` we average
+          the two endpoint normals to get a per-segment normal.  Falls back to
+          a geometric normal (rotate the segment vector 90° and pick the
+          half-space pointing away from the mesh centroid) when no per-point
+          normals are available.
+
+        Existing pools for tags not touched by the current mesh (e.g. the
+        Shapely-side pools that ``PolygonDomain._register_*_tag`` populated
+        before a later ``build_mesh()``) are left intact — only tags present
+        in ``_tag_triangles`` / ``_tag_edges`` are overwritten.
+        """
+        points = getattr(self, "points", None)
+        if points is None or len(points) == 0:
+            return
+        points_d = points[:, : self.dimension]
+        mesh_centroid = points_d.mean(axis=0) if len(points_d) else None
+
+        # Track which tags get a triangle pool in this build so the segment
+        # loop knows to skip them (a tag with both triangles + boundary edges
+        # is sampled as an interior — boundary edges are auxiliary).
+        triangle_tags_this_build: set = set()
+
+        # 2-D interior tags (triangle pool, no normals).
+        for tag, tri_indices in self._tag_triangles.items():
+            tri_coords = points_d[tri_indices]
+            if tri_coords.ndim == 3 and tri_coords.shape[1] == 3 and tri_coords.shape[2] == 2:
+                self._simplex_pools[tag] = SimplexPool.from_triangles(tri_coords)
+                triangle_tags_this_build.add(tag)
+
+        # 1-D interior + 2-D boundary tags (segment pool, with normals on dim=2).
+        for tag, edge_indices in self._tag_edges.items():
+            if tag in triangle_tags_this_build:
+                continue  # this tag is being sampled as an interior
+            seg_coords = points_d[edge_indices]
+            if seg_coords.ndim != 3 or seg_coords.shape[1] != 2:
+                continue
+
+            normals = None
+            if self.dimension == 2 and mesh_centroid is not None:
+                vectors = seg_coords[:, 1, :] - seg_coords[:, 0, :]
+                lengths = np.linalg.norm(vectors, axis=1, keepdims=True)
+                lengths = np.where(lengths > 0, lengths, 1.0)
+                tangents = vectors / lengths
+                cand = np.stack([-tangents[:, 1], tangents[:, 0]], axis=-1)
+                midpoints = 0.5 * (seg_coords[:, 0, :] + seg_coords[:, 1, :])
+                outward = midpoints - mesh_centroid
+                flip = (cand * outward).sum(axis=-1) < 0.0
+                cand[flip] *= -1.0
+                normals = cand.astype(np.float32)
+
+            self._simplex_pools[tag] = SimplexPool.from_segments(seg_coords, normals=normals)
 
     def _extract_points_from_mesh(self, mesh):
         """Extract points and normals from mesh and organize by tag."""

--- a/jno/domain/polygon_domain.py
+++ b/jno/domain/polygon_domain.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from .boundary_region import BoundaryRegion
 from .domain_class import domain
+from .simplex_pool import SimplexPool
 
 if TYPE_CHECKING:
     from shapely.geometry.base import BaseGeometry
@@ -291,6 +292,9 @@ class PolygonDomain(domain):
         self._polygon_boundary_segments: Dict[str, np.ndarray] = {}
         self._polygon_boundary_normal_geometries: Dict[str, BaseGeometry] = {}
         self._area_part_cache: Dict[str, Tuple[List[BaseGeometry], np.ndarray]] = {}
+        # Precomputed simplex pools for in-JIT collocation sampling — populated
+        # lazily by _register_interior_tag / _register_boundary_tag.
+        self._simplex_pools: Dict[str, SimplexPool] = {}
 
         if geometry is None:
             if vertices is None:
@@ -1339,6 +1343,15 @@ class PolygonDomain(domain):
 
         if polygon_tag and (wants_lazy_count or not has_mesh_entry):
             if isinstance(sample, tuple) and len(sample) > 0 and isinstance(sample[0], (int, type(None))):
+                # No explicit count → default to 1 point with per-step fresh resampling.
+                # This makes ``domain.variable("interior")`` a one-liner for Monte-Carlo
+                # PINN mode: one fresh random collocation point at every training epoch.
+                if sample[0] is None and not has_mesh_entry:
+                    from ..utils.adaptive.resampling import RandomResampling
+
+                    sample = (1, sample[1])
+                    if resampling_strategy is None:
+                        resampling_strategy = RandomResampling(resample_every=1, resample_fraction=1.0)
                 self.sample_dict.append([tag, sample, resampling_strategy, normals, view_factor])
                 _, sampled_indices, sampled_tag = self.sample(
                     {tag: sample},

--- a/jno/domain/simplex_pool.py
+++ b/jno/domain/simplex_pool.py
@@ -1,0 +1,119 @@
+"""Static simplex pools for in-JIT collocation-point sampling.
+
+A ``SimplexPool`` is a domain-side precompute: at register / mesh-load time we
+decompose each samplable tag into a flat list of simplices (segments for 1-D
+interiors and 2-D boundaries, triangles for 2-D interiors) and store them as
+JAX arrays.  The in-JIT sampler then draws fresh collocation points by
+
+1. Picking a simplex index via measure-weighted ``jax.random.choice``.
+2. Drawing barycentric coordinates inside the picked simplex.
+3. Mapping those barycentrics back to world coordinates.
+
+This keeps the per-step cost on the GPU (no Shapely round-trips) and removes
+the host-side rebuild that currently dominates the resampling pipeline.
+
+The dataclass is frozen and JAX-static — the arrays are jnp arrays but their
+shapes are baked into the trace at JIT-compile time and never change during
+training.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import jax.numpy as jnp
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SimplexPool:
+    """Flat list of simplices for in-JIT uniform sampling.
+
+    Attributes
+    ----------
+    simplices:
+        Vertex coordinates, shape ``(T, V, D)``.  ``V`` is the number of
+        vertices per simplex (2 for segments, 3 for triangles).  ``D`` is the
+        spatial dimension.
+    weights:
+        Per-simplex measure (length for V=2, area for V=3), shape ``(T,)``.
+        Not normalised; the sampler divides by ``weights.sum()`` at use time so
+        downstream code can rely on the raw measures.
+    kind:
+        Either ``"lerp"`` (V=2, uniform-on-segment via linear interpolation)
+        or ``"barycentric"`` (V=3, uniform-on-triangle via the sqrt trick).
+    normals:
+        Optional ``(T, D)`` per-simplex outward unit normal.  Populated only
+        for boundary tags so the sampler can simultaneously emit ``n_<tag>``
+        alongside the spatial coordinates.
+    """
+
+    simplices: jnp.ndarray
+    weights: jnp.ndarray
+    kind: str
+    normals: Optional[jnp.ndarray] = None
+
+    @classmethod
+    def from_segments(
+        cls,
+        segments: np.ndarray,
+        normals: Optional[np.ndarray] = None,
+    ) -> "SimplexPool":
+        """Build a V=2 pool from segment endpoints.
+
+        ``segments`` has shape ``(T, 2, D)``.  Optional ``normals`` has shape
+        ``(T, D)``.  Per-segment weight is the Euclidean length.
+        """
+        segments = np.asarray(segments, dtype=np.float32)
+        if segments.ndim != 3 or segments.shape[1] != 2:
+            raise ValueError(f"segments must have shape (T, 2, D); got {segments.shape}")
+        vectors = segments[:, 1, :] - segments[:, 0, :]
+        lengths = np.linalg.norm(vectors, axis=1).astype(np.float32)
+        if normals is not None:
+            normals = np.asarray(normals, dtype=np.float32)
+            if normals.shape != (segments.shape[0], segments.shape[2]):
+                raise ValueError(f"normals must have shape ({segments.shape[0]}, {segments.shape[2]}); got {normals.shape}")
+            normals_j = jnp.asarray(normals)
+        else:
+            normals_j = None
+        return cls(
+            simplices=jnp.asarray(segments),
+            weights=jnp.asarray(lengths),
+            kind="lerp",
+            normals=normals_j,
+        )
+
+    @classmethod
+    def from_triangles(cls, triangles: np.ndarray) -> "SimplexPool":
+        """Build a V=3 pool from triangle vertex coordinates.
+
+        ``triangles`` has shape ``(T, 3, D)`` with ``D=2`` (we only support
+        2-D interiors at this layer; 3-D tets land via a separate factory).
+        Per-triangle weight is the Shoelace area.
+        """
+        triangles = np.asarray(triangles, dtype=np.float32)
+        if triangles.ndim != 3 or triangles.shape[1] != 3:
+            raise ValueError(f"triangles must have shape (T, 3, D); got {triangles.shape}")
+        if triangles.shape[2] != 2:
+            raise ValueError(
+                f"SimplexPool.from_triangles supports D=2; got D={triangles.shape[2]}. "
+                "3-D tet pools land via a future factory."
+            )
+        # Shoelace: 0.5 * |x1(y2 - y3) + x2(y3 - y1) + x3(y1 - y2)|
+        x = triangles[:, :, 0]
+        y = triangles[:, :, 1]
+        areas = 0.5 * np.abs(
+            x[:, 0] * (y[:, 1] - y[:, 2]) + x[:, 1] * (y[:, 2] - y[:, 0]) + x[:, 2] * (y[:, 0] - y[:, 1])
+        ).astype(np.float32)
+        return cls(
+            simplices=jnp.asarray(triangles),
+            weights=jnp.asarray(areas),
+            kind="barycentric",
+            normals=None,
+        )
+
+    def __repr__(self) -> str:
+        t, v, d = self.simplices.shape
+        nrm = "+normals" if self.normals is not None else ""
+        return f"SimplexPool(T={t}, V={v}, D={d}, kind={self.kind!r}{nrm})"

--- a/jno/utils/adaptive/resampling.py
+++ b/jno/utils/adaptive/resampling.py
@@ -33,6 +33,12 @@ class ResamplingStrategy(ABC):
     interesting dynamics.
     """
 
+    # Whether ``resample()`` actually reads its ``residuals`` argument.
+    # Subclasses that ignore residuals (e.g. uniform random resampling)
+    # override to False so the training loop can skip an expensive
+    # residual forward pass on resample epochs.
+    needs_residuals: bool = True
+
     def __init__(
         self,
         resample_every: int = 100,
@@ -799,6 +805,8 @@ class RandomResampling(ResamplingStrategy):
 
     Useful as a baseline to prevent overfitting to specific points.
     """
+
+    needs_residuals = False
 
     def resample(
         self,

--- a/tests/test_domain_geometries.py
+++ b/tests/test_domain_geometries.py
@@ -576,3 +576,65 @@ class TestDistanceFunction:
         d_var = dom.distance_function("interior", name="my_dist")
         assert d_var.tag == "my_dist"
         assert "my_dist" in dom.context
+
+
+# Tensor-tag attachment via domain.variable(sample=array)
+# ---------------------------------------------------------------------------
+
+
+class TestVariableTensorAttach:
+    """Attach arrays of varying leading-dim length via ``variable(sample=...)``.
+
+    The compiler routes by ``shape[0]`` (see ``jno/trace_compiler.py``):
+
+      * ``shape[0] == B`` → per-batch (vmapped)
+      * ``shape[0] == 1`` → broadcast across the batch
+      * ``shape[0]`` anything else → shared, full array exposed every step
+
+    All three paths must accept the attached tensor without warning.
+    """
+
+    def _dom(self):
+        return jno.domain(constructor=jno.domain.line(mesh_size=0.2))
+
+    def test_per_batch_shape(self):
+        import numpy as np
+
+        dom = self._dom()
+        B = dom._effective_batch_count()
+        arr = np.zeros((B, 3), dtype=np.float32)
+        dom.variable("per_batch", sample=arr)
+        assert dom.context["per_batch"].shape == (B, 3)
+        assert "per_batch" in dom._param_tags
+
+    def test_broadcast_shape(self):
+        import numpy as np
+
+        dom = self._dom()
+        arr = np.zeros((1, 3), dtype=np.float32)
+        dom.variable("bcast", sample=arr)
+        assert dom.context["bcast"].shape == (1, 3)
+        assert "bcast" in dom._param_tags
+
+    def test_shared_length_mismatch_no_warning(self, caplog):
+        """Length-mismatched tensor stores cleanly and emits no warning."""
+        import logging
+
+        import numpy as np
+
+        dom = self._dom()
+        arr = np.zeros((16, 3), dtype=np.float32)
+        with caplog.at_level(logging.WARNING):
+            dom.variable("u_labels", sample=arr)
+        assert dom.context["u_labels"].shape == (16, 3)
+        assert "u_labels" in dom._param_tags
+        assert not any("Was this intended" in r.message for r in caplog.records)
+
+    def test_returned_object_is_tensor_tag(self):
+        import numpy as np
+
+        from jno.trace import TensorTag
+
+        dom = self._dom()
+        result = dom.variable("coeff", sample=np.zeros((1, 1), dtype=np.float32))
+        assert isinstance(result, TensorTag)

--- a/tests/test_polygon_domain_build_mesh.py
+++ b/tests/test_polygon_domain_build_mesh.py
@@ -120,8 +120,9 @@ def test_build_mesh_is_idempotent_and_refines():
 
 
 def test_lazy_path_unchanged_without_build_mesh():
-    """Without ``build_mesh``, AD on lazy samples still works; the
-    explicit-count-required error stays put."""
+    """Without ``build_mesh``, AD on lazy samples still works; a missing sample
+    count auto-defaults to a single Monte-Carlo point with per-step resampling
+    (the pinn-gaps default), rather than raising."""
     np.random.seed(0)
     dom = jno.domain.csg([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)])
 
@@ -132,9 +133,11 @@ def test_lazy_path_unchanged_without_build_mesh():
     exact = np.asarray(ev.evaluate(2 * x, context=dom.context)).reshape(ad.shape)
     assert float(np.max(np.abs(ad - exact))) < 1e-10
 
+    # No explicit count → auto-default to one Monte-Carlo point (+ per-step
+    # RandomResampling); see tests/test_polygon_domain_csg.py for the full spec.
     dom_no_mesh = jno.domain.csg([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)])
-    with pytest.raises(ValueError, match="explicit sample count"):
-        dom_no_mesh.variable("interior")
+    xn, _yn, _tn = dom_no_mesh.variable("interior")
+    assert dom_no_mesh.context[xn.tag][0, 0].shape == (1, 2)
 
 
 def test_build_mesh_rejects_empty_geometry():

--- a/tests/test_polygon_domain_csg.py
+++ b/tests/test_polygon_domain_csg.py
@@ -331,3 +331,77 @@ def test_numbered_boundary_subtags_are_geometrically_distinct():
 
     # Four distinct faces ↔ four distinct (axis, value) pairs
     assert len(constant_coords) == 4, f"Expected 4 distinct edges, got {len(constant_coords)}: {constant_coords}"
+
+
+# ---------------------------------------------------------------------------
+# Auto-default sampling (no explicit sample count)
+# ---------------------------------------------------------------------------
+
+
+def test_variable_no_sample_defaults_to_one_point():
+    """Calling variable() without a sample count materializes exactly 1 point."""
+    dom = jno.domain.csg(SQUARE_A, name="a")
+    x, y, _ = dom.variable("interior")
+    pts = dom.context[x.tag][0, 0]
+    assert pts.shape == (1, 2), f"expected (1, 2), got {pts.shape}"
+    # Point must lie inside the unit square
+    assert 0.0 < pts[0, 0] < 1.0
+    assert 0.0 < pts[0, 1] < 1.0
+
+
+def test_variable_no_sample_attaches_per_step_resampling():
+    """Auto-default path attaches RandomResampling(resample_every=1, fraction=1.0)."""
+    from jno.utils.adaptive.resampling import RandomResampling
+
+    dom = jno.domain.csg(SQUARE_A, name="a")
+    x, y, _ = dom.variable("interior")
+    tag = x.tag
+    assert tag in dom._resampling_strategies, "no resampling strategy was registered"
+    strat = dom._resampling_strategies[tag]
+    assert isinstance(strat, RandomResampling)
+    assert strat.resample_every == 1
+    assert strat.resample_fraction == 1.0
+
+
+def test_variable_explicit_count_unchanged():
+    """variable('interior', (64, None)) still works, uses the given count, no auto-resample."""
+    np.random.seed(0)
+    dom = jno.domain.csg(SQUARE_A, name="a")
+    x, y, _ = dom.variable("interior", (64, None))
+    pts = dom.context[x.tag][0, 0]
+    assert pts.shape == (64, 2)
+    # Explicit count → no auto-resampling strategy attached
+    assert x.tag not in dom._resampling_strategies
+
+
+def test_variable_no_sample_explicit_resampling_strategy_respected():
+    """If the user explicitly passes a resampling_strategy, it is not overridden."""
+    from jno.utils.adaptive.resampling import RandomResampling
+
+    custom = RandomResampling(resample_every=50, resample_fraction=0.5)
+    dom = jno.domain.csg(SQUARE_A, name="a")
+    x, y, _ = dom.variable("interior", resampling_strategy=custom)
+    tag = x.tag
+    assert dom._resampling_strategies[tag] is custom
+    assert dom._resampling_strategies[tag].resample_every == 50
+
+
+@pytest.mark.integration
+def test_variable_no_sample_drives_crux_solve_end_to_end():
+    """Auto-default + crux.solve must run: 1 point + per-step random resample."""
+    import foundax
+    import jax
+    import optax
+
+    dom = jno.domain.csg(SQUARE_A, name="a")
+    x, y, _ = dom.variable("interior")
+    net = jno.nn(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(0)))
+    net.optimizer(optax.adam(1e-3))
+    u = net(jno.np.concat([x, y], axis=-1)) * x * (1 - x) * y * (1 - y)
+    pde = u.laplacian(x, y)
+    crux = jno.core([pde.mse], domain=dom)
+    stats = crux.solve(3)
+    # End-to-end smoke: solve runs without crashing and the loop exercised the
+    # resample → step pipeline at every epoch (resample_every=1) — that's what
+    # the auto-default + RandomResampling combination is supposed to deliver.
+    assert stats is not None


### PR DESCRIPTION
Bundles the genuinely-unmerged work from stale feature branches onto current `main` (post-#63). Three of the five candidate branches turned out already-merged (via #61, #62, and earlier optimizer work) — the squash 3-way merge produced an empty net diff for each — so this PR is **two folds**:

## `fold(remove-add-tensor-tag)` (`53bdc24`)
Inline tensor-attach into `domain.variable()`.

## `fold(pinn-gaps)` (`703ca52`)
- Fixes the `compiled_resample_constraints_fn` **ARG_SHARDING crash** under `JAX_PLATFORMS=cuda,cpu` (greens `test_solve_invokes_resampling_strategy_each_epoch`, which is red on `main`) via a `needs_residuals` skip-path + `device_put` co-location.
- Adds the **simplex pool** (`jno/domain/simplex_pool.py`).
- Makes `domain.variable("interior")` with **no sample count** auto-default to one Monte-Carlo point + per-step `RandomResampling`.

### Behavior change
`variable()` with no explicit count previously **raised** on a lazy polygon domain; it now **auto-defaults** (Monte-Carlo). `test_lazy_path_unchanged_without_build_mesh` updated to match; pinn-gaps' own `test_variable_no_sample_*` tests cover the new contract.

## Verification
Full suite green under `JAX_PLATFORMS=cuda,cpu`: **1892 passed** (non-tutorial) + **60 passed** (tutorials, run separately per the 8GB-GPU OOM constraint), 0 failures.

## Excluded
pinn-gaps' `whitepapers/` artifacts (gitignored as of 89fc8de) are intentionally left out — code-only PR. The `resampling-timing.tex` source remains recoverable from `feature/pinn-gaps`.
