### PR TITLE
fix: L-BFGS integer cast, ModelCall.scale nondim, mkdocs YAML

### DIFF
--- a/jno/core.py
+++ b/jno/core.py
@@ -2156,7 +2156,10 @@ class core:
 
             def _init(params):
                 state = built.init(optax.tree_utils.tree_cast(params, jnp.float32))
-                return optax.tree_utils.tree_cast(state, param_dtype)
+                return jax.tree.map(
+                    lambda t: t.astype(param_dtype) if jnp.issubdtype(t.dtype, jnp.floating) else t,
+                    state,
+                )
 
             return optax.GradientTransformation(_init, built.update)
 

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -2360,10 +2360,18 @@ class ModelCall(Placeholder):
         self.model.optimizer(opt_fn)
         return self
 
-    def scale(self, scale: Any) -> "ModelCall":
-        """Proxy for :meth:`Model.scale` -- multiply the learning rate (e.g. with a
-        ``dlrs(...)`` schedule for loss-adaptive scaling). Chains after ``optimizer(...)``."""
-        self.model.scale(scale)
+    def scale(self, scale: float) -> "ModelCall":
+        """Declare the characteristic magnitude of this model output.
+
+        Equivalent to :meth:`Placeholder.scale` — sets the dimensional scale used
+        by :func:`jno.units.rescale` to map the network output back to physical
+        units::
+
+            u = net(x).unit("K").scale(50.0)   # output ∈ O(1); physical = 50 K
+
+        To set the model learning-rate scale, call :meth:`Model.scale` on the model
+        object directly (e.g. ``net.optimizer(optax.adam).scale(lrs(1e-3))``)."""
+        self._scale = float(scale)
         return self
 
     def constrain(self, transform: Callable) -> "ModelCall":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,7 +154,7 @@ nav:
       - 2D Schrödinger Wave Packet: tutorials/08-fem-and-varpinns/schrodinger-wavepacket-2d.md
       - 2D Maxwell (complex vector E): tutorials/08-fem-and-varpinns/maxwell-2d-vector.md
       - Linear Elasticity (Cantilever): tutorials/08-fem-and-varpinns/linear-elasticity-cantilever.md
-      - Elasticity: Plate with a Hole: tutorials/08-fem-and-varpinns/elasticity-plate-with-hole.md
+      - "Elasticity: Plate with a Hole": tutorials/08-fem-and-varpinns/elasticity-plate-with-hole.md
       - Stokes Channel (Poiseuille): tutorials/08-fem-and-varpinns/stokes-channel-poiseuille.md
       - Stokes Flow Past a Cylinder: tutorials/08-fem-and-varpinns/stokes-flow-around-cylinder.md
       - Navier-Stokes Lid-Driven Cavity: tutorials/08-fem-and-varpinns/navier-stokes-cavity-2d.md


### PR DESCRIPTION
## Summary

- **`jno/core.py`** — `optax.tree_utils.tree_cast` was casting L-BFGS's integer `count` field to `float32`, causing `x.at[float_index].set(y)` to raise `TypeError: Indexer must have integer or boolean type`. Replaced with a float-leaf-only `jax.tree.map` that leaves integer leaves untouched.

- **`jno/trace/__init__.py`** — The `ModelCall.lr()→scale()` rename in #69 overrode `Placeholder.scale()` (added in #66), so `net(x).unit("K").scale(U)` never set `_scale`. The `rescaler.field_scale` stayed `None`, making `to_physical()` a no-op and producing ~80% round-trip error in `test_rescaled_solve_recovers_physical_field`. No callers of the LR-proxy form existed; restored `Placeholder.scale()` semantics and redirected LR callers to `Model.scale()`.

- **`mkdocs.yml`** — Unquoted colon in nav entry `Elasticity: Plate with a Hole` was a YAML syntax error that broke the GitHub Pages build entirely.

## Test plan

- `tests/test_optimizers.py::TestSingleOptimizerConvergence::test_lbfgs` — passes
- `tests/test_optimizers.py::TestMultiOptimizerInverseProblem::test_seven_optimizers_converge` — passes
- `tests/test_nondim.py::TestEndToEndSolve::test_rescaled_solve_recovers_physical_field` — passes
- Full suite (excl. tutorials + known GPU OOM): **2179 passed, 4 skipped, 0 failures**
- `mkdocs build --strict` — passes