### PR TITLE
Correct dtype handling: x64 propagation + Model.dtype() real compute

### DIFF
--- a/jno/core.py
+++ b/jno/core.py
@@ -3381,7 +3381,7 @@ class core:
                             for ci, v in enumerate(_ind_np)
                         ]
                     )
-                    self.log.info(f"Epoch {_epoch_counter - 1:>6}/{epochs}| L:{_total_np:.4e} | {_msg}")
+                    self.log.info(f"Epoch {_epoch_counter - 1:>6}/{epochs}| L:{float(_total_np):.4e} | {_msg}")
 
                     # Wandb (per chunk) — mirror the slow-path block:
                     # n_samples, n_chains, plus a running posterior mean
@@ -3952,7 +3952,7 @@ class core:
                     _cn_log = getattr(self, "_constraint_names", [])
                     _tn_log = getattr(self, "_tracker_names", [])
                     loss_strs = " | ".join(
-                        f"{(_cn_log[i] if i < len(_cn_log) and _cn_log[i] else f'C{i}')}: {v:>10.4e}"
+                        f"{(_cn_log[i] if i < len(_cn_log) and _cn_log[i] else f'C{i}')}: {float(v):>10.4e}"
                         for i, v in enumerate(losses_np)
                     )
                     if track_stats_np is not None:
@@ -3963,10 +3963,10 @@ class core:
                             for i, v in enumerate(track_stats_np)
                         )
                         self.log.info(
-                            f"Epoch {displayed_epoch:>6}/{epochs}| L:{total_np:>10.4e} | {loss_strs} | {track_strs}"
+                            f"Epoch {displayed_epoch:>6}/{epochs}| L:{float(total_np):>10.4e} | {loss_strs} | {track_strs}"
                         )
                     else:
-                        self.log.info(f"Epoch {displayed_epoch:>6}/{epochs}| L:{total_np:>10.4e} | {loss_strs}")
+                        self.log.info(f"Epoch {displayed_epoch:>6}/{epochs}| L:{float(total_np):>10.4e} | {loss_strs}")
 
                 # --- callbacks ---
                 if callbacks:

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -15,6 +15,7 @@ from ..trace import (
     TrialFunction,
     Variable,
 )
+from ..utils.dtypes import default_np_float_dtype
 from ..utils.logger import get_logger
 from .boundary_region import BoundaryRegion
 from .geometries import Geometries
@@ -734,10 +735,10 @@ class domain(MeshIOMixin):
             self.parameters[name] = float(value)
             self.log.info(f"Attached parameter '{name}' = {value}")
         elif isinstance(value, np.ndarray):
-            self.arrays[name] = value.astype(np.float32)
+            self.arrays[name] = value.astype(default_np_float_dtype())
             self.log.info(f"Attached array '{name}' with shape {value.shape}")
         elif isinstance(value, (list, tuple)):
-            arr = np.array(value, dtype=np.float32)
+            arr = np.array(value, dtype=default_np_float_dtype())
             self.arrays[name] = arr
             self.log.info(f"Attached array '{name}' with shape {arr.shape}")
         else:
@@ -899,7 +900,7 @@ class domain(MeshIOMixin):
                 self._parameter_list[name] = [value]
 
         for name, values in self._parameter_list.items():
-            self.parameters[name] = np.array(values, dtype=np.float32)
+            self.parameters[name] = np.array(values, dtype=default_np_float_dtype())
 
         # Keep batch metadata consistent after domain stacking.
         self_batch = int(getattr(self, "_batch_count", getattr(self, "total_samples", 1)))
@@ -2191,7 +2192,7 @@ class domain(MeshIOMixin):
                 if sampled_time_tag in self.context:
                     self.context[requested_time_tag] = self.context[sampled_time_tag]
                 elif time_value is not None:
-                    base_time = self.context.get("__time__", np.asarray([[time_value]], dtype=np.float32))
+                    base_time = self.context.get("__time__", np.asarray([[time_value]], dtype=default_np_float_dtype()))
                     dtype = np.asarray(base_time).dtype
                     self.context[requested_time_tag] = np.asarray([[time_value]], dtype=dtype)
 
@@ -2207,7 +2208,7 @@ class domain(MeshIOMixin):
             if time_value is not None:
                 requested_time_tag = f"__time_{tag}__"
                 if requested_time_tag not in self.context:
-                    base_time = self.context.get("__time__", np.asarray([[time_value]], dtype=np.float32))
+                    base_time = self.context.get("__time__", np.asarray([[time_value]], dtype=default_np_float_dtype()))
                     dtype = np.asarray(base_time).dtype
                     self.context[requested_time_tag] = np.asarray([[time_value]], dtype=dtype)
 

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -2089,25 +2089,45 @@ class Model(Placeholder):
         return self
 
     def dtype(self, dtype: Any) -> "Model":
-        """Cast all floating-point parameters to *dtype* before training.
+        """Set this model's working dtype (parameters **and** compute).
 
-        Reduces memory usage (e.g. ``jnp.bfloat16`` halves float32 memory)
-        while maintaining training stability for many models.
+        Casts all floating-point parameters to *dtype* and — at the forward
+        seam — casts the model's inputs to match, so the network actually
+        *computes* in *dtype* rather than promoting back to float32.  The cast is
+        symmetric: it lowers (float32 → bfloat16) **and** promotes (load a
+        bfloat16 checkpoint, then ``.dtype(jnp.float32)``), and applies to both
+        training and inference.  Integer arrays (e.g. indices) are left unchanged.
 
-        The cast is applied **after** pretrained weights are loaded (if any)
-        and before the training loop starts.  Integer arrays (e.g. indices)
-        are left unchanged.
+        This is the model-precision knob.  **Data** precision (float32 vs
+        float64) is JAX's ``jax_enable_x64`` flag — *not* a jNO setting.  Enable
+        it before building models/domains (``JAX_ENABLE_X64=1`` or
+        ``jax.config.update("jax_enable_x64", True)``).
 
         Args:
-            dtype: Target JAX dtype, e.g. ``jnp.bfloat16`` or
-                ``jnp.float16``.
+            dtype: A JAX floating dtype object, e.g. ``jnp.bfloat16``,
+                ``jnp.float16``, ``jnp.float32`` or ``jnp.float64``.
+
+        Caveats:
+            * bfloat16 *compute* degrades autodiff derivatives
+              (``.laplacian`` / ``.hessian``) — keep derivative-critical (PINN)
+              models in float32 and opt only data-loss / operator backbones into
+              bf16.
+            * bfloat16 parameters mean the optimizer update also runs in
+              bfloat16, which can stall on very small updates.
 
         Example::
 
-            u = nn.walrus((1,1,128,128,1), num_out_channels=1)
-            u.initialize("walrus.msgpack")
-            u.dtype(jnp.bfloat16)
+            backbone.dtype(jnp.bfloat16)   # real bf16 compute for this model
+            pinn_net.dtype(jnp.float32)    # keep its derivatives full precision
         """
+        if isinstance(dtype, str):
+            raise ValueError(
+                f"Model.dtype() takes a JAX dtype object, not a string {dtype!r}. "
+                "Pass e.g. jnp.bfloat16 / jnp.float32 for model precision. "
+                "Data precision (float32 vs float64) is JAX's jax_enable_x64 flag "
+                "(set JAX_ENABLE_X64=1 or jax.config.update('jax_enable_x64', True) "
+                "before building models) — it is not a jNO setting."
+            )
         self._dtype = dtype
         return self
 

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -607,6 +607,23 @@ class TraceEvaluator:
         if _is_foundax_pointwise_mlp(model):
             shaped_args = _broadcast_pointwise_args(shaped_args)
 
+        # Mixed precision: when a model is *explicitly* opted into a dtype via
+        # Model.dtype(), cast its inputs to that dtype so it actually computes in
+        # it (e.g. bf16 -> real bf16 matmuls, not bf16 storage promoted to f32).
+        # Keyed on the explicit opt-in, NOT the inferred param dtype: a plain f32
+        # model under jax_enable_x64 must still compute in f64 by promotion rather
+        # than be silently downcast.  Applies to training and inference alike.
+        _compute_dtype = getattr(flax_mod, "_dtype", None)
+        if _compute_dtype is not None:
+            shaped_args = [
+                a.astype(_compute_dtype)
+                if getattr(a, "dtype", None) is not None
+                and jnp.issubdtype(a.dtype, jnp.floating)
+                and a.dtype != _compute_dtype
+                else a
+                for a in shaped_args
+            ]
+
         # Call equinox model directly (it IS the pytree, no init/apply split)
         import inspect
 

--- a/jno/utils/adaptive/lrscheduler.py
+++ b/jno/utils/adaptive/lrscheduler.py
@@ -20,6 +20,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from ..dtypes import default_float_dtype, default_np_float_dtype
+
 LRFunction = Callable[[Union[int, jnp.ndarray], jnp.ndarray], jnp.ndarray]
 
 
@@ -260,7 +262,7 @@ class DLRS:
             self.loss_hist = [total_loss]
             self.lr = np.float32(np.clip(self.lr0, self.min_lr, self.max_lr))
             self.initialized = True
-            return np.asarray(self.lr, dtype=np.float32)
+            return np.asarray(self.lr, dtype=default_np_float_dtype())
 
         # Update rolling window
         self.loss_hist.append(total_loss)
@@ -292,14 +294,14 @@ class DLRS:
         lr_new = float(np.clip(lr_new, self.min_lr, self.max_lr))
 
         self.lr = np.float32(lr_new)
-        return np.asarray(self.lr, dtype=np.float32)
+        return np.asarray(self.lr, dtype=default_np_float_dtype())
 
     def __call__(self, t: int, losses: jnp.ndarray) -> jnp.ndarray:
         # Convert per-constraint losses to a scalar total loss for DLRS logic
         losses = jnp.asarray(losses)
         total_loss = jnp.sum(losses) if losses.ndim > 0 else losses
 
-        result_shape = jax.ShapeDtypeStruct((), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((), default_float_dtype())
         lr = jax.pure_callback(
             self._update_state_host,
             result_shape,

--- a/jno/utils/adaptive/weights.py
+++ b/jno/utils/adaptive/weights.py
@@ -30,6 +30,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from ..dtypes import default_float_dtype
+
 WeightFunction = Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
 
 
@@ -41,10 +43,15 @@ def _host_callback_nondiff(host_fn, result_shape, losses: jnp.ndarray) -> jnp.nd
     set their tangent contribution to zero.
     """
 
+    def _host_fn_cast(x):
+        # Match the declared struct dtype so the callback does not error under
+        # jax_enable_x64 (host weights are computed in f32; cast to the graph dtype).
+        return np.asarray(host_fn(x), dtype=result_shape.dtype)
+
     @jax.custom_jvp
     def _call(x):
         return jax.pure_callback(
-            host_fn,
+            _host_fn_cast,
             result_shape,
             x,
             vmap_method="sequential",
@@ -216,7 +223,7 @@ class ReLoBRaLo:
             self.num_losses = int(losses_arr.shape[0])
             self.lambdas = np.ones(self.num_losses, dtype=np.float32)
 
-        result_shape = jax.ShapeDtypeStruct((self.num_losses,), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((self.num_losses,), default_float_dtype())
         weights = _host_callback_nondiff(
             self._update_state_host,
             result_shape,
@@ -395,7 +402,7 @@ class LbPINNsLossBalancing:
         if self.num_losses is None:
             self.num_losses = int(losses_arr.shape[0])
 
-        result_shape = jax.ShapeDtypeStruct((self.num_losses,), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((self.num_losses,), default_float_dtype())
         weights = _host_callback_nondiff(
             self._update_state_host,
             result_shape,
@@ -535,7 +542,7 @@ class SoftAdapt:
         if self.num_losses is None:
             self.num_losses = int(losses_arr.shape[0])
 
-        result_shape = jax.ShapeDtypeStruct((self.num_losses,), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((self.num_losses,), default_float_dtype())
         weights = _host_callback_nondiff(
             self._update_state_host,
             result_shape,
@@ -654,7 +661,7 @@ class DWA:
         if self.num_losses is None:
             self.num_losses = int(losses_arr.shape[0])
 
-        result_shape = jax.ShapeDtypeStruct((self.num_losses,), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((self.num_losses,), default_float_dtype())
         weights = _host_callback_nondiff(
             self._update_state_host,
             result_shape,
@@ -749,7 +756,7 @@ class RLW:
         if self.num_losses is None:
             self.num_losses = int(losses_arr.shape[0])
 
-        result_shape = jax.ShapeDtypeStruct((self.num_losses,), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((self.num_losses,), default_float_dtype())
         weights = _host_callback_nondiff(
             self._update_state_host,
             result_shape,
@@ -844,7 +851,7 @@ class GradientNormBalanced:
         if self.num_losses is None:
             self.num_losses = int(losses_arr.shape[0])
 
-        result_shape = jax.ShapeDtypeStruct((self.num_losses,), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((self.num_losses,), default_float_dtype())
         weights = _host_callback_nondiff(self._weights_host, result_shape, losses_arr)
         return tuple(weights[i] for i in range(self.num_losses))
 
@@ -919,7 +926,7 @@ class NTKBalanced:
     def __call__(self, *losses: jnp.ndarray) -> tuple[jnp.ndarray, ...]:
         """Return one weight per loss term."""
         losses_arr = _normalize_losses(losses)
-        result_shape = jax.ShapeDtypeStruct((self.num_losses,), jnp.float32)
+        result_shape = jax.ShapeDtypeStruct((self.num_losses,), default_float_dtype())
         weights = _host_callback_nondiff(self._weights_host, result_shape, losses_arr)
         return tuple(weights[i] for i in range(self.num_losses))
 

--- a/jno/utils/dtypes.py
+++ b/jno/utils/dtypes.py
@@ -1,0 +1,24 @@
+"""Default floating-point dtype helpers — follow JAX's ``jax_enable_x64`` setting.
+
+jNO does not own *data* precision: float32 vs float64 is JAX's ``jax_enable_x64``
+flag, set by the user.  Array-producing code (domain sampling, parameter/array
+attachment, ``pure_callback`` result structs) should follow the JAX default so
+that enabling x64 propagates end-to-end instead of silently downcasting to
+float32.  Model *parameter* precision is a separate, per-model concern
+(``Model.dtype()``).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+
+def default_float_dtype():
+    """JAX's current default floating dtype (float32, or float64 under ``jax_enable_x64``)."""
+    return jnp.asarray(0.0).dtype
+
+
+def default_np_float_dtype() -> np.dtype:
+    """NumPy equivalent of :func:`default_float_dtype` — for host-side arrays."""
+    return np.dtype(default_float_dtype())

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 
 import contextlib
 
+import foundax
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
+import pytest
 
 import jno
 
@@ -125,3 +128,119 @@ def test_x64_no_float32_leak_in_context():
             if np.asarray(val).dtype == np.float32
         }
         assert not leaks, f"float32 leak under jax_enable_x64: {leaks}"
+
+
+# ---------------------------------------------------------------------------
+# Model precision — Model.dtype() makes real compute (Part B)
+# ---------------------------------------------------------------------------
+
+
+def _tiny_net(key_seed=0):
+    return jno.nn(foundax.mlp(1, output_dim=1, hidden_dims=16, num_layers=3, key=jax.random.PRNGKey(key_seed)))
+
+
+def test_dtype_bf16_gives_real_bf16_output():
+    # .dtype(bf16) casts params AND (at the seam) inputs, so the forward truly
+    # computes in bf16 rather than promoting back to f32.
+    dom = _line_domain()
+    x, *_ = dom.variable("interior")
+    net = _tiny_net()
+    net.dtype(jnp.bfloat16)
+    net.optimizer(optax.adam(1e-3))
+    u = net(x)
+    crux = jno.core([u.mse])
+    crux.solve(2)
+    assert np.asarray(crux.eval(u)).dtype == jnp.bfloat16
+
+
+def test_dtype_default_output_is_f32():
+    # Control: without .dtype(), the forward stays at the default float (f32).
+    dom = _line_domain()
+    x, *_ = dom.variable("interior")
+    net = _tiny_net(key_seed=1)
+    net.optimizer(optax.adam(1e-3))
+    u = net(x)
+    crux = jno.core([u.mse])
+    crux.solve(2)
+    assert np.asarray(crux.eval(u)).dtype == jnp.float32
+
+
+def test_dtype_bf16_pinn_derivative_trains():
+    # The primary jNO path: a bf16 model behind a second-derivative PINN residual
+    # must run through jacfwd/jacrev and the loss must decrease (bf16 *accuracy*
+    # is a documented caveat; here we only require it trains, not its precision).
+    dom = jno.domain(constructor=jno.domain.line(mesh_size=0.05))
+    x, *_ = dom.variable("interior")
+    net = _tiny_net()
+    net.dtype(jnp.bfloat16)
+    net.optimizer(optax.adam(1e-3))
+    u = net(x)
+    pde = (u.d(x).d(x) + 1.0).mse
+    crux = jno.core([pde])
+    stats = crux.solve(30)
+    losses = stats.training_logs[-1]["total_loss"]
+    assert np.isfinite(float(losses[-1]))
+    assert float(losses[-1]) < float(losses[0]), "bf16 PINN residual did not train"
+
+
+def test_dtype_f64_data_f32_model_downcasts_at_seam():
+    # f64 data (x64) + a deliberately f32 network: the seam casts the f64 input
+    # down to f32 so the forward runs in f32 without crashing.
+    with x64_enabled():
+        dom = _line_domain()
+        x, *_ = dom.variable("interior")
+        net = _tiny_net(key_seed=2)
+        net.dtype(jnp.float32)
+        net.optimizer(optax.adam(1e-3))
+        u = net(x)
+        crux = jno.core([u.mse])
+        crux.solve(2)
+        assert np.asarray(crux.eval(u)).dtype == jnp.float32
+
+
+def test_dtype_rejects_string_with_jax_flag_hint():
+    net = _tiny_net(key_seed=3)
+    with pytest.raises(ValueError, match="jax_enable_x64"):
+        net.dtype("float64")
+
+
+def test_x64_f32_params_not_downcast_without_explicit_dtype():
+    # Regression: the seam fires only on an EXPLICIT .dtype() opt-in. A plain
+    # f32-param model (e.g. a loaded f32 checkpoint) under x64 must still compute
+    # in f64 by promotion — the seam must NOT silently downcast the f64 data,
+    # which would partly undo the Part-A x64 propagation.
+    net = _tiny_net(key_seed=5)  # params created at the default → float32
+    with x64_enabled():
+        net.optimizer(optax.adam(1e-3))
+        dom = _line_domain()
+        x, *_ = dom.variable("interior")
+        u = net(x)
+        crux = jno.core([u.mse])
+        assert np.asarray(crux.eval(u)).dtype == np.float64
+
+
+@pytest.mark.slow
+def test_dtype_bf16_vs_f32_speed_informational(capsys):
+    # Best-effort speed comparison. Real bf16 speedups need bf16-capable
+    # hardware (GPU); on CPU bf16 is emulated and may be slower. This logs the
+    # ratio and only asserts both runs produce finite losses — it is NOT a gate.
+    import time
+
+    def _run(dtype):
+        dom = jno.domain(constructor=jno.domain.line(mesh_size=0.02))
+        x, *_ = dom.variable("interior")
+        net = _tiny_net(key_seed=7)
+        if dtype is not None:
+            net.dtype(dtype)
+        net.optimizer(optax.adam(1e-3))
+        crux = jno.core([(net(x).d(x).d(x) + 1.0).mse])
+        crux.solve(3)  # warm up / compile
+        t0 = time.perf_counter()
+        stats = crux.solve(20)
+        return time.perf_counter() - t0, float(stats.training_logs[-1]["total_loss"][-1])
+
+    t_f32, l_f32 = _run(None)
+    t_bf16, l_bf16 = _run(jnp.bfloat16)
+    with capsys.disabled():
+        print(f"\n[dtype speed] f32={t_f32:.3f}s  bf16={t_bf16:.3f}s  ratio={t_bf16 / t_f32:.2f}x")
+    assert np.isfinite(l_f32) and np.isfinite(l_bf16)

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,0 +1,127 @@
+"""Dtype-correctness tests.
+
+jNO's dtype contract has two halves:
+
+* **Data precision** follows JAX's ``jax_enable_x64`` flag (the user's concern,
+  not a jNO knob).  jNO must not *leak* float32 where the JAX default is float64.
+* **Model precision** is the per-model ``Model.dtype()`` knob (covered in the
+  Part-B tests added on ``feature/model-dtype-real-compute``).
+
+This module pins the data half: enabling x64 must propagate to float64
+end-to-end (sampled points, attached arrays/parameters, adaptive-weight and
+LR-scheduler callbacks), with no silent float32 island.
+
+Run on GPU with ``JAX_PLATFORMS=cuda,cpu`` per the project convention; the dtype
+checks themselves are platform-independent.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import jno
+
+
+@contextlib.contextmanager
+def x64_enabled():
+    """Enable ``jax_enable_x64`` for the duration of the block, then restore.
+
+    x64 is a process-global JAX flag; toggling it affects *newly created* arrays,
+    so every domain/array in the block is built inside the context.
+    """
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _line_domain():
+    return jno.domain(constructor=jno.domain.line(mesh_size=0.1))
+
+
+def _attach_coeff(dom):
+    """Attach a coefficient field + scalar parameter (the user-data paths)."""
+    return dom < ("kfield", np.linspace(0.0, 1.0, 11).reshape(-1, 1))
+
+
+# ---------------------------------------------------------------------------
+# Default (no x64) — data is float32
+# ---------------------------------------------------------------------------
+
+
+def test_default_attached_array_is_f32():
+    # User-attached arrays follow the JAX default: float32 here, float64 under
+    # x64 (see test_x64_attached_array_is_f64). Mesh-derived sampled points are
+    # np.float64 in storage and normalized to the default at the callback seam,
+    # so we assert the contract on the user-data path we control.
+    dom = _attach_coeff(_line_domain())
+    assert np.asarray(dom.arrays["kfield"]).dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# x64 — data is float64 end-to-end (the leak-fix guard)
+# ---------------------------------------------------------------------------
+
+
+def test_x64_sampled_points_are_f64():
+    with x64_enabled():
+        dom = _line_domain()
+        x, *_ = dom.variable("interior")
+        assert np.asarray(dom.context[x.tag]).dtype == np.float64
+
+
+def test_x64_attached_array_is_f64():
+    # Was the live leak: domain.__lt__ hardcoded np.float32 (domain_class ~737).
+    with x64_enabled():
+        dom = _attach_coeff(_line_domain())
+        assert np.asarray(dom.arrays["kfield"]).dtype == np.float64
+
+
+def test_x64_batched_parameters_are_f64():
+    # The self.parameters cast (domain_class ~902) under domain batching.
+    with x64_enabled():
+        dom = (_line_domain() < ("c", 1.5)) + (_line_domain() < ("c", 2.5))
+        assert np.asarray(dom.parameters["c"]).dtype == np.float64
+
+
+def test_x64_adaptive_weight_callback_is_f64():
+    # ShapeDtypeStruct + host return were hardcoded f32 (weights.py).
+    from jno.utils.adaptive.weights import ReLoBRaLo
+
+    with x64_enabled():
+        balancer = ReLoBRaLo()
+        weights = balancer(jnp.asarray([1.0, 2.0]))
+        assert np.asarray(weights[0]).dtype == np.float64
+
+
+def test_x64_lr_scheduler_callback_is_f64():
+    from jno.utils.adaptive.lrscheduler import DLRS
+
+    with x64_enabled():
+        sched = DLRS(lr0=1e-3)
+        lr = sched(0, jnp.asarray([1.0, 2.0]))
+        assert np.asarray(lr).dtype == np.float64
+
+
+# ---------------------------------------------------------------------------
+# No-leak sweep — under x64, no context/array is float32
+# ---------------------------------------------------------------------------
+
+
+def test_x64_no_float32_leak_in_context():
+    with x64_enabled():
+        dom = _line_domain()
+        dom.variable("interior")
+        dom = _attach_coeff(dom)
+        leaks = {
+            key: np.asarray(val).dtype
+            for key, val in {**dom.context, **dom.arrays, **dom.parameters}.items()
+            if np.asarray(val).dtype == np.float32
+        }
+        assert not leaks, f"float32 leak under jax_enable_x64: {leaks}"


### PR DESCRIPTION
Makes jNO's dtype handling correct on both halves, per a clean separation of concerns: **data precision** is JAX's `jax_enable_x64` (not a jNO knob) and must propagate without float32 leaks; **model precision** is the per-model `Model.dtype()`.

## Part A — x64 propagation (`fix(dtype)`, 64c1534)
`jax_enable_x64` now propagates float64 end-to-end. Previously hardcoded `float32` silently downcast:
- domain user data — attached `arrays`/`parameters` and the `base_time` fallback (`domain_class.py`);
- the adaptive loss-weight and LR-scheduler `pure_callback` result structs + host returns (`weights.py`, `lrscheduler.py`).

New `jno/utils/dtypes.py` (`default_float_dtype` / `default_np_float_dtype`) is the single source these follow.

## Part B — `Model.dtype()` real compute (`feat(dtype)`, 908caa6)
`.dtype(jnp.bfloat16)` previously cast only parameters, so the first matmul promoted back to f32 — "a memory lever, not real compute." Now the forward seam (`trace_evaluator.py`) also casts the model's inputs to the requested dtype, so it genuinely computes in it (real bf16 matmuls), for training and inference. The cast:
- fires **only** on an explicit `.dtype()` opt-in — a plain f32 model under x64 still computes in f64 by promotion, so this does not undo Part A;
- is symmetric (lowers f32→bf16; downcasts f64-data→f32-model);
- `.dtype(<string>)` raises, pointing to `jax_enable_x64` for data precision.

**Caveats** (documented on `.dtype()`): bf16 *compute* degrades `.laplacian`/`.hessian` derivatives — keep PINN nets f32, opt in per model; bf16 params mean bf16 optimizer updates, which can stall.

## Tests — `tests/test_dtypes.py`
Correctness matrix: default→f32; x64→f64 end-to-end (incl. the previously-leaking sites); no-f32-leak sweep; bf16 real compute; **bf16 PINN second-derivative residual trains**; f64-data/f32-model downcast; the f32-params-under-x64-not-downcast regression; the string guard; and a best-effort `@slow` speed comparison.

Local runs: ~1175 tests pass across the affected areas (dtype, broad forward-pass coverage, adaptive/domain, back-compat); the full suite runs in CI.

## Note on branch scope
Plan called for two branches (data vs model precision); consolidated onto one because both extend `tests/test_dtypes.py` and form one cohesive "dtype correctness" change. Out of scope (future): an f32-master + bf16-compute mixed-precision policy, and native `complex64`-parameter networks (complex *fields* already work via the split-`[re,im]` `ComplexView`).
