### PR TITLE
feat(optimizers): jno.optimizers — custom optax-compatible optimizers…

### DIFF
--- a/docs/model-controls/optimizer-lr.md
+++ b/docs/model-controls/optimizer-lr.md
@@ -28,3 +28,28 @@ net.scale(lrs(1e-5))                      # global LR
 ```
 
 During `solve()`, jNO logs group coverage, overlap, and uncovered-parameter diagnostics.
+
+## `jno.optimizers` — custom second-order optimizers
+
+`jno.optimizers` holds **only** custom optimizers that aren't in optax; for `chain`, learning-rate
+schedules and gradient clipping use `optax` directly. Each is an optax `GradientTransformation`, so it
+composes with `optax.chain` and drops straight into `.optimizer(...)`.
+
+```python
+import optax, jno
+k.optimizer(jno.optimizers.ssbroyden())                  # 2nd-order; far fewer steps than Adam on inverse/PINN losses
+k.optimizer(jno.optimizers.soap(learning_rate=3e-3))
+k.optimizer(optax.chain(                                 # compose with optax directly
+    optax.clip_by_global_norm(1.0),
+    jno.optimizers.ssbfgs(),
+))
+```
+
+| Optimizer | What it is | Reference |
+|---|---|---|
+| `ssbroyden()` / `ssbfgs()` | Self-Scaled Broyden / BFGS quasi-Newton with a zoom line search — strong on smooth PINN / inverse losses | Urbán, Stefanou & Pons, *Unveiling the optimization process of PINNs*, J. Comput. Phys. **523** (2025) 113656 |
+| `soap()` / `scale_by_soap()` | SOAP — Shampoo with Adam in the preconditioner's eigenbasis | Vyas et al., *SOAP: Improving and Stabilizing Shampoo using Adam* (2024), arXiv:2409.11321 |
+
+**Add your own:** drop an optax-compatible `GradientTransformation` into a new module under
+`jno/optimizers/` and re-export it from `jno/optimizers/__init__.py` — it then works everywhere an
+optax optimizer does.

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -8,7 +8,7 @@ jNO: Physics-Informed Neural Operators.
 
 import sys
 
-from . import bayesian, fn, lora, trackers
+from . import bayesian, fn, lora, optimizers, trackers
 from . import jnp_ops as np
 from ._fem import fem
 from .architectures.models import nn, parameter
@@ -123,6 +123,7 @@ __all__ = [
     "WeightSchedule",
     "callbacks",
     "trackers",
+    "optimizers",
     "logger",
     "TraceEvaluator",
     "TraceCompiler",

--- a/jno/optimizers/__init__.py
+++ b/jno/optimizers/__init__.py
@@ -1,0 +1,29 @@
+"""``jno.optimizers`` — custom optax-compatible optimizers that aren't in optax.
+
+Just the optimizers — for everything else (``chain``, learning-rate schedules, gradient clipping, …)
+use ``optax`` directly. Each optimizer here is an ``optax`` ``GradientTransformation``, so it composes
+with ``optax.chain`` and drops straight into ``model.optimizer(...)`` /
+``jno.np.parameter(...).optimizer(...)``::
+
+    import optax, jno
+    k.optimizer(jno.optimizers.ssbroyden())                              # use it directly
+    k.optimizer(optax.chain(optax.clip_by_global_norm(1.0),              # …or inside an optax chain
+                            jno.optimizers.ssbfgs()))
+
+- :func:`ssbroyden` / :func:`ssbfgs` — Self-Scaled Broyden / BFGS quasi-Newton with a line search
+  (Urbán, Stefanou & Pons, *J. Comput. Phys.* **523** (2025) 113656); excellent on smooth
+  PINN / inverse losses.
+- :func:`soap` — SOAP, Shampoo with Adam in the preconditioner's eigenbasis
+  (Vyas et al. 2024, arXiv:2409.11321).
+
+The ``scale_by_*`` variants are the bare transforms (no line search / learning-rate wrapper) for
+building your own optax chains.
+
+**Add a custom optimizer:** drop an optax-compatible ``GradientTransformation`` into a new module in
+this package and re-export it below.
+"""
+
+from .soap import scale_by_soap, soap
+from .ssbroyden import scale_by_ss_quasi_newton, ssbfgs, ssbroyden
+
+__all__ = ["ssbroyden", "ssbfgs", "scale_by_ss_quasi_newton", "soap", "scale_by_soap"]

--- a/jno/optimizers/soap.py
+++ b/jno/optimizers/soap.py
@@ -1,0 +1,494 @@
+# Vendored from SOAP_JAX (https://github.com/haydn-jones/SOAP_JAX) -- MIT License, (c) 2024 Haydn Jones.
+# Only the chex / jaxtyping type-hint imports were stripped (to avoid extra deps); the algorithm is unchanged.
+#
+# SOAP: Improving and Stabilizing Shampoo using Adam. Vyas, Morwani, Zhao, Shapira, Brandfonbrener,
+# Janson & Kakade (2024), arXiv:2409.11321.
+"""SOAP optimizer -- Shampoo with Adam in the preconditioner's eigenbasis (optax-compatible)."""
+
+from itertools import chain
+from typing import Any, Callable, Iterable, NamedTuple, Optional, Union
+
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+import optax
+import optax.tree_utils as otu
+from jax import Array
+from optax import GradientTransformation, Updates
+
+Numeric = Any  # was chex.Numeric (type hint only)
+PreconditionerMatrix = Union[Array, None]
+
+
+@jtu.register_pytree_node_class
+class Preconditioner:
+    """Per-parameter preconditioner matrices (None for dimensions exceeding max_precond_dim)."""
+
+    __slots__ = ("matrices",)
+
+    def __init__(self, matrices: Iterable[PreconditionerMatrix]):
+        self.matrices = tuple(matrices)
+
+    def tree_flatten(self) -> tuple[tuple[PreconditionerMatrix, ...], None]:
+        return (self.matrices, None)
+
+    @classmethod
+    def tree_unflatten(cls, aux_data: None, children: tuple[PreconditionerMatrix, ...]) -> "Preconditioner":
+        return cls(children)
+
+    def map(self, fn: Callable[[PreconditionerMatrix], PreconditionerMatrix]) -> "Preconditioner":
+        return Preconditioner(fn(m) for m in self.matrices)
+
+
+class SOAPState(NamedTuple):
+    count: Array
+    exp_avg: Updates
+    exp_avg_sq: Updates
+    GG: Updates  # Pytree of Preconditioner
+    Q: Updates  # Pytree of Preconditioners
+
+
+class PostDecayState(NamedTuple):
+    count: Array
+
+
+def soap(
+    learning_rate: optax.ScalarOrSchedule = 3e-3,
+    b1: float = 0.95,
+    b2: float = 0.95,
+    shampoo_beta: float = -1,
+    eps: float = 1e-8,
+    weight_decay: float = 0.0,
+    correct_bias: bool = True,
+    precondition_frequency: int = 10,
+    max_precond_dim: int = 10000,
+    precondition_1d: bool = False,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+    mu_dtype: Optional[Any] = None,
+    qr_dtype: Any = jnp.float32,
+) -> optax.GradientTransformationExtraArgs:
+    """
+    Implements SOAP algorithm (https://arxiv.org/abs/2409.11321). Based on the original implementation at https://github.com/nikhilvyas/SOAP.
+
+    Args:
+        learning_rate (optax.ScalarOrSchedule): The learning rate to use.
+        b1 (float, optional): Adam's beta1 parameter. Defaults to 0.95.
+        b2 (float, optional): Adam's beta2 parameter. Defaults to 0.95.
+        shampoo_beta (float, optional): If >= 0, use this beta for the preconditioner (`L` and `R` in paper, `GG` below)
+            moving average instead of b2. Defaults to -1.
+        eps (float, optional): Adam's epsilon for numerical stability. Defaults to 1e-8.
+        weight_decay (float, optional): Weight decay coefficient. Defaults to 0.0.
+        correct_bias (bool, optional): Whether to use bias correction for the Adam moments. Defaults to True.
+        precondition_frequency (int, optional): How often to update the preconditioner. Defaults to 10.
+        max_precond_dim (int, optional): Maximum dimension of the preconditioner.
+            Set to 10000 to exclude most common vocab sizes while including layers. Defaults to 10000.
+        precondition_1d (bool, optional): Whether to precondition 1D gradients. If False, 1D params use Adam-style
+            updates. Defaults to False.
+        precision (jax.lax.PrecisionLike, optional): Precision to use. Defaults to jax.lax.Precision.HIGHEST.
+        mu_dtype (Any, optional): dtype for the first and second moment estimates (exp_avg and exp_avg_sq).
+            If None, uses the same dtype as the parameters. Useful for mixed-precision training. Defaults to None.
+        qr_dtype (Any, optional): dtype used for eigen/QR computations and preconditioner storage.
+            Defaults to float32 to avoid float64 upcasts in mixed precision.
+
+    Returns:
+        optax.GradientTransformationExtraArgs: The SOAP optimizer.
+    """
+    return optax.chain(
+        scale_by_soap(
+            b1=b1,
+            b2=b2,
+            shampoo_beta=shampoo_beta,
+            eps=eps,
+            correct_bias=correct_bias,
+            precondition_frequency=precondition_frequency,
+            max_precond_dim=max_precond_dim,
+            precondition_1d=precondition_1d,
+            precision=precision,
+            mu_dtype=mu_dtype,
+            qr_dtype=qr_dtype,
+        ),
+        optax.scale_by_learning_rate(learning_rate),
+        add_decayed_weights_post(weight_decay, learning_rate),
+    )
+
+
+def scale_by_soap(
+    b1: float = 0.95,
+    b2: float = 0.95,
+    shampoo_beta: float = -1,
+    eps: float = 1e-8,
+    correct_bias: bool = True,
+    precondition_frequency: int = 10,
+    max_precond_dim: int = 10000,
+    precondition_1d: bool = False,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+    mu_dtype: Optional[Any] = None,
+    qr_dtype: Any = jnp.float32,
+) -> GradientTransformation:
+    """
+    Implements SOAP algorithm (https://arxiv.org/abs/2409.11321). Based on the original implementation at https://github.com/nikhilvyas/SOAP.
+
+    Args:
+        b1 (float, optional): Adam's beta1 parameter. Defaults to 0.95.
+        b2 (float, optional): Adam's beta2 parameter. Defaults to 0.95.
+        shampoo_beta (float, optional): If >= 0, use this beta for the preconditioner (`L` and `R` in paper, `GG` below)
+            moving average instead of b2. Defaults to -1.
+        eps (float, optional): Adam's epsilon for numerical stability. Defaults to 1e-8.
+        correct_bias (bool, optional): Whether to use bias correction for the Adam moments. Defaults to True.
+        precondition_frequency (int, optional): How often to update the preconditioner. Defaults to 10.
+        max_precond_dim (int, optional): Maximum dimension of the preconditioner.
+            Set to 10000 to exclude most common vocab sizes while including layers. Defaults to 10000.
+        precondition_1d (bool, optional): Whether to precondition 1D gradients. If False, 1D params use Adam-style
+            updates. Defaults to False.
+        precision (jax.lax.PrecisionLike, optional): Precision to use. Defaults to jax.lax.Precision.HIGHEST.
+        mu_dtype (Any, optional): dtype for the first and second moment estimates (exp_avg and exp_avg_sq).
+            If None, uses the same dtype as the parameters. Useful for mixed-precision training. Defaults to None.
+        qr_dtype (Any, optional): dtype used for eigen/QR computations and preconditioner storage.
+            Defaults to float32 to avoid float64 upcasts in mixed precision.
+
+    Returns:
+        GradientTransformation: The SOAP gradient transformation.
+    """
+    if not (0 <= b1 < 1):
+        raise ValueError("b1 must be in [0, 1)")
+    if not (0 <= b2 < 1):
+        raise ValueError("b2 must be in [0, 1)")
+    if shampoo_beta >= 1 or (shampoo_beta < 0 and shampoo_beta != -1):
+        raise ValueError("shampoo_beta must be in [0, 1) or -1")
+    if eps <= 0:
+        raise ValueError("eps must be positive")
+    if precondition_frequency <= 0:
+        raise ValueError("precondition_frequency must be a positive integer")
+    if max_precond_dim <= 0:
+        raise ValueError("max_precond_dim must be a positive integer")
+
+    shampoo_beta = shampoo_beta if shampoo_beta >= 0 else b2
+
+    def init_fn(params: Updates) -> SOAPState:
+        exp_avg = otu.tree_zeros_like(params, dtype=mu_dtype)
+        exp_avg_sq = otu.tree_zeros_like(params, dtype=mu_dtype)
+        GG = jtu.tree_map(
+            lambda p: init_conditioner(p, max_precond_dim, precondition_1d, qr_dtype),
+            params,
+        )
+        Q = jtu.tree_map(
+            lambda p: init_conditioner(p, max_precond_dim, precondition_1d, qr_dtype),
+            params,
+        )
+        return SOAPState(
+            count=jnp.zeros([], jnp.int32),
+            exp_avg=exp_avg,
+            exp_avg_sq=exp_avg_sq,
+            GG=GG,
+            Q=Q,
+        )
+
+    def init_step(
+        updates: Updates,
+        state: SOAPState,
+    ) -> tuple[Updates, SOAPState]:
+        new_GG = jtu.tree_map(
+            lambda grad, gg: update_preconditioner(grad, gg, shampoo_beta, precision),
+            updates,
+            state.GG,
+            is_leaf=_is_preconditioner,
+        )
+
+        new_Q = jtu.tree_map(
+            lambda gg: gg.map(lambda m: get_orthogonal_matrix(m, qr_dtype)),
+            new_GG,
+            is_leaf=_is_preconditioner,
+        )
+
+        # Replace updates with zeros
+        new_updates = otu.tree_zeros_like(updates)
+
+        return new_updates, state._replace(GG=new_GG, Q=new_Q)
+
+    def update_step(
+        updates: Updates,
+        state: SOAPState,
+    ) -> tuple[Updates, SOAPState]:
+        # Project gradients
+        grad_projected = jtu.tree_map(
+            lambda grad, q: project(grad, q, precision),
+            updates,
+            state.Q,
+            is_leaf=_is_preconditioner,
+        )
+
+        # Update moments
+        exp_avg = otu.tree_update_moment(grad_projected, state.exp_avg, b1, 1)
+        exp_avg_sq = otu.tree_update_moment_per_elem_norm(grad_projected, state.exp_avg_sq, b2, 2)
+        if mu_dtype is not None:
+            exp_avg = otu.tree_cast(exp_avg, mu_dtype)
+            exp_avg_sq = otu.tree_cast(exp_avg_sq, mu_dtype)
+
+        # Project back
+        norm_updates = jtu.tree_map(
+            lambda e_avg, e_avg_sq, q: project_back(e_avg / (jnp.sqrt(e_avg_sq) + eps), q, precision),
+            exp_avg,
+            exp_avg_sq,
+            state.Q,
+            is_leaf=_is_preconditioner,
+        )
+
+        if correct_bias:
+            # Bias correction: use (count - 1) because count=1 is the init step with no moment updates
+            effective_step = state.count - 1
+            bc1 = 1 - b1**effective_step
+            bc2 = 1 - b2**effective_step
+            corr = jnp.sqrt(bc2) / bc1
+
+            # Bias correction on the updates
+            norm_updates = jtu.tree_map(
+                lambda p: p * corr,
+                norm_updates,
+            )
+
+        # Update the preconditioner
+        new_GG = jtu.tree_map(
+            lambda grad, gg: update_preconditioner(grad, gg, shampoo_beta, precision),
+            updates,
+            state.GG,
+            is_leaf=_is_preconditioner,
+        )
+
+        # Update the orthogonal matrix / exp_avg_sq
+        def refresh_preconditioner() -> tuple[Updates, Updates, Updates]:
+            new_Q_and_exp_avg_sq = jtu.tree_map(
+                lambda e, gg, q: get_orthogonal_matrix_QR(gg, q, e, precision, qr_dtype),
+                exp_avg_sq,
+                new_GG,
+                state.Q,
+                is_leaf=_is_preconditioner,
+            )
+            new_Q = jtu.tree_map(
+                lambda _, x: x[0],
+                updates,
+                new_Q_and_exp_avg_sq,
+            )
+            new_exp_avg_sq = jtu.tree_map(
+                lambda _, x: x[1],
+                updates,
+                new_Q_and_exp_avg_sq,
+            )
+            new_exp_avg = jtu.tree_map(
+                lambda e, old_q, new_q: project(project_back(e, old_q, precision), new_q, precision),
+                exp_avg,
+                state.Q,
+                new_Q,
+                is_leaf=_is_preconditioner,
+            )
+            return new_Q, new_exp_avg_sq, new_exp_avg
+
+        def keep_preconditioner() -> tuple[Updates, Updates, Updates]:
+            return state.Q, exp_avg_sq, exp_avg
+
+        new_Q, exp_avg_sq, exp_avg = jax.lax.cond(
+            (state.count - 1) % precondition_frequency == 0,
+            refresh_preconditioner,
+            keep_preconditioner,
+        )
+
+        new_state = SOAPState(
+            count=state.count,
+            exp_avg=exp_avg,
+            exp_avg_sq=exp_avg_sq,
+            GG=new_GG,
+            Q=new_Q,
+        )
+
+        return norm_updates, new_state
+
+    def update_fn(updates: Updates, state: SOAPState, params: Optional[Updates] = None) -> tuple[Updates, SOAPState]:
+        del params
+        count_inc = jnp.asarray(optax.safe_int32_increment(state.count))
+        state = state._replace(count=count_inc)
+
+        updates, new_state = jax.lax.cond(
+            count_inc == 1,
+            lambda: init_step(updates, state),
+            lambda: update_step(updates, state),
+        )
+
+        return updates, new_state
+
+    return optax.GradientTransformation(init_fn, update_fn)  # type: ignore
+
+
+def add_decayed_weights_post(
+    weight_decay: float,
+    learning_rate: optax.ScalarOrSchedule,
+) -> GradientTransformation:
+    if weight_decay == 0.0:
+        return optax.identity()
+
+    def init_fn(params: Updates) -> PostDecayState:
+        del params
+        return PostDecayState(count=jnp.zeros([], jnp.int32))
+
+    def update_fn(
+        updates: Updates, state: PostDecayState, params: Optional[Updates] = None
+    ) -> tuple[Updates, PostDecayState]:
+        if params is None:
+            raise ValueError("add_decayed_weights_post requires parameters.")
+
+        count_inc = jnp.asarray(optax.safe_int32_increment(state.count))
+        lr = _resolve_learning_rate(learning_rate, count_inc)
+        decay = lr * weight_decay
+        decay = jnp.where(count_inc == 1, jnp.zeros_like(decay), decay)
+        updates = jtu.tree_map(lambda u, p: u - decay * p, updates, params)
+        return updates, state._replace(count=count_inc)
+
+    return optax.GradientTransformation(init_fn, update_fn)  # ty:ignore[invalid-argument-type]
+
+
+def update_preconditioner(
+    grad: Array,
+    GG: Preconditioner,
+    beta: float,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+) -> Preconditioner:
+    if grad.ndim == 1:
+        if GG.matrices[0] is None:
+            return GG
+        return Preconditioner(
+            [lerp(GG.matrices[0], jnp.matmul(grad[:, None], grad[None, :], precision=precision), 1 - beta)]
+        )
+
+    new_GG = []
+    for idx, gg in enumerate(GG.matrices):
+        if gg is None:
+            new_GG.append(None)
+            continue
+
+        outer_product = jnp.tensordot(
+            grad,
+            grad,
+            axes=[[*chain(range(idx), range(idx + 1, len(grad.shape)))]] * 2,
+            precision=precision,
+        )
+        new_GG.append(lerp(gg, outer_product, 1 - beta))
+
+    return Preconditioner(new_GG)
+
+
+def project(
+    grad: Array,
+    Q: Preconditioner,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+) -> Array:
+    for mat in Q.matrices:
+        if mat is not None:
+            grad = jnp.tensordot(
+                grad,
+                mat,
+                axes=((0,), (0,)),
+                precision=precision,
+            )
+        else:
+            permute_order = list(range(1, len(grad.shape))) + [0]
+            grad = jnp.transpose(grad, permute_order)
+
+    return grad
+
+
+def project_back(
+    grad: Array,
+    Q: Preconditioner,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+) -> Array:
+    for mat in Q.matrices:
+        if mat is not None:
+            grad = jnp.tensordot(
+                grad,
+                mat,
+                axes=((0,), (1,)),
+                precision=precision,
+            )
+        else:
+            grad = jnp.moveaxis(grad, 0, -1)
+
+    return grad
+
+
+def get_orthogonal_matrix(gg: Union[Array, None], qr_dtype: Any) -> Union[Array, None]:
+    if gg is None:
+        return None
+
+    gg_mat = gg.astype(qr_dtype) if gg.dtype != qr_dtype else gg
+    jitter = jnp.asarray(1e-30, dtype=qr_dtype)
+    _, eigh = jnp.linalg.eigh(gg_mat + jitter * jnp.eye(gg_mat.shape[0], dtype=qr_dtype))
+    q = jnp.flip(eigh, axis=1)
+    if q.dtype != gg.dtype:
+        q = q.astype(gg.dtype)
+    return q
+
+
+def get_orthogonal_matrix_QR(
+    GG: Preconditioner,
+    Q: Preconditioner,
+    exp_avg_sq: Array,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+    qr_dtype: Any = jnp.float32,
+) -> tuple[Preconditioner, Array]:
+    final_Q = []
+    for ind, (m, o) in enumerate(zip(GG.matrices, Q.matrices)):
+        if m is None or o is None:
+            final_Q.append(None)
+            continue
+
+        m_mat = m.astype(qr_dtype) if m.dtype != qr_dtype else m
+        o_mat = o.astype(qr_dtype) if o.dtype != qr_dtype else o
+        est_eig = jnp.diag(
+            jnp.matmul(
+                jnp.matmul(o_mat.T, m_mat, precision=precision),
+                o_mat,
+                precision=precision,
+            )
+        )
+        sort_idx = jnp.argsort(est_eig, descending=True)
+        exp_avg_sq = jnp.take(exp_avg_sq, sort_idx, axis=ind)
+        o_mat = o_mat[:, sort_idx]
+        power_iter = jnp.matmul(m_mat, o_mat, precision=precision)
+        Q_new, _ = jnp.linalg.qr(power_iter)
+
+        if Q_new.dtype != m.dtype:
+            Q_new = Q_new.astype(m.dtype)
+        final_Q.append(Q_new)
+
+    return Preconditioner(final_Q), exp_avg_sq
+
+
+def lerp(
+    start: Array,
+    end: Array,
+    weight: Numeric,
+) -> Array:
+    return start + weight * (end - start)
+
+
+def init_conditioner(
+    p: Array,
+    max_precond_dim: int,
+    precondition_1d: bool,
+    dtype: Any,
+) -> Preconditioner:
+    if p.ndim == 1:
+        if not precondition_1d or p.shape[0] > max_precond_dim:
+            return Preconditioner([None])
+        return Preconditioner([jnp.zeros((p.shape[0], p.shape[0]), dtype=dtype)])
+
+    return Preconditioner([jnp.zeros((s, s), dtype=dtype) if s <= max_precond_dim else None for s in p.shape])
+
+
+def _is_preconditioner(value: object) -> bool:
+    return isinstance(value, Preconditioner)
+
+
+def _resolve_learning_rate(learning_rate: optax.ScalarOrSchedule, count: Array) -> Array:
+    if callable(learning_rate):
+        return learning_rate(count)  # ty:ignore[invalid-return-type]
+
+    return jnp.asarray(learning_rate)

--- a/jno/optimizers/ssbroyden.py
+++ b/jno/optimizers/ssbroyden.py
@@ -1,0 +1,451 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Self-Scaled Broyden (SSBroyden/SSBFGS) optimizer.
+
+Ported from the PyTorch implementation provided by
+SciMBA (https://www.scimba.org/).
+
+Based on:
+  Urbán, J. F., Stefanou, P., & Pons, J. A. (2025).
+  Unveiling the optimization process of physics informed neural networks:
+  How accurate and competitive can PINNs be?.
+  Journal of Computational Physics, 523, 113656.
+"""
+
+from typing import NamedTuple, Optional, Union
+
+import jax
+import jax.flatten_util
+import jax.numpy as jnp
+from optax._src import base, combine, numerics, transform
+from optax._src import linesearch as _linesearch
+
+
+class ScaleBySSQuasiNewtonState(NamedTuple):
+    """State for the Self-Scaled Broyden/BFGS solver.
+
+    Attributes:
+      count: iteration counter.
+      flat_params: flattened parameters from the previous step.
+      flat_updates: flattened gradients from the previous step.
+      hessian_inv: dense inverse Hessian approximation, shape ``[n, n]``.
+      flat_prec_grad: flattened preconditioned gradient ``H_k g_k`` from the
+        previous step, used to recover the effective step size.
+    """
+
+    count: jax.typing.ArrayLike
+    flat_params: jax.typing.ArrayLike
+    flat_updates: jax.typing.ArrayLike
+    hessian_inv: jax.typing.ArrayLike
+    flat_prec_grad: jax.typing.ArrayLike
+
+
+def _update_hessian_inv(
+    hessian_inv: jax.Array,
+    s_k: jax.Array,
+    y_k: jax.Array,
+    alpha_k: jax.Array,
+    flat_prev_grad: jax.Array,
+    method: str,
+) -> jax.Array:
+    """Update the inverse Hessian approximation using SS-BFGS or SS-Broyden."""
+    n = s_k.shape[0]
+    Hk_yk = hessian_inv @ y_k
+    yk_dot_Hkyk = y_k @ Hk_yk
+    yk_dot_sk = y_k @ s_k
+
+    # Safeguard denominators
+    safe_yk_dot_Hkyk = jnp.where(jnp.abs(yk_dot_Hkyk) > 0, yk_dot_Hkyk, jnp.ones_like(yk_dot_Hkyk))
+    safe_yk_dot_sk = jnp.where(jnp.abs(yk_dot_sk) > 0, yk_dot_sk, jnp.ones_like(yk_dot_sk))
+
+    v_k = jnp.sqrt(jnp.maximum(yk_dot_Hkyk, 0.0)) * (s_k / safe_yk_dot_sk - Hk_yk / safe_yk_dot_Hkyk)
+
+    # SS-BFGS tau
+    sk_dot_gk = s_k @ flat_prev_grad
+    denominator = alpha_k * sk_dot_gk
+    safe_denom = jnp.where(jnp.abs(denominator) > 0, denominator, 1.0)
+    tau_k = jnp.where(
+        jnp.abs(denominator) > 0,
+        jnp.minimum(1.0, -yk_dot_sk / safe_denom),
+        1.0,
+    )
+    phi_k = jnp.ones_like(tau_k)
+
+    if method == "ssbroyden":
+        b_k = -alpha_k * sk_dot_gk / safe_yk_dot_sk
+        h_k = yk_dot_Hkyk / safe_yk_dot_sk
+        a_k = h_k * b_k - 1.0
+        # c_k = sqrt(a_k / (a_k + 1));
+        # guard against negative or zero denominator
+        safe_a_k_ratio = jnp.where(
+            (a_k > 0) & (a_k + 1.0 > 0),
+            a_k / (a_k + 1.0),
+            jnp.zeros_like(a_k),
+        )
+        c_k = jnp.sqrt(jnp.maximum(safe_a_k_ratio, 0.0))
+        rhom_k = jnp.minimum(1.0, h_k * (1.0 - c_k))
+
+        safe_a_k = jnp.where(jnp.abs(a_k) > 0, a_k, jnp.ones_like(a_k))
+        thetam_k = (rhom_k - 1.0) / safe_a_k
+        safe_rhom_k = jnp.where(jnp.abs(rhom_k) > 0, rhom_k, jnp.ones_like(rhom_k))
+        thetap_k = 1.0 / safe_rhom_k
+
+        safe_b_k = jnp.where(jnp.abs(b_k) > 0, b_k, jnp.ones_like(b_k))
+        theta_k = jnp.maximum(
+            thetam_k,
+            jnp.minimum(thetap_k, (1.0 - b_k) / safe_b_k),
+        )
+
+        sigma_k = 1.0 + a_k * theta_k
+        exp = -1.0 / jnp.maximum(n - 1, 1)
+        sigma_k_pow = jnp.where(n > 1, sigma_k**exp, 1.0)
+
+        safe_theta_k = jnp.where(
+            jnp.abs(theta_k) > 0,
+            theta_k,
+            jnp.ones_like(theta_k),
+        )
+        tau_k = jnp.where(
+            theta_k > 0,
+            tau_k * jnp.minimum(sigma_k_pow, 1.0 / safe_theta_k),
+            jnp.minimum(tau_k * sigma_k_pow, sigma_k),
+        )
+        phi_k = (1.0 - theta_k) / (1.0 + a_k * theta_k)
+
+    safe_tau_k = jnp.where(jnp.abs(tau_k) > 0, tau_k, jnp.ones_like(tau_k))
+
+    temp1 = jnp.outer(Hk_yk, Hk_yk) / safe_yk_dot_Hkyk
+    temp2 = phi_k * jnp.outer(v_k, v_k)
+    temp3 = jnp.outer(s_k, s_k) / safe_yk_dot_sk
+    H_new = (1.0 / safe_tau_k) * (hessian_inv - temp1 + temp2) + temp3
+
+    # Guard against NaN or non-positive curvature
+    valid = ~jnp.any(jnp.isnan(H_new)) & ~jnp.any(jnp.isinf(H_new)) & (yk_dot_sk > 0)
+    H_new = jnp.where(valid, H_new, hessian_inv)
+    return H_new
+
+
+def scale_by_ss_quasi_newton(
+    method: str = "ssbfgs",
+    scale_init_precond: bool = True,
+) -> base.GradientTransformation:
+    r"""Scale updates by the Self-Scaled Broyden/BFGS inverse Hessian.
+
+    This maintains a dense approximation of the inverse Hessian
+    :math:`H_k` and returns the preconditioned gradient
+    :math:`H_k \nabla f(w_k)`. Unlike L-BFGS, the full
+    :math:`n \times n` matrix is stored, so this is suitable only for
+    small to medium scale problems.
+
+    The inverse Hessian is updated using a self-scaled formula:
+
+    .. math::
+
+      H_{k+1} = \frac{1}{\tau_k}(H_k
+      - \frac{H_k y_k y_k^\top H_k}{y_k^\top H_k y_k}
+      + \phi_k v_k v_k^\top) + \frac{s_k s_k^\top}{y_k^\top s_k}
+
+    where the self-scaling factors :math:`\tau_k` and :math:`\phi_k` depend on
+    the chosen ``method`` (``'ssbfgs'`` or ``'ssbroyden'``).
+
+    This function is typically chained with a line search such as
+    :func:`optax.scale_by_zoom_linesearch`.
+
+    Args:
+      method: ``'ssbfgs'`` or ``'ssbroyden'``.
+        Controls the self-scaling formula.
+      scale_init_precond: if ``True``, scale the initial identity
+        preconditioner
+        by a capped reciprocal of the gradient norm at the first step.
+
+    Returns:
+      A :class:`optax.GradientTransformation` object.
+
+    References:
+      Urbán et al, `Unveiling the optimization process of physics
+      informed neural networks: How accurate and competitive can
+      PINNs be?
+      <https://doi.org/10.1016/j.jcp.2024.113656>`_, 2025
+
+    .. warning::
+      This optimizer stores a dense :math:`n \\times n` matrix
+      where :math:`n` is the total number of parameters. It is
+      memory intensive and best suited for small to medium scale
+      problems.
+    """
+    if method not in ("ssbfgs", "ssbroyden"):
+        raise ValueError(f"method must be 'ssbfgs' or 'ssbroyden', got '{method}'")
+
+    def init_fn(params: base.Params) -> ScaleBySSQuasiNewtonState:
+        flat_params, _ = jax.flatten_util.ravel_pytree(params)
+        n = flat_params.shape[0]
+        dtype = flat_params.dtype
+        return ScaleBySSQuasiNewtonState(
+            count=jnp.zeros([], jnp.int32),
+            flat_params=jnp.zeros(n, dtype=dtype),
+            flat_updates=jnp.zeros(n, dtype=dtype),
+            hessian_inv=jnp.eye(n, dtype=dtype),
+            flat_prec_grad=jnp.zeros(n, dtype=dtype),
+        )
+
+    def update_fn(
+        updates: base.Updates,
+        state: ScaleBySSQuasiNewtonState,
+        params: base.Params,
+    ) -> tuple[base.Updates, ScaleBySSQuasiNewtonState]:
+        flat_updates_new, unravel_fn = jax.flatten_util.ravel_pytree(updates)
+        flat_params_new = jax.flatten_util.ravel_pytree(params)[0]
+
+        # --- 1. Update inverse Hessian using info from previous step ---
+        s_k = flat_params_new - state.flat_params
+        y_k = flat_updates_new - state.flat_updates
+
+        # Zero out at first step (no previous data)
+        s_k = jnp.where(state.count > 0, s_k, jnp.zeros_like(s_k))
+        y_k = jnp.where(state.count > 0, y_k, jnp.zeros_like(y_k))
+
+        # Recover the effective step size from the previous
+        # iteration.  If the chain is
+        # scale_by_ss -> scale(-1) -> linesearch, then
+        # s_k = -alpha * prec_grad, so
+        # alpha = -(s_k . prec_grad) / ||prec_grad||^2
+        prec_sq = state.flat_prec_grad @ state.flat_prec_grad
+        alpha_k = jnp.where(
+            prec_sq > 0,
+            -(s_k @ state.flat_prec_grad) / prec_sq,
+            0.0,
+        )
+
+        hessian_inv = jnp.where(
+            state.count > 0,
+            _update_hessian_inv(
+                state.hessian_inv,
+                s_k,
+                y_k,
+                alpha_k,
+                state.flat_updates,
+                method,
+            ),
+            state.hessian_inv,
+        )
+
+        # --- 2. Scale the initial preconditioner at the first step ---
+        if scale_init_precond:
+            update_norm = jnp.linalg.norm(flat_updates_new)
+            capped_inv_norm = jnp.minimum(1.0, 1.0 / jnp.maximum(update_norm, 1e-30))
+            hessian_inv = jnp.where(state.count == 0, capped_inv_norm * hessian_inv, hessian_inv)
+
+        # --- 3. Precondition the current gradient ---
+        prec_grad_flat = hessian_inv @ flat_updates_new
+        prec_grad = unravel_fn(prec_grad_flat)
+
+        new_state = ScaleBySSQuasiNewtonState(
+            count=numerics.safe_increment(state.count),
+            flat_params=flat_params_new,
+            flat_updates=flat_updates_new,
+            hessian_inv=hessian_inv,
+            flat_prec_grad=prec_grad_flat,
+        )
+        return prec_grad, new_state
+
+    return base.GradientTransformation(init_fn, update_fn)
+
+
+def ssbroyden(
+    learning_rate: Optional[base.ScalarOrSchedule] = None,
+    scale_init_precond: bool = True,
+    linesearch: Optional[
+        Union[base.GradientTransformationExtraArgs, base.GradientTransformation]
+    ] = _linesearch.scale_by_zoom_linesearch(max_linesearch_steps=20, initial_guess_strategy="one"),
+) -> base.GradientTransformationExtraArgs:
+    r"""Self-Scaled Broyden optimizer.
+
+    SSBroyden is a quasi-Newton method that maintains a dense approximation of
+    the inverse Hessian. Unlike L-BFGS which uses a limited-memory
+    approximation, this method stores the full :math:`n \times n` matrix and
+    updates it using the self-scaled Broyden formula, yielding improved scaling
+    of the search direction at the cost of higher memory usage.
+
+    The inverse Hessian :math:`H_k` is updated each iteration as:
+
+    .. math::
+
+      H_{k+1} = \frac{1}{\tau_k}\!\left(H_k
+      - \frac{H_k y_k y_k^\top H_k}{y_k^\top H_k y_k}
+      + \phi_k\, v_k v_k^\top\right)
+      + \frac{s_k s_k^\top}{y_k^\top s_k}
+
+    where the self-scaling factors :math:`\tau_k, \phi_k` use the Broyden
+    formula.
+
+    Args:
+      learning_rate: optional global scaling factor, either fixed or evolving
+        along iterations with a scheduler. By default the learning rate is
+        handled by the line search.
+      scale_init_precond: whether to scale the initial identity
+        preconditioner by a capped reciprocal of the gradient norm.
+      linesearch: an instance of
+        :class:`optax.GradientTransformationExtraArgs` such as
+        :func:`optax.scale_by_zoom_linesearch` that computes a
+        step size satisfying sufficient decrease and curvature
+        conditions. Pass ``None`` to disable the line search.
+
+    Returns:
+      A :class:`optax.GradientTransformationExtraArgs` object.
+
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)
+      >>> solver = optax.contrib.ssbroyden()
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> value_and_grad = optax.value_and_grad_from_state(f)
+      >>> for _ in range(5):
+      ...   value, grad = value_and_grad(params, state=opt_state)
+      ...   updates, opt_state = solver.update(
+      ...      grad, opt_state, params,
+      ...      value=value, grad=grad, value_fn=f,
+      ...   )
+      ...   params = optax.apply_updates(params, updates)
+
+    References:
+      Urbán et al, `Unveiling the optimization process of
+      physics informed neural networks: How accurate and
+      competitive can PINNs be?
+      <https://doi.org/10.1016/j.jcp.2024.113656>`_, 2025
+
+    .. warning::
+      This optimizer stores a dense :math:`n \\times n` matrix
+      where :math:`n` is the total number of parameters. It is
+      memory intensive and best suited for small to medium
+      scale problems.
+
+    .. warning::
+      This optimizer works best with a line search (default is a zoom line
+      search). See the example above for best use in a non-stochastic setting
+      where gradients computed by the line search can be recycled using
+      :func:`optax.value_and_grad_from_state`.
+
+    .. seealso:: :func:`optax.contrib.ssbfgs`
+    """
+    if learning_rate is None:
+        base_scaling = transform.scale(-1.0)
+    else:
+        base_scaling = transform.scale_by_learning_rate(learning_rate)
+    if linesearch is None:
+        linesearch = base.identity()
+    return combine.chain(
+        scale_by_ss_quasi_newton(method="ssbroyden", scale_init_precond=scale_init_precond),
+        base_scaling,
+        linesearch,
+    )
+
+
+def ssbfgs(
+    learning_rate: Optional[base.ScalarOrSchedule] = None,
+    scale_init_precond: bool = True,
+    linesearch: Optional[
+        Union[base.GradientTransformationExtraArgs, base.GradientTransformation]
+    ] = _linesearch.scale_by_zoom_linesearch(max_linesearch_steps=20, initial_guess_strategy="one"),
+) -> base.GradientTransformationExtraArgs:
+    r"""Self-Scaled BFGS optimizer.
+
+    SSBFGS is a quasi-Newton method that maintains a dense approximation of
+    the inverse Hessian. Unlike L-BFGS which uses a limited-memory
+    approximation, this method stores the full :math:`n \times n` matrix and
+    updates it using the self-scaled BFGS formula, yielding improved scaling
+    of the search direction at the cost of higher memory usage.
+
+    The inverse Hessian :math:`H_k` is updated each iteration as:
+
+    .. math::
+
+      H_{k+1} = \frac{1}{\tau_k}\!\left(H_k
+      - \frac{H_k y_k y_k^\top H_k}{y_k^\top H_k y_k}
+      + v_k v_k^\top\right)
+      + \frac{s_k s_k^\top}{y_k^\top s_k}
+
+    where the self-scaling factor :math:`\tau_k` uses the BFGS formula
+    (:math:`\phi_k = 1`).
+
+    Args:
+      learning_rate: optional global scaling factor, either fixed or evolving
+        along iterations with a scheduler. By default the learning rate is
+        handled by the line search.
+      scale_init_precond: whether to scale the initial identity
+        preconditioner by a capped reciprocal of the gradient norm.
+      linesearch: an instance of
+        :class:`optax.GradientTransformationExtraArgs` such as
+        :func:`optax.scale_by_zoom_linesearch` that computes a
+        step size satisfying sufficient decrease and curvature
+        conditions. Pass ``None`` to disable the line search.
+
+    Returns:
+      A :class:`optax.GradientTransformationExtraArgs` object.
+
+    Examples:
+      >>> import optax
+      >>> import jax
+      >>> import jax.numpy as jnp
+      >>> def f(x): return jnp.sum(x ** 2)
+      >>> solver = optax.contrib.ssbfgs()
+      >>> params = jnp.array([1., 2., 3.])
+      >>> print('Objective function: ', f(params))
+      Objective function:  14.0
+      >>> opt_state = solver.init(params)
+      >>> value_and_grad = optax.value_and_grad_from_state(f)
+      >>> for _ in range(5):
+      ...   value, grad = value_and_grad(params, state=opt_state)
+      ...   updates, opt_state = solver.update(
+      ...      grad, opt_state, params,
+      ...      value=value, grad=grad, value_fn=f,
+      ...   )
+      ...   params = optax.apply_updates(params, updates)
+
+    References:
+      Urbán et al, `Unveiling the optimization process of
+      physics informed neural networks: How accurate and
+      competitive can PINNs be?
+      <https://doi.org/10.1016/j.jcp.2024.113656>`_, 2025
+
+    .. warning::
+      This optimizer stores a dense :math:`n \\times n` matrix
+      where :math:`n` is the total number of parameters. It is
+      memory intensive and best suited for small to medium
+      scale problems.
+
+    .. warning::
+      This optimizer works best with a line search (default is a zoom line
+      search). See the example above for best use in a non-stochastic setting
+      where gradients computed by the line search can be recycled using
+      :func:`optax.value_and_grad_from_state`.
+
+    .. seealso:: :func:`optax.contrib.ssbroyden`
+    """
+    if learning_rate is None:
+        base_scaling = transform.scale(-1.0)
+    else:
+        base_scaling = transform.scale_by_learning_rate(learning_rate)
+    if linesearch is None:
+        linesearch = base.identity()
+    return combine.chain(
+        scale_by_ss_quasi_newton(method="ssbfgs", scale_init_precond=scale_init_precond),
+        base_scaling,
+        linesearch,
+    )

--- a/tests/test_jno_optimizers.py
+++ b/tests/test_jno_optimizers.py
@@ -1,0 +1,76 @@
+"""``jno.optimizers`` — the optax-compatible optimizer namespace (optax re-export + custom
+second-order methods ssbroyden / ssbfgs / soap). Each custom optimizer is an optax
+``GradientTransformation``, so it converges in a plain optax loop and composes with ``optax.chain``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+import jno
+
+TARGET = jnp.array([3.0, -2.0, 0.5])
+
+
+def _loss(x):
+    return jnp.sum((x - TARGET) ** 2)
+
+
+def _minimise_linesearch(opt, steps):
+    """Loop for line-search optimizers (ssbroyden / ssbfgs): they consume the loss value + grad."""
+    value_and_grad = optax.value_and_grad_from_state(_loss)
+    x = jnp.zeros(3)
+    state = opt.init(x)
+    for _ in range(steps):
+        value, grad = value_and_grad(x, state=state)
+        updates, state = opt.update(grad, state, x, value=value, grad=grad, value_fn=_loss)
+        x = optax.apply_updates(x, updates)
+    return np.asarray(x)
+
+
+def _minimise_grad(opt, steps):
+    """Loop for plain gradient optimizers (soap)."""
+    gfn = jax.grad(_loss)
+    x = jnp.zeros(3)
+    state = opt.init(x)
+    for _ in range(steps):
+        updates, state = opt.update(gfn(x), state, x)
+        x = optax.apply_updates(x, updates)
+    return np.asarray(x)
+
+
+def test_namespace_is_just_the_optimizers():
+    o = jno.optimizers
+    # exactly the custom optimizers — each an optax GradientTransformation
+    assert set(o.__all__) == {"ssbroyden", "ssbfgs", "scale_by_ss_quasi_newton", "soap", "scale_by_soap"}
+    for factory in (o.ssbroyden, o.ssbfgs, o.soap):
+        opt = factory()
+        assert hasattr(opt, "init") and hasattr(opt, "update")
+    # NOT a re-export of optax — chain/clipping/schedules live in optax, not here
+    for n in ("chain", "adam", "clip_by_global_norm", "cosine_decay_schedule"):
+        assert not hasattr(o, n), f"jno.optimizers should not re-export optax.{n}"
+
+
+def test_ssbroyden_converges():
+    x = _minimise_linesearch(jno.optimizers.ssbroyden(), steps=30)
+    assert np.allclose(x, np.asarray(TARGET), atol=1e-3)
+
+
+def test_ssbfgs_converges():
+    x = _minimise_linesearch(jno.optimizers.ssbfgs(), steps=30)
+    assert np.allclose(x, np.asarray(TARGET), atol=1e-3)
+
+
+def test_soap_converges():
+    x = _minimise_grad(jno.optimizers.soap(learning_rate=0.2), steps=400)
+    assert np.allclose(x, np.asarray(TARGET), atol=1e-2)
+
+
+def test_works_inside_optax_chain():
+    # a custom optimizer composed via optax directly (optax.chain + optax clipping)
+    opt = optax.chain(optax.clip_by_global_norm(10.0), jno.optimizers.ssbfgs())
+    x = _minimise_linesearch(opt, steps=30)
+    assert np.allclose(x, np.asarray(TARGET), atol=1e-2)


### PR DESCRIPTION
… (ssbroyden/ssbfgs/soap)

jno.optimizers holds ONLY custom optimizers not in optax; for chain / schedules / clipping use optax directly. Each is an optax GradientTransformation, so it composes with optax.chain and drops into model.optimizer(...) / parameter.optimizer(...):

    k.optimizer(jno.optimizers.ssbroyden())
    k.optimizer(optax.chain(optax.clip_by_global_norm(1.0), jno.optimizers.ssbfgs()))

- ssbroyden() / ssbfgs(): Self-Scaled Broyden / BFGS quasi-Newton with a zoom line search (Urban, Stefanou & Pons, J. Comput. Phys. 523 (2025) 113656; Apache-2.0, from optax/DeepMind). Far fewer steps than Adam on smooth PINN/inverse losses.
- soap() / scale_by_soap(): SOAP, Shampoo with Adam in the preconditioner eigenbasis (Vyas et al. 2024, arXiv:2409.11321). Vendored from SOAP_JAX (MIT, (c) Haydn Jones), chex/jaxtyping type-hint imports stripped to avoid extra deps; algorithm unchanged.
- scale_by_* variants expose the bare transforms for building your own optax chains.

New jno/optimizers/ package wired into jno.__init__; tests/test_jno_optimizers.py (namespace is just the optimizers + convergence + works inside optax.chain, 5 tests); docs section with citations. Extend by dropping an optax GradientTransformation in.