### PR TITLE
Graph-time dimensional analysis + automatic de-dimensionalization (jno.units)

### DIFF
--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -34,6 +34,7 @@ from .trace import (
     TestFunction,
     TrialFunction,
     Variable,
+    units,
 )
 from .trace.views import (
     ComplexView,
@@ -143,6 +144,7 @@ __all__ = [
     "fn",
     "lora",
     "noise",
+    "units",
     "StateField",
     "ScalarView",
     "VectorView",

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -261,6 +261,52 @@ class Placeholder:
         self._user_name = label
         return self
 
+    # Graph-time physical unit (dimensional metadata). ``None`` = undeclared.
+    # Only ever set explicitly here on a leaf; inferred units for intermediate
+    # nodes are computed non-destructively by ``jno.units.check`` and never
+    # written back onto the graph.
+    _unit: "object | None" = None
+
+    def unit(self, spec: "str") -> "Placeholder":
+        """Declare the physical unit of this expression for dimensional analysis.
+
+        Attaches graph-time metadata used by :func:`jno.units.check` to audit
+        that a PDE is dimensionally consistent.  Returns *self* so it chains
+        inline::
+
+            x = x.unit("m")
+            u = net(x, t).unit("K")
+
+        ``spec`` is a unit string such as ``"m"``, ``"m/s"``, ``"kg/m^3"`` or
+        ``"Pa"`` (see :meth:`jno.units.Unit.parse`).
+        """
+        from .units import Unit
+
+        self._unit = Unit.parse(spec)
+        return self
+
+    # Graph-time characteristic magnitude (the *scale* that complements the
+    # *dimension* set by ``.unit``). ``None`` = undeclared. Like ``_unit`` it is
+    # only ever set explicitly on a leaf; intermediate magnitudes are computed
+    # non-destructively by ``jno.units.nondimensionalize`` and never written back.
+    _scale: "float | None" = None
+
+    def scale(self, value: float) -> "Placeholder":
+        """Declare the characteristic *magnitude* of this variable/field.
+
+        Units give the *dimension* (``.unit("m")`` → a length); the scale gives
+        the *magnitude* in that unit (``.scale(0.1)`` → the characteristic length
+        is 0.1 m).  The two are orthogonal and used together by
+        :func:`jno.units.nondimensionalize` to derive dimensionless groups and
+        rescale a problem to ``O(1)``.  Returns *self* so it chains inline::
+
+            x = x.unit("m").scale(0.1)        # L  = 0.1 m
+            u = net(x, t).unit("K").scale(50.0)
+            alpha = alpha.unit("m^2/s").scale(1e-5)
+        """
+        self._scale = float(value)
+        return self
+
     @property
     def stop_gradient(self) -> "FunctionCall":
         """Block gradient flow through this expression.

--- a/jno/trace/unit_log.py
+++ b/jno/trace/unit_log.py
@@ -374,10 +374,14 @@ def _infer_scale(node, smap: Dict[int, Optional[float]], coeff_neutral: bool = F
         TensorTag,
         TestFunction,
         Tracker,
+        Variable,
     )
 
     def cs(child):  # child scale
         return smap.get(id(child))
+
+    def vs(v):  # coordinate scale, read DIRECTLY (not from the possibly-neutralized smap)
+        return getattr(v, "_scale", None)
 
     if coeff_neutral and isinstance(node, (Constant, TensorTag)):
         return 1.0
@@ -410,10 +414,10 @@ def _infer_scale(node, smap: Dict[int, Optional[float]], coeff_neutral: bool = F
             return sl**exponent
         return None
 
-    # --- derivatives ---------------------------------------------------------
+    # --- derivatives (read coordinate scales DIRECTLY via vs(), see vs note) --
     if isinstance(node, Jacobian):
         st = cs(node.target)
-        var_scales = [cs(v) for v in node.variables]
+        var_scales = [vs(v) for v in node.variables]
         if st is None or any(s is None for s in var_scales):
             return None
         if len(set(var_scales)) > 1:
@@ -422,7 +426,7 @@ def _infer_scale(node, smap: Dict[int, Optional[float]], coeff_neutral: bool = F
 
     if isinstance(node, Hessian):
         st = cs(node.target)
-        var_scales = [cs(v) for v in node.variables]
+        var_scales = [vs(v) for v in node.variables]
         if st is None or any(s is None for s in var_scales):
             return None
         if node.trace:  # Laplacian
@@ -432,20 +436,20 @@ def _infer_scale(node, smap: Dict[int, Optional[float]], coeff_neutral: bool = F
         return None
 
     if isinstance(node, TemporalDerivative):
-        st, sv = cs(node.target), cs(getattr(node, "time_var", None))
+        st, sv = cs(node.target), vs(getattr(node, "time_var", None))
         return st / sv if st is not None and sv is not None else None
 
     if isinstance(node, Integral):
         st = cs(node.target)
         coord = _first_spatial_var(node.target)
-        sc = smap.get(id(coord)) if coord is not None else None
+        sc = vs(coord) if coord is not None else None
         if st is None or sc is None:
             return None
         ndim = int(getattr(coord, "size", 1) or 1)
         return st * (sc**ndim)
 
     if isinstance(node, IntegralTime):
-        st, sv = cs(node.target), cs(getattr(node, "time_var", None))
+        st, sv = cs(node.target), vs(getattr(node, "time_var", None))
         return st * sv if st is not None and sv is not None else None
 
     # --- function calls ------------------------------------------------------
@@ -461,7 +465,16 @@ def _infer_scale(node, smap: Dict[int, Optional[float]], coeff_neutral: bool = F
             return first
         return None
 
-    # --- leaves carrying a user-declared scale (Variable/TrialFunction/...) ---
+    # --- bare-coordinate leaf -------------------------------------------------
+    # A coordinate Variable appearing as a value (child of arithmetic/function)
+    # contributes magnitude 1 in the coefficient-excluded K-walk: its scale L is
+    # materialized in the graph by the bare-coordinate rewrite, so counting it
+    # here too would double-apply L.  Derivative rules above read the real L via
+    # vs() directly, independent of this neutralization.
+    if isinstance(node, Variable):
+        return 1.0 if coeff_neutral else getattr(node, "_scale", None)
+
+    # --- other leaves carrying a user-declared scale (TrialFunction/Model/...) -
     return getattr(node, "_scale", None)
 
 
@@ -702,6 +715,80 @@ def _collect_scaled_leaves(constraints):
     return list(coords.values()), (field_scales[0] if field_scales else None)
 
 
+def _unwrap_view(op):
+    """Unwrap a typed semantic view (ScalarView/FieldView/…) to its Placeholder."""
+    from .views import _VIEW_TYPES
+
+    return op._expr if isinstance(op, _VIEW_TYPES) else op
+
+
+def _scaled_coord_map(node):
+    """``{id(var): (var, L)}`` for every scaled coordinate Variable under *node*."""
+    from . import Variable
+
+    out: Dict[int, tuple] = {}
+    seen = set()
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if id(n) in seen:
+            continue
+        seen.add(id(n))
+        if isinstance(n, Variable) and getattr(n, "_scale", None) is not None:
+            out[id(n)] = (n, n._scale)
+        stack.extend(_children(n))
+    return out
+
+
+def _rewrite_bare_coords(node, coord_map):
+    """Return *node* with bare-coordinate leaves ``x`` replaced by ``L·x``.
+
+    A coordinate is rewritten only where it appears as a *value* (child of an
+    arithmetic/function node) — never as a network input (``ModelCall`` arg) or
+    a differentiation variable (``Jacobian``/``Hessian``/``TemporalDerivative``
+    ``.variables``/``.time_var``), which instead ride the rescaled context. This
+    keeps analytic targets like ``sin(π·x/L)`` physical on the rescaled context
+    while derivatives stay dimensionless. ``coord_map``: ``{id(var): (var, L)}``.
+    """
+    from . import (
+        BinaryOp,
+        FunctionCall,
+        Hessian,
+        Jacobian,
+        Literal,
+        ModelCall,
+        Placeholder,
+        TemporalDerivative,
+    )
+
+    def as_value(child):
+        # *child* used as a value: wrap a scaled coordinate, else recurse.
+        if not isinstance(child, Placeholder):
+            return child
+        info = coord_map.get(id(child))
+        if info is not None:
+            var, length = info
+            return BinaryOp("*", Literal(length), var)
+        return rewrite(child)
+
+    def rewrite(n):
+        if isinstance(n, BinaryOp):
+            return BinaryOp(n.op, as_value(n.left), as_value(n.right))
+        if isinstance(n, FunctionCall):
+            return n.copy_with_args([as_value(a) for a in n.args])
+        if isinstance(n, ModelCall):
+            return n  # network inputs ride the rescaled context — leave args
+        if isinstance(n, Jacobian):
+            return Jacobian(rewrite(n.target), n.variables, n.scheme)
+        if isinstance(n, Hessian):
+            return Hessian(rewrite(n.target), n.variables, n.scheme, n.trace)
+        if isinstance(n, TemporalDerivative):
+            return TemporalDerivative(rewrite(n.target), n.time_var)
+        return n  # leaves & other nodes unchanged
+
+    return as_value(node)
+
+
 def rescale(constraints, domain=None):
     """Transform residual constraint(s) into a solvable dimensionless form.
 
@@ -731,11 +818,14 @@ def rescale(constraints, domain=None):
     from . import BinaryOp, Literal
 
     single = not isinstance(constraints, (list, tuple))
-    items = [constraints] if single else list(constraints)
+    items = [_unwrap_view(c) for c in ([constraints] if single else list(constraints))]
 
     transformed = []
     for root in items:
+        coord_map = _scaled_coord_map(root)
         terms = _additive_terms(root)
+        # gᵢ is computed on the ORIGINAL term (pre-rewrite) so the rewrite's L
+        # factor is not counted twice; the rewrite then materializes it once.
         full = [_scale_of(t) for _, t in terms]
         kvals = [_scale_of(t, coeff_neutral=True) for _, t in terms]
 
@@ -745,8 +835,9 @@ def rescale(constraints, domain=None):
         node = None
         for (sign, term), k in zip(terms, kvals):
             g = (k / s_ref) if (k is not None and s_ref) else 1.0
+            rewritten = _rewrite_bare_coords(term, coord_map)
             coeff = sign * g
-            piece = term if coeff == 1.0 else BinaryOp("*", Literal(coeff), term)
+            piece = rewritten if coeff == 1.0 else BinaryOp("*", Literal(coeff), rewritten)
             node = piece if node is None else BinaryOp("+", node, piece)
         transformed.append(node if node is not None else root)
 

--- a/jno/trace/unit_log.py
+++ b/jno/trace/unit_log.py
@@ -1,0 +1,592 @@
+"""Dimensional-analysis inference walk, warnings, and human-readable log.
+
+This module is the engine behind ``jno.units.check(nodes, log=...)``.  It walks
+the traced expression graph(s) in post-order, infers a :class:`~jno.trace.units.Unit`
+for every node from its already-visited children, and records mismatches
+(adding unlike units; passing a dimensioned argument to ``exp``/``log``/``sin``…).
+
+Design notes
+------------
+* **Walk-based, not eager.**  Inference runs only when ``check()`` is called, so
+  the hot graph-construction path (``BinaryOp.__init__`` etc.) is untouched and
+  the feature costs nothing unless opted into.
+* **Non-mutating.**  Inferred units for intermediate nodes live in a local
+  ``id(node) -> Unit`` map for the duration of one ``check()`` call; nodes are
+  never written to (a stored/shared graph can be checked repeatedly with no
+  cross-talk).  Only *user-declared* leaf units live on the node, set explicitly
+  via :meth:`Placeholder.unit`.
+* **Honest about the unknown.**  A unit of ``None`` means "not derivable" (an
+  undeclared leaf, or an operation on an undeclared operand) and never triggers
+  a warning — only two *known* but incompatible units do.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .units import DIMENSIONLESS, Unit
+
+# Functions whose argument must be dimensionless; result is dimensionless.
+_TRANSCENDENTAL = {
+    "exp",
+    "exp2",
+    "expm1",
+    "log",
+    "log2",
+    "log10",
+    "log1p",
+    "sin",
+    "cos",
+    "tan",
+    "arcsin",
+    "arccos",
+    "arctan",
+    "sinh",
+    "cosh",
+    "tanh",
+    "arcsinh",
+    "arccosh",
+    "arctanh",
+}
+# Functions that pass their (single) argument's unit through unchanged.
+_UNIT_PRESERVING = {
+    "abs",
+    "absolute",
+    "neg",
+    "negative",
+    "identity",
+    "reshape",
+    "getitem",
+    "print",
+    "stop_gradient",
+    "copy",
+    "real",
+    "imag",
+}
+
+
+class UnitLogger:
+    """Accumulates one ``(label, unit, warnings)`` entry per visited node."""
+
+    def __init__(self):
+        self.entries: List[Tuple[str, Optional[Unit], List[str]]] = []
+
+    @property
+    def warnings(self) -> List[str]:
+        """Flat list of every warning string recorded across all nodes."""
+        return [w for _, _, ws in self.entries for w in ws]
+
+    def record(self, label: str, unit: Optional[Unit], warnings: Sequence[str] = ()) -> None:
+        self.entries.append((label, unit, list(warnings)))
+
+    def render(self) -> str:
+        width = max((len(label) for label, _, _ in self.entries), default=0)
+        lines = []
+        for label, unit, warnings in self.entries:
+            unit_str = "?" if unit is None else repr(unit)
+            line = f"  {label.ljust(width)}  →  {unit_str}"
+            for w in warnings:
+                line += f"    [WARN: {w}]"
+            lines.append(line)
+        return "\n".join(lines)
+
+    def write(self, path: str) -> None:
+        header = "# jno dimensional-analysis log\n# node  →  inferred unit  [warnings]\n\n"
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(header + self.render() + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Child enumeration — mirrors the attribute set used by the trace compiler's
+# own graph walk so every node type is traversed uniformly.
+# ---------------------------------------------------------------------------
+_CHILD_ATTRS = ("target", "left", "right", "expr", "volume_expr", "time_var", "integration_var")
+_CHILD_LIST_ATTRS = ("variables", "args", "boundary_exprs", "options")
+
+
+def _children(node):
+    from . import Placeholder
+
+    out = []
+    for attr in _CHILD_ATTRS:
+        child = getattr(node, attr, None)
+        if isinstance(child, Placeholder):
+            out.append(child)
+    for attr in _CHILD_LIST_ATTRS:
+        children = getattr(node, attr, None)
+        if isinstance(children, (list, tuple)):
+            out.extend(c for c in children if isinstance(c, Placeholder))
+    return out
+
+
+def _fn_name(node) -> str:
+    name = getattr(node, "_name", None) or getattr(getattr(node, "fn", None), "__name__", "")
+    return str(name).lower()
+
+
+def _label(node) -> str:
+    text = repr(node)
+    return text if len(text) <= 60 else text[:57] + "..."
+
+
+def _infer_unit(node, umap: Dict[int, Optional[Unit]]) -> Tuple[Optional[Unit], List[str]]:
+    """Infer a unit for *node* from already-inferred child units in *umap*.
+
+    Returns ``(unit_or_None, warnings)``.  ``None`` = not derivable.
+    """
+    from . import (
+        BinaryOp,
+        FunctionCall,
+        Hessian,
+        Integral,
+        IntegralTime,
+        Jacobian,
+        Literal,
+        TemporalDerivative,
+        TestFunction,
+        Tracker,
+    )
+
+    warnings: List[str] = []
+
+    def cu(child):  # child unit
+        return umap.get(id(child))
+
+    # --- leaves --------------------------------------------------------------
+    if isinstance(node, Literal):
+        return DIMENSIONLESS, warnings
+    if isinstance(node, TestFunction):
+        # Convention: the test function is dimensionless (the weak form divides
+        # it out).  TrialFunction, by contrast, is a leaf that carries a
+        # user-declared unit like any other unknown field.
+        return DIMENSIONLESS, warnings
+    if isinstance(node, Tracker):
+        return cu(node.expr), warnings
+
+    # --- arithmetic ----------------------------------------------------------
+    if isinstance(node, BinaryOp):
+        lu, ru = cu(node.left), cu(node.right)
+        if node.op in ("+", "-"):
+            if lu is not None and ru is not None and lu != ru:
+                warnings.append(f"left={lu!r} right={ru!r} — units mismatch under '{node.op}'")
+                return lu, warnings
+            return (lu if lu is not None else ru), warnings
+        if node.op == "*":
+            return (lu * ru if lu is not None and ru is not None else None), warnings
+        if node.op == "/":
+            return (lu / ru if lu is not None and ru is not None else None), warnings
+        if node.op == "**":
+            exponent = _literal_scalar(node.right)
+            if lu is None or exponent is None:
+                return None, warnings
+            return lu**exponent, warnings
+        return None, warnings
+
+    # --- derivatives ---------------------------------------------------------
+    if isinstance(node, Jacobian):
+        tu = cu(node.target)
+        var_units = [cu(v) for v in node.variables]
+        if tu is None or any(u is None for u in var_units):
+            return None, warnings
+        if len({u for u in var_units}) > 1:
+            # heterogeneous gradient vector — no single unit
+            return None, warnings
+        return tu / var_units[0], warnings
+
+    if isinstance(node, Hessian):
+        tu = cu(node.target)
+        var_units = [cu(v) for v in node.variables]
+        if tu is None or any(u is None for u in var_units):
+            return None, warnings
+        distinct = {u for u in var_units}
+        if node.trace:  # Laplacian: Σ ∂²/∂vᵢ² — all vᵢ must share a unit
+            if len(distinct) > 1:
+                warnings.append("Laplacian over variables with differing units")
+            return tu / (var_units[0] ** 2), warnings
+        # full Hessian matrix: single unit only for a single variable
+        if len(distinct) == 1:
+            return tu / (var_units[0] ** 2), warnings
+        return None, warnings
+
+    if isinstance(node, TemporalDerivative):
+        tu, vu = cu(node.target), cu(getattr(node, "time_var", None))
+        return (tu / vu if tu is not None and vu is not None else None), warnings
+
+    # --- integrals (best-effort: needs a declared spatial coordinate) --------
+    if isinstance(node, Integral):
+        tu = cu(node.target)
+        coord = _first_spatial_var(node.target)
+        cu_coord = umap.get(id(coord)) if coord is not None else None
+        if tu is None or cu_coord is None:
+            return None, warnings
+        ndim = int(getattr(coord, "size", 1) or 1)
+        return tu * (cu_coord**ndim), warnings
+
+    if isinstance(node, IntegralTime):
+        tu, vu = cu(node.target), cu(getattr(node, "time_var", None))
+        return (tu * vu if tu is not None and vu is not None else None), warnings
+
+    # --- function calls ------------------------------------------------------
+    if isinstance(node, FunctionCall):
+        name = _fn_name(node)
+        arg_units = [cu(a) for a in _children(node)]
+        first = arg_units[0] if arg_units else None
+        if name in _TRANSCENDENTAL:
+            if first is not None and not first.is_dimensionless():
+                warnings.append(f"argument of '{name}' has unit {first!r} — must be dimensionless")
+            return DIMENSIONLESS, warnings
+        if name in ("sqrt",):
+            return (first**0.5 if first is not None else None), warnings
+        if name in _UNIT_PRESERVING:
+            return first, warnings
+        return None, warnings
+
+    # --- everything else (Model/ModelCall/Variable/TensorTag/TrialFunction) --
+    # User-declared unit if present (set via Placeholder.unit()), else unknown.
+    return getattr(node, "_unit", None), warnings
+
+
+def _literal_scalar(node) -> Optional[float]:
+    """Extract a Python float from a Literal exponent node, else None."""
+    from . import Literal
+
+    if not isinstance(node, Literal):
+        return None
+    try:
+        value = node.value
+        return float(value.item() if hasattr(value, "item") else value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_spatial_var(root):
+    """Return the first spatial Variable found under *root* (pre-order), or None."""
+    from . import Variable
+
+    seen = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        if isinstance(node, Variable) and getattr(node, "axis", "spatial") == "spatial":
+            return node
+        stack.extend(_children(node))
+    return None
+
+
+def check(nodes, log: Optional[str] = None) -> UnitLogger:
+    """Infer and audit physical units across one or more expression trees.
+
+    Walks each node in *nodes* (a single :class:`~jno.trace.Placeholder` or a
+    list/tuple of them) in post-order, inferring a unit for every sub-node and
+    recording any dimensional inconsistencies.  Optionally writes a
+    human-readable log.
+
+    Parameters
+    ----------
+    nodes:
+        A traced expression or a sequence of them (e.g. the residuals passed to
+        ``jno.fem([...])``).
+    log:
+        If given, a filesystem path the per-node log is written to.
+
+    Returns
+    -------
+    UnitLogger
+        Inspect ``.entries`` (``(label, unit, warnings)`` triples) or
+        ``.warnings`` (flat list) programmatically.
+    """
+    if not isinstance(nodes, (list, tuple)):
+        nodes = [nodes]
+
+    logger = UnitLogger()
+    umap: Dict[int, Optional[Unit]] = {}
+    visited = set()
+
+    def visit(node):
+        if id(node) in visited:
+            return
+        visited.add(id(node))
+        for child in _children(node):
+            visit(child)
+        unit, warnings = _infer_unit(node, umap)
+        umap[id(node)] = unit
+        logger.record(_label(node), unit, warnings)
+
+    for root in nodes:
+        visit(root)
+
+    if log is not None:
+        logger.write(log)
+    return logger
+
+
+def infer(node) -> Optional[Unit]:
+    """Convenience: return the inferred unit of a single expression's root.
+
+    Equivalent to ``check([node]).entries[-1][1]`` — runs a fresh, non-mutating
+    walk and hands back the top node's unit (``None`` if not derivable).
+    """
+    return check([node]).entries[-1][1]
+
+
+# ===========================================================================
+# Non-dimensionalization (Phase A: analysis / dimensionless groups)
+# ---------------------------------------------------------------------------
+# Units give a node's *dimension*; ``.scale(value)`` gives a leaf's
+# characteristic *magnitude*.  The magnitude walk below mirrors ``_infer_unit``
+# rule-for-rule but propagates the per-leaf scales (floats) through each term's
+# subtree.  The dimensionless group of an additive term is then its magnitude
+# divided by a reference term's magnitude — e.g. the heat equation's diffusion
+# term yields the Fourier number ``ατ/L²`` and advection–diffusion yields the
+# Péclet number ``VL/α`` (Buckingham-π non-dimensionalization;
+# see e.g. Barenblatt, *Scaling, Self-similarity, and Intermediate Asymptotics*,
+# CUP 1996, Ch. 1).  Crucially the group must come from this subtree walk, NOT
+# from a term's *net* unit: in a consistent residual every additive term shares
+# the same net unit, so a net-unit formula collapses every group to 1.
+# ===========================================================================
+
+
+def _infer_scale(node, smap: Dict[int, Optional[float]]) -> Optional[float]:
+    """Magnitude (float) of *node* from child magnitudes in *smap*.
+
+    Sibling of :func:`_infer_unit` with identical dispatch and the same
+    :func:`_children` traversal.  ``None`` = not derivable (an undeclared leaf,
+    or an op on one).
+    """
+    from . import (
+        BinaryOp,
+        FunctionCall,
+        Hessian,
+        Integral,
+        IntegralTime,
+        Jacobian,
+        Literal,
+        TemporalDerivative,
+        TestFunction,
+        Tracker,
+    )
+
+    def cs(child):  # child scale
+        return smap.get(id(child))
+
+    # --- leaves --------------------------------------------------------------
+    if isinstance(node, Literal):
+        try:
+            mag = abs(float(node.value.item() if hasattr(node.value, "item") else node.value))
+        except (TypeError, ValueError):
+            return None
+        return mag or 1.0  # a bare 0/±1 carries no magnitude → neutral in products
+    if isinstance(node, TestFunction):
+        return 1.0  # dimensionless by convention; magnitude 1
+    if isinstance(node, Tracker):
+        return cs(node.expr)
+
+    # --- arithmetic ----------------------------------------------------------
+    if isinstance(node, BinaryOp):
+        sl, sr = cs(node.left), cs(node.right)
+        if node.op in ("+", "-"):
+            return sl if sl is not None else sr  # terms share a magnitude
+        if node.op == "*":
+            return sl * sr if sl is not None and sr is not None else None
+        if node.op == "/":
+            return sl / sr if sl is not None and sr is not None else None
+        if node.op == "**":
+            exponent = _literal_scalar(node.right)
+            if sl is None or exponent is None:
+                return None
+            return sl**exponent
+        return None
+
+    # --- derivatives ---------------------------------------------------------
+    if isinstance(node, Jacobian):
+        st = cs(node.target)
+        var_scales = [cs(v) for v in node.variables]
+        if st is None or any(s is None for s in var_scales):
+            return None
+        if len(set(var_scales)) > 1:
+            return None
+        return st / var_scales[0]
+
+    if isinstance(node, Hessian):
+        st = cs(node.target)
+        var_scales = [cs(v) for v in node.variables]
+        if st is None or any(s is None for s in var_scales):
+            return None
+        if node.trace:  # Laplacian
+            return st / (var_scales[0] ** 2)
+        if len(set(var_scales)) == 1:
+            return st / (var_scales[0] ** 2)
+        return None
+
+    if isinstance(node, TemporalDerivative):
+        st, sv = cs(node.target), cs(getattr(node, "time_var", None))
+        return st / sv if st is not None and sv is not None else None
+
+    if isinstance(node, Integral):
+        st = cs(node.target)
+        coord = _first_spatial_var(node.target)
+        sc = smap.get(id(coord)) if coord is not None else None
+        if st is None or sc is None:
+            return None
+        ndim = int(getattr(coord, "size", 1) or 1)
+        return st * (sc**ndim)
+
+    if isinstance(node, IntegralTime):
+        st, sv = cs(node.target), cs(getattr(node, "time_var", None))
+        return st * sv if st is not None and sv is not None else None
+
+    # --- function calls ------------------------------------------------------
+    if isinstance(node, FunctionCall):
+        name = _fn_name(node)
+        child_scales = [cs(a) for a in _children(node)]
+        first = child_scales[0] if child_scales else None
+        if name in _TRANSCENDENTAL:
+            return 1.0
+        if name == "sqrt":
+            return first**0.5 if first is not None else None
+        if name in _UNIT_PRESERVING:
+            return first
+        return None
+
+    # --- leaves carrying a user-declared scale (Variable/TrialFunction/...) ---
+    return getattr(node, "_scale", None)
+
+
+def _scale_of(node) -> Optional[float]:
+    """Run a fresh non-mutating magnitude walk and return *node*'s magnitude."""
+    smap: Dict[int, Optional[float]] = {}
+    visited = set()
+
+    def visit(n):
+        if id(n) in visited:
+            return
+        visited.add(id(n))
+        for child in _children(n):
+            visit(child)
+        smap[id(n)] = _infer_scale(n, smap)
+
+    visit(node)
+    return smap[id(node)]
+
+
+def _additive_terms(node, sign: int = 1) -> List[Tuple[int, object]]:
+    """Flatten the top-level ``+``/``-`` chain into signed additive terms."""
+    from . import BinaryOp
+
+    if isinstance(node, BinaryOp) and node.op in ("+", "-"):
+        left = _additive_terms(node.left, sign)
+        right_sign = sign if node.op == "+" else -sign
+        right = _additive_terms(node.right, right_sign)
+        return left + right
+    return [(sign, node)]
+
+
+class TermInfo:
+    """One additive term of a residual: its node, sign, unit, magnitude, π."""
+
+    def __init__(self, term, sign: int, unit: Optional[Unit], scale: Optional[float]):
+        self.term = term
+        self.sign = sign
+        self.unit = unit
+        self.scale = scale
+        self.pi: Optional[float] = None
+
+    def __repr__(self):
+        return f"TermInfo({_label(self.term)}, unit={self.unit!r}, scale={self.scale}, pi={self.pi})"
+
+
+class ResidualReport:
+    """Per-residual non-dimensionalization result."""
+
+    def __init__(self, root, terms: List[TermInfo], ref_index: Optional[int]):
+        self.root = root
+        self.terms = terms
+        self.ref_index = ref_index
+
+    @property
+    def pis(self) -> List[Optional[float]]:
+        return [t.pi for t in self.terms]
+
+
+class NondimReport:
+    """Result of :func:`nondimensionalize`: one :class:`ResidualReport` each."""
+
+    def __init__(self, residuals: List[ResidualReport]):
+        self.residuals = residuals
+
+    def render(self) -> str:
+        blocks = []
+        for r in self.residuals:
+            labels = [_label(t.term) for t in r.terms]
+            width = max((len(s) for s in labels), default=0)
+            lines = [f"residual: {_label(r.root)}"]
+            for i, t in enumerate(r.terms):
+                unit_str = "?" if t.unit is None else repr(t.unit)
+                scale_str = "?" if t.scale is None else f"{t.scale:.6g}"
+                pi_str = "?" if t.pi is None else f"{t.pi:.6g}"
+                ref_mark = "  (ref)" if i == r.ref_index else ""
+                lines.append(f"  {labels[i].ljust(width)}  unit={unit_str}  scale={scale_str}  π={pi_str}{ref_mark}")
+            blocks.append("\n".join(lines))
+        return "\n\n".join(blocks)
+
+    def write(self, path: str) -> None:
+        header = "# jno non-dimensionalization report\n# per additive term: inferred unit, characteristic magnitude, dimensionless group π\n\n"
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(header + self.render() + "\n")
+
+
+def nondimensionalize(nodes, ref: Optional[int] = None, report: Optional[str] = None) -> NondimReport:
+    """Derive characteristic magnitudes and dimensionless groups for residual(s).
+
+    For each residual in *nodes*, splits the top-level additive terms, infers
+    each term's :class:`~jno.trace.units.Unit` (via :func:`infer`) and
+    characteristic magnitude (via the per-leaf ``.scale`` walk), then forms the
+    dimensionless group of each term as ``πᵢ = Sᵢ / S_ref``.
+
+    Phase A only — this is pure analysis and does **not** change what the solver
+    computes.
+
+    Parameters
+    ----------
+    nodes:
+        A residual expression or a sequence of them.
+    ref:
+        Index of the reference term whose magnitude normalises the groups.
+        Defaults to the first term with both a known unit and a known scale.
+    report:
+        If given, a path the human-readable report is written to.
+
+    Returns
+    -------
+    NondimReport
+        ``.residuals[i].terms[j].pi`` holds each term's dimensionless group.
+    """
+    if not isinstance(nodes, (list, tuple)):
+        nodes = [nodes]
+
+    residuals: List[ResidualReport] = []
+    for root in nodes:
+        terms = [TermInfo(term, sign, infer(term), _scale_of(term)) for sign, term in _additive_terms(root)]
+
+        if ref is not None:
+            ref_index: Optional[int] = ref if 0 <= ref < len(terms) else None
+        else:
+            ref_index = next(
+                (i for i, t in enumerate(terms) if t.unit is not None and t.scale is not None),
+                None,
+            )
+
+        if ref_index is not None and terms[ref_index].scale:
+            s_ref = terms[ref_index].scale
+            for t in terms:
+                t.pi = t.scale / s_ref if t.scale is not None else None
+
+        residuals.append(ResidualReport(root, terms, ref_index))
+
+    result = NondimReport(residuals)
+    if report is not None:
+        result.write(report)
+    return result

--- a/jno/trace/unit_log.py
+++ b/jno/trace/unit_log.py
@@ -349,15 +349,21 @@ def infer(node) -> Optional[Unit]:
 # ===========================================================================
 
 
-def _infer_scale(node, smap: Dict[int, Optional[float]]) -> Optional[float]:
+def _infer_scale(node, smap: Dict[int, Optional[float]], coeff_neutral: bool = False) -> Optional[float]:
     """Magnitude (float) of *node* from child magnitudes in *smap*.
 
     Sibling of :func:`_infer_unit` with identical dispatch and the same
     :func:`_children` traversal.  ``None`` = not derivable (an undeclared leaf,
     or an op on one).
+
+    When *coeff_neutral* is set, coefficient leaves (``Constant``/``TensorTag``)
+    contribute magnitude 1 instead of their declared scale — this yields the
+    coordinate-plus-field magnitude ``Kᵢ`` used by the rescale transform, as
+    opposed to the full magnitude ``Sᵢ``.
     """
     from . import (
         BinaryOp,
+        Constant,
         FunctionCall,
         Hessian,
         Integral,
@@ -365,12 +371,16 @@ def _infer_scale(node, smap: Dict[int, Optional[float]]) -> Optional[float]:
         Jacobian,
         Literal,
         TemporalDerivative,
+        TensorTag,
         TestFunction,
         Tracker,
     )
 
     def cs(child):  # child scale
         return smap.get(id(child))
+
+    if coeff_neutral and isinstance(node, (Constant, TensorTag)):
+        return 1.0
 
     # --- leaves --------------------------------------------------------------
     if isinstance(node, Literal):
@@ -455,8 +465,12 @@ def _infer_scale(node, smap: Dict[int, Optional[float]]) -> Optional[float]:
     return getattr(node, "_scale", None)
 
 
-def _scale_of(node) -> Optional[float]:
-    """Run a fresh non-mutating magnitude walk and return *node*'s magnitude."""
+def _scale_of(node, coeff_neutral: bool = False) -> Optional[float]:
+    """Run a fresh non-mutating magnitude walk and return *node*'s magnitude.
+
+    With *coeff_neutral*, coefficient leaves count as magnitude 1 (returns the
+    coordinate-plus-field magnitude ``Kᵢ`` rather than the full ``Sᵢ``).
+    """
     smap: Dict[int, Optional[float]] = {}
     visited = set()
 
@@ -466,7 +480,7 @@ def _scale_of(node) -> Optional[float]:
         visited.add(id(n))
         for child in _children(n):
             visit(child)
-        smap[id(n)] = _infer_scale(n, smap)
+        smap[id(n)] = _infer_scale(n, smap, coeff_neutral)
 
     visit(node)
     return smap[id(node)]
@@ -590,3 +604,152 @@ def nondimensionalize(nodes, ref: Optional[int] = None, report: Optional[str] = 
     if report is not None:
         result.write(report)
     return result
+
+
+# ===========================================================================
+# Non-dimensionalization (Phase B: transform a problem to dimensionless form)
+# ---------------------------------------------------------------------------
+# The transform is Phase A applied constructively.  Each additive term is
+# multiplied by ``gᵢ = Kᵢ / S_ref`` where ``Kᵢ`` is the term's *coordinate +
+# field* magnitude (coefficients excluded) and ``S_ref`` the reference term's
+# full magnitude.  On a coordinate context rescaled to O(1) — and with the
+# network/trial output representing the O(1) dimensionless field — the
+# transformed residual evaluates to ``Σ signᵢ·πᵢ·term̂ᵢ`` (the dimensionless
+# residual whose leading coefficients are the Fourier/Péclet numbers).
+#
+# Note: the transformed graph is *not* symbolically dimensionless — the
+# dimensional coordinates/coefficients remain in it; dimensionlessness is
+# realized numerically once the rescaled (O(1)) context and field are supplied.
+# Multiplying by ``gᵢ`` (rather than substituting coefficients) is the
+# least-invasive correct mechanism: it never touches Variable identity, so the
+# derivative semantics of Jacobian/Hessian are preserved.
+# ===========================================================================
+
+
+def _scale_columns(arr, d0: int, d1: Optional[int], factor: float):
+    """Return *arr* with last-axis columns ``[d0:d1]`` multiplied by *factor*."""
+    hi = arr.shape[-1] if d1 is None else d1
+    if hasattr(arr, "at"):  # jax array — functional update
+        return arr.at[..., d0:hi].multiply(factor)
+    import numpy as _np
+
+    out = _np.array(arr, copy=True)
+    out[..., d0:hi] = out[..., d0:hi] * factor
+    return out
+
+
+class Rescaler:
+    """Back-map between physical and dimensionless (O(1)) coordinates/fields.
+
+    Produced by :func:`rescale`.  Holds the characteristic length(s) ``L`` of
+    each coordinate and the field scale ``U`` so a rescaled problem can be set
+    up and its solution recovered: ``u_physical(x) = U · û(x / L)``.
+    """
+
+    def __init__(self, coords, field_scale: Optional[float]):
+        # coords: list of (tag, (d0, d1), L) — one per scaled coordinate column
+        self._coords = coords
+        self.field_scale = field_scale
+
+    def rescaled_context(self, context: dict) -> dict:
+        """Return a new context dict with each coordinate column scaled to O(1)."""
+        out = dict(context)
+        for tag, (d0, d1), L in self._coords:
+            if tag in out and L:
+                out[tag] = _scale_columns(out[tag], d0, d1, 1.0 / L)
+        return out
+
+    def rescaled_domain(self, domain):
+        """Return a shallow copy of *domain* whose context is rescaled to O(1).
+
+        The user's *domain* is never mutated.
+        """
+        import copy as _copy
+
+        dom = _copy.copy(domain)
+        dom.context = self.rescaled_context(domain.context)
+        return dom
+
+    def to_physical(self, field):
+        """Map a dimensionless field value ``û`` back to physical units (``U·û``)."""
+        return field if self.field_scale is None else field * self.field_scale
+
+    def __repr__(self):
+        return f"Rescaler(coords={len(self._coords)}, field_scale={self.field_scale})"
+
+
+def _collect_scaled_leaves(constraints):
+    """Find scaled coordinate Variables and the field scale across *constraints*."""
+    from . import Model, ModelCall, TrialFunction, Variable
+
+    coords: Dict[int, tuple] = {}
+    field_scales: List[float] = []
+    seen = set()
+    stack = list(constraints)
+    while stack:
+        n = stack.pop()
+        if id(n) in seen:
+            continue
+        seen.add(id(n))
+        s = getattr(n, "_scale", None)
+        if s is not None:
+            if isinstance(n, Variable):
+                d = tuple(n.dim) if n.dim is not None else (0, None)
+                coords[(n.tag, d)] = (n.tag, d, s)
+            elif isinstance(n, (Model, ModelCall, TrialFunction)):
+                field_scales.append(s)
+        stack.extend(_children(n))
+    return list(coords.values()), (field_scales[0] if field_scales else None)
+
+
+def rescale(constraints, domain=None):
+    """Transform residual constraint(s) into a solvable dimensionless form.
+
+    Multiplies each additive term of every residual by ``gᵢ = Kᵢ / S_ref`` so
+    that, evaluated on the :class:`Rescaler`'s O(1) coordinate context (and with
+    the network/trial output representing the dimensionless field), the residual
+    becomes ``Σ signᵢ·πᵢ·term̂ᵢ`` — O(1) and dimensionless, with the
+    dimensionless groups (Fourier/Péclet) as the leading coefficients.
+
+    Phase B — opt-in.  Returns ``(transformed_constraints, rescaler)``; nothing
+    is solved and the input *domain* is never mutated.
+
+    Parameters
+    ----------
+    constraints:
+        A residual expression or a sequence of them.
+    domain:
+        Unused for the transform itself; accepted so callers can pair it with
+        ``rescaler.rescaled_domain(domain)``.
+
+    Returns
+    -------
+    (list, Rescaler)
+        The transformed constraints (same length/order as the input) and the
+        back-map :class:`Rescaler`.
+    """
+    from . import BinaryOp, Literal
+
+    single = not isinstance(constraints, (list, tuple))
+    items = [constraints] if single else list(constraints)
+
+    transformed = []
+    for root in items:
+        terms = _additive_terms(root)
+        full = [_scale_of(t) for _, t in terms]
+        kvals = [_scale_of(t, coeff_neutral=True) for _, t in terms]
+
+        ref_index = next((i for i, s in enumerate(full) if s), None)
+        s_ref = full[ref_index] if ref_index is not None else None
+
+        node = None
+        for (sign, term), k in zip(terms, kvals):
+            g = (k / s_ref) if (k is not None and s_ref) else 1.0
+            coeff = sign * g
+            piece = term if coeff == 1.0 else BinaryOp("*", Literal(coeff), term)
+            node = piece if node is None else BinaryOp("+", node, piece)
+        transformed.append(node if node is not None else root)
+
+    coords, field_scale = _collect_scaled_leaves(items)
+    rescaler = Rescaler(coords, field_scale)
+    return (transformed[0] if single else transformed), rescaler

--- a/jno/trace/units.py
+++ b/jno/trace/units.py
@@ -188,9 +188,27 @@ _ALIASES: _Dict[str, Unit] = {
 # Public entry points live in unit_log; re-export here so the whole feature is
 # reachable as ``jno.units.*`` (``jno.units.check``, ``jno.units.Unit``, …).
 # Imported last so the algebra above is fully defined before unit_log loads it.
-from .unit_log import NondimReport, UnitLogger, check, infer, nondimensionalize  # noqa: E402
+from .unit_log import (  # noqa: E402
+    NondimReport,
+    Rescaler,
+    UnitLogger,
+    check,
+    infer,
+    nondimensionalize,
+    rescale,
+)
 
-__all__ = ["Unit", "DIMENSIONLESS", "UnitLogger", "check", "infer", "nondimensionalize", "NondimReport"]
+__all__ = [
+    "Unit",
+    "DIMENSIONLESS",
+    "UnitLogger",
+    "check",
+    "infer",
+    "nondimensionalize",
+    "NondimReport",
+    "rescale",
+    "Rescaler",
+]
 
 
 def __dir__():

--- a/jno/trace/units.py
+++ b/jno/trace/units.py
@@ -1,0 +1,199 @@
+"""Lightweight physical-unit algebra for graph-time dimensional analysis.
+
+Units are graph-level metadata: they live on jno's Python wrapper objects
+(:class:`jno.trace.Placeholder`) and are inferred at *trace time*, before any
+JAX computation, so a user can audit that a PDE formulation is dimensionally
+consistent.  See :mod:`jno.trace.unit_log` for the inference walk and the
+public ``jno.units.check(...)`` entry point.
+
+``pint`` is intentionally not a dependency — jno minimises external deps and
+the algebra needed here is small.  A :class:`Unit` is just a map from SI base
+dimension to a :class:`fractions.Fraction` exponent (fractions so ``sqrt``
+stays exact).  The seven SI bases plus a handful of common derived aliases are
+recognised by :meth:`Unit.parse`.
+"""
+
+from __future__ import annotations
+
+import re as _re
+from fractions import Fraction as _Fraction
+from typing import Dict as _Dict
+from typing import Union as _Union
+
+_Number = _Union[int, float, _Fraction]
+
+# Seven SI base dimensions.  Order fixes the pretty-print order.
+_SI_BASES = ("kg", "m", "s", "A", "K", "mol", "cd")
+
+# Superscript digits for pretty exponents (e.g. m·s⁻²).
+_SUPERSCRIPT = {
+    "-": "⁻",
+    "0": "⁰",
+    "1": "¹",
+    "2": "²",
+    "3": "³",
+    "4": "⁴",
+    "5": "⁵",
+    "6": "⁶",
+    "7": "⁷",
+    "8": "⁸",
+    "9": "⁹",
+    "/": "ᐟ",
+    ".": "·",
+}
+
+
+class Unit:
+    """A physical unit as a map of SI base dimension → rational exponent.
+
+    Instances are immutable value objects: equality and hashing are by the
+    (zero-stripped) exponent map, so ``Unit.parse("m/s") == Unit.parse("m s^-1")``.
+    """
+
+    __slots__ = ("_exp",)
+
+    def __init__(self, exponents: _Dict[str, _Number] | None = None):
+        exp: _Dict[str, _Fraction] = {}
+        for base, power in (exponents or {}).items():
+            f = _Fraction(power)
+            if f != 0:
+                exp[base] = f
+        self._exp = exp
+
+    # -- construction ---------------------------------------------------------
+    @classmethod
+    def parse(cls, spec: "str | Unit") -> "Unit":
+        """Parse a unit string such as ``'m'``, ``'m/s'``, ``'kg/m^3'``, ``'Pa'``.
+
+        Grammar (informal): a ``numerator`` optionally followed by ``/`` and a
+        ``denominator``; each is a juxtaposition of ``base[^power]`` factors
+        separated by spaces, ``*``, or ``·``.  Powers may be negative or
+        fractional (``m^1/2``).  Recognises the 7 SI bases plus the aliases in
+        :data:`_ALIASES` (``T``→K, ``Pa``, ``N``, ``J``, ``W``, ``Hz``, …).
+        Dimensionless is spelled ``''``, ``'1'``, or ``'-'``.
+        """
+        if isinstance(spec, Unit):
+            return spec
+        # Accept Python-style '**' as well as '^' for exponents.
+        text = spec.strip().replace("**", "^")
+        if text in ("", "1", "-", "dimensionless"):
+            return DIMENSIONLESS
+
+        # Split a single top-level '/' into numerator / denominator.
+        if "/" in text:
+            num, _, den = text.partition("/")
+            return cls._parse_product(num) / cls._parse_product(den)
+        return cls._parse_product(text)
+
+    @classmethod
+    def _parse_product(cls, text: str) -> "Unit":
+        text = text.strip().strip("()")
+        if text in ("", "1"):
+            return DIMENSIONLESS
+        result = DIMENSIONLESS
+        # factors separated by space, '*' or '·'
+        for factor in _re.split(r"[\s*·]+", text):
+            if not factor:
+                continue
+            result = result * cls._parse_factor(factor)
+        return result
+
+    @classmethod
+    def _parse_factor(cls, factor: str) -> "Unit":
+        m = _re.fullmatch(r"([A-Za-zµ]+)(?:\^?(-?\d+(?:/\d+)?))?", factor.strip())
+        if m is None:
+            raise ValueError(f"Cannot parse unit factor {factor!r}")
+        symbol, power = m.group(1), m.group(2)
+        exponent = _Fraction(power) if power is not None else _Fraction(1)
+        base = _ALIASES.get(symbol)
+        if base is None:
+            if symbol in _SI_BASES:
+                base = Unit({symbol: 1})
+            else:
+                raise ValueError(f"Unknown unit symbol {symbol!r}")
+        return base**exponent
+
+    # -- algebra --------------------------------------------------------------
+    def __mul__(self, other: "Unit") -> "Unit":
+        exp = dict(self._exp)
+        for base, power in other._exp.items():
+            exp[base] = exp.get(base, _Fraction(0)) + power
+        return Unit(exp)
+
+    def __truediv__(self, other: "Unit") -> "Unit":
+        exp = dict(self._exp)
+        for base, power in other._exp.items():
+            exp[base] = exp.get(base, _Fraction(0)) - power
+        return Unit(exp)
+
+    def __pow__(self, n: _Number) -> "Unit":
+        f = _Fraction(n).limit_denominator(1_000_000)
+        return Unit({base: power * f for base, power in self._exp.items()})
+
+    # -- queries --------------------------------------------------------------
+    def is_dimensionless(self) -> bool:
+        return not self._exp
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Unit):
+            return NotImplemented
+        return self._exp == other._exp
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self._exp.items()))
+
+    # -- display --------------------------------------------------------------
+    def __repr__(self) -> str:
+        if not self._exp:
+            return "1"
+        order = list(_SI_BASES) + sorted(b for b in self._exp if b not in _SI_BASES)
+        # Positive exponents first, then negative — the conventional reading
+        # (e.g. K·m⁻¹ rather than m⁻¹·K), each group in SI-base order.
+        positive = [b for b in order if self._exp.get(b, 0) > 0]
+        negative = [b for b in order if self._exp.get(b, 0) < 0]
+        parts = [self._format_factor(b, self._exp[b]) for b in positive + negative]
+        return "·".join(parts)
+
+    @staticmethod
+    def _format_factor(base: str, power: _Fraction) -> str:
+        if power == 1:
+            return base
+        sup = "".join(_SUPERSCRIPT.get(ch, ch) for ch in str(power))
+        return f"{base}{sup}"
+
+
+DIMENSIONLESS = Unit({})
+
+# Derived-unit and convenience aliases → concrete Unit objects.
+# Defined after the class so the algebra is available.
+_ALIASES: _Dict[str, Unit] = {
+    # SI bases (identity)
+    **{b: Unit({b: 1}) for b in _SI_BASES},
+    # common temperature / angle spellings
+    "T": Unit({"K": 1}),  # temperature shorthand used in PDE write-ups
+    "rad": DIMENSIONLESS,  # plane angle is dimensionless
+    "sr": DIMENSIONLESS,  # solid angle is dimensionless
+    "g": Unit({"kg": 1}),  # treat gram as a mass dimension (prefix ignored)
+    # named derived units
+    "N": Unit({"kg": 1, "m": 1, "s": -2}),  # newton
+    "Pa": Unit({"kg": 1, "m": -1, "s": -2}),  # pascal
+    "J": Unit({"kg": 1, "m": 2, "s": -2}),  # joule
+    "W": Unit({"kg": 1, "m": 2, "s": -3}),  # watt
+    "Hz": Unit({"s": -1}),  # hertz
+    "C": Unit({"A": 1, "s": 1}),  # coulomb
+    "V": Unit({"kg": 1, "m": 2, "s": -3, "A": -1}),  # volt
+    "Ohm": Unit({"kg": 1, "m": 2, "s": -3, "A": -2}),  # ohm
+}
+
+# Public entry points live in unit_log; re-export here so the whole feature is
+# reachable as ``jno.units.*`` (``jno.units.check``, ``jno.units.Unit``, …).
+# Imported last so the algebra above is fully defined before unit_log loads it.
+from .unit_log import NondimReport, UnitLogger, check, infer, nondimensionalize  # noqa: E402
+
+__all__ = ["Unit", "DIMENSIONLESS", "UnitLogger", "check", "infer", "nondimensionalize", "NondimReport"]
+
+
+def __dir__():
+    # Present only the curated public surface as ``jno.units.*`` (PEP 562):
+    # hides helper imports and the ``from __future__`` ``annotations`` artifact.
+    return list(__all__)

--- a/tests/test_nondim.py
+++ b/tests/test_nondim.py
@@ -133,6 +133,15 @@ def _coefficient(value):
     return Constant("P", "c", jnp.asarray(value))
 
 
+def _field(scale_value, unit="K"):
+    """A realistic field leaf (non-coordinate, non-coefficient) standing in for
+    the network output net(...). A bare ``make_var`` would be misread as a
+    coordinate by the coefficient-excluded magnitude walk."""
+    from jno.trace import TrialFunction
+
+    return TrialFunction("u").unit(unit).scale(scale_value)
+
+
 def _leading_coeff(term_node):
     """Effective scalar coefficient prepended to a transformed additive term."""
     from jno.trace import BinaryOp, Literal
@@ -151,7 +160,7 @@ class TestRescaleTransform:
         L, tau, U, alpha0 = 0.1, 5.0, 50.0, 1e-5
         x = make_var("x").unit("m").scale(L)
         t = make_var("t").unit("s").scale(tau)
-        u = make_var("u").unit("K").scale(U)
+        u = _field(U)
         alpha = _coefficient(alpha0).unit("m^2/s").scale(alpha0)
 
         residual = u.d(t) - alpha * u.d2(x)
@@ -172,7 +181,7 @@ class TestRescaleTransform:
         # realized numerically on the rescaled context (documents the design).
         x = make_var("x").unit("m").scale(0.1)
         t = make_var("t").unit("s").scale(5.0)
-        u = make_var("u").unit("K").scale(50.0)
+        u = _field(50.0)
         alpha = _coefficient(1e-5).unit("m^2/s").scale(1e-5)
         transformed, _ = jno.units.rescale(u.d(t) - alpha * u.d2(x))
         assert jno.units.infer(transformed) == Unit.parse("K/s")
@@ -230,3 +239,105 @@ class TestRescaler:
         coord_tags = {tag for tag, _, _ in coords}
         assert x.tag in coord_tags  # the coordinate is rescaled
         assert "u" not in coord_tags  # the field is NOT a coordinate
+
+
+def _wraps_coord(node, var, L):
+    """True if *var* appears wrapped as ``L·var`` (the bare-coordinate rewrite)."""
+    from jno.trace import BinaryOp, Literal
+
+    seen = set()
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if id(n) in seen:
+            continue
+        seen.add(id(n))
+        if (
+            isinstance(n, BinaryOp)
+            and n.op == "*"
+            and isinstance(n.left, Literal)
+            and math.isclose(float(n.left.value), L, rel_tol=1e-5)
+            and n.right is var
+        ):
+            return True
+        for attr in ("left", "right", "target", "expr"):
+            child = getattr(n, attr, None)
+            if child is not None:
+                stack.append(child)
+        for attr in ("args", "variables"):
+            for c in getattr(n, attr, None) or []:
+                stack.append(c)
+    return False
+
+
+class TestBareCoordinateRewrite:
+    """The crux of the general transform: coordinate-dependent analytic targets.
+
+    These FAIL a double-count implementation (which would give g = L³/U for a
+    linear source instead of L²/U), so a sin-only suite cannot catch the bug.
+    """
+
+    def test_linear_source_coefficient_is_L2_over_U(self):
+        # residual:  u_xx − C·x   (Poisson with a linear source)
+        # u_xx scale = U/L²; source term g = L²/U; with the ×L rewrite the
+        # effective dimensionless source coefficient is C·L³/U.
+        from jno.trace.unit_log import _additive_terms
+
+        L, U, C0 = 0.2, 100.0, 3.0
+        x = make_var("x").unit("m").scale(L)
+        u = _field(U)
+        C = _coefficient(C0).unit("K/m^3").scale(C0)
+
+        residual = u.d2(x) - C * x
+        transformed, _ = jno.units.rescale(residual)
+
+        terms = _additive_terms(transformed)
+        assert len(terms) == 2
+        # source term g = L²/U  (a double-count bug yields L³/U).  Tolerance is
+        # float32-grade because Literal stores the coefficient as a jax array.
+        g_src = abs(_leading_coeff(terms[1][1]))
+        assert math.isclose(g_src, L**2 / U, rel_tol=1e-5)
+        # a double-count (g = L³/U) would be ~5× off here — well outside 1e-5
+        assert not math.isclose(g_src, L**3 / U, rel_tol=1e-2)
+        # and the bare coordinate x was rewritten to L·x exactly once
+        assert _wraps_coord(terms[1][1], x, L)
+        # effective dimensionless source coefficient = C·L³/U
+        assert math.isclose(g_src * C0 * L, C0 * L**3 / U, rel_tol=1e-5)
+
+    def test_variable_coefficient_bare_x_is_rewritten(self):
+        # residual: (1 + x)·u_xx  — the bare x inside the coefficient must be
+        # rewritten so it stays physical on the rescaled context.
+        L, U = 0.5, 10.0
+        x = make_var("x").unit("m").scale(L)
+        u = _field(U)
+
+        residual = (1.0 + x) * u.d2(x)
+        transformed, _ = jno.units.rescale(residual)
+
+        # the bare x in (1 + x) is wrapped as L·x; the x inside u.d2(x)
+        # (a derivative variable) is left alone.
+        assert _wraps_coord(transformed, x, L)
+
+
+class TestViewUnwrap:
+    def test_rescale_unwraps_a_view(self):
+        # The tutorial field API wraps expressions in views (ScalarView, …);
+        # rescale must unwrap (._expr) before transforming.
+        L, U, alpha0 = 0.3, 20.0, 1e-4
+        x = make_var("x").unit("m").scale(L)
+        t = make_var("t").unit("s").scale(4.0)
+        u = _field(U)
+        alpha = _coefficient(alpha0).unit("m^2/s").scale(alpha0)
+
+        residual = u.d(t) - alpha * u.d2(x)
+        view = residual.scalar  # wrap in a ScalarView
+        from jno.trace.views import _VIEW_TYPES
+
+        assert isinstance(view, _VIEW_TYPES)
+
+        transformed, rescaler = jno.units.rescale(view)
+        from jno.trace import Placeholder
+
+        assert isinstance(transformed, Placeholder)
+        assert not isinstance(transformed, _VIEW_TYPES)
+        assert jno.units.infer(transformed) == Unit.parse("K/s")

--- a/tests/test_nondim.py
+++ b/tests/test_nondim.py
@@ -341,3 +341,57 @@ class TestViewUnwrap:
         assert isinstance(transformed, Placeholder)
         assert not isinstance(transformed, _VIEW_TYPES)
         assert jno.units.infer(transformed) == Unit.parse("K/s")
+
+
+class TestEndToEndSolve:
+    def test_rescaled_solve_recovers_physical_field(self):
+        # Fit a network to a poorly-scaled physical target u*(x) = U·sin(π·x/L)
+        # on x ∈ [0, L] with L, U ≠ 1 (a coordinate-EXPRESSION target — exercises
+        # the bare-coordinate rewrite).  Solve the rescaled O(1) problem, then
+        # check to_physical(û) recovers u* — the genuine solvable round-trip.
+        # (heat_1d as-is has L=τ=U=1 and would pass even with a scale bug.)
+        import foundax
+        import jax
+        import optax
+
+        import jno
+        import jno.jnp_ops as jnn
+
+        L, U = 2.0, 5.0
+        pi = float(jno.np.pi)
+
+        dom = jno.domain(constructor=jno.domain.line(x_range=(0.0, L), mesh_size=L / 40))
+        (x,) = dom.variable("interior")[:1]
+        x = x.unit("m").scale(L)
+
+        net = jnn.nn.wrap(foundax.mlp(1, output_dim=1, hidden_dims=32, num_layers=3, key=jax.random.PRNGKey(0)))
+        net.optimizer(optax.adam(2e-3))
+
+        u_field = net(x).unit("K").scale(U)  # scale attaches to the ModelCall
+        # The amplitude U is a DIMENSIONAL quantity → declare it as a Constant
+        # (a bare float would be a dimensionless Literal and would not be divided
+        # out, leaving the network to learn U·sin instead of the O(1) sin).
+        U_amp = _coefficient(U).unit("K").scale(U)
+        target = U_amp * jnn.sin(pi * x / L)  # physical, coordinate-expression target
+        data = u_field - target
+
+        transformed, rescaler = jno.units.rescale([data], dom)
+        rdom = rescaler.rescaled_domain(dom)
+
+        # original domain context is untouched by the transform
+        import numpy as np
+
+        assert not np.allclose(np.asarray(rdom.context["interior"]), np.asarray(dom.context["interior"]))
+
+        crux = jno.core([transformed[0].mse], domain=rdom)
+        crux.solve(4000)
+
+        # û on the rescaled (O(1)) domain; map back to physical units.
+        u_hat = np.asarray(crux.eval([net(x)], domain=rdom)).reshape(-1)
+        u_phys = rescaler.to_physical(u_hat)
+
+        x_hat = np.asarray(rdom.context["interior"]).reshape(-1)
+        u_exact = U * np.sin(pi * x_hat)  # = U·sin(π·x_phys/L)
+
+        rel_l2 = np.linalg.norm(u_phys - u_exact) / (np.linalg.norm(u_exact) + 1e-8)
+        assert rel_l2 < 0.1, f"rescaled-solve round-trip error too large: {rel_l2:.3e}"

--- a/tests/test_nondim.py
+++ b/tests/test_nondim.py
@@ -1,0 +1,121 @@
+"""Tests for automatic de-dimensionalization (``jno.units.nondimensionalize``).
+
+Phase A: per-variable characteristic scales, the magnitude walk, and the
+dimensionless groups (Fourier / Péclet) it recovers.
+"""
+
+import math
+
+import jno
+from jno.trace.units import Unit
+from tests.conftest import make_var
+
+
+# ======================================================================
+# Scale-declaration API
+# ======================================================================
+class TestScaleApi:
+    def test_scale_sets_slot_and_chains(self):
+        x = make_var("x").unit("m").scale(0.1)
+        assert x._scale == 0.1
+        assert isinstance(x._scale, float)
+        # chains in either order relative to .unit, returns self
+        y = make_var("y").scale(2.0).unit("s")
+        assert y._scale == 2.0 and y._unit == Unit.parse("s")
+
+    def test_undeclared_scale_is_unknown(self):
+        a = make_var("a").unit("m")  # unit but no scale
+        report = jno.units.nondimensionalize(a)
+        # single-term "residual": its magnitude is unknown → π undefined
+        assert report.residuals[0].terms[0].scale is None
+
+
+# ======================================================================
+# Magnitude-walk primitives (mirror the unit propagation tests)
+# ======================================================================
+class TestMagnitudeWalk:
+    def _scale_of(self, node):
+        from jno.trace.unit_log import _scale_of
+
+        return _scale_of(node)
+
+    def test_product_quotient_power(self):
+        a = make_var("a").unit("m").scale(3.0)
+        b = make_var("b").unit("s").scale(2.0)
+        assert self._scale_of(a * b) == 6.0
+        assert self._scale_of(a / b) == 1.5
+        assert self._scale_of(a**2) == 9.0
+
+    def test_jacobian_and_laplacian(self):
+        x = make_var("x").unit("m").scale(4.0)
+        u = make_var("u").unit("K").scale(10.0)
+        assert self._scale_of(u.d(x)) == 10.0 / 4.0
+        assert self._scale_of(u.d2(x)) == 10.0 / 16.0
+
+
+# ======================================================================
+# Discriminating analytic cases — these FAIL a net-unit implementation
+# ======================================================================
+class TestDimensionlessGroups:
+    def test_heat_equation_fourier_number(self):
+        # ∂u/∂t = α ∂²u/∂x²  →  Fourier number Fo = α₀ τ / L²
+        L, tau, U, alpha0 = 0.1, 5.0, 50.0, 1e-5
+        x = make_var("x").unit("m").scale(L)
+        t = make_var("t").unit("s").scale(tau)
+        u = make_var("u").unit("K").scale(U)
+        alpha = make_var("alpha").unit("m^2/s").scale(alpha0)
+
+        residual = u.d(t) - alpha * u.d2(x)
+        report = jno.units.nondimensionalize(residual)
+        terms = report.residuals[0].terms
+        assert len(terms) == 2
+
+        # term 0 = ∂u/∂t (U/τ), term 1 = α ∂²u/∂x² (α₀ U / L²)
+        ratio = terms[1].pi / terms[0].pi
+        assert math.isclose(ratio, alpha0 * tau / L**2, rel_tol=1e-9)
+        # both terms are dimensionally identical (K/s) — the physics is in π
+        assert terms[0].unit == terms[1].unit == Unit.parse("K/s")
+
+    def test_advection_diffusion_peclet_number(self):
+        # ∂u/∂t + V ∂u/∂x = α ∂²u/∂x²  →  Péclet Pe = V L / α₀
+        L, tau, U, V0, alpha0 = 0.2, 3.0, 50.0, 2.0, 1e-4
+        x = make_var("x").unit("m").scale(L)
+        t = make_var("t").unit("s").scale(tau)
+        u = make_var("u").unit("K").scale(U)
+        vel = make_var("vel").unit("m/s").scale(V0)
+        alpha = make_var("alpha").unit("m^2/s").scale(alpha0)
+
+        residual = u.d(t) + vel * u.d(x) - alpha * u.d2(x)
+        report = jno.units.nondimensionalize(residual)
+        terms = report.residuals[0].terms
+        assert len(terms) == 3
+
+        # advection term (index 1) / diffusion term (index 2) = Péclet
+        peclet = terms[1].pi / terms[2].pi
+        assert math.isclose(peclet, V0 * L / alpha0, rel_tol=1e-9)
+
+    def test_ref_term_normalisation(self):
+        # the reference term's π is 1 by construction
+        x = make_var("x").unit("m").scale(0.1)
+        t = make_var("t").unit("s").scale(5.0)
+        u = make_var("u").unit("K").scale(50.0)
+        alpha = make_var("alpha").unit("m^2/s").scale(1e-5)
+        report = jno.units.nondimensionalize(u.d(t) - alpha * u.d2(x))
+        r = report.residuals[0]
+        assert r.terms[r.ref_index].pi == 1.0
+
+
+# ======================================================================
+# Report file
+# ======================================================================
+class TestReport:
+    def test_writes_report(self, tmp_path):
+        x = make_var("x").unit("m").scale(0.1)
+        t = make_var("t").unit("s").scale(5.0)
+        u = make_var("u").unit("K").scale(50.0)
+        alpha = make_var("alpha").unit("m^2/s").scale(1e-5)
+        path = tmp_path / "nondim.txt"
+        jno.units.nondimensionalize(u.d(t) - alpha * u.d2(x), report=str(path))
+        assert path.exists()
+        text = path.read_text()
+        assert "π=" in text and "residual:" in text

--- a/tests/test_nondim.py
+++ b/tests/test_nondim.py
@@ -119,3 +119,114 @@ class TestReport:
         assert path.exists()
         text = path.read_text()
         assert "π=" in text and "residual:" in text
+
+
+# ======================================================================
+# Phase B — transform to a solvable dimensionless problem
+# ======================================================================
+def _coefficient(value):
+    """A realistic dimensional coefficient leaf (Constant, not a bare Variable)."""
+    import jax.numpy as jnp
+
+    from jno.trace import Constant
+
+    return Constant("P", "c", jnp.asarray(value))
+
+
+def _leading_coeff(term_node):
+    """Effective scalar coefficient prepended to a transformed additive term."""
+    from jno.trace import BinaryOp, Literal
+
+    if isinstance(term_node, BinaryOp) and term_node.op == "*" and isinstance(term_node.left, Literal):
+        return float(term_node.left.value)
+    return 1.0
+
+
+class TestRescaleTransform:
+    def test_heat_transform_coefficient_is_fourier(self):
+        # The transformed diffusion term's effective dimensionless coefficient,
+        # combined with the physical α₀, is exactly the Fourier number ατ/L².
+        from jno.trace.unit_log import _additive_terms
+
+        L, tau, U, alpha0 = 0.1, 5.0, 50.0, 1e-5
+        x = make_var("x").unit("m").scale(L)
+        t = make_var("t").unit("s").scale(tau)
+        u = make_var("u").unit("K").scale(U)
+        alpha = _coefficient(alpha0).unit("m^2/s").scale(alpha0)
+
+        residual = u.d(t) - alpha * u.d2(x)
+        transformed, rescaler = jno.units.rescale(residual)
+
+        terms = _additive_terms(transformed)
+        assert len(terms) == 2
+        # time term is the reference → g = 1 (no Literal prepended)
+        assert _leading_coeff(terms[0][1]) == 1.0
+        # diffusion term: |g| = τ/L²  ⇒  |g|·α₀ = Fourier
+        g_diff = abs(_leading_coeff(terms[1][1]))
+        assert math.isclose(g_diff, tau / L**2, rel_tol=1e-9)
+        assert math.isclose(g_diff * alpha0, alpha0 * tau / L**2, rel_tol=1e-9)
+        assert isinstance(rescaler, jno.units.Rescaler)
+
+    def test_transform_is_not_symbolically_dimensionless(self):
+        # The graph keeps dimensional coords/coefficients; dimensionlessness is
+        # realized numerically on the rescaled context (documents the design).
+        x = make_var("x").unit("m").scale(0.1)
+        t = make_var("t").unit("s").scale(5.0)
+        u = make_var("u").unit("K").scale(50.0)
+        alpha = _coefficient(1e-5).unit("m^2/s").scale(1e-5)
+        transformed, _ = jno.units.rescale(u.d(t) - alpha * u.d2(x))
+        assert jno.units.infer(transformed) == Unit.parse("K/s")
+
+
+class TestRescaler:
+    def test_rescaled_context_scales_columns(self):
+        import numpy as np
+
+        from jno.trace.unit_log import Rescaler
+
+        # one tag "xy" with x in column 0 (L=0.1) and y in column 1 (L=0.2)
+        rescaler = Rescaler([("xy", (0, 1), 0.1), ("xy", (1, 2), 0.2)], field_scale=50.0)
+        ctx = {"xy": np.array([[2.0, 4.0], [6.0, 8.0]])}
+        out = rescaler.rescaled_context(ctx)
+        assert np.allclose(out["xy"][:, 0], [20.0, 60.0])  # /0.1
+        assert np.allclose(out["xy"][:, 1], [20.0, 40.0])  # /0.2
+        # original untouched
+        assert np.allclose(ctx["xy"], [[2.0, 4.0], [6.0, 8.0]])
+
+    def test_rescaled_domain_does_not_mutate_original(self):
+        import types
+
+        import numpy as np
+
+        from jno.trace.unit_log import Rescaler
+
+        dom = types.SimpleNamespace(context={"x": np.array([[1.0], [2.0]])})
+        rescaler = Rescaler([("x", (0, 1), 0.5)], field_scale=10.0)
+        new = rescaler.rescaled_domain(dom)
+        assert np.allclose(new.context["x"], [[2.0], [4.0]])  # /0.5
+        assert np.allclose(dom.context["x"], [[1.0], [2.0]])  # original intact
+
+    def test_to_physical_applies_field_scale(self):
+        import numpy as np
+
+        from jno.trace.unit_log import Rescaler
+
+        rescaler = Rescaler([], field_scale=50.0)
+        assert np.allclose(rescaler.to_physical(np.array([0.5, 1.0])), [25.0, 50.0])
+
+    def test_role_classification_by_node_type(self):
+        # The crux of a *solvable* transform: tell coordinates (domain Variables)
+        # apart from the field (TrialFunction/Model) and coefficients (Constant)
+        # by node type — they share units but get different rescaling operations.
+        from jno.trace import TrialFunction
+        from jno.trace.unit_log import _collect_scaled_leaves
+
+        x = make_var("x").unit("m").scale(0.1)
+        u = TrialFunction("u").unit("K").scale(50.0)  # the field
+        alpha = _coefficient(1e-5).unit("m^2/s").scale(1e-5)  # a coefficient
+
+        coords, field_scale = _collect_scaled_leaves([alpha * u.d2(x)])
+        assert field_scale == 50.0  # field U picked up from the TrialFunction
+        coord_tags = {tag for tag, _, _ in coords}
+        assert x.tag in coord_tags  # the coordinate is rescaled
+        assert "u" not in coord_tags  # the field is NOT a coordinate

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,192 @@
+"""Tests for graph-time dimensional analysis (``jno.units``).
+
+Covers the :class:`Unit` algebra, the inference walk's propagation rules, the
+dimensional-consistency warnings, and the PINN / FEM smoke paths.
+"""
+
+import jax.numpy as jnp
+
+import jno
+from jno.trace import FunctionCall, TrialFunction
+from jno.trace.units import DIMENSIONLESS, Unit
+from tests.conftest import make_var
+
+
+# ======================================================================
+# Unit algebra
+# ======================================================================
+class TestUnitAlgebra:
+    def test_parse_round_trips(self):
+        assert Unit.parse("m") == Unit({"m": 1})
+        assert Unit.parse("K") == Unit({"K": 1})
+        assert Unit.parse("m/s") == Unit({"m": 1, "s": -1})
+        assert Unit.parse("kg/m^3") == Unit({"kg": 1, "m": -3})
+        assert Unit.parse("Pa") == Unit({"kg": 1, "m": -1, "s": -2})
+
+    def test_parse_power_syntaxes_agree(self):
+        # '^', '**', and bare-digit spellings are equivalent.
+        assert Unit.parse("m^2") == Unit.parse("m**2") == Unit({"m": 2})
+
+    def test_dimensionless_spellings(self):
+        for spec in ("", "1", "-", "rad"):
+            assert Unit.parse(spec).is_dimensionless()
+        assert DIMENSIONLESS.is_dimensionless()
+
+    def test_mul_div_pow(self):
+        assert Unit.parse("m") * Unit.parse("s^-1") == Unit.parse("m/s")
+        assert Unit.parse("m") / Unit.parse("s") == Unit.parse("m/s")
+        assert Unit.parse("m") ** 3 == Unit.parse("m^3")
+
+    def test_sqrt_is_half_power(self):
+        # sqrt(m^2) == m, exactly (Fraction-backed exponents).
+        assert (Unit.parse("m^2") ** 0.5) == Unit.parse("m")
+
+    def test_equality_independent_of_spelling(self):
+        assert Unit.parse("m s^-1") == Unit.parse("m/s")
+        assert hash(Unit.parse("m/s")) == hash(Unit.parse("m s^-1"))
+
+
+# ======================================================================
+# Propagation rules (queried via the non-mutating inference walk)
+# ======================================================================
+class TestPropagation:
+    def test_jacobian(self):
+        x = make_var("x").unit("m")
+        u = make_var("u").unit("K")
+        assert jno.units.infer(u.d(x)) == Unit.parse("K/m")
+
+    def test_second_derivative_is_target_over_var_squared(self):
+        # d2/dd build a trace=True Hessian (Laplacian); K / m^2.
+        x = make_var("x").unit("m")
+        u = make_var("u").unit("K")
+        assert jno.units.infer(u.d2(x)) == Unit.parse("K/m^2")
+
+    def test_full_hessian_single_var_is_second_order(self):
+        # .hessian(x) is trace=False; a single variable still yields K/m^2
+        # (the dimensionally-correct rule, not the plan's K/m).
+        x = make_var("x").unit("m")
+        u = make_var("u").unit("K")
+        assert jno.units.infer(u.hessian(x)) == Unit.parse("K/m^2")
+
+    def test_product_and_quotient(self):
+        a = make_var("a").unit("m")
+        b = make_var("b").unit("s")
+        assert jno.units.infer(a * b) == Unit.parse("m*s")
+        assert jno.units.infer(a / b) == Unit.parse("m/s")
+
+    def test_power(self):
+        a = make_var("a").unit("m")
+        assert jno.units.infer(a**3) == Unit.parse("m^3")
+
+    def test_undeclared_leaf_is_unknown(self):
+        a = make_var("a")  # no unit declared
+        assert jno.units.infer(a) is None
+        # an op touching an unknown operand stays unknown, without warning
+        b = make_var("b").unit("m")
+        logger = jno.units.check([a * b])
+        assert logger.entries[-1][1] is None
+        assert logger.warnings == []
+
+
+# ======================================================================
+# Dimensional-consistency warnings
+# ======================================================================
+class TestWarnings:
+    def test_add_mismatch_warns(self):
+        u = make_var("u").unit("K")
+        v = make_var("v").unit("Pa")
+        logger = jno.units.check([u + v])
+        assert any("mismatch" in w for w in logger.warnings)
+
+    def test_add_match_is_silent(self):
+        u = make_var("u").unit("K")
+        w = make_var("w").unit("K")
+        logger = jno.units.check([u + w])
+        assert logger.warnings == []
+
+    def test_exp_of_dimensioned_arg_warns(self):
+        theta = make_var("theta").unit("rad")  # rad is dimensionless → silent
+        logger = jno.units.check([FunctionCall(jnp.exp, [theta])])
+        assert logger.warnings == []
+
+        psi = make_var("psi").unit("K")  # genuinely dimensioned → warns
+        logger = jno.units.check([FunctionCall(jnp.exp, [psi])])
+        assert any("dimensionless" in w for w in logger.warnings)
+
+    def test_exp_result_is_dimensionless(self):
+        psi = make_var("psi").unit("K")
+        assert jno.units.infer(FunctionCall(jnp.exp, [psi])) == DIMENSIONLESS
+
+
+# ======================================================================
+# Smoke tests — PINN heat equation and FEM weak form
+# ======================================================================
+class TestHeatEquationSmoke:
+    def test_heat_equation_terms_agree(self):
+        # ∂u/∂t = alpha ∂²u/∂x²  — both terms must be K/s, no warnings.
+        x = make_var("x").unit("m")
+        t = make_var("t").unit("s")
+        u = make_var("u").unit("K")
+        alpha = make_var("alpha").unit("m^2/s")
+
+        residual = u.d(t) - alpha * u.d2(x)
+        logger = jno.units.check([residual])
+
+        assert jno.units.infer(u.d(t)) == Unit.parse("K/s")
+        assert jno.units.infer(alpha * u.d2(x)) == Unit.parse("K/s")
+        assert logger.warnings == []
+
+
+class TestFemWeakFormSmoke:
+    def test_trial_is_leaf_test_is_dimensionless(self):
+        # TrialFunction carries a user-declared unit (it wraps no Variable, so
+        # it is treated as a leaf); TestFunction is dimensionless by convention.
+        # Imported locally so pytest doesn't try to collect ``TestFunction``.
+        from jno.trace import TestFunction
+
+        u = TrialFunction("u").unit("K")
+        phi = TestFunction("phi")
+        x = make_var("x").unit("m")
+
+        assert jno.units.infer(u) == Unit.parse("K")
+        assert jno.units.infer(phi) == DIMENSIONLESS
+        # a flux-like weak term inherits the trial unit through the derivative
+        assert jno.units.infer(u.d(x)) == Unit.parse("K/m")
+
+    def test_check_on_integrated_weak_form(self):
+        # A faithful pre-assembly weak form — the kind passed to jno.fem([...]):
+        #   ∫ (∇u·∇φ − f φ) dΩ   (steady diffusion residual).
+        # check() must traverse the TrialFunction/TestFunction/Jacobian/Integral
+        # tree without crashing, propagate units to the root, and list the
+        # trial/test symbols among its entries.
+        from jno.trace import Integral, TestFunction
+
+        u = TrialFunction("u").unit("K")
+        phi = TestFunction("phi")
+        x = make_var("x").unit("m")
+        f = make_var("f").unit("K/m^2")  # source matched to the Laplacian term
+
+        weak = (u.d(x) * phi.d(x) - f * phi).integrate(x)
+        logger = jno.units.check([weak])
+
+        # root is an Integral and its unit is derivable (terms agree → no warns)
+        assert isinstance(weak, Integral)
+        assert logger.entries[-1][1] is not None
+        assert logger.warnings == []
+
+        # the trial and test symbols were actually visited
+        labels = [label for label, _, _ in logger.entries]
+        assert any("TrialFunction" in lbl for lbl in labels)
+        assert any("TestFunction" in lbl for lbl in labels)
+
+
+class TestLogFile:
+    def test_writes_log(self, tmp_path):
+        x = make_var("x").unit("m")
+        u = make_var("u").unit("K")
+        path = tmp_path / "units.log"
+        logger = jno.units.check([u.d(x)], log=str(path))
+        assert path.exists()
+        text = path.read_text()
+        assert "K·m⁻¹" in text or "K/m" in text
+        assert logger.entries  # at least the leaves + the Jacobian


### PR DESCRIPTION
Adds a `jno.units` module: physical units and characteristic scales on traced
variables, dimensional auditing, and automatic non-dimensionalization of a PINN
problem into a solvable O(1) form with a back-map to physical units.

## API
- `Placeholder.unit(spec)` / `Placeholder.scale(value)` — chainable graph-time metadata
  (dimension and characteristic magnitude; orthogonal).
- `jno.units.check(nodes, log=)` / `infer(node)` — infer every node's unit; flag
  mismatches (`u+v` of unlike units, dimensioned `exp/log/sin` arguments).
- `jno.units.nondimensionalize(nodes, ...)` — per-term magnitude walk → dimensionless
  groups (recovers Fourier, Péclet, Thiele, Helmholtz numbers). Analysis only.
- `jno.units.rescale(constraints, domain)` → `(transformed, Rescaler)` — transforms the
  constraint graph to a dimensionless O(1) problem; `Rescaler` rescales the coordinate
  context and maps the solution back (`u = U·û(x/L)`).

## How it works
- Magnitude walk mirrors the unit walk; the dimensionless group of an additive term is
  its coordinate+field magnitude over a reference term's magnitude (coefficients excluded).
- Coordinate-dependent analytic targets (e.g. a manufactured `sin(πx/L)`) handled by a
  `cse`-style bare-coordinate rewrite (`x → L·x`) so they stay physical on the rescaled
  context; the view/`.bind` field API (`net(t,x).scalar.bind(...)`, `u.t`, `u.xx`) is
  unwrapped first. The transform is non-mutating.

## Validation
- `tests/test_units.py`, `tests/test_nondim.py` — unit algebra, propagation, mismatch
  warnings, the magnitude walk, the bare-coordinate rewrite (discriminating linear-source /
  variable-coefficient cases), view unwrap, and an end-to-end rescaled-solve round-trip that
  recovers a known physical field (L, U ≠ 1).

## Scope
PINN-specific (the benefit is loss-term balancing for gradient descent). It does not apply
to `jno.fem` (a direct linear solve breaks the weak-form structure and gains nothing from
rescaling); FEM is explicitly out of scope.