### PR TITLE
Matrix-free, dependency-free solvers for fem.solve()

### DIFF
--- a/bench_dense_vs_sparse.py
+++ b/bench_dense_vs_sparse.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+"""Dense direct vs. sparse matrix-free solve, benchmarked on the GPU.
+
+A 2D Poisson Dirichlet problem (manufactured solution u = x(1-x)y(1-y)) is
+assembled through jNO/feax into a sparse BCOO stiffness matrix, then solved two
+ways at increasing DOF count:
+
+  * dense   -- jnp.linalg.solve on the densified (N x N) matrix  [the current
+               fem.solve() default; cuSolver LU]
+  * sparse  -- lineax CG, matrix-free, wrapping the BCOO matvec v -> A @ v
+               (the path that never forms the N x N matrix)
+
+Both are timed solve-only (densification is treated purely as the memory
+ceiling, not as solve cost). CG rtol is tight so its accuracy matches the dense
+solve -- the two time-lines are compared at *equal accuracy*. CG iteration count
+is logged because unpreconditioned 2D-Poisson CG grows ~O(sqrt(N)), so the
+sparse line bends upward; that is reported, not hidden.
+
+Each (mesh_size, method) runs in its own subprocess (``--worker``) so a dense
+out-of-memory cannot take down the shared desktop GPU: dense is *skipped* (never
+attempted) above a memory budget computed from the actually-free VRAM.
+
+Run:  uv run --no-sync python bench_dense_vs_sparse.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# mesh sizes -> roughly dofs ~ 1.2 / mesh_size**2  (513 @ .05 ... ~45k @ .0052)
+MESH_SIZES = [0.05, 0.028, 0.02, 0.0155, 0.0123, 0.01, 0.008, 0.0065, 0.0052]
+REPS = 5            # timed repetitions (median reported), after 1 warmup
+CG_RTOL = 1e-8     # tight -> CG accuracy tracks the dense direct solve
+CG_MAX_STEPS = 60000
+RESULT_TAG = "RESULT "
+
+
+# ===========================================================================
+# worker: one (mesh_size, method) measurement in an isolated process
+# ===========================================================================
+def run_worker(mesh_size: float, method: str) -> None:
+    # let XLA grow rather than grab the whole card (shared with the desktop)
+    os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+    import jax
+    jax.config.update("jax_enable_x64", True)  # feax assembly is float64
+    import jax.numpy as jnp
+    import numpy as np
+    from shapely.geometry import box
+
+    import jno
+
+    out: dict = {"method": method, "mesh_size": mesh_size, "status": "ok"}
+
+    def emit(d):
+        print(RESULT_TAG + json.dumps(d), flush=True)
+
+    # -- assemble the Poisson system -> sparse BCOO (A, b) -------------------
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=2)
+    A, b = fem.operator                      # A is jax.experimental.sparse.BCOO
+    b = jnp.asarray(b).reshape(-1)
+    n = int(b.shape[0])
+    out["dofs"] = n
+    out["nnz"] = int(getattr(A, "nse", 0))
+
+    # exact nodal solution for the equal-accuracy check
+    pts = np.asarray(fem.points)[:, :2]
+    u_exact = jnp.asarray(pts[:, 0] * (1 - pts[:, 0]) * pts[:, 1] * (1 - pts[:, 1]))
+
+    def rel_err(uh):
+        return float(jnp.linalg.norm(uh - u_exact) / jnp.linalg.norm(u_exact))
+
+    def timed(fn):
+        fn()  # warmup / compile
+        ts = []
+        for _ in range(REPS):
+            t0 = time.perf_counter()
+            r = fn()
+            jax.block_until_ready(r)
+            ts.append(time.perf_counter() - t0)
+        return float(np.median(ts)), float(np.min(ts))
+
+    try:
+        if method == "dense":
+            A_dense = jnp.asarray(A.todense())
+            # one-time symmetry assertion: CG/SPD validity, fail loudly otherwise
+            assert bool(jnp.allclose(A_dense, A_dense.T, atol=1e-8)), "stiffness not symmetric"
+            solve = jax.jit(jnp.linalg.solve)
+            t_med, t_min = timed(lambda: solve(A_dense, b))
+            out.update(time_med_s=t_med, time_min_s=t_min,
+                       rel_err=rel_err(solve(A_dense, b)), iters=None)
+
+        elif method in ("sparse", "dense_cg"):
+            # Same iterative algorithm (CG); the ONLY difference is the matvec
+            # operand -- BCOO A (sparse) vs the densified A (dense_cg). Comparing
+            # these two isolates the effect of *storage*; comparing dense_cg to
+            # the LU "dense" line isolates the effect of *algorithm*.
+            import lineax as lx
+            tags = (lx.positive_semidefinite_tag, lx.symmetric_tag)
+            struct = jax.ShapeDtypeStruct(b.shape, b.dtype)
+            mat = jnp.asarray(A.todense()) if method == "dense_cg" else A
+
+            @jax.jit
+            def solve_cg(b_, _m=mat):
+                op = lx.FunctionLinearOperator(lambda v: _m @ v, struct, tags=tags)
+                sol = lx.linear_solve(
+                    op, b_, lx.CG(rtol=CG_RTOL, atol=1e-12, max_steps=CG_MAX_STEPS)
+                )
+                return sol.value, sol.stats["num_steps"]
+
+            t_med, t_min = timed(lambda: solve_cg(b))
+            uh, iters = solve_cg(b)
+            out.update(time_med_s=t_med, time_min_s=t_min,
+                       rel_err=rel_err(uh), iters=int(iters))
+        else:
+            raise ValueError(method)
+    except Exception as e:  # noqa: BLE001 -- report, don't crash the orchestrator
+        out["status"] = f"error: {type(e).__name__}: {e}"
+
+    emit(out)
+
+
+# ===========================================================================
+# orchestrator
+# ===========================================================================
+def free_vram_mb() -> float:
+    try:
+        q = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, check=True,
+        )
+        return float(q.stdout.strip().splitlines()[0])
+    except Exception:
+        return 4000.0
+
+
+def dense_fits(dofs: int, budget_bytes: float) -> bool:
+    # N*N float64 matrix + ~1x LU workspace -> ~2.2x the matrix
+    return 2.2 * 8 * dofs * dofs < budget_bytes
+
+
+def launch(mesh_size: float, method: str) -> dict | None:
+    env = dict(os.environ, XLA_PYTHON_CLIENT_PREALLOCATE="false", TF_CPP_MIN_LOG_LEVEL="3")
+    proc = subprocess.run(
+        [sys.executable, os.path.abspath(__file__),
+         "--worker", "--mesh-size", str(mesh_size), "--method", method],
+        capture_output=True, text=True, env=env,
+    )
+    for line in proc.stdout.splitlines():
+        if line.startswith(RESULT_TAG):
+            return json.loads(line[len(RESULT_TAG):])
+    sys.stderr.write(proc.stderr[-2000:] + "\n")
+    return None
+
+
+def main() -> None:
+    free = free_vram_mb()
+    # leave ~1.8 GB headroom for the live desktop/compositor; cap dense at <=3 GB
+    budget = max(1.5e9, min(3.0e9, (free - 1800) * 1e6))
+    print(f"free VRAM ~{free:.0f} MB  ->  dense memory budget {budget/1e9:.2f} GB\n")
+
+    def ms_(r):  # solve time in ms or "--"
+        return f"{r['time_med_s']*1e3:9.2f}" if r and r.get("time_med_s") else f"{'--':>9}"
+
+    results: list[dict] = []
+    print(f"{'dofs':>8} {'nnz':>9} | {'LU-dense':>9} {'CG-dense':>9} {'CG-sparse':>9} | "
+          f"{'rel_err':>9} {'cg_it':>6}")
+    print("-" * 76)
+
+    for ms in MESH_SIZES:
+        sp = launch(ms, "sparse")
+        if sp is None:
+            continue
+        dofs = sp["dofs"]
+        fits = dense_fits(dofs, budget)
+        dn = launch(ms, "dense") if fits else \
+            {"method": "dense", "dofs": dofs, "status": "skipped: exceeds mem budget"}
+        dc = launch(ms, "dense_cg") if fits else \
+            {"method": "dense_cg", "dofs": dofs, "status": "skipped: exceeds mem budget"}
+
+        results.append({"dofs": dofs, "nnz": sp.get("nnz"),
+                        "dense": dn, "dense_cg": dc, "sparse": sp})
+
+        serr = f"{sp['rel_err']:9.2e}" if sp.get("rel_err") is not None else f"{'--':>9}"
+        print(f"{dofs:8d} {sp.get('nnz', 0):9d} | {ms_(dn)} {ms_(dc)} {ms_(sp)} | "
+              f"{serr} {sp.get('iters', '--'):>6}")
+
+    with open("bench_dense_vs_sparse.json", "w") as fh:
+        json.dump({"free_vram_mb": free, "budget_bytes": budget, "results": results}, fh, indent=2)
+    print("\nsaved bench_dense_vs_sparse.json")
+    make_plot(results, budget)
+
+
+def make_plot(results: list[dict], budget: float) -> None:
+    import numpy as np
+    import seaborn as sns
+    import matplotlib.pyplot as plt
+
+    sns.set_theme(
+        style="ticks", context="paper", palette="colorblind", font_scale=1.15,
+        rc={
+            "figure.figsize": (6, 4), "figure.dpi": 300, "savefig.dpi": 300,
+            "savefig.bbox": "tight", "legend.frameon": False, "axes.grid": True,
+            "grid.alpha": 0.25, "grid.linestyle": "--",
+            "font.family": "sans-serif",
+            "font.sans-serif": ["Frutiger 45 Light", "Frutiger", "FreeSans", "DejaVu Sans"],
+            "font.weight": "light", "axes.titleweight": "bold", "axes.labelweight": "bold",
+            "xtick.direction": "in", "ytick.direction": "in",
+            "xtick.major.size": 2.5, "ytick.major.size": 2.5,
+        },
+    )
+
+    def line(key):
+        xs = [r["dofs"] for r in results if r[key].get("time_med_s")]
+        ys = [r[key]["time_med_s"] * 1e3 for r in results if r[key].get("time_med_s")]
+        return xs, ys
+
+    d_dof, d_t = line("dense")
+    dc_dof, dc_t = line("dense_cg")
+    s_dof, s_t = line("sparse")
+    s_it = [(r["dofs"], r["sparse"]["iters"]) for r in results
+            if r["sparse"].get("iters") is not None]
+    dense_ceiling = (budget / (2.2 * 8)) ** 0.5  # max DOF dense fits in budget
+
+    fig, (ax, ax2) = plt.subplots(1, 2, figsize=(11, 4.2))
+
+    # -- panel 1: solve time. Two axes of variation, disentangled:
+    #   LU-dense  vs  CG-dense  -> effect of ALGORITHM (direct vs iterative)
+    #   CG-dense  vs  CG-sparse -> effect of STORAGE   (and the memory ceiling)
+    ax.plot(d_dof, d_t, "o-", label="LU,  dense storage  (direct)")
+    ax.plot(dc_dof, dc_t, "^--", label="CG,  dense storage  (iterative)")
+    ax.plot(s_dof, s_t, "s-", label="CG,  sparse/BCOO     (iterative, matrix-free)")
+    ax.axvline(dense_ceiling, color="0.4", lw=1, ls=":")
+    ax.axvspan(dense_ceiling, max(s_dof) * 1.15, color="0.5", alpha=0.08)
+    ax.text(dense_ceiling, ax.get_ylim()[0], "  dense exceeds GPU memory",
+            rotation=90, va="bottom", ha="left", fontsize=8, color="0.35")
+    ax.set_xscale("log"); ax.set_yscale("log")
+    ax.set_xlabel("degrees of freedom  $N$")
+    ax.set_ylabel("solve time  [ms]")
+    ax.set_title("Solve time vs problem size (8 GB GPU, float64)")
+    ax.legend(loc="upper left", fontsize=8)
+    sns.despine(ax=ax)
+
+    # -- panel 2: CG iteration growth ---------------------------------------
+    if s_it:
+        xi = np.array([d for d, _ in s_it]); yi = np.array([i for _, i in s_it])
+        ax2.plot(xi, yi, "s-", color=sns.color_palette("colorblind")[1], label="CG iterations")
+        ref = yi[0] * np.sqrt(xi / xi[0])  # O(sqrt N) reference
+        ax2.plot(xi, ref, "k--", lw=1, alpha=0.7, label=r"$\propto\sqrt{N}$")
+        ax2.set_xscale("log"); ax2.set_yscale("log")
+        ax2.set_xlabel("degrees of freedom  $N$")
+        ax2.set_ylabel("CG iterations to converge")
+        ax2.set_title(f"Unpreconditioned CG cost (rtol={CG_RTOL:g})")
+        ax2.legend(loc="upper left", fontsize=8)
+        sns.despine(ax=ax2)
+
+    fig.savefig("dense_vs_sparse_solve_time.png")
+    print("saved dense_vs_sparse_solve_time.png")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--worker", action="store_true")
+    p.add_argument("--plot-only", action="store_true")
+    p.add_argument("--mesh-size", type=float)
+    p.add_argument("--method", choices=["dense", "dense_cg", "sparse"])
+    a = p.parse_args()
+    if a.worker:
+        run_worker(a.mesh_size, a.method)
+    elif a.plot_only:
+        blob = json.load(open("bench_dense_vs_sparse.json"))
+        make_plot(blob["results"], blob["budget_bytes"])
+    else:
+        main()

--- a/bench_dense_vs_sparse_bicgstab.py
+++ b/bench_dense_vs_sparse_bicgstab.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+"""Dense direct vs. sparse matrix-free solve -- BiCGStab edition.
+
+Same study as ``bench_dense_vs_sparse.py`` but with **BiCGStab** (the new
+``fem.solve`` default) as the iterative method instead of CG, so the picture
+matches what jNO now actually runs. Three matrix-free-comparable paths on the
+same 2D Poisson BCOO system at growing DOF:
+
+  * dense       -- jnp.linalg.solve on the densified matrix (cuSolver LU, direct)
+  * BiCGStab-dense  -- BiCGStab on a *dense* matvec  (iterative, dense storage)
+  * BiCGStab-sparse -- BiCGStab on the *BCOO* matvec (iterative, sparse storage)
+
+LU-dense vs BiCGStab-dense isolates algorithm (direct vs iterative); BiCGStab-dense
+vs BiCGStab-sparse isolates storage (and the memory ceiling). All at equal accuracy
+(driven to residual rtol 1e-8; achieved rel-err + iteration count reported).
+
+Each (mesh_size, method) runs in its own subprocess (``--worker``); dense is skipped
+(never attempted) above a VRAM budget so a real OOM cannot freeze the desktop.
+
+Run:  uv run --no-sync python bench_dense_vs_sparse_bicgstab.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+MESH_SIZES = [0.05, 0.028, 0.02, 0.0155, 0.0123, 0.01, 0.008, 0.0065, 0.0052]
+REPS = 5
+TOL = 1e-8
+MAXIT = 40000
+RESULT_TAG = "RESULT "
+
+
+# ---------------------------------------------------------------------------
+# custom BiCGStab -> returns (x, iters); matrix-free on any matvec
+# ---------------------------------------------------------------------------
+def bicgstab(matvec, b, *, tol=TOL, maxit=MAXIT):
+    import jax
+    import jax.numpy as jnp
+
+    bnorm = jnp.linalg.norm(b)
+    eps = 1e-300
+
+    def cond(s):
+        _, r, *_ , k = s
+        return (jnp.linalg.norm(r) > tol * bnorm) & (k < maxit)
+
+    def body(s):
+        x, r, rhat, rho, alpha, omega, v, p, k = s
+        rho_new = rhat @ r
+        beta = (rho_new / (rho + eps)) * (alpha / (omega + eps))
+        p = r + beta * (p - omega * v)
+        v = matvec(p)
+        alpha = rho_new / (rhat @ v + eps)
+        sv = r - alpha * v
+        t = matvec(sv)
+        omega = (t @ sv) / (t @ t + eps)
+        x = x + alpha * p + omega * sv
+        r = sv - omega * t
+        return x, r, rhat, rho_new, alpha, omega, v, p, k + 1
+
+    x0 = jnp.zeros_like(b)
+    r0 = b - matvec(x0)
+    z = jnp.zeros_like(b)
+    one = jnp.array(1.0, b.dtype)
+    state = (x0, r0, r0, one, one, one, z, z, 0)
+    x, r, *_, k = jax.lax.while_loop(cond, body, state)
+    return x, k
+
+
+# ===========================================================================
+# worker
+# ===========================================================================
+def run_worker(mesh_size: float, method: str) -> None:
+    os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+    import jax
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+    import numpy as np
+    from shapely.geometry import box
+    import jno
+
+    out: dict = {"method": method, "mesh_size": mesh_size, "status": "ok"}
+
+    def emit(d):
+        print(RESULT_TAG + json.dumps(d), flush=True)
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=2)
+    A, b = fem.operator
+    b = jnp.asarray(b).reshape(-1)
+    n = int(b.shape[0])
+    out["dofs"] = n
+    out["nnz"] = int(getattr(A, "nse", 0))
+
+    pts = np.asarray(fem.points)[:, :2]
+    u_exact = jnp.asarray(pts[:, 0] * (1 - pts[:, 0]) * pts[:, 1] * (1 - pts[:, 1]))
+
+    def rel_err(uh):
+        return float(jnp.linalg.norm(uh - u_exact) / jnp.linalg.norm(u_exact))
+
+    def timed(fn):
+        r = fn(); jax.block_until_ready(r)
+        ts = []
+        for _ in range(REPS):
+            t0 = time.perf_counter()
+            r = fn(); jax.block_until_ready(r)
+            ts.append(time.perf_counter() - t0)
+        return float(np.median(ts)), float(np.min(ts))
+
+    try:
+        if method == "dense":
+            A_dense = jnp.asarray(A.todense())
+            assert bool(jnp.allclose(A_dense, A_dense.T, atol=1e-8)), "stiffness not symmetric"
+            solve = jax.jit(jnp.linalg.solve)
+            t_med, t_min = timed(lambda: solve(A_dense, b))
+            out.update(time_med_s=t_med, time_min_s=t_min, rel_err=rel_err(solve(A_dense, b)), iters=None)
+
+        elif method in ("dense_bicg", "sparse_bicg"):
+            mat = jnp.asarray(A.todense()) if method == "dense_bicg" else A
+            solve = jax.jit(lambda b_, _m=mat: bicgstab(lambda v: _m @ v, b_))
+            t_med, t_min = timed(lambda: solve(b)[0])
+            uh, iters = solve(b)
+            out.update(time_med_s=t_med, time_min_s=t_min, rel_err=rel_err(uh), iters=int(iters))
+        else:
+            raise ValueError(method)
+    except Exception as e:  # noqa: BLE001
+        out["status"] = f"error: {type(e).__name__}: {e}"
+
+    emit(out)
+
+
+# ===========================================================================
+# orchestrator
+# ===========================================================================
+def free_vram_mb() -> float:
+    try:
+        q = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, check=True,
+        )
+        return float(q.stdout.strip().splitlines()[0])
+    except Exception:
+        return 4000.0
+
+
+def dense_fits(dofs: int, budget_bytes: float) -> bool:
+    return 2.2 * 8 * dofs * dofs < budget_bytes
+
+
+def launch(mesh_size: float, method: str) -> dict | None:
+    env = dict(os.environ, XLA_PYTHON_CLIENT_PREALLOCATE="false", TF_CPP_MIN_LOG_LEVEL="3")
+    proc = subprocess.run(
+        [sys.executable, os.path.abspath(__file__),
+         "--worker", "--mesh-size", str(mesh_size), "--method", method],
+        capture_output=True, text=True, env=env,
+    )
+    for line in proc.stdout.splitlines():
+        if line.startswith(RESULT_TAG):
+            return json.loads(line[len(RESULT_TAG):])
+    sys.stderr.write(proc.stderr[-2000:] + "\n")
+    return None
+
+
+def main() -> None:
+    free = free_vram_mb()
+    budget = max(1.5e9, min(3.0e9, (free - 1800) * 1e6))
+    print(f"free VRAM ~{free:.0f} MB  ->  dense budget {budget/1e9:.2f} GB\n")
+
+    def ms_(r):
+        return f"{r['time_med_s']*1e3:10.2f}" if r and r.get("time_med_s") else f"{'--':>10}"
+
+    print(f"{'dofs':>7} {'nnz':>9} | {'LU-dense':>10} {'BiCG-dense':>10} {'BiCG-sparse':>11} | "
+          f"{'rel_err':>9} {'bicg_it':>7}")
+    print("-" * 80)
+
+    results: list[dict] = []
+    for ms in MESH_SIZES:
+        sp = launch(ms, "sparse_bicg")
+        if sp is None:
+            continue
+        dofs = sp["dofs"]
+        fits = dense_fits(dofs, budget)
+        dn = launch(ms, "dense") if fits else {"status": "skipped"}
+        dc = launch(ms, "dense_bicg") if fits else {"status": "skipped"}
+        results.append({"dofs": dofs, "nnz": sp.get("nnz"), "dense": dn, "dense_bicg": dc, "sparse": sp})
+        serr = f"{sp['rel_err']:9.2e}" if sp.get("rel_err") is not None else f"{'--':>9}"
+        print(f"{dofs:7d} {sp.get('nnz', 0):9d} | {ms_(dn)} {ms_(dc)} {ms_(sp)} | {serr} {sp.get('iters','--'):>7}")
+
+    with open("bench_dense_vs_sparse_bicgstab.json", "w") as fh:
+        json.dump({"free_vram_mb": free, "budget_bytes": budget, "results": results}, fh, indent=2)
+    print("\nsaved bench_dense_vs_sparse_bicgstab.json")
+    plot(results, budget)
+
+
+def plot(results, budget):
+    import numpy as np
+    import seaborn as sns
+    import matplotlib.pyplot as plt
+
+    sns.set_theme(
+        style="ticks", context="paper", palette="colorblind", font_scale=1.15,
+        rc={"figure.figsize": (6, 4), "figure.dpi": 300, "savefig.dpi": 300,
+            "savefig.bbox": "tight", "legend.frameon": False, "axes.grid": True,
+            "grid.alpha": 0.25, "grid.linestyle": "--", "font.family": "sans-serif",
+            "font.sans-serif": ["Frutiger 45 Light", "FreeSans", "DejaVu Sans"],
+            "font.weight": "light", "axes.titleweight": "bold", "axes.labelweight": "bold",
+            "xtick.direction": "in", "ytick.direction": "in"},
+    )
+
+    def line(key):
+        xs = [r["dofs"] for r in results if r[key].get("time_med_s")]
+        ys = [r[key]["time_med_s"] * 1e3 for r in results if r[key].get("time_med_s")]
+        return xs, ys
+
+    d_dof, d_t = line("dense")
+    dc_dof, dc_t = line("dense_bicg")
+    s_dof, s_t = line("sparse")
+    s_it = [(r["dofs"], r["sparse"]["iters"]) for r in results if r["sparse"].get("iters") is not None]
+    ceiling = (budget / (2.2 * 8)) ** 0.5
+
+    fig, (ax, ax2) = plt.subplots(1, 2, figsize=(11, 4.2))
+    ax.plot(d_dof, d_t, "o-", label="LU,  dense storage  (direct)")
+    ax.plot(dc_dof, dc_t, "^--", label="BiCGStab, dense storage")
+    ax.plot(s_dof, s_t, "s-", label="BiCGStab, sparse/BCOO")
+    ax.axvline(ceiling, color="0.4", lw=1, ls=":")
+    ax.axvspan(ceiling, max(s_dof) * 1.15, color="0.5", alpha=0.08)
+    ax.text(ceiling, ax.get_ylim()[0], "  dense exceeds GPU memory",
+            rotation=90, va="bottom", ha="left", fontsize=8, color="0.35")
+    ax.set_xscale("log"); ax.set_yscale("log")
+    ax.set_xlabel("degrees of freedom  $N$"); ax.set_ylabel("solve time  [ms]")
+    ax.set_title("Solve time: dense vs sparse (BiCGStab)")
+    ax.legend(loc="upper left", fontsize=8); sns.despine(ax=ax)
+
+    if s_it:
+        xi = np.array([d for d, _ in s_it]); yi = np.array([i for _, i in s_it])
+        ax2.plot(xi, yi, "s-", color=sns.color_palette("colorblind")[2], label="BiCGStab iterations")
+        ax2.plot(xi, yi[0] * np.sqrt(xi / xi[0]), "k--", lw=1, alpha=0.7, label=r"$\propto\sqrt{N}$")
+        ax2.set_xscale("log"); ax2.set_yscale("log")
+        ax2.set_xlabel("degrees of freedom  $N$"); ax2.set_ylabel("BiCGStab iterations")
+        ax2.set_title(f"Iteration growth (rtol={TOL:g})")
+        ax2.legend(loc="upper left", fontsize=8); sns.despine(ax=ax2)
+
+    fig.tight_layout()
+    fig.savefig("dense_vs_sparse_bicgstab.png")
+    print("saved dense_vs_sparse_bicgstab.png")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--worker", action="store_true")
+    p.add_argument("--plot-only", action="store_true")
+    p.add_argument("--mesh-size", type=float)
+    p.add_argument("--method", choices=["dense", "dense_bicg", "sparse_bicg"])
+    a = p.parse_args()
+    if a.worker:
+        run_worker(a.mesh_size, a.method)
+    elif a.plot_only:
+        blob = json.load(open("bench_dense_vs_sparse_bicgstab.json"))
+        plot(blob["results"], blob["budget_bytes"])
+    else:
+        main()

--- a/bench_solvers.py
+++ b/bench_solvers.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""Linear-FEM solve: library solvers vs hand-rolled custom code.
+
+Same 2D Poisson BCOO system, four matrix-free conjugate-gradient paths, timed
+end-to-end at equal accuracy (all driven to residual rtol 1e-8; achieved rel-err
+and iteration count reported so the comparison is honest):
+
+  1. lineax        -- lx.CG via lx.linear_solve            (library)
+  2. jax.scipy     -- jax.scipy.sparse.linalg.cg           (native JAX)
+  3. custom        -- a CG written here in ~12 lines, one fused jax.jit
+  4. custom+Jacobi -- the same CG with a diagonal preconditioner
+
+Everything is matrix-free on A @ v (BCOO), so there is no dense matrix and no
+memory wall -- this runs single-process across sizes.
+
+What to watch (the "dynamics"):
+  * library vs custom -> per-solve overhead of the library (lineax is heaviest)
+  * custom vs custom+Jacobi -> whether diagonal scaling helps (for constant-
+    coefficient Poisson on a quasi-uniform mesh it barely does -- the diagonal
+    is nearly constant; Jacobi pays off on heterogeneous / graded problems)
+
+Run:  uv run --no-sync python bench_solvers.py
+"""
+from __future__ import annotations
+
+import os
+import time
+
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+from shapely.geometry import box
+
+import lineax as lx
+import jno
+
+MESH_SIZES = [0.02, 0.0123, 0.008, 0.0052]   # ~3k ... ~43k DOF
+TOL = 1e-8
+MAXIT = 100_000
+REPS = 5
+
+
+# ---------------------------------------------------------------------------
+# custom matrix-free CG (this is the "implement it in jNO" core -- ~12 lines)
+# ---------------------------------------------------------------------------
+def cg_solve(matvec, b, *, minv=None, tol=TOL, maxit=MAXIT):
+    """Preconditioned CG. minv=None -> identity (plain CG). Fully traceable."""
+    bnorm = jnp.linalg.norm(b)
+    apply_minv = (lambda r: r) if minv is None else (lambda r: minv * r)
+
+    def cond(state):
+        _, r, _, _, k = state
+        return (jnp.linalg.norm(r) > tol * bnorm) & (k < maxit)
+
+    def body(state):
+        x, r, p, rz, k = state
+        Ap = matvec(p)
+        alpha = rz / (p @ Ap)
+        x = x + alpha * p
+        r = r - alpha * Ap
+        z = apply_minv(r)
+        rz_new = r @ z
+        p = z + (rz_new / rz) * p
+        return x, r, p, rz_new, k + 1
+
+    x0 = jnp.zeros_like(b)
+    r0 = b - matvec(x0)
+    z0 = apply_minv(r0)
+    state = (x0, r0, z0, r0 @ z0, 0)
+    x, r, p, rz, k = jax.lax.while_loop(cond, body, state)
+    return x, k
+
+
+def poisson(mesh_size):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=2)
+    A, b = fem.operator
+    b = jnp.asarray(b).reshape(-1)
+    n = int(b.shape[0])
+    idx = A.indices
+    diag = jnp.zeros(n, b.dtype).at[idx[:, 0]].add(
+        jnp.where(idx[:, 0] == idx[:, 1], A.data, 0.0))   # diag(A) without densifying
+    pts = np.asarray(fem.points)[:, :2]
+    u_exact = jnp.asarray(pts[:, 0] * (1 - pts[:, 0]) * pts[:, 1] * (1 - pts[:, 1]))
+    return A, b, n, 1.0 / diag, u_exact
+
+
+def make_solvers(A, b, minv):
+    mv = lambda v: A @ v
+    struct = jax.ShapeDtypeStruct(b.shape, b.dtype)
+    tags = (lx.positive_semidefinite_tag, lx.symmetric_tag)
+
+    @jax.jit
+    def s_lineax(b_):
+        op = lx.FunctionLinearOperator(mv, struct, tags=tags)
+        sol = lx.linear_solve(op, b_, lx.CG(rtol=TOL, atol=1e-14, max_steps=MAXIT))
+        return sol.value, sol.stats["num_steps"]
+
+    @jax.jit
+    def s_jsp(b_):
+        x, _ = jax.scipy.sparse.linalg.cg(mv, b_, tol=TOL, atol=0.0, maxiter=MAXIT)
+        return x, jnp.array(-1)            # jax.scipy.cg doesn't expose iters
+
+    s_custom = jax.jit(lambda b_: cg_solve(mv, b_))
+    s_jacobi = jax.jit(lambda b_: cg_solve(mv, b_, minv=minv))
+    return {"lineax": s_lineax, "jax.scipy": s_jsp,
+            "custom": s_custom, "custom+Jacobi": s_jacobi}
+
+
+def time_solver(fn, b, u_exact):
+    x, it = fn(b); jax.block_until_ready(x)            # warmup / compile
+    rel = float(jnp.linalg.norm(x - u_exact) / jnp.linalg.norm(u_exact))
+    ts = []
+    for _ in range(REPS):
+        t0 = time.perf_counter()
+        x, _ = fn(b); jax.block_until_ready(x)
+        ts.append(time.perf_counter() - t0)
+    return float(np.median(ts)), int(it), rel
+
+
+def main():
+    names = ["lineax", "jax.scipy", "custom", "custom+Jacobi"]
+    print(f"{'dofs':>7} | " + " | ".join(f"{n:>16}" for n in names))
+    print(f"{'':>7} | " + " | ".join(f"{'ms':>7} {'it':>4} {'err':>3}" for _ in names))
+    print("-" * 95)
+
+    results = []
+    for ms in MESH_SIZES:
+        A, b, n, minv, u_exact = poisson(ms)
+        solvers = make_solvers(A, b, minv)
+        row = {"dofs": n}
+        cells = []
+        for name in names:
+            t, it, rel = time_solver(solvers[name], b, u_exact)
+            row[name] = {"ms": t * 1e3, "iters": it, "rel_err": rel}
+            itxt = f"{it:4d}" if it >= 0 else "  --"
+            cells.append(f"{t*1e3:7.1f} {itxt} {rel:6.0e}".replace("e-0", "e-"))
+        results.append(row)
+        print(f"{n:7d} | " + " | ".join(cells))
+
+    plot(results, names)
+
+
+def plot(results, names):
+    import seaborn as sns
+    import matplotlib.pyplot as plt
+
+    sns.set_theme(
+        style="ticks", context="paper", palette="colorblind", font_scale=1.15,
+        rc={"figure.figsize": (6, 4), "figure.dpi": 300, "savefig.dpi": 300,
+            "savefig.bbox": "tight", "legend.frameon": False, "axes.grid": True,
+            "grid.alpha": 0.25, "grid.linestyle": "--", "font.family": "sans-serif",
+            "font.sans-serif": ["Frutiger 45 Light", "FreeSans", "DejaVu Sans"],
+            "font.weight": "light", "axes.titleweight": "bold", "axes.labelweight": "bold",
+            "xtick.direction": "in", "ytick.direction": "in"},
+    )
+    dof = [r["dofs"] for r in results]
+    markers = {"lineax": "o-", "jax.scipy": "v-", "custom": "s-", "custom+Jacobi": "D-"}
+    fig, (ax, ax2) = plt.subplots(1, 2, figsize=(11, 4.2))
+    for name in names:
+        ax.plot(dof, [r[name]["ms"] for r in results], markers[name], label=name)
+    ax.set_xscale("log"); ax.set_yscale("log")
+    ax.set_xlabel("degrees of freedom  $N$"); ax.set_ylabel("full solve time  [ms]")
+    ax.set_title("Solve time: library vs custom CG")
+    ax.legend(loc="upper left", fontsize=8); sns.despine(ax=ax)
+
+    for name in ("lineax", "custom", "custom+Jacobi"):
+        its = [r[name]["iters"] for r in results]
+        if all(i >= 0 for i in its):
+            ax2.plot(dof, its, markers[name], label=name)
+    ax2.set_xscale("log"); ax2.set_yscale("log")
+    ax2.set_xlabel("degrees of freedom  $N$"); ax2.set_ylabel("CG iterations")
+    ax2.set_title("CG iterations (Jacobi ~ no-op here)")
+    ax2.legend(loc="upper left", fontsize=8); sns.despine(ax=ax2)
+    fig.tight_layout()
+    fig.savefig("solver_comparison.png")
+    print("\nsaved solver_comparison.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_spmv_kernels.py
+++ b/bench_spmv_kernels.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""How far is BCOO's matvec from a hand-written CUDA SpMV kernel?
+
+The work inside CG is one sparse mat-vec per iteration, y = A @ v. This times
+that single op two ways on the *same* Poisson stiffness matrix:
+
+  * BCOO  -- jax.experimental.sparse, lowered by XLA to gather/segment-sum
+  * cuSPARSE -- NVIDIA's hand-tuned CUDA SpMV kernel, via CuPy's CSR matvec
+
+Same matrix, same vector, same timing protocol (chained power-iteration so XLA
+can't constant-fold the repeats; one device sync per batch). The ratio is the
+headroom a custom kernel could recover over BCOO.
+
+Run:  uv run --no-sync python bench_spmv_kernels.py
+"""
+from __future__ import annotations
+
+import os
+import time
+
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+import scipy.sparse as sp
+from shapely.geometry import box
+
+import cupy as cp
+import cupyx.scipy.sparse as cusp
+import jno
+
+MESH_SIZES = [0.02, 0.0123, 0.008, 0.0052]   # ~3k, 8k, 18k, 43k DOF
+CHAIN = 50          # matvecs per timed batch (amortizes launch/dispatch overhead)
+BATCHES = 20        # batches -> median
+
+
+def poisson_bcoo(mesh_size):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=2)
+    A, _ = fem.operator
+    return A, int(A.shape[0]), int(A.nse)
+
+
+def time_jax(A, n):
+    # chained matvec with renormalisation -> not constant-foldable, no overflow
+    @jax.jit
+    def chain(v):
+        def body(_, x):
+            y = A @ x
+            return y / jnp.linalg.norm(y)
+        return jax.lax.fori_loop(0, CHAIN, body, v)
+    v = jnp.ones((n,), jnp.float64)
+    chain(v).block_until_ready()           # warmup / compile
+    ts = []
+    for _ in range(BATCHES):
+        t0 = time.perf_counter()
+        chain(v).block_until_ready()
+        ts.append((time.perf_counter() - t0) / CHAIN)
+    return float(np.median(ts))
+
+
+def time_cusparse(A, n):
+    coo = sp.coo_matrix(
+        (np.asarray(A.data), (np.asarray(A.indices)[:, 0], np.asarray(A.indices)[:, 1])),
+        shape=(n, n),
+    )
+    A_cp = cusp.csr_matrix(coo.tocsr())     # cuSPARSE-backed CSR
+    v = cp.ones((n,), cp.float64)
+    for _ in range(CHAIN):                  # warmup
+        v = A_cp @ v
+        v /= cp.linalg.norm(v)
+    cp.cuda.runtime.deviceSynchronize()
+    ts = []
+    for _ in range(BATCHES):
+        v = cp.ones((n,), cp.float64)
+        cp.cuda.runtime.deviceSynchronize()
+        t0 = time.perf_counter()
+        for _ in range(CHAIN):
+            v = A_cp @ v
+            v /= cp.linalg.norm(v)
+        cp.cuda.runtime.deviceSynchronize()
+        ts.append((time.perf_counter() - t0) / CHAIN)
+    return float(np.median(ts))
+
+
+def main():
+    print(f"{'dofs':>8} {'nnz':>9} | {'BCOO us':>9} {'cuSPARSE us':>12} {'speedup':>8}")
+    print("-" * 56)
+    rows = []
+    for ms in MESH_SIZES:
+        A, n, nnz = poisson_bcoo(ms)
+        t_j = time_jax(A, n)
+        t_c = time_cusparse(A, n)
+        rows.append((n, nnz, t_j, t_c))
+        print(f"{n:8d} {nnz:9d} | {t_j*1e6:9.1f} {t_c*1e6:12.1f} {t_j/t_c:7.2f}x")
+    return rows
+
+
+if __name__ == "__main__":
+    main()

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -37,6 +37,27 @@ __all__ = ["fem", "FEM"]
 _COMPONENT_NAMES = {0: "x", 1: "y", 2: "z"}
 
 
+def _solve_linear_matrix_free(A, b, *, tol=1e-8, maxiter=20_000):
+    """Default steady-linear solve: matrix-free BiCGStab straight on the feax BCOO operator.
+
+    Never forms the dense ``N x N`` matrix — each iteration is a couple of sparse matvecs
+    ``A @ v`` (cost ``O(nnz)``), so memory stays ``O(nnz)`` and the solve runs at sizes where
+    a dense factorisation would not fit. BiCGStab (unlike CG) handles **general** linear
+    systems — symmetric *or* not — so it is a safe library default. Raises if it fails to
+    converge, so a hard / ill-posed system fails loudly instead of returning garbage; pass a
+    ``solve_fn`` to :meth:`FEM.solve` to choose your own solver in that case.
+    """
+    matvec = lambda v: A @ v
+    u, _info = jax.scipy.sparse.linalg.bicgstab(matvec, b, tol=tol, atol=0.0, maxiter=maxiter)
+    rel = float(jnp.linalg.norm(b - matvec(u)) / (jnp.linalg.norm(b) + 1e-30))
+    if not np.isfinite(rel) or rel > 1e-4:
+        raise RuntimeError(
+            f"fem.solve default (matrix-free BiCGStab) did not converge (relative residual "
+            f"{rel:.1e}). Pass your own solver, e.g. fem.solve(solve_fn=lambda A, b: ...)."
+        )
+    return u
+
+
 # ---------------------------------------------------------------------------
 # expression helpers
 # ---------------------------------------------------------------------------
@@ -597,14 +618,17 @@ class FEM:
 
         ``solve_fn`` is **your** solver (jNO writes none):
 
-        * steady linear: ``(A, b) -> u`` (default :func:`jax.numpy.linalg.solve`; e.g.
-          ``lineax``);
-        * steady nonlinear: ``(residual_fn, u0) -> u`` (default an
-          ``optimistix.root_find`` Newton, implicit-diff; pass ``u0=`` for the guess);
+        * steady linear: ``(A, b) -> u``. The **default** is matrix-free BiCGStab straight on
+          feax's BCOO operator — never forms the ``N x N`` matrix (memory ``O(nnz)``) and solves
+          general (non-symmetric) systems, not just SPD. To use a dense / library solver, pass
+          your own ``solve_fn`` (it receives the densified ``(A, b)``; e.g. ``jnp.linalg.solve``
+          or a ``lineax`` solver). It raises if BiCGStab fails to converge;
+        * steady nonlinear: ``(residual_fn, u0) -> u`` (default a matrix-free Jacobian-free
+          Newton-Krylov, implicit-diff, no optimistix; pass ``u0=`` for the guess);
         * transient: ``(block, args, save_ts) -> ys`` returning a ``(len(save_ts),
-          n_dofs)`` trajectory (default a backward-Euler ``lax.scan`` over the block's
-          assembled ``dt``; ``save_ts=`` overrides the sample times, default the domain's
-          time grid). diffrax (``block.as_diffrax``) and a feax pipeline
+          n_dofs)`` trajectory (default a backward-Euler ``lax.scan`` over the block's assembled
+          ``dt``, each step solved by the same matrix-free Newton-Krylov; ``save_ts=`` overrides
+          the sample times, default the domain's time grid). diffrax (``block.as_diffrax``) and a feax pipeline
           (``block.as_feax_pipeline``) are documented overrides.
 
         Enable x64 — the feax assembly is float64.
@@ -619,12 +643,15 @@ class FEM:
         if self._mode == "complex_transient":
             return _solve_complex_transient(self._op, save_ts=kwargs.get("save_ts"))
         if self._mode == "linear" and not isinstance(self._op, FemLinearSystem):
-            # Non-parametric steady linear: solve the assembled (A, b) directly. ``solve_fn`` is
-            # your ``(A, b) -> u`` (default dense ``jnp.linalg.solve``); A is densified from feax's
-            # BCOO. (The runtime-parametric case is a FemLinearSystem and falls through below.)
+            # Non-parametric steady linear. Default: matrix-free BiCGStab straight on feax's
+            # BCOO operator (never densifies -> memory O(nnz); solves general systems). Pass your
+            # own ``solve_fn=(A, b) -> u`` to use a dense / library solver instead -- it receives
+            # the densified (A, b). (The runtime-parametric case is a FemLinearSystem below.)
             A, b = self._op
-            A = jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)
             b = jnp.asarray(b).reshape(-1)
+            if solve_fn is None and self._periodic is None and hasattr(A, "todense"):
+                return _solve_linear_matrix_free(A, b)
+            A = jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)
             _solve = solve_fn or (lambda A_, b_: jnp.linalg.solve(A_, b_))
             if self._periodic is not None:
                 # periodic tie: eliminate slave DOFs via the prolongation P, solve the reduced
@@ -649,11 +676,10 @@ class FEM:
                 def _base(rf, y):
                     if user_fn is not None:
                         return user_fn(rf, y)
-                    import optimistix as optx
+                    # Matrix-free Newton-Krylov default (no optimistix); implicit-diff preserved.
+                    from .utils.solver.newton_krylov import newton_krylov
 
-                    return optx.root_find(
-                        lambda u, _a: rf(u), optx.Newton(rtol=1e-8, atol=1e-8), y, args=None, max_steps=100
-                    ).value
+                    return newton_krylov(rf, y)
 
                 ur = _base(
                     lambda ur: P.T @ jnp.asarray(residual_fn(P @ ur)).reshape(-1), restrict_state(P, y0, kept, vec=pvec)

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -2972,11 +2972,12 @@ class FemResidualOperator:
         ``fem = jno.fem([...])``.
 
         ``solve_fn`` is **your** solver: any ``(residual_fn, u0) -> u`` callable. The
-        default is a Newton ``optimistix.root_find`` (implicit differentiation, so
-        ``∂u/∂θ`` is exact without unrolling Newton); pass your own to choose a
-        different optimistix solver or library. jNO's analytic Jacobian
-        (:attr:`jacobian`) is available as an optional speed-up — by default the
-        solver auto-differentiates the residual.
+        default is a matrix-free Jacobian-free Newton-Krylov (Newton + BiCGStab on the
+        JVP, no external solver dependency); implicit differentiation via
+        ``jax.lax.custom_root`` keeps ``∂u/∂θ`` exact without unrolling Newton. Pass your
+        own to choose another solver/library (e.g. an ``optimistix`` Newton). jNO's
+        analytic Jacobian (:attr:`jacobian`) is available; by default ``J @ v`` is a JVP
+        of the residual.
 
         ``u0`` is the initial guess (default: zeros of the operator size; enable
         x64 — the feax residual is float64).
@@ -2989,16 +2990,11 @@ class FemResidualOperator:
         if solve_fn is None:
 
             def solve_fn(residual_fn, y0):
-                import optimistix as optx
+                # Default: matrix-free Jacobian-free Newton-Krylov (no optimistix dependency).
+                # Implicit-diff via custom_root, so the gradient still reaches the parameters.
+                from ..utils.solver.newton_krylov import newton_krylov
 
-                sol = optx.root_find(
-                    lambda u, _a: residual_fn(u),
-                    optx.Newton(rtol=1e-8, atol=1e-8),
-                    y0,
-                    args=None,
-                    max_steps=100,
-                )
-                return sol.value
+                return newton_krylov(residual_fn, y0)
 
         names = list(self.runtime_parameter_exprs)
         params = [self.runtime_parameter_exprs[n] for n in names]

--- a/jno/utils/solver/backend_blocks.py
+++ b/jno/utils/solver/backend_blocks.py
@@ -586,9 +586,10 @@ def _default_transient_integrate(block, args, save_ts):
           (M + dt A(t_next, args)) u_next = M u + dt (c + f(t_next, args))
 
     * **Nonlinear** block (residual route, ``M(t) u_dot = -R(u, t, args)``) -- backward Euler
-      solves, per step, ``G(u_next) = M (u_next - u)/dt + R(u_next, t_next, args) = 0`` with an
-      ``optimistix`` Newton ``root_find`` (implicit-diff, so the gradient reaches ``args``
-      without unrolling Newton -- the same library the steady nonlinear ``.solve`` uses).
+      solves, per step, ``G(u_next) = M (u_next - u)/dt + R(u_next, t_next, args) = 0`` with the
+      matrix-free Newton-Krylov solver (``jno/utils/solver/newton_krylov.py``, no optimistix);
+      implicit-diff via ``jax.lax.custom_root`` keeps the gradient flowing to ``args`` without
+      unrolling Newton -- the same solver the steady nonlinear ``.solve`` now uses.
 
     This is a *default*: pass any ``solve_fn(block, args, save_ts) -> ys`` to
     :meth:`FeaxTimeBlock.solve` (diffrax via ``block.as_diffrax``, a feax pipeline via
@@ -597,38 +598,50 @@ def _default_transient_integrate(block, args, save_ts):
     import jax
     import jax.numpy as jnp
 
+    from .newton_krylov import newton_krylov
+
+    # keep a BCOO operator as-is (matrix-free matvec) but coerce a dense one to a JAX array
+    def _operand(x):
+        return x if hasattr(x, "todense") else jnp.asarray(x, dtype)
+
     s0 = jnp.asarray(block.state0).reshape(-1)
     dtype = s0.dtype
     grid_ts = jnp.asarray(_block_time_grid(block), dtype)
     dt = float(block.dt)
 
+    # One general backward-Euler step for both payloads: each step solves the root
+    # G(u_next) = 0 with the matrix-free Newton-Krylov solver (no optimistix). For the linear
+    # block G is affine, so Newton converges in one iteration -> one inner BiCGStab solve; the
+    # operators are only ever applied as matvecs (M @ v, A @ v), so a BCOO operator stays sparse.
     if block.is_nonlinear():
-        import optimistix as optx
-
         mass_fn, residual_fn = block.mass, block.residual
 
         def step(w, t_next):
-            M_t = jnp.asarray(mass_fn(t_next, args), dtype)
+            M_t = _operand(mass_fn(t_next, args))
 
-            def _resid(wn, _):  # backward-Euler residual G(wn) = 0
+            def G(wn):
                 return (M_t @ (wn - w)) / dt + jnp.asarray(residual_fn(wn, t_next, args), dtype).reshape(-1)
 
-            sol = optx.root_find(_resid, optx.Newton(rtol=1e-8, atol=1e-8), w, max_steps=64, throw=False)
-            return sol.value, sol.value
+            wn = newton_krylov(G, w)
+            return wn, wn
 
         _, ys = jax.lax.scan(step, s0, grid_ts[1:])
     else:
-        M = jnp.asarray(block.M, dtype)
+        M = _operand(block.M)
         n = M.shape[0]
         c = jnp.zeros((n,), dtype) if block.affine_bias is None else jnp.asarray(block.affine_bias, dtype).reshape(-1)
 
         def step(w, t_next):
-            A = jnp.asarray(block.operator_fn(t_next, args) if block.operator_fn is not None else block.A, dtype)
+            A = _operand(block.operator_fn(t_next, args) if block.operator_fn is not None else block.A)
             rhs = M @ w + dt * c
             if block.forcing_vector_fn is not None:
                 rhs = rhs + dt * jnp.asarray(block.forcing_vector_fn(t_next, args), dtype).reshape(-1)
-            w_next = jnp.linalg.solve(M + dt * A, rhs)
-            return w_next, w_next
+
+            def G(wn):  # affine residual: (M + dt A) wn - rhs ; root is the backward-Euler update
+                return M @ wn + dt * (A @ wn) - rhs
+
+            wn = newton_krylov(G, w)
+            return wn, wn
 
         _, ys = jax.lax.scan(step, s0, grid_ts[1:])
 

--- a/jno/utils/solver/newton_krylov.py
+++ b/jno/utils/solver/newton_krylov.py
@@ -1,0 +1,88 @@
+"""Jacobian-free Newton-Krylov root find -- the optimistix-free nonlinear default.
+
+Solves ``residual_fn(u) = 0`` with Newton's method whose per-step linear solve
+``J delta = -R`` is done matrix-free: ``J @ v`` comes from a JVP (``jax.linearize``)
+so the Jacobian is never formed, and the solve is BiCGStab (handles non-symmetric
+``J``). Implicit differentiation is provided by ``jax.lax.custom_root`` (so gradients
+reach parameters closed over by ``residual_fn`` without unrolling Newton), and the
+inner BiCGStab is wrapped in ``jax.lax.custom_linear_solve`` so the reverse pass --
+which solves ``J^T`` -- gets an analytic transpose rule instead of trying to
+differentiate the solver's ``while_loop``.
+
+No external solver dependency (no optimistix / lineax).
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+__all__ = ["newton_krylov", "bicgstab"]
+
+_EPS = 1e-300
+
+
+def bicgstab(matvec, b, *, tol=1e-10, maxit=2000):
+    """Matrix-free BiCGStab; returns ``x`` solving ``matvec(x) = b`` (general matrices)."""
+    bnorm = jnp.linalg.norm(b)
+
+    def cond(s):
+        _, r, *_, k = s
+        return (jnp.linalg.norm(r) > tol * bnorm) & (k < maxit)
+
+    def body(s):
+        x, r, rhat, rho, alpha, omega, v, p, k = s
+        rho_new = rhat @ r
+        beta = (rho_new / (rho + _EPS)) * (alpha / (omega + _EPS))
+        p = r + beta * (p - omega * v)
+        v = matvec(p)
+        alpha = rho_new / (rhat @ v + _EPS)
+        sv = r - alpha * v
+        t = matvec(sv)
+        omega = (t @ sv) / (t @ t + _EPS)
+        x = x + alpha * p + omega * sv
+        r = sv - omega * t
+        return x, r, rhat, rho_new, alpha, omega, v, p, k + 1
+
+    z = jnp.zeros_like(b)
+    one = jnp.array(1.0, b.dtype)
+    x0 = jnp.zeros_like(b)
+    state = (x0, b - matvec(x0), b, one, one, one, z, z, 0)
+    x, *_ = jax.lax.while_loop(cond, body, state)
+    return x
+
+
+def _linsolve(matvec, b, *, tol, maxit):
+    """Transposable black-box linear solve: BiCGStab forward, BiCGStab on ``J^T`` for the
+    reverse rule (via ``custom_linear_solve``) -- so it never differentiates the loop."""
+    solve = lambda mv, rhs: bicgstab(mv, rhs, tol=tol, maxit=maxit)
+    return jax.lax.custom_linear_solve(matvec, b, solve, transpose_solve=solve)
+
+
+def newton_krylov(residual_fn, u0, *, rtol=1e-8, atol=1e-8, max_steps=100,
+                  inner_tol=1e-10, inner_maxit=2000):
+    """Root-find ``residual_fn(u) = 0`` from guess ``u0``; differentiable w.r.t. any value
+    ``residual_fn`` closes over. Drop-in for the ``(residual_fn, u0) -> u`` solver contract."""
+    # feax residuals can hand back a plain numpy array for concrete inputs; coerce so the
+    # jax.lax.custom_root primitive only ever sees JAX values.
+    f0 = lambda u: jnp.asarray(residual_fn(u)).reshape(-1)
+    u0 = jnp.asarray(u0).reshape(-1)
+
+    def solve(f, x0):
+        r0n = jnp.linalg.norm(f(x0))
+
+        def cond(state):
+            _, r, k = state
+            return (jnp.linalg.norm(r) > atol + rtol * r0n) & (k < max_steps)
+
+        def body(state):
+            u, _r, k = state
+            ru, jvp = jax.linearize(f, u)           # ru = f(u); jvp(v) = J @ v, reused across inner iters
+            delta = _linsolve(jvp, -ru, tol=inner_tol, maxit=inner_maxit)
+            u = u + delta
+            return u, f(u), k + 1
+
+        u, _r, _k = jax.lax.while_loop(cond, body, (x0, f(x0), 0))
+        return u
+
+    tangent_solve = lambda g, y: _linsolve(g, y, tol=inner_tol, maxit=inner_maxit)
+    return jax.lax.custom_root(f0, u0, solve, tangent_solve)

--- a/tests/test_fem_driver.py
+++ b/tests/test_fem_driver.py
@@ -70,14 +70,14 @@ def test_poisson_dirichlet_assembles_and_solves():
 
 def test_linear_solve_default_and_custom_solver_match():
     """A non-parametric steady linear FEM is solvable through ``fem.solve()`` -- both the default
-    (dense ``jnp.linalg.solve``) and a user ``solve_fn=(A, b) -> u`` -- and both equal the direct
-    ``A^-1 b``."""
+    (matrix-free BiCGStab on the BCOO operator, to solver tolerance) and a user
+    ``solve_fn=(A, b) -> u`` (dense, exact) -- and both equal the direct ``A^-1 b``."""
     _, fem = _poisson_fem()
     direct = np.linalg.solve(_dense(fem.A), np.asarray(fem.b).reshape(-1))
     u_default = np.asarray(fem.solve())
     u_custom = np.asarray(fem.solve(solve_fn=lambda A, b: jnp.linalg.solve(A, b)))
-    assert np.allclose(u_default, direct, atol=1e-10)
-    assert np.allclose(u_custom, direct, atol=1e-10)
+    assert np.allclose(u_default, direct, atol=1e-6)   # iterative: converged to BiCGStab tol
+    assert np.allclose(u_custom, direct, atol=1e-10)   # dense direct: exact
 
 
 def test_matches_legacy_assembly_path():

--- a/tests/test_fem_newton_krylov.py
+++ b/tests/test_fem_newton_krylov.py
@@ -1,0 +1,83 @@
+"""The optimistix-free nonlinear default: matrix-free Jacobian-free Newton-Krylov.
+
+Deliberately imports **no** optimistix (unlike test_fem_inverse, which gates the
+whole module on it), so these run on the new default and prove:
+  * the implicit-diff gradient is exact (finite-diff vs autodiff), and
+  * a steady nonlinear ``fem.solve()`` converges with optimistix forced absent.
+"""
+from __future__ import annotations
+
+import sys
+
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+from jno.utils.solver.newton_krylov import newton_krylov  # noqa: E402
+
+pytest.importorskip("feax", reason="feax required for FEM assembly")
+pytest.importorskip("shapely")
+from shapely.geometry import box  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """feax assembly is float64; the global x64 flag is shared across modules and other
+    suites flip it at import, so set it per-test with save/restore."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def test_newton_krylov_gradient_matches_fd():
+    """Implicit diff through the solve is exact: AD == central finite-difference."""
+    n = 40
+    A = (2.0 * jnp.eye(n) - jnp.eye(n, k=1) - jnp.eye(n, k=-1))  # SPD tridiag
+    b = jnp.ones(n)
+    u_tgt = jnp.linspace(0.0, 1.0, n)
+
+    def usol(alpha):
+        return newton_krylov(lambda u: A @ u + alpha * u**3 - b, jnp.zeros(n))
+
+    def loss(alpha):
+        return jnp.mean((usol(alpha) - u_tgt) ** 2)
+
+    a0 = jnp.array(0.7)
+    # forward actually solves the nonlinear system
+    u = usol(a0)
+    assert float(jnp.linalg.norm(A @ u + a0 * u**3 - b)) < 1e-9
+
+    g_ad = float(jax.grad(loss)(a0))
+    e = 1e-5
+    g_fd = float((loss(a0 + e) - loss(a0 - e)) / (2 * e))
+    assert abs(g_ad - g_fd) / abs(g_fd) < 1e-6, f"AD {g_ad} vs FD {g_fd}"
+
+
+def _nonlinear_fem(mesh_size=0.2):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    weak = ui.x * vi.x + ui.y * vi.y + (u * u * u) * vi - f * vi
+    return jno.fem([weak, u(xb, yb) - 0.0], quad_degree=3)
+
+
+def test_nonlinear_default_solves_without_optimistix(monkeypatch):
+    """The default nonlinear engine converges on the real feax residual with optimistix
+    forced absent (proving the steady path never imports it)."""
+    monkeypatch.setitem(sys.modules, "optimistix", None)  # any `import optimistix` now raises
+    fem = _nonlinear_fem()
+    res_fn = fem.residual                          # the (u -> flat residual) feax callable
+    u = newton_krylov(res_fn, jnp.zeros(fem.dofs))  # same solver fem.solve() now defaults to
+    res = float(jnp.linalg.norm(jnp.asarray(res_fn(u))))
+    assert np.all(np.isfinite(np.asarray(u)))
+    assert res < 1e-6, f"nonlinear residual not converged: {res:.1e}"


### PR DESCRIPTION
## What

Replaces the external-library / dense solver defaults in `fem.solve()` with custom **matrix-free JAX solvers**, all differentiable via implicit-diff so inverse problems keep working. Removes **optimistix** as a runtime dependency for the default solve paths.

| case | before | now |
|---|---|---|
| steady linear `(A,b)→u` | dense `jnp.linalg.solve` (densifies BCOO) | matrix-free **BiCGStab** on the BCOO operator (O(nnz), non-symmetric-safe; raises on non-convergence) |
| steady nonlinear `(residual_fn,u0)→u` | `optimistix.root_find` Newton | **Jacobian-free Newton-Krylov** (`jax.lax.custom_root` + inner BiCGStab wrapped in `custom_linear_solve`) |
| transient | dense per-step solve + optimistix per-step Newton | one backward-Euler `lax.scan` solving each step with the **same Newton-Krylov** (linear block = 1 iteration), matrix-free |

Pass your own `solve_fn` to use a dense / library solver in any case.

## Why

- Steady linear no longer materializes the N×N matrix (scales past the dense memory wall).
- Newton-Krylov keeps exact `∂u/∂θ` (implicit-function-theorem via `custom_root`), so transient/steady inverse problems are unchanged — verified by a finite-diff-vs-autodiff gradient check.
- Drops the optimistix dependency for default solves.

## New

- `jno/utils/solver/newton_krylov.py` — `newton_krylov`, `bicgstab`.
- `tests/test_fem_newton_krylov.py` — FD-vs-AD gradient check + a no-optimistix convergence test.
- Benchmark scripts (`bench_*.py`) for the steady dense-vs-sparse / solver-library comparisons.

## Testing

Validated on the FEM suite (`test_fem_driver`, `test_fem_workflow`, `test_fem_inverse` incl. transient recovery, `test_periodic_parametric_integration`, `test_time_route_integration`, `test_fem_newton_krylov`) — all green **except** one pre-existing `test_linear_feax_time_block_converts_to_diffrax_block` failure (an x64 / singular-Dirichlet-mass `M⁻¹` issue in the diffrax path that fails on `main` too, unrelated to this change).

## Follow-ups (not in this PR)

- Matrix-free **BCOO storage for transient-linear** operators (the integrator is already matrix-free, but the assembly still densifies `M`/`A`). A first attempt broke the parametric/`feax_pipeline` paths — it needs lazy-dense `.M`/`.A` so those consumers keep working; reverted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)