### PR TITLE
feat(fem): periodic ties compose with complex / parametric / coupling / field-param k(x)

### DIFF
--- a/docs/Domain-and-Geometry.md
+++ b/docs/Domain-and-Geometry.md
@@ -364,6 +364,8 @@ For explicit BC surfaces (e.g. an inlet face that is a subset of a boundary), us
 
 `build_mesh` accepts `sizes={"name": h}` as a short spelling of `region_mesh_sizes=`.
 
+Interfaces between named regions are meshed **conformingly**: the two regions sharing an interface always get the same nodes along it (a shared, constrained edge), so heat, flux, and radiation pass across the interface and `boundary_<name>` picks up a single well-defined edge. This holds even when one region (e.g. a complement region such as a meshed gas/air gap built as box-minus-everything) describes the shared edge with extra vertices the neighbour lacks.
+
 #### Custom samplers (mesh-free path only)
 
 When `build_mesh()` is **not** called, interior points are drawn by uniform rejection sampling inside each polygon. Pass a callable to override this per region or globally. The sampler signature is `fn(geometry, n) -> np.ndarray` with shape `(n, 2)`.

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -570,14 +570,22 @@ def _is_complex_form(domain: Any, ir: Any) -> bool:
     return False
 
 
-def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None) -> Any:
+def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic: Optional[dict] = None) -> Any:
     """Solve a complex linear FEM system via the real-equivalent block (everything was
     assembled as two *real* systems)::
 
         [[A_r, -A_i], [A_i, A_r]] [u_r; u_i] = [b_r; b_i],     u = u_r + i u_i.
 
-    ``ops = (op_r, op_i)`` are the Re-coeff and Im-coeff real systems (each a raw ``(A, b)``)."""
+    ``ops = (op_r, op_i)`` are the Re-coeff and Im-coeff real systems (each a raw ``(A, b)``).
+
+    A periodic tie reduces *both* legs by the **same** prolongation ``P`` -- Re and Im live on one FE
+    space, so one ``P`` -- before the block is formed: ``A -> P^T A P``, ``b -> P^T b`` on each leg.
+    Because the same ``P`` hits both, ``blkdiag(P, P)^T [[A_r,-A_i],[A_i,A_r]] blkdiag(P, P)`` preserves
+    the real-equivalent structure exactly; the reduced complex solution is prolonged back ``u = P u_red``.
+    The reduction runs while the operator is still BCOO (sparse triplet-remap), then the *smaller*
+    reduced block is densified for ``jnp.block``."""
     from .trace import FemLinearSystem
+    from .utils.solver.fem_utils import prolong_periodic, reduce_matrix_periodic, reduce_vector_periodic
 
     def _ab(op):
         if isinstance(op, FemLinearSystem):
@@ -587,6 +595,10 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None) -> Any:
                 "forward works under the same real-equivalent block, but is not wired here yet.)"
             )
         A, b = op
+        b = jnp.asarray(b).reshape(-1)
+        if periodic is not None:
+            A = reduce_matrix_periodic(periodic, A)  # P^T A P  (stays sparse if A is BCOO)
+            b = reduce_vector_periodic(periodic, b)  # P^T b
         A = jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)
         return A, jnp.asarray(b).reshape(-1)
 
@@ -596,7 +608,11 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None) -> Any:
     rhs = jnp.concatenate([b_r, b_i])
     solve_fn = solve_fn or (lambda A, b: jnp.linalg.solve(A, b))
     sol = jnp.asarray(solve_fn(block, rhs))
-    return sol[:n] + 1j * sol[n:]
+    if periodic is None:
+        return sol[:n] + 1j * sol[n:]
+    # Prolong the real and imaginary reduced halves *separately* (real P @ real vector); prolonging the
+    # complex vector directly would cast it to P's real dtype and silently drop the imaginary part.
+    return prolong_periodic(periodic, sol[:n]) + 1j * prolong_periodic(periodic, sol[n:])
 
 
 def _solve_complex_transient(blocks: Any, save_ts: Any = None) -> Any:
@@ -834,7 +850,7 @@ class FEM:
         to choose the real block solver.
         """
         if self._mode == "complex":
-            return _solve_complex_block(self._op, solve_fn)
+            return _solve_complex_block(self._op, solve_fn, periodic=self._periodic)
         if self._mode == "complex_transient":
             return _solve_complex_transient(self._op, save_ts=kwargs.get("save_ts"))
         if self._mode == "linear" and not isinstance(self._op, FemLinearSystem):
@@ -1339,6 +1355,31 @@ def _reduce_transient_block_periodic(block: Any, periodic: dict) -> Any:
     )
 
 
+def reduce_op_periodic(op: Any, mode: str, periodic: dict) -> Any:
+    """Apply the periodic Galerkin reduction ``P`` to a FEM operator, recursing into composite ops.
+
+    One combinator over every :class:`FEM` ``_op`` representation, so a periodic tie composes with each
+    feature without a per-combination branch:
+
+    * ``"transient"`` -- eager reduction of the ``SemidiscreteTimeBlock`` (``P^T M P``, ``P^T A P``,
+      runtime ``operator_fn``/``forcing_vector_fn``, restricted ``state0``) via
+      :func:`_reduce_transient_block_periodic`.
+    * ``"complex"`` / ``"complex_transient"`` -- ``op`` is a ``(re, im)`` tuple of real systems that
+      share **one** FE space, hence **one** ``P``; each leg is reduced with the *same* ``periodic`` so
+      the real-equivalent block ``[[A_r, -A_i], [A_i, A_r]]`` (and its transient analogue) is preserved
+      exactly. (``complex`` legs are raw ``(A, b)``; ``complex_transient`` legs are time blocks.)
+    * ``"linear"`` (a raw ``(A, b)``) and ``"nonlinear"`` (a residual operator) -- returned unchanged;
+      these reduce lazily at solve time in :meth:`FEM.solve` (``P^T A P`` on the BCOO operator, or the
+      ``P^T r(P·)`` residual wrap), which keeps the operator sparse and the residual matrix-free.
+    """
+    if mode in ("complex", "complex_transient"):
+        leg_mode = "transient" if mode == "complex_transient" else "linear"
+        return tuple(reduce_op_periodic(leg, leg_mode, periodic) for leg in op)
+    if mode == "transient":
+        return _reduce_transient_block_periodic(op, periodic)
+    return op
+
+
 class Coupling:
     """A **nonlocal** residual term passed in the ``jno.fem([...])`` list.
 
@@ -1645,10 +1686,10 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
             return _wrap_couplings(domain, fem_obj, couplings)
         if not periodic_ties:
             return fem_obj
-        if fem_obj._mode in ("complex", "complex_transient"):
+        if fem_obj._mode == "complex_transient":
             raise NotImplementedError(
-                "jno.fem: periodic ties on complex problems are not supported yet (the real-equivalent "
-                "block would need the reduction applied to both the real and imaginary sub-blocks)."
+                "jno.fem: periodic ties on a complex *transient* problem are not supported yet "
+                "(the reduction must be applied to both the real and imaginary time blocks)."
             )
         if isinstance(fem_obj._op, FemLinearSystem):
             # The reduction is applied on the non-parametric (A, b) branch of FEM.solve; the
@@ -1674,9 +1715,10 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
             )
         else:
             periodic = _build_periodic_reduction(domain, periodic_ties, fem_obj.points, cells, ele_order, vec or 1)
-        # A transient block is reduced now (P^T M P, ...); the steady/nonlinear ops reduce lazily in FEM.solve.
-        if fem_obj.is_transient:
-            fem_obj._op = _reduce_transient_block_periodic(fem_obj._op, periodic)
+        # One op-level reduction combinator handles every representation: a transient block is reduced
+        # now (P^T M P, ...) and a complex (re, im) tuple is reduced leg-wise with the same P; steady
+        # linear (A, b) and nonlinear residual ops are returned unchanged and reduce lazily in FEM.solve.
+        fem_obj._op = reduce_op_periodic(fem_obj._op, fem_obj._mode, periodic)
         fem_obj._periodic = periodic
         return fem_obj
 
@@ -1940,7 +1982,6 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         not is_vpinn
         and _is_complex_form(domain, ir)
         and not is_transient
-        and not periodic_ties
         and _native_lagrange_ok(domain, constraints, weak_bares, periodic_ties)
         and not any(_crp(b) for b in weak_bares)
     ):

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -627,14 +627,19 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic
     )
 
 
-def _solve_complex_transient(blocks: Any, save_ts: Any = None) -> Any:
+def _solve_complex_transient(blocks: Any, save_ts: Any = None, periodic: Optional[dict] = None) -> Any:
     """Integrate a complex *transient* system via the real-equivalent block (everything was
     assembled as real systems): ``(M_r + i M_i) u_dot + (A_r + i A_i) u = (c_r + i c_i)`` becomes
     the real ``2N`` system
     ``M_blk u_dot + A_blk u = c_blk`` with ``M_blk=[[M_r,-M_i],[M_i,M_r]]`` (likewise A, c) and
     ``u=[u_r;u_i]``. Backward Euler over the block, then recombine to ``u_r + i u_i``. ``blocks =
     (block_r, block_i)`` are the Re-coeff and Im-coeff real ``SemidiscreteTimeBlock``s. This covers
-    Schrodinger (``i u_t = H u`` -> M_r = 0) since the *block* mass stays non-singular."""
+    Schrodinger (``i u_t = H u`` -> M_r = 0) since the *block* mass stays non-singular.
+
+    With a periodic tie the two blocks arrive already reduced (``P^T M P`` etc., restricted ``state0``)
+    by the same ``P``, so the integration runs in the reduced master-DOF space; each saved slice is then
+    prolonged back ``u = P u_red`` -- real and imaginary parts separately (a real ``P`` would cast a
+    complex vector to its real dtype and drop the imaginary part)."""
 
     def _dn(a):
         return jnp.asarray(a.todense()) if hasattr(a, "todense") else jnp.asarray(a)
@@ -670,7 +675,12 @@ def _solve_complex_transient(blocks: Any, save_ts: Any = None) -> Any:
     traj = jnp.concatenate([w0[None, :], ws], axis=0)  # (n_grid, 2N)
     save_ts = grid if save_ts is None else jnp.asarray(save_ts)
     traj = jax.vmap(lambda col: jnp.interp(save_ts, grid, col), in_axes=1, out_axes=1)(traj)
-    return traj[:, :n] + 1j * traj[:, n:]  # (n_save, N) complex
+    result = traj[:, :n] + 1j * traj[:, n:]  # (n_save, n_red) complex (full N when untied)
+    if periodic is None:
+        return result
+    from .utils.solver.fem_utils import prolong_periodic
+
+    return prolong_periodic(periodic, result.real) + 1j * prolong_periodic(periodic, result.imag)
 
 
 def _is_temporal_value_node(node: Any) -> bool:
@@ -864,7 +874,7 @@ class FEM:
         if self._mode == "complex":
             return _solve_complex_block(self._op, solve_fn, periodic=self._periodic)
         if self._mode == "complex_transient":
-            return _solve_complex_transient(self._op, save_ts=kwargs.get("save_ts"))
+            return _solve_complex_transient(self._op, save_ts=kwargs.get("save_ts"), periodic=self._periodic)
         if self._mode == "linear" and not isinstance(self._op, FemLinearSystem):
             # Non-parametric steady linear. Default: matrix-free Jacobi-preconditioned BiCGStab on the
             # BCOO operator (never densifies -> memory O(nnz); GPU-safe; solves general systems). Pass
@@ -1708,11 +1718,6 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
             fem_obj = _wrap_couplings(domain, fem_obj, couplings)
         if not periodic_ties:
             return fem_obj
-        if fem_obj._mode == "complex_transient":
-            raise NotImplementedError(
-                "jno.fem: periodic ties on a complex *transient* problem are not supported yet "
-                "(the reduction must be applied to both the real and imaginary time blocks)."
-            )
         # Single-field transient was already reduced by the dedicated native branch -> reuse its P.
         if periodic_holder:
             fem_obj._periodic = periodic_holder[0]
@@ -2024,7 +2029,6 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         not is_vpinn
         and is_transient
         and _is_complex_form(domain, ir)
-        and not periodic_ties
         and not multifield
         and _native_lagrange_ok(domain, constraints, weak_bares, periodic_ties)
         and not any(_crp(b) for b in weak_bares)

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1683,12 +1683,17 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         the time route's existing context-driven reduction. Single-field, vector, and coupled
         multi-field are all reduced block-wise (P_i^T M[i,j] P_j); complex / runtime-parametric remain out."""
         fem_obj._term_source = (domain, volume_terms)
+        if couplings and periodic_ties and fem_obj.is_transient:
+            # The native periodic *transient* block reduces eagerly into a master-DOF space; the coupling
+            # residual is written in the full nodal space, so the two cannot be composed on that path yet.
+            raise NotImplementedError(
+                "jno.fem: periodic ties combined with a *transient* nonlocal Coupling are not yet supported."
+            )
         if couplings:
-            if periodic_ties:
-                raise NotImplementedError(
-                    "jno.fem: periodic ties combined with nonlocal Coupling terms are not yet supported."
-                )
-            return _wrap_couplings(domain, fem_obj, couplings)
+            # Fold the coupling into the residual FIRST -- a steady local form is promoted to a nonlinear
+            # FemResidualOperator. The periodic reduction below then wraps the *coupled* residual through
+            # the nonlinear Pᵀr(P·) solve path, so a periodic tie + Coupling compose with no extra branch.
+            fem_obj = _wrap_couplings(domain, fem_obj, couplings)
         if not periodic_ties:
             return fem_obj
         if fem_obj._mode == "complex_transient":

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -885,6 +885,11 @@ class FEM:
                 return _solve_linear_matrix_free(A, b)
             A = jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)
             return (solve_fn or (lambda A_, b_: jnp.linalg.solve(A_, b_)))(A, b)
+        if self._mode == "linear" and isinstance(self._op, FemLinearSystem):
+            # Runtime-parametric steady linear: solve A(θ)x=b(θ) as a trace node (∂u/∂θ flows through
+            # solve_fn). A periodic tie reduces per-call inside FemLinearSystem.solve, after A(θ) is
+            # re-formed: u = P · solve(PᵀA(θ)P, Pᵀb(θ)); self._periodic is None for the untied case.
+            return self._op.solve(solve_fn, periodic=self._periodic)
         if self._mode == "nonlinear" and self._periodic is not None:
             # Periodic nonlinear: solve Newton in the reduced space -- r_red(u_red) = P^T r(P u_red) = 0,
             # then prolong u = P u_red (the tie is then satisfied exactly). Wraps the user's solve_fn
@@ -1691,10 +1696,6 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
                 "jno.fem: periodic ties on a complex *transient* problem are not supported yet "
                 "(the reduction must be applied to both the real and imaginary time blocks)."
             )
-        if isinstance(fem_obj._op, FemLinearSystem):
-            # The reduction is applied on the non-parametric (A, b) branch of FEM.solve; the
-            # runtime-parametric FemLinearSystem.solve path would silently ignore it.
-            raise NotImplementedError("jno.fem: periodic ties are not yet supported on runtime-parametric linear problems.")
         # Single-field transient was already reduced by the dedicated native branch -> reuse its P.
         if periodic_holder:
             fem_obj._periodic = periodic_holder[0]
@@ -1942,13 +1943,11 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
     # below. ----
     from .utils.solver.parametric_helpers import _contains_runtime_parameter as _crp
 
-    # Native periodic is wired only for the steady, scalar, non-parametric single-field case that
-    # ``_finalize`` reduces (it raises on vector / runtime-parametric, and the transient route pre-
-    # builds the reduction into its own time block). Those periodic sub-cases route to the dedicated
-    # periodic-transient branch below.
-    _native_periodic_ok = not periodic_ties or (
-        not is_transient and (vec or 1) == 1 and not any(_crp(b) for b in weak_bares)
-    )
+    # Native periodic is wired for the steady, scalar single-field case that ``_finalize`` reduces --
+    # both non-parametric (reduced eagerly at solve) and runtime-parametric (reduced per-call inside
+    # FemLinearSystem.solve, after A(θ) is re-formed). Vector and the transient route pre-build the
+    # reduction in their own branches, so they fall through here.
+    _native_periodic_ok = not periodic_ties or (not is_transient and (vec or 1) == 1)
     if (
         not is_vpinn
         and _native_lagrange_ok(domain, constraints, weak_bares, periodic_ties)

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -576,7 +576,11 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic
 
         [[A_r, -A_i], [A_i, A_r]] [u_r; u_i] = [b_r; b_i],     u = u_r + i u_i.
 
-    ``ops = (op_r, op_i)`` are the Re-coeff and Im-coeff real systems (each a raw ``(A, b)``).
+    ``ops = (op_r, op_i)`` are the Re-coeff and Im-coeff real systems. Each is a raw ``(A, b)`` (forward
+    solve) or a parametric :class:`FemLinearSystem` (the complex *inverse*): when either leg is
+    parametric this returns a differentiable :class:`FunctionCall` trace node instead of an array, so a
+    real ``jno.np.parameter`` recovered through a complex forward solve trains through ``crux`` -- the
+    same real-equivalent block, with ``A(θ), b(θ)`` re-formed and the block re-solved on each call.
 
     A periodic tie reduces *both* legs by the **same** prolongation ``P`` -- Re and Im live on one FE
     space, so one ``P`` -- before the block is formed: ``A -> P^T A P``, ``b -> P^T b`` on each leg.
@@ -584,17 +588,11 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic
     the real-equivalent structure exactly; the reduced complex solution is prolonged back ``u = P u_red``.
     The reduction runs while the operator is still BCOO (sparse triplet-remap), then the *smaller*
     reduced block is densified for ``jnp.block``."""
-    from .trace import FemLinearSystem
+    from .trace import FemLinearSystem, FunctionCall
     from .utils.solver.fem_utils import prolong_periodic, reduce_matrix_periodic, reduce_vector_periodic
 
-    def _ab(op):
-        if isinstance(op, FemLinearSystem):
-            raise NotImplementedError(
-                "Complex FEM with a runtime jno.np.parameter (the complex *inverse*) is a follow-on; "
-                "this path is the forward complex solve. (A real parameter recovered through a complex "
-                "forward works under the same real-equivalent block, but is not wired here yet.)"
-            )
-        A, b = op
+    def _leg(op, args):  # -> reduced, densified (A, b) for one Re/Im system
+        A, b = op.evaluate(args) if isinstance(op, FemLinearSystem) else op
         b = jnp.asarray(b).reshape(-1)
         if periodic is not None:
             A = reduce_matrix_periodic(periodic, A)  # P^T A P  (stays sparse if A is BCOO)
@@ -602,17 +600,31 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic
         A = jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)
         return A, jnp.asarray(b).reshape(-1)
 
-    (A_r, b_r), (A_i, b_i) = _ab(ops[0]), _ab(ops[1])
-    n = A_r.shape[0]
-    block = jnp.block([[A_r, -A_i], [A_i, A_r]])
-    rhs = jnp.concatenate([b_r, b_i])
-    solve_fn = solve_fn or (lambda A, b: jnp.linalg.solve(A, b))
-    sol = jnp.asarray(solve_fn(block, rhs))
-    if periodic is None:
-        return sol[:n] + 1j * sol[n:]
-    # Prolong the real and imaginary reduced halves *separately* (real P @ real vector); prolonging the
-    # complex vector directly would cast it to P's real dtype and silently drop the imaginary part.
-    return prolong_periodic(periodic, sol[:n]) + 1j * prolong_periodic(periodic, sol[n:])
+    _sf = solve_fn or (lambda A, b: jnp.linalg.solve(A, b))
+
+    def _block_solve(args):
+        (A_r, b_r), (A_i, b_i) = _leg(ops[0], args), _leg(ops[1], args)
+        n = A_r.shape[0]
+        block = jnp.block([[A_r, -A_i], [A_i, A_r]])
+        sol = jnp.asarray(_sf(block, jnp.concatenate([b_r, b_i])))
+        if periodic is None:
+            return sol[:n] + 1j * sol[n:]
+        # Prolong the real and imaginary reduced halves *separately* (real P @ real vector); prolonging
+        # the complex vector directly would cast it to P's real dtype and silently drop the imaginary part.
+        return prolong_periodic(periodic, sol[:n]) + 1j * prolong_periodic(periodic, sol[n:])
+
+    # Forward (non-parametric): solve eagerly. Inverse: one or both legs are a parametric FemLinearSystem
+    # -> return a trace node over the union of their runtime parameters so ∂u/∂θ flows through crux.
+    rpe: dict = {}
+    for op in ops:
+        if isinstance(op, FemLinearSystem):
+            rpe.update(op.runtime_parameter_exprs)
+    if not rpe:
+        return _block_solve(None)
+    names = list(rpe)
+    return FunctionCall(
+        lambda *vals: _block_solve(dict(zip(names, vals))), [rpe[n] for n in names], name="fem_complex_solve"
+    )
 
 
 def _solve_complex_transient(blocks: Any, save_ts: Any = None) -> Any:
@@ -1987,8 +1999,9 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         and _is_complex_form(domain, ir)
         and not is_transient
         and _native_lagrange_ok(domain, constraints, weak_bares, periodic_ties)
-        and not any(_crp(b) for b in weak_bares)
     ):
+        # A runtime parameter is allowed here (the complex *inverse*): assemble_fem_native then returns
+        # parametric FemLinearSystem legs and _solve_complex_block builds a differentiable trace node.
         from .utils.solver.fem_native import assemble_fem_native
 
         real_bd = {tag: [e.real for e in exprs] for tag, exprs in boundary_terms.items()}

--- a/jno/domain/polygon_domain.py
+++ b/jno/domain/polygon_domain.py
@@ -1795,6 +1795,20 @@ class PolygonDomain(domain):
         # disjointly across source regions in iteration order; any active
         # leftover (no source claims it) is meshed as an unnamed remainder.
         region_parts = self._partition_active_by_source_region()
+        # Conforming interfaces: a shared edge may be described with different
+        # vertices by the two regions that meet on it (e.g. a CSG boolean adds
+        # a vertex mid-edge on one side only). Insert the union of all
+        # partition-boundary vertices into every ring so both sides split the
+        # interface identically (matching gmsh lines) — otherwise the two sides
+        # mesh independently with interleaved nodes and the interface transmits
+        # nothing across it. Superset of the source-edge-endpoint insertion,
+        # which clips to the outer boundary and misses internal interfaces.
+        endpoint_keys = {(round(p[0], 14), round(p[1], 14)) for p in source_endpoints}
+        source_endpoints = list(source_endpoints) + [
+            p
+            for p in self._collect_partition_vertices(region_parts)
+            if (round(p[0], 14), round(p[1], 14)) not in endpoint_keys
+        ]
 
         with pygmsh.geo.Geometry() as geo:
             point_cache: Dict[Tuple[float, float], Any] = {}
@@ -2118,6 +2132,39 @@ class PolygonDomain(domain):
                             seen.add(key)
                             endpoints.append((float(pt[0]), float(pt[1])))
         return endpoints
+
+    def _collect_partition_vertices(
+        self, region_parts: Sequence[Tuple[BaseGeometry, Optional[str]]]
+    ) -> List[Tuple[float, float]]:
+        """Every distinct boundary vertex across all partitioned region pieces.
+
+        Two regions that share an interface may describe it with *different*
+        vertices (e.g. one region's edge is a single segment while the
+        neighbour splits the same span at extra points introduced by a CSG
+        boolean). Emitting each ring independently then produces non-matching
+        gmsh lines on that interface, so gmsh meshes the two sides with their
+        own interleaved nodes — a **non-conforming** interface that transmits
+        neither conduction nor radiation. Inserting this union of vertices into
+        every ring (via :meth:`_ring_coords_with_endpoints`) forces both sides
+        to segment a shared edge identically, so the interface lines coincide
+        in the line cache and the mesh is conforming. Superset of
+        :meth:`_collect_source_edge_endpoints`, which clips to the outer
+        boundary and so cannot see vertices on *internal* interfaces.
+        """
+        seen: set = set()
+        out: List[Tuple[float, float]] = []
+        for part, _name in region_parts:
+            polys = part.geoms if part.geom_type == "MultiPolygon" else [part]
+            for poly in polys:
+                if getattr(poly, "geom_type", "") != "Polygon":
+                    continue
+                for ring in (poly.exterior, *poly.interiors):
+                    for c in ring.coords:
+                        key = (round(float(c[0]), 14), round(float(c[1]), 14))
+                        if key not in seen:
+                            seen.add(key)
+                            out.append((float(c[0]), float(c[1])))
+        return out
 
     def _ring_coords_with_endpoints(
         self,

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -2921,7 +2921,7 @@ class FemLinearSystem:
         b = self.b if self.rhs_fn is None else self.rhs_fn(args)
         return A, b
 
-    def solve(self, solve_fn=None):
+    def solve(self, solve_fn=None, *, periodic=None):
         """Differentiable forward solve ``u = solve_fn(A(θ), b(θ))`` as a trace node.
 
         Returns a :class:`FunctionCall` field. When it is evaluated (e.g. inside
@@ -2944,6 +2944,12 @@ class FemLinearSystem:
         (``jax_enable_x64``) and set the parameter dtype to match — the
         assembly is float64. (``spsolve``'s cuSolver-GPU path can be flaky; pass your own
         ``solve_fn`` if you hit it on GPU.)
+
+        ``periodic`` (a periodic-reduction dict) reduces the system *per call*, after ``A(θ), b(θ)`` are
+        re-formed: ``u = P · solve_fn(PᵀA(θ)P, Pᵀb(θ))``. The reduction must run here (not statically on
+        ``self.A``) because ``operator_fn``/``rhs_fn`` re-evaluate the operator on every ``θ`` -- a static
+        reduction would be silently re-overwritten. The reduction stays sparse (BCOO triplet-remap), so
+        ``∂u/∂θ`` still flows through ``solve_fn`` on the reduced operator.
         """
         if solve_fn is None:
             from ..utils.solver.linear import sparse_lu_solve
@@ -2955,9 +2961,17 @@ class FemLinearSystem:
 
         def _solve(*values):
             A, b = self.evaluate(dict(zip(names, values)))
+            b = jnp.asarray(b).reshape(-1)
+            if periodic is not None:
+                from ..utils.solver.fem_utils import prolong_periodic, reduce_matrix_periodic, reduce_vector_periodic
+
+                A = reduce_matrix_periodic(periodic, A)  # PᵀA(θ)P (stays BCOO when A is BCOO)
+                b = reduce_vector_periodic(periodic, b)  # Pᵀb(θ)
+                A = A if hasattr(A, "todense") else jnp.asarray(A)
+                return prolong_periodic(periodic, solve_fn(A, b))
             # keep a BCOO ``A`` sparse for the sparse solver (only coerce a plain dense operator)
             A = A if hasattr(A, "todense") else jnp.asarray(A)
-            return solve_fn(A, jnp.asarray(b).reshape(-1))
+            return solve_fn(A, b)
 
         return FunctionCall(_solve, params, name="fem_solve")
 

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -508,10 +508,30 @@ def assemble_fem_native(
             _collect_runtime_parameter_exprs(bare, _rt_param_exprs)
     runtime_parameter_tags: Tuple[str, ...] = tuple(sorted(_rt_param_exprs))
     _field_param_names: set = {n for n, expr in _rt_param_exprs.items() if _is_fem_field_parameter(expr)}
+    # A nodal FIELD parameter k(x) interpolates on one field's FE space. Single field -> field 0. For a
+    # coupled (multi-field) problem, associate it with the field whose test function appears in the
+    # term(s) that reference it (e.g. mu(x)*(grad u . grad v) -> the velocity field), so its nodal values
+    # gather/interpolate on THAT field's mesh. All field params must resolve to one field (a single shared
+    # ``shape_vals`` threads the interpolation), else it is rejected.
+    _field_param_field_idx = 0
     if _field_param_names and len(fields) > 1:
-        raise NotImplementedError(
-            "jno.fem (native): a FEM field parameter k(x) is supported on single-field problems only."
-        )
+        from .parametric_helpers import _contains_fem_field_parameter
+
+        _pf_idxs: set = set()
+        for bare in volume_terms:
+            for sign, sub in _split_additive_terms(domain, bare):
+                coeff = _lower_statefield_to_trial(_apply_sign(domain, sign, sub), {})
+                if _contains_fem_field_parameter(coeff):
+                    tfi = _test_field_index(coeff, field_index)
+                    if tfi is not None:
+                        _pf_idxs.add(int(tfi))
+        if len(_pf_idxs) != 1:
+            raise NotImplementedError(
+                "jno.fem (native): a FEM field parameter k(x) on a coupled (multi-field) problem must "
+                "appear in the terms of exactly one field (its nodal values interpolate on that field's "
+                f"FE space); resolved to fields {sorted(_pf_idxs)}."
+            )
+        _field_param_field_idx = _pf_idxs.pop()
 
     # -------------------------------------------------------------------------
     # Surface integration setup
@@ -585,11 +605,12 @@ def assemble_fem_native(
                 # Parameter not supplied for this assembly (e.g. the mass matrix, which references no
                 # parameter): pack a zero placeholder of the right width. It is only ever read back if
                 # the term actually contains the parameter node, in which case args carries its value.
-                pv.append(jnp.zeros((n_local_f[0] if name in _field_param_names else 1,), dtype))
+                pv.append(jnp.zeros((n_local_f[_field_param_field_idx] if name in _field_param_names else 1,), dtype))
                 continue
             flat = jnp.reshape(jnp.asarray(a[name], dtype=dtype), (-1,))
-            # Single-field nodal field parameter -> this cell's local nodal values (field 0).
-            pv.append(flat[cells_f_j[0][c]] if name in _field_param_names else flat[:1])
+            # Nodal field parameter -> this cell's local nodal values on its field's mesh (field 0 for a
+            # single-field problem; the resolved field for a coupled one).
+            pv.append(flat[cells_f_j[_field_param_field_idx][c]] if name in _field_param_names else flat[:1])
         return tv + tuple(pv)
 
     # -------------------------------------------------------------------------
@@ -629,10 +650,10 @@ def assemble_fem_native(
             "trial_vec": vecs[tfi],
         }
         if _field_param_names:
-            # The field parameter's nodal slice is interpolated to the quad points with the field's
-            # shape functions (single-field: field 0). _runtime_parameter_value_from_internal_vars
-            # reads this top-level shape_vals.
-            loc["shape_vals"] = per[0]["shape_vals"]
+            # The field parameter's nodal slice is interpolated to the quad points with its field's shape
+            # functions (field 0 single-field; the resolved field for a coupled problem).
+            # _runtime_parameter_value_from_internal_vars reads this top-level shape_vals.
+            loc["shape_vals"] = per[_field_param_field_idx]["shape_vals"]
         return _integrate_term(domain, coeff, loc, qw_shared * meas)
 
     def _surf_elem_res(fi, local_all, bcoeff, btfi, region, t=0.0, args=None):
@@ -677,7 +698,7 @@ def assemble_fem_native(
             "trial_vec": vecs[btfi],
         }
         if _field_param_names:
-            loc["shape_vals"] = per_f[0]["shape_vals"]
+            loc["shape_vals"] = per_f[_field_param_field_idx]["shape_vals"]
         return _integrate_term(domain, bcoeff, loc, face_w * jac_f)
 
     def _classify_one(coeff, where: str) -> List[Tuple[Any, int]]:

--- a/tests/test_fem_complex_parametric.py
+++ b/tests/test_fem_complex_parametric.py
@@ -1,0 +1,101 @@
+"""A runtime parameter recovered through a complex forward solve -- the complex *inverse* (Phase 5).
+
+A complex weak form assembles as two real systems solved via the real-equivalent block. With a runtime
+``jno.np.parameter`` the legs become parametric ``FemLinearSystem``s and ``jno.fem`` returns a
+differentiable trace node: ``A(θ), b(θ)`` are re-formed and the block re-solved per call, so ``∂u/∂θ``
+flows to ``crux`` (previously this raised NotImplementedError -- "the complex inverse is a follow-on").
+Here the parameter is *real* (it scales the diffusion), so only the real-coefficient leg is parametric
+and the imaginary leg is a constant ``(A, b)`` -- the mixed case the block solve must handle.
+
+Run with x64 (the solution is complex128).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import optax  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+from jno.trace import FemLinearSystem  # noqa: E402
+
+PI = np.pi
+KAPPA_TRUE = 0.8
+_DUMMY = jno.domain.from_array({"_": np.zeros((1, 1))})
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _kappa(start, lr=5e-2):
+    k = jno.np.parameter((1,), key=jax.random.PRNGKey(1), name="kappa")
+    k.initialize(jax.nn.initializers.constant(start))
+    k.dtype(jnp.float64)
+    k.optimizer(optax.adam(lr))
+    return k
+
+
+def _complex_fem(kappa, mesh_size=0.08):
+    """Complex Helmholtz ``κ(-Δu) + d·u = f`` (all-Neumann box), ``d = 1+0.3i``, manufactured complex
+    ``u* = (1+0.5i) cos(πx) cos(πy)`` (zero normal derivative). With ``-Δu* = 2π² u*`` the source is
+    ``f = (2π² KAPPA_TRUE + d) u*``. ``kappa`` is a float (forward) or a real ``jno.np.parameter``."""
+    dom = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = dom.fem_symbols()
+    xi, yi, _ = dom.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    d_coef = 1.0 + 0.3j
+    amp = 1.0 + 0.5j
+    g = jno.np.cos(PI * xi) * jno.np.cos(PI * yi)
+    f = (2 * PI**2 * KAPPA_TRUE + d_coef) * amp * g
+    weak = kappa * (ui.x * vi.x + ui.y * vi.y) + d_coef * (u * vi) - f * vi
+    return jno.fem([weak])
+
+
+def test_complex_parametric_yields_parametric_legs_and_node():
+    """A real parameter in a complex form -> at least the real-coefficient leg is a parametric
+    FemLinearSystem (the assembler registers κ on whichever Re/Im legs reference it) and solve() is a
+    trace node, not an array -- so the parameter can flow to crux."""
+    fem = _complex_fem(_kappa(start=1.0))
+    assert fem.is_complex
+    op_r, _op_i = fem._op
+    assert isinstance(op_r, FemLinearSystem) and op_r.is_parametric, "the real leg must carry κ"
+    assert list(op_r.runtime_parameter_exprs) == ["kappa"]
+    assert not isinstance(fem.solve(), jax.Array), "a parametric complex solve must be a trace node"
+
+
+def test_complex_parametric_forward_matches_nonparametric():
+    """Eval the parametric node at κ_true: it must match the non-parametric complex solve and recover u*."""
+    u_ref = np.asarray(_complex_fem(KAPPA_TRUE).solve())  # non-parametric complex forward
+    u_node = _complex_fem(_kappa(start=KAPPA_TRUE)).solve()
+    crux = jno.core([(u_node - u_ref).mae], domain=_DUMMY)
+    u_par = np.asarray(crux.eval([u_node])).reshape(-1)
+    assert np.allclose(u_par, u_ref.reshape(-1), atol=1e-8), "parametric complex solve disagrees with forward"
+
+    pts = np.asarray(_complex_fem(KAPPA_TRUE).points)
+    u_star = (1.0 + 0.5j) * np.cos(PI * pts[:, 0]) * np.cos(PI * pts[:, 1])
+    rel = float(np.linalg.norm(u_ref.reshape(-1) - u_star) / np.linalg.norm(u_star))
+    assert rel < 2e-2, f"complex forward does not recover u*: rel-L2 {rel:.3e}"
+    assert float(np.abs(u_ref.imag).max()) > 0.1, "must be genuinely complex"
+
+
+def test_complex_parametric_recovers_kappa():
+    """Gradient check: recover the real κ from complex full-field data through the real-equivalent block.
+    ∂u/∂κ must flow through the (parametric) real leg; adam from κ=1.5 must reach KAPPA_TRUE."""
+    u_obs = np.asarray(_complex_fem(KAPPA_TRUE).solve())  # complex clean data
+    kappa = _kappa(start=1.5)
+    u_node = _complex_fem(kappa).solve()
+    crux = jno.core([(u_node - u_obs).mae], domain=_DUMMY)  # mean|·| -> a real loss on a complex residual
+    crux.solve(250)
+    rec = float(np.asarray(crux.eval([kappa])).reshape(-1)[0])
+    assert abs(rec - KAPPA_TRUE) < 0.05, f"κ not recovered through the complex inverse: {rec:.4f}"

--- a/tests/test_fem_coupled_field_parameter.py
+++ b/tests/test_fem_coupled_field_parameter.py
@@ -1,0 +1,105 @@
+"""A nodal FEM field parameter k(x) on a coupled (multi-field) problem (Phase 7 of the compose work).
+
+Previously ``jno.fem (native)`` rejected a ``jno.np.parameter(phi)`` coefficient *field* on any
+multi-field problem (single-field only). It now associates the field parameter with the field whose
+test function appears in the term(s) referencing it (e.g. ``k(x)·(grad p . grad q)`` -> the ``p`` field),
+so its nodal values gather/interpolate on **that** field's FE space. A field parameter spanning two
+fields is rejected with a clear error. (Coupled-steady-parametric is blocked upstream regardless, so
+this exercises the coupled *transient* native path, which threads runtime parameters per step.)
+
+Correctness mirrors the single-field nodal-parameter test: a *linear* nodal field must assemble the
+same spatial operator as the equivalent coordinate-function coefficient (P1 interpolation of a linear
+field is exact), which catches any gather/node-order/field-index error.
+
+Run with x64 (FEM assembly is float64).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _dense(A):
+    return np.asarray(A.todense() if hasattr(A, "todense") else A)
+
+
+def _build(use_param, span_both=False):
+    """Coupled transient diffusion of ``u`` (field 0) and ``p`` (field 1); ``p``'s diffusion is scaled by
+    ``k`` -- a nodal field parameter on ``p``'s FE space (``use_param``) or the equivalent coordinate
+    function ``0.6 + 0.8x + 0.5y``. ``span_both`` also scales ``u``'s diffusion by ``k`` (a parameter
+    referenced by two fields -> the ambiguous case)."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.15, time=(0.0, 0.02, 6))
+    u, v = d.fem_symbols(names=("u", "v"))
+    p, q = d.fem_symbols(names=("p", "q"))
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    pi, qi = p.bind(x=xi, y=yi, t=ti), q.bind(x=xi, y=yi, t=ti)
+    k = jno.np.parameter(q, name="k") if use_param else (0.6 + 0.8 * xi + 0.5 * yi)
+    u_diff = (k if span_both else 1.0) * (ui.x * vi.x + ui.y * vi.y)
+    cons = [
+        ui.t * vi + u_diff,
+        pi.t * qi + k * (pi.x * qi.x + pi.y * qi.y),  # k on the p (field-1) equation
+        u(xb, yb) - 0.0,
+        p(xb, yb) - 0.0,
+        u(ci[0], ci[1]) - 0.0,
+        p(ci[0], ci[1]) - 0.0,
+    ]
+    return d, jno.fem(cons)
+
+
+def test_coupled_field_parameter_on_second_field_matches_coordinate_coeff():
+    """A nodal field parameter k(x) on the *second* field assembles (previously rejected) and produces
+    the same coupled spatial operator as the equivalent coordinate-function coefficient -- proving the
+    field parameter is gathered/interpolated on the right field's FE space (P1 interpolation of a linear
+    field is exact). Compared on the non-Dirichlet rows: a Dirichlet row is a pinned identity whose
+    representation differs between the parametric ``operator_fn`` and the constant ``.A`` (it differs in
+    the param-free u-block too), so it carries no field-parameter information."""
+    d, fem = _build(use_param=True)
+    assert fem.is_transient
+    assert list(fem.operator.runtime_parameter_exprs) == ["k"], "k must be a (single) runtime parameter"
+
+    # k(x) on field 1's (p) P1 nodes -> the linear field, exact under P1 interpolation
+    pts1 = np.asarray(fem.field_points[1])
+    k_true = jnp.asarray(0.6 + 0.8 * pts1[:, 0] + 0.5 * pts1[:, 1])
+    A_param = _dense(fem.operator.operator_fn(0.0, {"k": k_true}))
+
+    _, fem_ref = _build(use_param=False)  # coordinate-function coefficient (same mesh_size -> same mesh)
+    A_ref = _dense(fem_ref.operator.A)
+
+    # free (non-Dirichlet) DOFs across both field blocks: where the assembled physics actually lives.
+    # A Dirichlet DOF is a pinned identity row+column whose representation differs between operator_fn
+    # and .A (in the param-free u-block too), so restrict the comparison to the free×free submatrix.
+    n = int(fem.offsets[1])
+    bnd = set(int(i) for i in np.asarray(d.tag_indices["boundary"]).ravel())
+    interior = np.array([i for i in range(n) if i not in bnd], dtype=int)
+    free = np.concatenate([interior, n + interior])
+    diff = np.max(np.abs(A_param[np.ix_(free, free)] - A_ref[np.ix_(free, free)]))
+    assert diff < 1e-9, f"field-parameter operator != coordinate-coeff operator on free DOFs: {diff:.2e}"
+
+
+def test_field_parameter_spanning_two_fields_raises():
+    """A field parameter referenced by *two* fields' terms cannot interpolate on a single FE space -> a
+    clear NotImplementedError (a single shared shape_vals threads the interpolation)."""
+    with pytest.raises(NotImplementedError, match="exactly one field"):
+        _build(use_param=True, span_both=True)

--- a/tests/test_fem_periodic_complex.py
+++ b/tests/test_fem_periodic_complex.py
@@ -1,0 +1,156 @@
+"""Periodic ties composed with a complex-valued FEM (Phase 2 of the compose work).
+
+A complex weak form is assembled as two real systems and solved via the real-equivalent block
+``[[A_r,-A_i],[A_i,A_r]]``. A periodic tie reduces the system with a prolongation ``P``. The two
+compose: because Re and Im share one FE space (hence one ``P``), reducing *both* legs with the same
+``P`` preserves the real-equivalent block exactly, ``blkdiag(P,P)^T[[A_r,-A_i],[A_i,A_r]]blkdiag(P,P)``.
+These tests pin the composition with manufactured complex solutions that are genuinely periodic.
+
+Run with x64 (the solution is complex128).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+
+import jax  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def test_periodic_complex_helmholtz_recovers_manufactured():
+    """Complex Helmholtz ``c(-Δu) + d·u = f`` periodic in x (``u(left)-u(right)``) and Dirichlet in y.
+    Manufactured ``u* = (1+0.5i) cos(2πx) sin(πy)`` -- periodic in x (matching value AND flux at the
+    tie), zero on y=0,1. With ``-Δu* = 5π² u*``, ``f = (5π² c + d) u*``. The complex solve runs through
+    the periodic reduction; recovery of the (genuinely complex) ``u*`` confirms the composition."""
+    dom = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.05)
+    # periodic faces are the OPEN edges (corners belong to the Dirichlet top/bottom, not the tie)
+    dom.tag("left", lambda x, y: (x < 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("right", lambda x, y: (x > 1 - 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("bottom", lambda x, y: y < 1e-6)
+    dom.tag("top", lambda x, y: y > 1 - 1e-6)
+
+    u, phi = dom.fem_symbols()
+    xi, yi, _ = dom.variable("interior", split=True)
+    xb, yb, _ = dom.variable("bottom", split=True)
+    xt, yt, _ = dom.variable("top", split=True)
+    xl, yl, _ = dom.variable("left", split=True)
+    xr, yr, _ = dom.variable("right", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+
+    sigma = 0.5 + 0.0 * xi  # traced complex coefficient (stresses complex division through the trace)
+    c = 1.0 / (1.0 + 1j * sigma)
+    d_coef = 1.0 + 0.2j  # nonzero reaction -> the periodic-in-x / Dirichlet-in-y problem is well-posed
+    amp = 1.0 + 0.5j
+    g = jno.np.cos(2 * PI * xi) * jno.np.sin(PI * yi)
+    f = (5 * PI**2 * c + d_coef) * amp * g
+
+    fem = jno.fem(
+        [
+            c * (ui.x * vi.x + ui.y * vi.y) + d_coef * (u * vi) - f * vi,
+            u(xb, yb) - 0.0,
+            u(xt, yt) - 0.0,
+            u(xl, yl) - u(xr, yr),  # periodic in x
+        ]
+    )
+    assert fem.is_complex
+    assert fem.problem is None  # native real-equivalent assembly
+    assert fem._periodic is not None, "the u(left)-u(right) tie must reduce the complex system"
+    assert fem._periodic["n_red"] < fem._periodic["n_full"], "the tie must eliminate the slave-face DOFs"
+
+    u_num = np.asarray(fem.solve())
+    assert np.iscomplexobj(u_num)
+    pts = np.asarray(fem.points)
+    u_star = amp * np.cos(2 * PI * pts[:, 0]) * np.sin(PI * pts[:, 1])
+    rel = float(np.linalg.norm(u_num - u_star) / np.linalg.norm(u_star))
+    assert rel < 2e-2, f"periodic complex Helmholtz recovery rel-L2 {rel:.3e}"
+    assert float(np.abs(u_num.imag).max()) > 0.1, "must be genuinely complex, not a real solve in disguise"
+
+
+def test_periodic_complex_homogeneous_is_zero():
+    """Extreme: zero source + homogeneous Dirichlet + periodic. The reaction term makes the operator
+    nonsingular, so the only solution is ``u ≡ 0`` -- the reduction must not inject a spurious field."""
+    dom = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.08)
+    dom.tag("left", lambda x, y: (x < 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("right", lambda x, y: (x > 1 - 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("bottom", lambda x, y: y < 1e-6)
+    dom.tag("top", lambda x, y: y > 1 - 1e-6)
+
+    u, phi = dom.fem_symbols()
+    xi, yi, _ = dom.variable("interior", split=True)
+    xb, yb, _ = dom.variable("bottom", split=True)
+    xt, yt, _ = dom.variable("top", split=True)
+    xl, yl, _ = dom.variable("left", split=True)
+    xr, yr, _ = dom.variable("right", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    c = 1.0 / (1.0 + 1j * (0.5 + 0.0 * xi))
+
+    fem = jno.fem(
+        [
+            c * (ui.x * vi.x + ui.y * vi.y) + (1.0 + 0.2j) * (u * vi),  # no source
+            u(xb, yb) - 0.0,
+            u(xt, yt) - 0.0,
+            u(xl, yl) - u(xr, yr),
+        ]
+    )
+    assert fem.is_complex and fem._periodic is not None
+    u_num = np.asarray(fem.solve())
+    assert float(np.abs(u_num).max()) < 1e-9, f"homogeneous periodic complex must be ~0, got {np.abs(u_num).max():.2e}"
+
+
+def test_doubly_periodic_complex_reaction_diffusion():
+    """Extreme: two tied face-pairs (a doubly-periodic complex cell). ``c(-Δu) + d·u = f`` periodic in
+    **both** x and y -- the four corners are each a slave in two directions and must collapse onto one
+    kept master (transitive corner resolution) *through* the complex real-equivalent block. Manufactured
+    ``u* = (1+0.5i) cos(2πx) cos(2πy)`` with ``-Δu* = 8π² u*``."""
+    dom = jno.domain(box(0.0, 0.0, 1.0, 1.0)).build_mesh(0.06)
+    for nm, pred in {
+        "left": lambda x, y: x < 1e-6,
+        "right": lambda x, y: x > 1 - 1e-6,
+        "bottom": lambda x, y: y < 1e-6,
+        "top": lambda x, y: y > 1 - 1e-6,
+    }.items():
+        dom.tag(nm, pred)
+
+    u, phi = dom.fem_symbols()
+    xi, yi, _ = dom.variable("interior", split=True)
+    xl, yl, _ = dom.variable("left", split=True)
+    xr, yr, _ = dom.variable("right", split=True)
+    xb, yb, _ = dom.variable("bottom", split=True)
+    xt, yt, _ = dom.variable("top", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+
+    c = 1.0 / (1.0 + 1j * (0.5 + 0.0 * xi))
+    d_coef = 1.0 + 0.2j
+    amp = 1.0 + 0.5j
+    g = jno.np.cos(2 * PI * xi) * jno.np.cos(2 * PI * yi)
+    f = (8 * PI**2 * c + d_coef) * amp * g
+
+    fem = jno.fem(
+        [
+            c * (ui.x * vi.x + ui.y * vi.y) + d_coef * (u * vi) - f * vi,
+            u(xl, yl) - u(xr, yr),  # periodic in x
+            u(xb, yb) - u(xt, yt),  # periodic in y
+        ]
+    )
+    assert fem.is_complex and fem._periodic is not None and fem._periodic["n_red"] < fem._periodic["n_full"]
+    u_num = np.asarray(fem.solve())
+    pts = np.asarray(fem.points)
+    u_star = amp * np.cos(2 * PI * pts[:, 0]) * np.cos(2 * PI * pts[:, 1])
+    rel = float(np.linalg.norm(u_num - u_star) / np.linalg.norm(u_star))
+    assert rel < 5e-2, f"doubly-periodic complex reaction-diffusion rel-L2 {rel:.3e}"
+    assert float(np.abs(u_num.imag).max()) > 0.1

--- a/tests/test_fem_periodic_complex_transient.py
+++ b/tests/test_fem_periodic_complex_transient.py
@@ -1,0 +1,91 @@
+"""Periodic ties composed with a complex *transient* FEM (Phase 6 of the compose work).
+
+A complex transient (e.g. Schrodinger/complex-diffusion) integrates the real-equivalent 2N time block
+``[[M_r,-M_i],[M_i,M_r]]`` etc. A periodic tie reduces *both* real/imag blocks by the same ``P`` (the
+combinator recurses into the ``(block_r, block_i)`` legs), the integration runs in the reduced master-
+DOF space, and each saved slice is prolonged back -- real/imag separately. (Previously this raised
+NotImplementedError.) Pinned with a manufactured decaying periodic mode and a zero-IC extreme.
+
+Run with x64 (the trajectory is complex128).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+
+import jax  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _build(amp_ic, mesh_size=0.07):
+    """Complex diffusion ``ψ_t = c Δψ`` (c = 0.5+1j), periodic in x + Dirichlet y. Manufactured periodic
+    mode ``ψ0 = amp_ic · cos(2πx) sin(πy)`` decays as ``ψ(t) = exp(-c·5π²·t) ψ0`` (``-Δψ0 = 5π² ψ0``)."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size, time=(0.0, 0.02, 41))
+    d.tag("left", lambda x, y: (x < 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    d.tag("right", lambda x, y: (x > 1 - 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    d.tag("bottom", lambda x, y: y < 1e-6)
+    d.tag("top", lambda x, y: y > 1 - 1e-6)
+    u, phi = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    xl, yl, _ = d.variable("left", split=True)
+    xr, yr, _ = d.variable("right", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), phi.bind(x=xi, y=yi, t=ti)
+    c = 0.5 + 1j
+    psi0 = amp_ic * jno.np.cos(2 * PI * ci[0]) * jno.np.sin(PI * ci[1])
+    fem = jno.fem(
+        [
+            ui.t * vi + c * (ui.x * vi.x + ui.y * vi.y),
+            u(xb, yb) - 0.0,
+            u(xt, yt) - 0.0,
+            u(xl, yl) - u(xr, yr),  # periodic in x
+            u(ci[0], ci[1]) - psi0,
+        ]
+    )
+    return fem, c
+
+
+def test_periodic_complex_transient_recovers_decaying_mode():
+    """The periodic complex-diffusion strip recovers the analytic decaying mode, with the tie reducing
+    the 2N time block."""
+    fem, c = _build(amp_ic=1.0)
+    assert fem.is_complex and fem.is_transient
+    assert fem._periodic is not None, "the u(left)-u(right) tie must reduce the complex transient block"
+    assert fem._periodic["n_red"] < fem._periodic["n_full"], "the tie must eliminate the slave-face DOFs"
+
+    traj = np.asarray(fem.solve())
+    assert np.iscomplexobj(traj)
+    pts = np.asarray(fem.points)
+    mode = np.cos(2 * PI * pts[:, 0]) * np.sin(PI * pts[:, 1])
+    t1 = float(fem.t1)
+    analytic = np.exp(-c * 5 * PI**2 * t1) * mode
+    rel = float(np.linalg.norm(traj[-1] - analytic) / np.linalg.norm(analytic))
+    assert rel < 5e-2, f"periodic complex transient recovery rel-L2 {rel:.3e}"
+    assert float(np.abs(traj[-1].imag).max()) > 1e-2, "must be genuinely complex"
+
+
+def test_periodic_complex_transient_zero_ic_is_zero():
+    """Extreme: a zero IC stays identically zero (homogeneous, no source) -- the reduction/prolongation
+    must not inject a spurious field on either the real or the imaginary block."""
+    fem, _ = _build(amp_ic=0.0)
+    traj = np.asarray(fem.solve())
+    assert float(np.abs(traj).max()) < 1e-10, (
+        f"zero-IC periodic complex transient must stay 0, got {np.abs(traj).max():.2e}"
+    )

--- a/tests/test_fem_periodic_coupling.py
+++ b/tests/test_fem_periodic_coupling.py
@@ -1,0 +1,117 @@
+"""Periodic ties composed with a nonlocal ``Coupling`` term (Phase 4 of the compose work).
+
+A ``Coupling`` folds a nonlocal residual ``c(u)`` into ``R(u) = A u - b + c(u)``, promoting a steady
+linear form to a nonlinear ``FemResidualOperator``. A periodic tie reduces the system. The two compose
+for free: the existing nonlinear-periodic solve path already solves ``Pᵀ r(P u_red) = 0``, so the
+*coupled* residual reduces through the same wrap -- no per-combination branch. (Previously this raised
+NotImplementedError.) These tests pin: the promotion+reduction is recognised, a zero coupling recovers
+the plain periodic linear solve across the two solve paths, and a constant-load coupling reproduces the
+*independent* plain periodic solve of the equivalent extra-source problem.
+
+Run with x64 (FEM assembly/solves are float64).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+
+
+_DUMMY = jno.domain.from_array({"_": np.zeros((1, 1))})  # global FEM solve -> crux needs a driver domain
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _eval(fem):
+    """Evaluate a solve to a full nodal array. A plain linear periodic solve is already a JAX array; a
+    coupled (nonlinear) periodic solve is a *traced* node, evaluated via a throwaway crux -- the
+    established nonlinear-periodic pattern (the residual may carry trainable params)."""
+    out = fem.solve()
+    if isinstance(out, jax.Array):
+        return np.asarray(out).reshape(-1)
+    crux = jno.core([out.mean], domain=_DUMMY)
+    return np.asarray(crux.eval([out])).reshape(-1)
+
+
+def _build(extra_source=None, coupling=None, mesh_size=0.07):
+    """Periodic-in-x, Dirichlet-in-y reaction-diffusion ``-Δu + u = f (+ extra_source)`` with manufactured
+    ``u* = cos(2πx) sin(πy)`` (``f = (5π²+1) u*``). Optionally add a constant extra local source and/or a
+    nonlocal ``coupling`` (a bare ``w -> (n_dofs,)`` function passed in the jno.fem list)."""
+    dom = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    dom.tag("left", lambda x, y: (x < 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("right", lambda x, y: (x > 1 - 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("bottom", lambda x, y: y < 1e-6)
+    dom.tag("top", lambda x, y: y > 1 - 1e-6)
+    u, phi = dom.fem_symbols()
+    xi, yi, _ = dom.variable("interior", split=True)
+    xb, yb, _ = dom.variable("bottom", split=True)
+    xt, yt, _ = dom.variable("top", split=True)
+    xl, yl, _ = dom.variable("left", split=True)
+    xr, yr, _ = dom.variable("right", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = (5 * PI**2 + 1.0) * jno.np.cos(2 * PI * xi) * jno.np.sin(PI * yi)
+    weak = ui.x * vi.x + ui.y * vi.y + ui * vi - f * vi
+    if extra_source is not None:
+        weak = weak - extra_source * vi
+    terms = [weak, u(xb, yb) - 0.0, u(xt, yt) - 0.0, u(xl, yl) - u(xr, yr)]
+    if coupling is not None:
+        terms.append(coupling)
+    return jno.fem(terms)
+
+
+def test_periodic_coupling_promotes_and_reduces():
+    """A periodic tie + a Coupling: the local form is promoted to nonlinear AND the tie reduces it."""
+    fem = _build(coupling=lambda w: jnp.zeros_like(jnp.asarray(w).reshape(-1)))
+    assert fem._mode == "nonlinear", "the coupling must promote the linear periodic form to nonlinear"
+    assert fem._periodic is not None, "the u(left)-u(right) tie must still reduce the coupled system"
+    assert fem._periodic["n_red"] < fem._periodic["n_full"], "the tie must eliminate the slave-face DOFs"
+
+
+def test_periodic_coupling_zero_is_plain_periodic():
+    """Extreme: a coupling returning zeros must give exactly the plain periodic *linear* solve -- the
+    promotion to a nonlinear residual + the periodic reduction must not perturb the solution. This also
+    cross-checks the nonlinear-periodic solve path against the linear-periodic path."""
+    u_plain = _eval(_build())  # linear periodic path
+    u_zero = _eval(_build(coupling=lambda w: jnp.zeros_like(jnp.asarray(w).reshape(-1))))  # nonlinear+periodic path
+    assert np.allclose(u_zero, u_plain, atol=1e-6), "zero coupling perturbed the periodic solve"
+
+    pts = np.asarray(_build().points)
+    u_star = np.cos(2 * PI * pts[:, 0]) * np.sin(PI * pts[:, 1])
+    rel = float(np.linalg.norm(u_plain - u_star) / np.linalg.norm(u_star))
+    assert rel < 2e-2, f"periodic solve does not recover u*: rel-L2 {rel:.3e}"
+
+
+def test_periodic_coupling_constant_load_matches_extra_source():
+    """Correctness vs an independent reference. A constant-load coupling ``c(w) = -extra`` makes the
+    coupled residual ``A u - b - extra = 0`` i.e. ``A u = b + extra``. Choosing ``extra`` to be the FE
+    load of a constant source ``s0`` (obtained as the difference of two independent linear assemblies'
+    RHS vectors), the coupled+periodic solve must reproduce the plain periodic *linear* solve of the
+    equivalent extra-source problem -- a reference that never touches the coupling/nonlinear path."""
+    s0 = 3.0  # a constant extra source
+    b_plain = np.asarray(_build()._op[1]).reshape(-1)  # raw (A, b): full RHS, un-reduced
+    b_loaded = np.asarray(_build(extra_source=s0)._op[1]).reshape(-1)
+    extra = jnp.asarray(b_loaded - b_plain)  # the FE load of s0*vi (Dirichlet rows cancel -> 0 there)
+
+    u_ref = _eval(_build(extra_source=s0))  # plain linear periodic, equivalent problem
+    u_coupled = _eval(_build(coupling=lambda w: -extra))  # nonlinear+periodic path
+    rel = float(np.linalg.norm(u_coupled - u_ref) / np.linalg.norm(u_ref))
+    assert rel < 1e-5, f"periodic+coupling disagrees with the equivalent extra-source periodic solve: {rel:.3e}"
+    # and the coupling genuinely moved the solution off the no-load periodic solve
+    u_plain = _eval(_build())
+    assert float(np.linalg.norm(u_coupled - u_plain)) > 1e-3, "the coupling did not change the solution"

--- a/tests/test_fem_periodic_parametric.py
+++ b/tests/test_fem_periodic_parametric.py
@@ -1,0 +1,103 @@
+"""Periodic ties composed with a runtime-parametric steady-linear FEM (Phase 3 of the compose work).
+
+A runtime parameter makes the steady system ``A(θ)x = b(θ)``; ``jno.fem`` returns a ``FemLinearSystem``
+so ``crux`` can recover ``θ`` from data (``∂u/∂θ`` via implicit diff through the user's ``solve_fn``).
+A periodic tie reduces the system. The two compose only if the reduction runs **per call**, *after*
+``A(θ)`` is re-formed: ``u = P · solve(PᵀA(θ)P, Pᵀb(θ))`` -- a static reduction would be silently
+re-overwritten when ``operator_fn`` re-evaluates the operator. These tests pin: the reduced parametric
+operator, agreement with the non-parametric periodic solve, and full recovery of ``θ`` through it.
+
+Run with x64 (FEM assembly/solves are float64).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import optax  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+KAPPA_TRUE = 0.7  # the diffusion coefficient the data is generated at
+_DUMMY = jno.domain.from_array({"_": np.zeros((1, 1))})  # global FEM solve -> crux needs a driver domain
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _kappa(start, lr=5e-2):
+    k = jno.np.parameter((1,), key=jax.random.PRNGKey(1), name="kappa")
+    k.initialize(jax.nn.initializers.constant(start))
+    k.dtype(jnp.float64)
+    k.optimizer(optax.adam(lr))
+    return k
+
+
+def _periodic_fem(kappa, mesh_size=0.07):
+    """Periodic-in-x, Dirichlet-in-y reaction-diffusion ``κ(-Δu) + u = f`` with a *fixed* source built
+    for ``κ = KAPPA_TRUE`` and manufactured ``u* = cos(2πx) sin(πy)`` (``-Δu* = 5π² u*``). ``kappa`` may
+    be a plain float (non-parametric) or a ``jno.np.parameter`` (the runtime-parametric system)."""
+    dom = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    dom.tag("left", lambda x, y: (x < 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("right", lambda x, y: (x > 1 - 1e-6) & (y > 1e-6) & (y < 1 - 1e-6))
+    dom.tag("bottom", lambda x, y: y < 1e-6)
+    dom.tag("top", lambda x, y: y > 1 - 1e-6)
+    u, phi = dom.fem_symbols()
+    xi, yi, _ = dom.variable("interior", split=True)
+    xb, yb, _ = dom.variable("bottom", split=True)
+    xt, yt, _ = dom.variable("top", split=True)
+    xl, yl, _ = dom.variable("left", split=True)
+    xr, yr, _ = dom.variable("right", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = (5 * PI**2 * KAPPA_TRUE + 1.0) * jno.np.cos(2 * PI * xi) * jno.np.sin(PI * yi)
+    weak = kappa * (ui.x * vi.x + ui.y * vi.y) + ui * vi - f * vi
+    return jno.fem([weak, u(xb, yb) - 0.0, u(xt, yt) - 0.0, u(xl, yl) - u(xr, yr)])
+
+
+def test_periodic_parametric_operator_is_reduced():
+    """The parametric periodic problem yields a parametric ``FemLinearSystem`` and a periodic reduction
+    that eliminates the slave-face DOFs (previously this combination raised NotImplementedError)."""
+    fem = _periodic_fem(_kappa(start=1.0))
+    assert fem.operator.is_parametric, "a runtime κ must produce a parametric FemLinearSystem"
+    assert list(fem.operator.runtime_parameter_exprs) == ["kappa"]
+    assert fem._periodic is not None, "the u(left)-u(right) tie must reduce the parametric system"
+    assert fem._periodic["n_red"] < fem._periodic["n_full"], "the tie must eliminate the slave-face DOFs"
+
+
+def test_periodic_parametric_forward_matches_nonparametric():
+    """The per-call reduction inside FemLinearSystem.solve must give the *same* field as the eager
+    reduction of the non-parametric periodic solve, evaluated at the same κ -- and recover u*."""
+    u_ref = np.asarray(_periodic_fem(KAPPA_TRUE).solve())  # non-parametric periodic solve (eager reduce)
+    u_node = _periodic_fem(_kappa(start=KAPPA_TRUE)).solve()  # parametric, initialized AT truth
+    crux = jno.core([(u_node - u_ref).mse], domain=_DUMMY)
+    u_par = np.asarray(crux.eval([u_node])).reshape(-1)  # forward eval at the initial κ (no optimization)
+    assert np.allclose(u_par, u_ref.reshape(-1), atol=1e-8), "per-call reduction disagrees with eager reduction"
+
+    pts = np.asarray(_periodic_fem(KAPPA_TRUE).points)
+    u_star = np.cos(2 * PI * pts[:, 0]) * np.sin(PI * pts[:, 1])
+    rel = float(np.linalg.norm(u_ref.reshape(-1) - u_star) / np.linalg.norm(u_star))
+    assert rel < 2e-2, f"periodic parametric forward does not recover u*: rel-L2 {rel:.3e}"
+
+
+def test_periodic_parametric_recovers_kappa():
+    """Gradient check: recover κ from full-field data through the reduced parametric solve. The
+    gradient ∂u/∂κ must flow through PᵀA(κ)P; starting far from truth, adam must reach KAPPA_TRUE."""
+    u_obs = np.asarray(_periodic_fem(KAPPA_TRUE).solve())  # FEM-consistent clean data
+    kappa = _kappa(start=1.5)  # start far from the truth 0.7
+    u_node = _periodic_fem(kappa).solve()
+    crux = jno.core([(u_node - u_obs).mse], domain=_DUMMY)
+    crux.solve(200)
+    rec = float(np.asarray(crux.eval([kappa])).reshape(-1)[0])
+    assert abs(rec - KAPPA_TRUE) < 0.05, f"κ not recovered through the reduced parametric solve: {rec:.4f}"

--- a/tests/test_polygon_domain_build_mesh.py
+++ b/tests/test_polygon_domain_build_mesh.py
@@ -392,6 +392,56 @@ def test_enclosure_view_factor_after_build_mesh_blocks_through_obstacle():
     assert float(np.sum(dom.context["v_rad_right__rad_left"])) == pytest.approx(0.0)
 
 
+def test_build_mesh_interface_is_conforming_across_internal_interface():
+    """Internal region interfaces must mesh CONFORMINGLY even when a neighbour
+    splits the shared edge at a vertex that lies *off the outer boundary*.
+
+    Furnace-faithful setup: a ``wall`` slab whose left edge x=2 is a single
+    segment (2,0)-(2,3); a ``block`` touching that edge over z in [1,2]; and
+    ``Air`` built as the scene-box minus everything (as cg_furnace does). Air's
+    boundary along x=2 is then split into (2,0)-(2,1) and (2,2)-(2,3) with
+    vertices (2,1)/(2,2) that the wall's single edge lacks. Those vertices sit
+    on an *internal* interface, so ``_collect_source_edge_endpoints`` (which
+    clips to the outer boundary) never sees them -- the wall and Air then emit
+    non-matching gmsh lines on x=2 and mesh it with their own interleaved
+    nodes. Every such edge carries only one triangle, so the interface
+    transmits neither conduction nor radiation. Inserting the union of
+    partition vertices makes both sides split identically. Regression for the
+    furnace wall|air interface that silently sealed the cooling air pocket.
+    """
+    from collections import defaultdict
+
+    from shapely.geometry import Polygon, box
+    from shapely.ops import unary_union
+
+    np.random.seed(7)
+    wall = Polygon([(2, 0), (3, 0), (3, 3), (2, 3)])
+    block = Polygon([(0, 1), (2, 1), (2, 2), (0, 2)])
+    air = box(0, 0, 3, 3).difference(unary_union([wall, block]))
+    dom = jno.domain.csg.from_regions({"wall": wall, "block": block, "Air": air}, time=None)
+    dom.build_mesh(mesh_size=0.4)
+
+    pts = np.asarray(dom.mesh.points)[:, :2]
+    tris = np.asarray(dom.mesh.cells_dict["triangle"])
+    adj: dict = defaultdict(int)
+    for a, b, c in tris:
+        for i, j in ((int(a), int(b)), (int(b), int(c)), (int(c), int(a))):
+            adj[(min(i, j), max(i, j))] += 1
+
+    on_iface = np.where(np.abs(pts[:, 0] - 2.0) < 1e-7)[0]
+    iface = set(on_iface.tolist())
+    iface_edges = [(i, j) for (i, j), n in adj.items() if i in iface and j in iface]
+    assert iface_edges, "expected mesh edges along the x=2 wall|air interface"
+    # conforming <=> every interior interface edge is shared by exactly 2 triangles
+    bad = [e for e in iface_edges if adj[e] != 2]
+    assert not bad, f"non-conforming interface: {len(bad)}/{len(iface_edges)} edge(s) with adjacency != 2"
+
+    # and no two distinct interface nodes are near-coincident (the interleaving
+    # signature of two independently-meshed sides)
+    z = np.sort(pts[on_iface, 1])
+    assert np.all(np.diff(z) > 1e-6), "interleaved near-coincident interface nodes (non-conforming)"
+
+
 def test_three_disjoint_pieces_keep_distinct_interior_tags():
     """Three non-touching squares from from_polygons must mesh as 3 separate
     pieces and keep distinct `interior_<name>` tags."""


### PR DESCRIPTION
## Summary

Landing the **FEM periodic-composition** feature — the last genuinely-unmerged FEM work that had been sitting
on a local branch (`feat/fem-feature-composition`), now rebased onto the latest `main` (element zoo + 3D
Nédélec) and re-verified.

Periodic ties (`u(A) - u(B)` residual ties) now **compose** with the rest of the FEM stack via a single
`reduce_op_periodic` combinator in `_fem.py`:
- periodic × **complex** (steady) and periodic × **complex-transient**
- periodic × **parametric** and periodic × **coupling** (multi-field)
- **complex-inverse** through periodic
- coupled **field-parameter `k(x)`** on a multi-field problem

Each leg (real/imag, per-field) is reduced by the same prolongation `P` and prolonged back independently.

## Validation
- The feature's own suite: `test_fem_periodic_{complex,complex_transient,coupling,parametric}` — all green on
  the new `main`.
- Integration gate after merging onto `main`: **180 FEM tests** green across the classifier / periodic /
  complex / coupled / non-nodal / native-Lagrange / inverse / transient blast radius — 0 failures.
- ci-fmt + ci-lint clean.

## Note
Consolidated during a branch-cleanup pass: this branch merges the old `feat/fem-feature-composition` onto the
current `main` (clean, no conflicts) so the feature isn't lost. The dtype-correctness and second-order-time
branches were found to be already-merged/stale and were pruned separately.
