### PR TITLE
feat(fem): slot solver API — composable solvers/preconditioners for fem.solve

### DIFF
--- a/docs/fem.md
+++ b/docs/fem.md
@@ -589,9 +589,21 @@ wrappers sit on `lax.custom_linear_solve`, Newton on `lax.custom_root`) — and 
 implementations (`jax.scipy.sparse.linalg`, `sparse_lu_solve`) rather than duplicating them.
 Slot solvers receive the assembler's **BCOO** operator directly (no densification), and compose
 with the periodic reduction and every parametric/inverse path unchanged. Pick by structure:
-`cg` for SPD (Poisson, elasticity, mass), `bicgstab`/`gmres` for non-symmetric, `lu` for
-indefinite saddle systems (Stokes/Biot — note `lu` has no vmap batching rule; use a Krylov
-solver inside batched solves), `dense` for small systems.
+
+| structure | solver | notes |
+|---|---|---|
+| SPD (Poisson, elasticity, mass) | `cg` | cheapest per iteration |
+| non-symmetric (advection, SUPG) | `bicgstab` / `gmres` | `bicgstab` == the historic default (with `jacobi()`) |
+| **iterative preconditioner** (inner Krylov, block/Schur with inexact inner solves) | `fgmres` | flexible right preconditioning — Saad, *SIAM J. Sci. Stat. Comput.* 14(2), 1993, Alg. 2.2 |
+| symmetric **indefinite** (Stokes/Biot saddle, biharmonic) | `minres` | monotone residual, `O(1)` memory — Paige & Saunders, *SIAM J. Numer. Anal.* 12(4), 1975 |
+| SPD, batched/GPU-heavy | `chebyshev` | inner-product free (no reductions) — Golub & Varga 1961; Saad, *Iterative Methods*, 2003, §12.3 |
+| indefinite, single solve | `lu` | sparse-direct; **no vmap rule** — use a Krylov solver inside batched solves |
+| small systems / coarse blocks | `dense` | LAPACK, vmap-native |
+
+Preconditioner specs so far: `jno.precond.jacobi()` (diagonal) and `jno.precond.chebyshev(degree=…)`
+— a fixed-degree Chebyshev **polynomial** preconditioner (same references as the solver): matvecs
+and AXPYs only, the GPU-era substitute for Gauss-Seidel/ILU smoothing, and a fixed *linear* map so
+it legally preconditions `cg`/`minres`.
 
 **User extension** is duck-typed — a linear solver is any
 `fn(A, b, *, M=None, x0=None) -> x` with `A` a `jno.solve.LinearOperator` (`.mv`, `.T`,

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -568,6 +568,47 @@ matrix-free BiCGStab as the iterative alternative; the nonlinear default is a ma
 Newton-Krylov, and the transient default backward-Euler over those. All are implicit-diff, so
 `crux.solve` recovers parameters through them. Bring your own `solve_fn` for anything else.
 
+### Choosing the solver — the slot API (`jno.solve` / `jno.precond`)
+
+Between "accept the default" and "write a full `solve_fn`" sits the **slot API**: the solver
+factorises into four orthogonal slots, each a configured **callable** (never a string) from the
+`jno.solve` / `jno.precond` namespaces — or your own with the same contract. Every `None` keeps
+today's default; `solve_fn=` stays the total override (passing both is an error).
+
+```python
+u = fem.solve(
+    x0        = u_guess,                 # warm start (previous solve, coarse solve, a surrogate…)
+    nonlinear = jno.solve.newton(),      # linearization driver (nonlinear problems)
+    linear    = jno.solve.gmres(),       # inner linear solve: lu / dense / cg / bicgstab / gmres
+    precond   = jno.precond.jacobi(),    # v -> M⁻¹v spec, materialized against the assembled A
+)
+```
+
+Everything shipped is **pure JAX** — `jit`- and `vmap`-native, differentiable (the Krylov
+wrappers sit on `lax.custom_linear_solve`, Newton on `lax.custom_root`) — and *reuses* existing
+implementations (`jax.scipy.sparse.linalg`, `sparse_lu_solve`) rather than duplicating them.
+Slot solvers receive the assembler's **BCOO** operator directly (no densification), and compose
+with the periodic reduction and every parametric/inverse path unchanged. Pick by structure:
+`cg` for SPD (Poisson, elasticity, mass), `bicgstab`/`gmres` for non-symmetric, `lu` for
+indefinite saddle systems (Stokes/Biot — note `lu` has no vmap batching rule; use a Krylov
+solver inside batched solves), `dense` for small systems.
+
+**User extension** is duck-typed — a linear solver is any
+`fn(A, b, *, M=None, x0=None) -> x` with `A` a `jno.solve.LinearOperator` (`.mv`, `.T`,
+`.diag()`, `.bcoo`, `.dense()`); a preconditioner is any `ctx -> (v -> M⁻¹v)`:
+
+```python
+def my_precond(ctx):                      # ctx.A, ctx.diag(), ctx.fem
+    inv = 1.0 / ctx.diag()
+    return lambda v: inv * v
+u = fem.solve(linear=jno.solve.cg(), precond=my_precond)
+```
+
+If your callable is pure JAX it inherits `jit`/`vmap`/AD automatically. Not yet supported (clear
+errors, see `plans/fem-solver-api.md` for the roadmap): slots on **transient** problems, `x0` on
+**complex** problems, and `precond=` on the matrix-free **nonlinear** path (form-based
+preconditioners are the planned route).
+
 ### Field parameters `k(x)` + regularization
 
 `jno.np.parameter(phi)` is a **nodal field** on the trial space — a trainable value per node.

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -671,10 +671,14 @@ def my_precond(ctx):                      # ctx.A, ctx.diag(), ctx.fem
 u = fem.solve(linear=jno.solve.cg(), precond=my_precond)
 ```
 
-If your callable is pure JAX it inherits `jit`/`vmap`/AD automatically. Not yet supported (clear
-errors, see `plans/fem-solver-api.md` for the roadmap): slots on **transient** problems, `x0` on
-**complex** problems, and `precond=` on the matrix-free **nonlinear** path (form-based
-preconditioners are the planned route).
+If your callable is pure JAX it inherits `jit`/`vmap`/AD automatically. On the matrix-free
+**nonlinear** path the `precond` spec is materialized *per Newton/Picard linearization* against
+the JVP operator — so `form`, `inner(...)`, `chebyshev`, a pre-built `amg`, and their
+`block_diag`/`triangular` compositions all work (this is the nonlinear-saddle production
+pattern: `nonlinear=picard() + linear=fgmres() + precond=triangular(...)`); only specs that
+need the assembled matrix (`jacobi`, an unbuilt `amg`) raise. Not yet supported (clear errors,
+see `plans/fem-solver-api.md`): slots on **transient** problems, `x0` on **complex** problems,
+and slots combined with `adapt=`.
 
 ### Field parameters `k(x)` + regularization
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -16,8 +16,6 @@ import jax.numpy as jnp
 from shapely.geometry import box
 import jno
 
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # A may be sparse or dense
-
 d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.1)
 u, phi = d.fem_symbols()                                   # trial / test functions
 xi, yi, _ = d.variable("interior", split=True)            # volume quadrature coords
@@ -26,13 +24,14 @@ ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)         # views with .x / .y d
 
 f = 2.0 * (xi * (1 - xi) + yi * (1 - yi))
 fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0])   # weak form + u = 0 on the boundary
-u_h = jnp.linalg.solve(fem.A, fem.b)
+u_h = fem.solve()          # matrix-free default; slots pick anything else (see "Choosing the solver")
 ```
 
 > The flat accessors — `fem.A`, `fem.b`, `fem.M`, `fem.state0`, and `fem.residual(u[, t])` /
-> `fem.jacobian(u[, t])` — return ready-to-use **dense** matrices and **flat** vectors, so no
+> `fem.jacobian(u[, t])` — return ready-to-use **dense** matrices and **flat** vectors for
+> hand-rolled experiments (e.g. `u_h = jnp.linalg.solve(fem.A, fem.b)`), so no
 > `.todense()`/`reshape` is needed. `fem.operator` still exposes the raw sparse (`BCOO`) operator
-> for large problems; the `dense(...)` helper above densifies those (e.g. `fem.operator.A`).
+> for large problems — `fem.solve()` and the solver slots work on that sparse operator directly.
 
 ---
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -600,10 +600,38 @@ with the periodic reduction and every parametric/inverse path unchanged. Pick by
 | indefinite, single solve | `lu` | sparse-direct; **no vmap rule** — use a Krylov solver inside batched solves |
 | small systems / coarse blocks | `dense` | LAPACK, vmap-native |
 
-Preconditioner specs so far: `jno.precond.jacobi()` (diagonal) and `jno.precond.chebyshev(degree=…)`
-— a fixed-degree Chebyshev **polynomial** preconditioner (same references as the solver): matvecs
-and AXPYs only, the GPU-era substitute for Gauss-Seidel/ILU smoothing, and a fixed *linear* map so
-it legally preconditions `cg`/`minres`.
+**Preconditioner specs** (declarative — materialized against the assembled operator at solve
+time; a preconditioner never changes the converged solution, only the speed, so specs need no
+gradient path):
+
+* `jno.precond.jacobi()` — diagonal.
+* `jno.precond.chebyshev(degree=…)` — fixed-degree Chebyshev **polynomial** preconditioner
+  (same references as the solver): matvecs and AXPYs only, the GPU-era substitute for
+  Gauss-Seidel/ILU smoothing, and a fixed *linear* map so it legally preconditions `cg`/`minres`.
+* `jno.precond.inner(solver)` — any `jno.solve` solver as the `M⁻¹` application (an inexact
+  block/system solve). Iterative inner ⇒ flexible outer (`fgmres`).
+* `jno.precond.form([...terms], inner=…)` — **preconditioners as weak forms**: assemble an
+  auxiliary operator from ordinary traced terms and invert it as `M⁻¹`. Weighted mass matrices,
+  local proxies of nonlocal (radiation) operators, shifted-Laplacian Helmholtz twins, low-order
+  proxies — written in the same language as the PDE.
+* `jno.precond.block_diag((field, spec), …)` / `jno.precond.triangular((field, spec), …)` —
+  per-field composition over `fem.blocks` (fields are the trial symbols; `fem.block_index`
+  resolves them, offsets-ordered). `triangular` is the standard saddle-point shape: last block
+  solved first, substituted back through the assembled off-diagonal matvecs.
+
+The flagship pattern — Taylor–Hood **Stokes** by FGMRES with an inexact velocity block solve and
+the viscosity-weighted pressure-mass Schur approximation (Elman, Silvester & Wathen, *Finite
+Elements and Fast Iterative Solvers*, 2nd ed., 2014, §9.2) — no densification anywhere:
+
+```python
+sol = fem.solve(
+    linear  = jno.solve.fgmres(tol=1e-10, restart=40),
+    precond = jno.precond.triangular(
+        (u, jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=60))),   # Â⁻¹: inexact CG
+        (p, jno.precond.form([(1.0/mu) * pp * qq], inner=jno.solve.dense())),  # Ŝ ≈ μ⁻¹ M_p
+    ),
+)
+```
 
 **User extension** is duck-typed — a linear solver is any
 `fn(A, b, *, M=None, x0=None) -> x` with `A` a `jno.solve.LinearOperator` (`.mv`, `.T`,

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -633,6 +633,26 @@ sol = fem.solve(
 )
 ```
 
+**Picard / lagged coefficients — `jno.lag`.** When a solution-dependent coefficient's Newton
+tangent destroys the linearized system's structure (the classic case: a shear-thinning viscosity
+`μ_eff(u)` in non-Newtonian/rigid-plastic Stokes flow, whose full-Newton velocity block is
+strongly nonsymmetric and defeats AMG/block preconditioners), freeze it with `jno.lag(...)` and
+drive with `jno.solve.picard()`:
+
+```python
+fem = jno.fem([2 * jno.lag(mu_eff) * inner(eps(ui), eps(vi)) - pi * div(vi), ...])
+sol = fem.solve(nonlinear=jno.solve.picard(damping=0.7), linear=jno.solve.fgmres(),
+                precond=jno.precond.triangular(...))
+```
+
+`lag` is `stop_gradient` on the traced expression, so the residual's linearization *is* the
+Picard operator — each outer step re-solves the lagged system (linear convergence, but every
+inner system keeps its symmetry/definiteness); the converged solution is identical to full
+Newton's. Without any `lag` marker, `picard(damping=…)` is exactly damped Newton
+(`jno.solve.newton(damping=…)` spells the same thing). Caveat for inverse problems: implicit
+differentiation then also uses the lagged Jacobian (the standard "Picard adjoint" approximation)
+— drop `lag` when exact parameter gradients matter more than per-step solvability.
+
 **User extension** is duck-typed — a linear solver is any
 `fn(A, b, *, M=None, x0=None) -> x` with `A` a `jno.solve.LinearOperator` (`.mv`, `.T`,
 `.diag()`, `.bcoo`, `.dense()`); a preconditioner is any `ctx -> (v -> M⁻¹v)`:

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -676,9 +676,21 @@ If your callable is pure JAX it inherits `jit`/`vmap`/AD automatically. On the m
 the JVP operator — so `form`, `inner(...)`, `chebyshev`, a pre-built `amg`, and their
 `block_diag`/`triangular` compositions all work (this is the nonlinear-saddle production
 pattern: `nonlinear=picard() + linear=fgmres() + precond=triangular(...)`); only specs that
-need the assembled matrix (`jacobi`, an unbuilt `amg`) raise. Not yet supported (clear errors,
-see `plans/fem-solver-api.md`): slots on **transient** problems, `x0` on **complex** problems,
-and slots combined with `adapt=`.
+need the assembled matrix (`jacobi`, an unbuilt `amg`) raise.
+
+**Transient problems.** The slots configure the *per-step* solves of the default theta-method
+integrator (the bring-your-own `(block, args, save_ts)` contract via `solve_fn=` is unchanged):
+`linear`/`precond` see the step operator `M + θ·dt·A` — when the operator is time-independent
+the step matrix is formed **once** and the preconditioner materialized **once before the time
+loop** (an AMG hierarchy or auxiliary `form` operator is then reused by every step; `jacobi`
+uses the exact step diagonal either way) — and `nonlinear` drives each implicit step of a
+nonlinear block (`picard` + `jno.lag` per step included). Second-order-in-time (`u_tt`) flows
+through the same augmented block unchanged. Each step warm-starts from the previous state
+(so `x0=` is rejected — the initial state is the ICs' job); `lu()` inside the time loop
+re-factorizes per step (JAX's `spsolve` has no factorization cache).
+
+Not yet supported (clear errors, see `plans/fem-solver-api.md`): slots on **complex** /
+complex-transient problems (`x0` on complex included), and slots combined with `adapt=`.
 
 ### Field parameters `k(x)` + regularization
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -618,6 +618,14 @@ gradient path):
   per-field composition over `fem.blocks` (fields are the trial symbols; `fem.block_index`
   resolves them, offsets-ordered). `triangular` is the standard saddle-point shape: last block
   solved first, substituted back through the assembled off-diagonal matvecs.
+* `jno.precond.amg(cycles=…)` — **hybrid algebraic multigrid**: setup once on the host via the
+  *optional* `pyamg` (smoothed aggregation — Vaněk, Mandel & Brezina, *Computing* 56, 1996;
+  PyAMG — Bell et al., *JOSS* 8(87):5495, 2023), applied as a pure-JAX V-cycle with Chebyshev
+  smoothing (Adams et al., *JCP* 188, 2003). The apply is `jit`/`vmap`-native (one frozen
+  hierarchy legitimately serves a whole batch) and exactly linear, so it preconditions
+  `cg`/`minres` too. Mesh-independent convergence ⇒ *the* choice for large elliptic blocks.
+  Inside traced/parametric solves, pre-build eagerly: `spec = jno.precond.amg(); spec.build(fem.A)`.
+  Without pyamg installed everything else works; using `amg` raises a clear install hint.
 
 The flagship pattern — Taylor–Hood **Stokes** by FGMRES with an inexact velocity block solve and
 the viscosity-weighted pressure-mass Schur approximation (Elman, Silvester & Wathen, *Finite

--- a/docs/tutorial_examples/08_fem_and_varpinns/clamped_kirchhoff_plate_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/clamped_kirchhoff_plate_2d.py
@@ -38,7 +38,6 @@ import numpy as np
 from shapely.geometry import box
 
 import jno
-from jno.utils.solver.linear import sparse_lu_solve
 
 PI = np.pi
 laplacian = jno.np.laplacian
@@ -55,7 +54,7 @@ def solve_plate(mesh_size):
     q = 1.0 + 0.0 * xi  # uniform transverse pressure
     # clamped = deflection w=0 (u(reg)-g) AND rotation ∂w/∂n=0 (u.dn(reg)-h); the boundary curvature stays free
     fem = jno.fem([laplacian(ui, [xi, yi]) * laplacian(vi, [xi, yi]) - q * vi, u(xb, yb) - 0.0, u.dn(xb, yb) - 0.0])
-    sol = np.asarray(fem.solve(sparse_lu_solve)).reshape(-1)  # sparse-direct: O(nnz) memory on the fine mesh
+    sol = np.asarray(fem.solve(linear=jno.solve.lu())).reshape(-1)  # sparse-direct: O(nnz) memory on the fine mesh
     pts = np.asarray(d.mesh.points)[:, :2]
     return d, pts, sol
 

--- a/docs/tutorial_examples/08_fem_and_varpinns/coupled_two_temperature_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/coupled_two_temperature_2d.py
@@ -12,8 +12,8 @@ This shows off the FEM solver on the things that matter in practice, not a unit 
   (steep gradients) while the ``bulk`` stays coarse (``build_mesh(..., sizes={"ring": ...})``);
 * genuine multi-field COUPLING -- two ``fem_symbols`` fields with a cross term, assembled as one
   block system;
-* the coupled system is solved with a bring-your-own dense solver (jnp.linalg.solve);
-  you never call jno's built-in solver.
+* the coupled system is solved sparse-direct via the slot API --
+  ``fem.solve(linear=jno.solve.lu())`` factorises the assembled BCOO operator (no densification).
 
 Verified by the method of manufactured solutions (impose a known ``T_s*, T_f*`` on the full
 boundary, recover it): a convergent rel-L2, the standard correctness gate for a FEM code.
@@ -29,7 +29,6 @@ jax.config.update("jax_enable_x64", True)  # the assembler builds in float64
 
 from pathlib import Path  # noqa: E402
 
-import jax.numpy as jnp  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 import matplotlib.tri as mtri  # noqa: E402
 import numpy as np  # noqa: E402
@@ -71,8 +70,8 @@ fem = jno.fem(
     ]
 )
 
-# bring-your-own solver: a dense direct solve (the default matrix-free Krylov is for large elliptic systems)
-sol = np.asarray(fem.solve(solve_fn=lambda A, b: jnp.linalg.solve(A, b)))
+# slot API: sparse-direct LU on the assembled BCOO operator (single coupled solve)
+sol = np.asarray(fem.solve(linear=jno.solve.lu()))
 off = fem.offsets  # per-field slices into the coupled solution vector
 Th_s, Th_f = sol[off[0] : off[1]], sol[off[1] :]
 pts = np.asarray(fem.points)
@@ -81,7 +80,7 @@ ref_s = 1 + 0.40 * np.sin(PI * xs / 2) * np.sin(PI * ys)
 ref_f = 1 + 0.25 * np.sin(PI * xs) * np.sin(PI * ys)
 rels = float(np.linalg.norm(Th_s - ref_s) / np.linalg.norm(ref_s))
 relf = float(np.linalg.norm(Th_f - ref_f) / np.linalg.norm(ref_f))
-print("\nCoupled two-temperature model on a plate with a cooling channel (dense solve)")
+print("\nCoupled two-temperature model on a plate with a cooling channel (sparse LU)")
 print(f"  fields={len(off) - 1}  dofs={fem.dofs}  bulk/ring mesh = 0.06 / 0.025")  # offsets = [0, n1, n2]
 print(f"  MMS recovery rel-L2:  T_s={rels:.3e}  T_f={relf:.3e}")
 

--- a/docs/tutorial_examples/08_fem_and_varpinns/diffusion_reaction_robinBC.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/diffusion_reaction_robinBC.py
@@ -18,7 +18,6 @@ import jno
 pi, sigma, a_r, a_t = np.pi, 4.0, 2.0, 3.0
 sin = jno.np.sin
 exact = lambda x, y: x * jnp.sin(jnp.pi * y) + y  # noqa: E731
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
 
 d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.22)
 u, phi = d.fem_symbols()
@@ -35,7 +34,7 @@ robin_right = (a_r * u.bind(x=xr, y=yr) - (sin(pi * yr) + a_r * (sin(pi * yr) + 
 robin_top = (a_t * u.bind(x=xt, y=yt) - (1.0 - pi * xt + a_t)) * phi.bind(x=xt, y=yt)
 fem = jno.fem([volume, robin_right, robin_top, u(xl, yl) - yl, u(xbo, ybo) - 0.0], quad_degree=3)
 
-u_fem = jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1))
+u_fem = jnp.asarray(fem.solve())  # default: Jacobi-preconditioned BiCGStab on the sparse operator
 pts = np.asarray(fem.points)
 rel_l2 = float(jnp.linalg.norm(exact(pts[:, 0], pts[:, 1]) - u_fem) / jnp.linalg.norm(exact(pts[:, 0], pts[:, 1])))
 print(f"\nReaction-diffusion, mixed Dirichlet/Robin via jno.fem: dofs={fem.dofs}  rel_L2={rel_l2:.3e}")

--- a/docs/tutorial_examples/08_fem_and_varpinns/helmholtz_3D.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/helmholtz_3D.py
@@ -24,7 +24,6 @@ import jno  # noqa: E402
 
 alpha, sigma, MS = 0.20, 4.0, 0.40
 exact = lambda z: z + alpha * jnp.sin(jnp.pi * z)  # noqa: E731
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
 
 
 def letter_F_3d(depth=1.0, mesh_size=MS):
@@ -75,7 +74,7 @@ volume = ui.x * vi.x + ui.y * vi.y + ui.z * vi.z + sigma * u * vi - f * vi
 top_neumann = -(1.0 - alpha * np.pi) * phi.bind(x=ct[0], y=ct[1], z=ct[2])  # du/dn given on the top face
 fem = jno.fem([volume, top_neumann, u(cb[0], cb[1], cb[2]) - 0.0], element_type="TET4", quad_degree=2)
 
-u_fem = jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1))
+u_fem = jnp.asarray(fem.solve(linear=jno.solve.lu()))  # indefinite Helmholtz -> sparse-direct slot
 pts = np.asarray(fem.points)
 rel_l2 = float(jnp.linalg.norm(exact(pts[:, 2]) - u_fem) / jnp.linalg.norm(exact(pts[:, 2])))
 print(f"\n3D F-domain screened Helmholtz via jno.fem: dofs={fem.dofs}  rel_L2={rel_l2:.3e}")

--- a/docs/tutorial_examples/08_fem_and_varpinns/helmholtz_mixedBC_fem.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/helmholtz_mixedBC_fem.py
@@ -20,7 +20,6 @@ sin, cos = jno.np.sin, jno.np.cos
 exact = lambda x, y: jnp.sin(jnp.pi * x) * (jnp.cos(jnp.pi * y) + y)  # noqa: E731
 flux_right = lambda x, y: -pi * (cos(pi * y) + y)  # u_x at x = 1  # noqa: E731
 flux_top = lambda x, y: sin(pi * x)  # u_y at y = 1  # noqa: E731
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
 
 d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.22)
 u, phi = d.fem_symbols()
@@ -37,7 +36,7 @@ neumann_right = -flux_right(xr, yr) * phi.bind(x=xr, y=yr)  # natural term -g ph
 neumann_top = -flux_top(xt, yt) * phi.bind(x=xt, y=yt)
 fem = jno.fem([volume, neumann_right, neumann_top, u(xl, yl) - 0.0, u(xbo, ybo) - sin(pi * xbo)], quad_degree=3)
 
-u_fem = jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1))
+u_fem = jnp.asarray(fem.solve(linear=jno.solve.lu()))  # indefinite Helmholtz -> sparse-direct slot
 pts = np.asarray(fem.points)
 rel_l2 = float(jnp.linalg.norm(exact(pts[:, 0], pts[:, 1]) - u_fem) / jnp.linalg.norm(exact(pts[:, 0], pts[:, 1])))
 print(f"\n2D Helmholtz, mixed Dirichlet/Neumann via jno.fem: dofs={fem.dofs}  rel_L2={rel_l2:.3e}")

--- a/docs/tutorial_examples/08_fem_and_varpinns/inverse_plate_stiffness_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/inverse_plate_stiffness_2d.py
@@ -80,7 +80,7 @@ def main():
     k.dtype(jnp.float64)
     k.initialize(jax.nn.initializers.constant(1.0))
     k.optimizer(optax.adam(3e-2))
-    crux = jno.core([(fem.solve(solver) - w_obs).mse], domain=_DUMMY)
+    crux = jno.core([(fem.solve(linear=jno.solve.dense()) - w_obs).mse], domain=_DUMMY)
     crux.solve(200)  # loss plateaus early; 200 steps recovers both defects with budget to spare
     k_rec = np.asarray(crux.eval([k])).reshape(-1)
 

--- a/docs/tutorial_examples/08_fem_and_varpinns/linear_elasticity_cantilever.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/linear_elasticity_cantilever.py
@@ -22,7 +22,6 @@ E, nu, L, H = 1000.0, 0.3, 10.0, 1.0
 lam, mu = E * nu / (1.0 - nu**2), E / (2.0 * (1.0 + nu))  # plane-stress Lame parameters
 Iz = H**3 / 12.0  # second moment of area (unit thickness)
 inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
 
 d = jno.domain(box(0.0, 0.0, L, H), mesh_size=0.5)
 u, phi = d.fem_symbols(value_shape=(2,), order=2)  # P2 vector displacement
@@ -36,7 +35,8 @@ weak = lam * trace(eu) * trace(ep) + 2.0 * mu * inner(eu, ep, n_contract=2)
 q = 0.1  # downward shear traction (0, -q) on the tip; total load P = q * H
 traction = -1.0 * inner(jnp.array([0.0, -q]), phi.bind(x=xr, y=yr), n_contract=1)
 fem = jno.fem([weak, u(xl, yl) - (0.0, 0.0), traction])
-sol = jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1)).reshape(-1, 2)  # (n_nodes, 2)
+# The slender-beam P2 stiffness matrix is too ill-conditioned for Jacobi-CG in float32 -> sparse-direct slot.
+sol = jnp.asarray(fem.solve(linear=jno.solve.lu())).reshape(-1, 2)  # (n_nodes, 2)
 tip = np.asarray(fem.points)[:, 0] > L - 1e-6
 delta, eb = float(-jnp.mean(sol[tip, 1])), (q * H) * L**3 / (3.0 * E * Iz)
 print(

--- a/docs/tutorial_examples/08_fem_and_varpinns/poisson_2d_fem.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/poisson_2d_fem.py
@@ -5,7 +5,10 @@
 
 A pure finite-element solve: write the weak form as a list of residual terms (volume physics
 + the essential condition ``u(region) - g``), hand it to ``jno.fem`` -- the single FEM entry --
-and solve the assembled ``A u = b``.
+and solve with ``fem.solve()``. The default is a matrix-free Jacobi-preconditioned BiCGStab on
+the sparse operator (never densifies); the solver slots choose anything else, e.g. CG for this
+SPD system: ``fem.solve(linear=jno.solve.cg(), precond=jno.precond.jacobi())`` -- see
+``docs/fem.md`` "Choosing the solver".
 """
 
 import jax.numpy as jnp
@@ -15,7 +18,6 @@ from shapely.geometry import box
 import jno
 
 exact = lambda x, y: x * (1 - x) * y * (1 - y)  # noqa: E731
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
 
 d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.18)
 u, phi = d.fem_symbols()
@@ -25,7 +27,7 @@ ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
 
 f = 2.0 * (xi * (1 - xi) + yi * (1 - yi))
 fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3)  # weak form + u = 0
-u_fem = jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1))  # solve A u = b
+u_fem = jnp.asarray(fem.solve(linear=jno.solve.cg(), precond=jno.precond.jacobi()))  # SPD -> CG
 
 pts = np.asarray(fem.points)  # coordinates the DOFs live on
 rel_l2 = float(jnp.linalg.norm(exact(pts[:, 0], pts[:, 1]) - u_fem) / jnp.linalg.norm(exact(pts[:, 0], pts[:, 1])))

--- a/docs/tutorial_examples/08_fem_and_varpinns/stokes_channel_poiseuille.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/stokes_channel_poiseuille.py
@@ -12,7 +12,10 @@ exact parabolic profile
 
 so we impose that profile as the velocity boundary data (zero on the walls, parabola at the
 inlet/outlet), pin the pressure at one vertex to remove its constant null space, and recover
-the analytic Poiseuille solution to machine precision.
+the analytic Poiseuille solution to the solver tolerance. The indefinite saddle system is solved
+matrix-free by FGMRES with a block upper-triangular preconditioner: an inexact CG solve on the
+velocity block and a viscosity-weighted pressure mass matrix as the Schur-complement
+approximation.
 """
 
 import jax
@@ -26,7 +29,6 @@ from shapely.geometry import box
 import jno
 
 inner, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
 G, mu, H, Lx = 1.0, 1.0, 1.0, 4.0
 u_profile = lambda y: (G / (2.0 * mu)) * y * (H - y)  # noqa: E731
 
@@ -50,9 +52,17 @@ fem = jno.fem(
 )
 
 off = fem.offsets  # per-field DOF offsets in the coupled solution vector
-sol = jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1))
+sol = jnp.asarray(
+    fem.solve(
+        linear=jno.solve.fgmres(tol=1e-10, restart=40, maxiter=4000),
+        precond=jno.precond.triangular(
+            (u, jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=60))),  # velocity block: inexact CG
+            (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.dense())),  # Schur ~ (1/mu)-weighted pressure mass
+        ),
+    )
+)
 uu = np.asarray(sol[off[0] : off[1]]).reshape(-1, 2)  # velocity (n_vel_nodes, 2)
-pts_v = np.asarray(fem.field_points[0])
+pts_v = np.asarray(fem.field_points[0])  # P2 velocity nodes (snapshotted -- safe after the aux precond assembly)
 rel_ux = float(np.linalg.norm(uu[:, 0] - u_profile(pts_v[:, 1])) / np.linalg.norm(u_profile(pts_v[:, 1])))
 max_uy = float(np.max(np.abs(uu[:, 1])))  # u_y == 0 and u_x x-independent => div u == 0
 print(f"\nStokes Poiseuille channel (Taylor-Hood P2/P1): dofs={fem.dofs}  u_x rel_L2={rel_ux:.3e}  max|u_y|={max_uy:.3e}")

--- a/docs/tutorial_examples/08_fem_and_varpinns/stokes_flow_around_cylinder.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/stokes_flow_around_cylinder.py
@@ -8,7 +8,8 @@ Taylor-Hood pair (P2 velocity, P1 pressure) coupled in one block:
   meshed finer than the rest of the channel (steep gradients hug the obstacle);
 * a parabolic profile drives the inlet AND the outlet -- exact for *Stokes* flow, which is
   fore-aft symmetric (Re = 0) -- while the walls and the cylinder are no-slip;
-* solved with a bring-your-own dense direct solver via `fem.solve(solve_fn=...)`.
+* solved sparse-direct via the slot API -- `fem.solve(linear=jno.solve.lu())` factorises the
+  assembled BCOO operator (the right pick for a single indefinite saddle solve; no densification).
 
 Verified without an analytic solution by a physical invariant: a centred cylinder makes the Stokes
 flow top-bottom symmetric, so the computed field must satisfy ``u_x(x, y) = u_x(x, H-y)`` and
@@ -26,7 +27,6 @@ jax.config.update("jax_enable_x64", True)  # the assembler builds in float64
 
 from pathlib import Path  # noqa: E402
 
-import jax.numpy as jnp  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 from scipy.interpolate import griddata  # noqa: E402
@@ -63,8 +63,8 @@ fem = jno.fem(
     ]
 )
 
-# bring-your-own solver: a dense direct solve (the default matrix-free Krylov is for large elliptic systems)
-sol = np.asarray(fem.solve(solve_fn=lambda A, b: jnp.linalg.solve(A, b)))
+# slot API: sparse-direct LU on the assembled BCOO operator (indefinite saddle system, single solve)
+sol = np.asarray(fem.solve(linear=jno.solve.lu()))
 off = fem.offsets
 uu = sol[off[0] : off[1]].reshape(-1, 2)  # velocity (n_vel_nodes, 2)
 pts_v = np.asarray(fem.field_points[0])
@@ -76,7 +76,7 @@ UX = np.where(inside, griddata(pts_v, uu[:, 0], (gx, gy), method="linear"), np.n
 UY = np.where(inside, griddata(pts_v, uu[:, 1], (gx, gy), method="linear"), np.nan)
 m = np.isfinite(UX) & np.isfinite(UX[::-1])  # nodes whose mirror is also valid
 sym = float(np.linalg.norm(np.r_[(UX - UX[::-1])[m], (UY + UY[::-1])[m]]) / np.linalg.norm(np.r_[UX[m], UY[m]]))
-print("\nStokes flow past a cylinder (Taylor-Hood P2/P1, dense solve)")
+print("\nStokes flow past a cylinder (Taylor-Hood P2/P1, sparse LU)")
 print(f"  fields={len(off) - 1}  dofs={fem.dofs}  channel/ring mesh = 0.12 / 0.05")  # offsets = [0, n_v, n_v+n_p]
 print(f"  top-bottom symmetry error (should be ~0): {sym:.3e}")
 

--- a/docs/tutorial_examples/08_fem_and_varpinns/supg_advection_diffusion_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/supg_advection_diffusion_2d.py
@@ -21,8 +21,6 @@ import numpy as np
 
 import jno
 
-dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
-
 N, NU = 20, 1e-2  # Pe_cell = (1)*(1/N)/(2 NU) = 2.5 >> 1  -> Galerkin oscillates
 dom = jno.domain(constructor=jno.domain.equi_distant_rect(x_range=(0.0, 1.0), y_range=(0.0, 1.0), nx=N, ny=N))
 dom.tag("inflow", lambda x, y: x < 1e-6)
@@ -49,7 +47,8 @@ bcs = [u(xin, yin) - 0.0, u(xout, yout) - 1.0]
 
 def solve(weak):
     fem = jno.fem([weak, *bcs])
-    return jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1)), fem
+    # non-symmetric advection operator -> GMRES
+    return jnp.asarray(fem.solve(linear=jno.solve.gmres(), precond=jno.precond.jacobi())), fem
 
 
 u_galerkin, fem_g = solve(galerkin)

--- a/docs/tutorials/08-fem-and-varpinns/clamped-kirchhoff-plate-2d.md
+++ b/docs/tutorials/08-fem-and-varpinns/clamped-kirchhoff-plate-2d.md
@@ -16,7 +16,7 @@ u, phi = d.fem_symbols(space="Argyris")
 q = 1.0 + 0.0 * xi                                    # uniform pressure, D = 1
 fem = jno.fem([laplacian(ui, [xi, yi]) * laplacian(vi, [xi, yi]) - q * vi,
                u(xb, yb) - 0.0, u.dn(xb, yb) - 0.0])  # clamped = deflection w=0 AND rotation ∂w/∂n=0
-sol = fem.solve(sparse_lu_solve)                      # sparse-direct: O(nnz) memory on the refined mesh
+sol = fem.solve(linear=jno.solve.lu())                # sparse-direct: O(nnz) memory on the refined mesh
 ```
 
 Clamped composes the two essential plate traces — `u(reg)-g` (deflection) and `u.dn(reg)-h` (rotation) — while

--- a/docs/tutorials/08-fem-and-varpinns/coupled-two-temperature-2d.md
+++ b/docs/tutorials/08-fem-and-varpinns/coupled-two-temperature-2d.md
@@ -42,13 +42,13 @@ fem = jno.fem([
 ])
 ```
 
-## Your own solver — you never call the built-in
+## Pick the solver with the slot API
 
-`fem.solve(solve_fn=...)` takes **your** `(A, b) -> u`. Here it is `lineax`; jno writes no solver:
+`fem.solve(linear=...)` selects the inner linear solver from the `jno.solve` factories. Here the
+single coupled solve goes sparse-direct — LU on the assembled BCOO operator, no densification:
 
 ```python
-import lineax
-sol = fem.solve(solve_fn=lambda A, b: lineax.linear_solve(lineax.MatrixLinearOperator(A), b).value)
+sol = fem.solve(linear=jno.solve.lu())         # sparse-direct on the BCOO operator
 off = fem.problem.offset                       # per-field slices of the coupled vector
 Th_s, Th_f = sol[off[0]:off[1]], sol[off[1]:]
 ```
@@ -69,9 +69,9 @@ $T_s-T_f$ — the local driving force for heat transfer between the phases.
   for the channel, a named `ring` refined independently of the `bulk`.
 - **Multi-field coupling** is just more residual terms; `fem.problem.offset` slices the block
   solution back into per-field vectors.
-- **Bring your own solver** through `solve_fn` (here `lineax`) — and the same hook accepts an
-  `optimistix` Newton (nonlinear) or a `diffrax` stepper (transient). `.solve()`'s default is only a
-  convenience.
+- **Pick the solver with the slot API** — `fem.solve(linear=jno.solve.lu())` for a single
+  sparse-direct solve; `solve_fn=` remains the total override if you want to bring your own
+  `(A, b) -> u`.
 - **Verified by the method of manufactured solutions:** impose a known $T_s^\*,T_f^\*$ on the full
   boundary and recover it — rel-L2 $\sim 3\times10^{-5}$, the standard correctness gate for a FEM
   code.

--- a/docs/tutorials/08-fem-and-varpinns/elasticity-plate-with-hole.md
+++ b/docs/tutorials/08-fem-and-varpinns/elasticity-plate-with-hole.md
@@ -34,7 +34,7 @@ weak = lam * trace(eu) * trace(ep) + 2.0 * mu * inner(eu, ep, n_contract=2)
 fem = jno.fem([weak - fx * phi.bind(x=xi, y=yi)[0],
                u(xb, yb)[0] - ux_star(xb, yb),
                u(xb, yb)[1] - uy_star(xb, yb)])
-sol = fem.solve(solve_fn=lambda A, b: lineax.linear_solve(lineax.MatrixLinearOperator(A), b).value)
+sol = fem.solve()   # matrix-free Jacobi-preconditioned BiCGStab default (O(nnz) memory)
 ```
 
 ## The result
@@ -52,7 +52,9 @@ along the pull, contracted across it (Poisson effect).
   independently — exactly the moves you need for real parts.
 - **Vector fields read like the math**: `symgrad`/`trace`/`inner` give $\boldsymbol\varepsilon$ and
   the bilinear form with no index bookkeeping; P2 (`order=2`) avoids shear locking.
-- **Bring your own solver** (`lineax`) through `solve_fn`.
+- **The built-in default solver is enough here**: plain `fem.solve()` runs matrix-free
+  Jacobi-preconditioned BiCGStab; pick another via the slot API (e.g.
+  `fem.solve(linear=jno.solve.cg())` for this SPD system) when the default is not the right fit.
 - **Verified by the method of manufactured solutions:** a known uniaxial-tension field
   $\mathbf u^\*$ (with a sinusoidal perturbation, so the gate is genuinely mesh-convergent rather
   than exactly polynomial) is imposed on the whole boundary and recovered to rel-L2 $\sim7\times10^{-6}$.

--- a/docs/tutorials/08-fem-and-varpinns/inverse-plate-stiffness-2d.md
+++ b/docs/tutorials/08-fem-and-varpinns/inverse-plate-stiffness-2d.md
@@ -27,7 +27,7 @@ ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
 fem = jno.fem([k * (laplacian(ui, [xi, yi]) * laplacian(vi, [xi, yi])) - q * vi, u(xb, yb) - 0.0])
 
 # recover k(x) end-to-end through crux, from a flat wrong guess k = 1
-crux = jno.core([(fem.solve(solver) - w_obs).mse], domain=_DUMMY)
+crux = jno.core([(fem.solve(linear=jno.solve.dense()) - w_obs).mse], domain=_DUMMY)
 crux.solve(200)
 ```
 

--- a/docs/tutorials/08-fem-and-varpinns/linear-elasticity-cantilever.md
+++ b/docs/tutorials/08-fem-and-varpinns/linear-elasticity-cantilever.md
@@ -22,10 +22,12 @@ eu, ep = symgrad(u, [xi, yi]), symgrad(phi, [xi, yi])
 weak = lam * trace(eu) * trace(ep) + 2.0 * mu * inner(eu, ep, n_contract=2)
 traction = -1.0 * inner(jnp.array([0.0, -q]), phi.bind(x=xr, y=yr), n_contract=1)
 fem = jno.fem([weak, u(xl, yl) - (0.0, 0.0), traction])
+sol = jnp.asarray(fem.solve(linear=jno.solve.lu())).reshape(-1, 2)
 ```
 
-The interleaved solution is read with `sol = solve(...).reshape(-1, 2)` (`[:, 0]` = $u_x$,
-`[:, 1]` = $u_y$), aligned with `fem.points`.
+The slender-beam P2 stiffness matrix is too ill-conditioned for a Jacobi-preconditioned Krylov
+solve in float32, so the solve picks the sparse-direct `lu` slot; the interleaved solution is
+read with `.reshape(-1, 2)` (`[:, 0]` = $u_x$, `[:, 1]` = $u_y$), aligned with `fem.points`.
 
 ## What to notice
 

--- a/docs/tutorials/08-fem-and-varpinns/poisson-2d-fem.md
+++ b/docs/tutorials/08-fem-and-varpinns/poisson-2d-fem.md
@@ -20,13 +20,17 @@ coordinates gives the `.x` / `.y` derivatives, and the Dirichlet condition is si
 ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
 f = 2.0 * (xi * (1 - xi) + yi * (1 - yi))
 fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3)
-u_fem = jnp.linalg.solve(dense(fem.A), jnp.asarray(fem.b).reshape(-1))
+u_fem = jnp.asarray(fem.solve(linear=jno.solve.cg(), precond=jno.precond.jacobi()))  # SPD -> CG
 ```
 
 ## What to notice
 
 - One call, `jno.fem([...])`, assembles the stiffness `fem.A` and load `fem.b`.
 - Boundary conditions are terms in the same list — no separate BC objects.
+- `fem.solve()` alone would also work (matrix-free Jacobi-BiCGStab on the sparse operator);
+  the **solver slots** pick a structure-appropriate method — CG for this SPD system — without
+  ever densifying. See [Choosing the solver](../../fem.md) for the full `jno.solve` /
+  `jno.precond` namespaces.
 - The solution is audited against the manufactured field $u^\*=x(1-x)y(1-y)$ (rel-$L^2 \approx 8\times10^{-3}$).
 
 ## Full script

--- a/docs/tutorials/08-fem-and-varpinns/stokes-channel-poiseuille.md
+++ b/docs/tutorials/08-fem-and-varpinns/stokes-channel-poiseuille.md
@@ -7,7 +7,9 @@
 
 Steady incompressible **Stokes flow** in a channel, $-\mu\Delta u+\nabla p=0,\ \nabla\!\cdot u=0$,
 solved with an inf-sup-stable **Taylor-Hood** pair (P2 velocity, P1 pressure). Fully-developed
-flow has the exact parabolic Poiseuille profile, recovered here to machine precision.
+flow has the exact parabolic Poiseuille profile, recovered here to the solver tolerance. The
+indefinite saddle system is solved matrix-free by **FGMRES** with a block upper-triangular
+preconditioner built from the slot API.
 
 ## Two coupled fields + a pressure pin
 
@@ -27,11 +29,32 @@ fem = jno.fem([mu * inner(gu, gv, n_contract=2) - pp * trace(gv),   # momentum
 
 Per-field blocks of the solution are sliced with `fem.problem.offset`.
 
+## A block-preconditioned saddle solve
+
+The Stokes matrix is symmetric **indefinite**, so plain CG/BiCGStab stall on it. The slot API
+composes the textbook remedy — flexible GMRES outside, a block upper-triangular preconditioner
+over the per-field DOF blocks inside: an *inexact* CG solve on the velocity block and the
+$(1/\mu)$-weighted **pressure mass matrix** as the Schur-complement approximation, written as an
+ordinary weak-form term via `jno.precond.form`. No matrix is ever densified:
+
+```python
+sol = jnp.asarray(fem.solve(
+    linear=jno.solve.fgmres(tol=1e-10, restart=40, maxiter=4000),
+    precond=jno.precond.triangular(
+        (u, jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=60))),  # velocity block: inexact CG
+        (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.dense())),  # Schur ~ (1/mu)-weighted pressure mass
+    ),
+))
+```
+
 ## What to notice
 
 - Coupled systems = one `fem_symbols` call per field, then momentum + continuity terms.
 - Taylor-Hood = `order=2` velocity + `order=1` pressure; gauge-fix the pressure with `p.pin()`.
-- Recovers the exact parabola $u_x=\tfrac{G}{2\mu}y(H-y)$ and $\nabla\!\cdot u\approx 0$ to $\sim 10^{-15}$.
+- Saddle systems want `fgmres` + `jno.precond.triangular` over the field blocks; the pressure
+  Schur block is just another weak form (`jno.precond.form`).
+- Recovers the exact parabola $u_x=\tfrac{G}{2\mu}y(H-y)$ and $\nabla\!\cdot u\approx 0$ to the
+  FGMRES tolerance ($\sim 10^{-9}$).
 
 ## Full script
 

--- a/docs/tutorials/08-fem-and-varpinns/stokes-flow-around-cylinder.md
+++ b/docs/tutorials/08-fem-and-varpinns/stokes-flow-around-cylinder.md
@@ -38,7 +38,7 @@ fem = jno.fem([
     u(xb, yb)[1] - 0.0,
     p.pin(),                                              # gauge-fix the pressure null space
 ])
-sol = fem.solve(solve_fn=lambda A, b: lineax.linear_solve(lineax.MatrixLinearOperator(A), b).value)
+sol = fem.solve(linear=jno.solve.lu())   # sparse-direct on the assembled BCOO operator
 ```
 
 ## The result
@@ -57,7 +57,8 @@ downstream — the textbook creeping-flow picture.
   independently of the `bulk`.
 - **Taylor-Hood multiphysics**: a P2 vector velocity and a P1 pressure as two `fem_symbols` fields,
   assembled as one inf-sup-stable block. `fem.problem.offset` slices the velocity back out.
-- **Bring your own solver** (`lineax`) through `solve_fn`.
+- **Pick the solver with the slot API**: `fem.solve(linear=jno.solve.lu())` — sparse-direct on
+  the assembled operator, the right choice for a single indefinite saddle solve (no densification).
 - **Verified by a physical invariant, not an analytic solution.** A centred cylinder makes Stokes
   flow top-bottom symmetric, so $u_x(x,y)=u_x(x,H-y)$ and $u_y(x,y)=-u_y(x,H-y)$; the measured
   symmetry error is $\sim2\times10^{-3}$.

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -8,7 +8,7 @@ jNO: Physics-Informed Neural Operators.
 
 import sys
 
-from . import bayesian, fn, lora, optimizers, trackers
+from . import bayesian, fn, lora, optimizers, precond, solve, trackers
 from . import jnp_ops as np
 from ._fem import Coupling, fem
 from .architectures.models import nn, parameter

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -10,7 +10,7 @@ import sys
 
 from . import bayesian, fn, lora, optimizers, precond, solve, trackers
 from . import jnp_ops as np
-from ._fem import Coupling, fem
+from ._fem import Coupling, fem, lag
 from .architectures.models import nn, parameter
 from .core import core
 from .differential_operators import DifferentialOperators

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -96,6 +96,37 @@ def _solve_linear_matrix_free(A, b, *, tol=1e-8, maxiter=20_000):
     return _residual_check(A, b, u, "Jacobi-preconditioned BiCGStab")
 
 
+def lag(expr: Any) -> Any:
+    """Mark a weak-form coefficient as **lagged**: frozen within each linearization, updated
+    between iterations — the Picard / fixed-point linearization as first-class API.
+
+    The canonical use is a solution-dependent coefficient whose Newton tangent destroys the
+    linearized system's structure — e.g. a shear-thinning viscosity ``mu_eff(u)`` in a
+    rigid-plastic/non-Newtonian Stokes flow, where full Newton produces a strongly nonsymmetric
+    velocity block that defeats AMG/block preconditioners, while the lagged (Picard) system is a
+    plain symmetric Stokes solve per step::
+
+        mu_eff = k_f / (3 * jno.np.sqrt(2/3 * rate2 + eps0**2))
+        fem = jno.fem([2 * jno.lag(mu_eff) * inner(eps(ui), eps(vi)) - ...])
+        fem.solve(nonlinear=jno.solve.picard(damping=0.7), linear=..., precond=...)
+
+    Mechanically ``lag`` is ``stop_gradient`` on the traced expression, so ``jax.linearize`` of
+    the residual yields the *lagged* operator: :func:`jno.solve.picard` (and plain Newton) then
+    iterate with that linearization automatically. The converged solution is unchanged —
+    ``R(u) = 0`` does not depend on gradient markers.
+
+    **Inverse-problem caveat**: implicit differentiation (``custom_root``) also uses the lagged
+    Jacobian for its tangent/adjoint solve, so gradients of ``fem.solve()`` w.r.t. parameters
+    become the standard "Picard adjoint" approximation — widely used and usually descent-worthy,
+    but not exact. Remove ``lag`` (full Newton) when exact parameter gradients matter more than
+    per-step solvability.
+    """
+    sg = getattr(expr, "stop_gradient", None)
+    if sg is not None and not callable(sg):
+        return sg  # traced view / placeholder: the .stop_gradient property
+    return jax.lax.stop_gradient(expr)  # plain arrays inside hand-written residuals
+
+
 # ---------------------------------------------------------------------------
 # expression helpers
 # ---------------------------------------------------------------------------

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1198,8 +1198,12 @@ class FEM:
         if meshes:
             return jnp.asarray(meshes[0].points)
         # Native Lagrange path (no problem object): the assembler records the DOF coordinates
-        # (vertices + edge midpoints for P2) the flat solution lives on.
-        native_pts = getattr(self.domain, "_fem_native_dof_points", None)
+        # (vertices + edge midpoints for P2) the flat solution lives on. Prefer the snapshot
+        # captured at finalize time — the domain attribute is overwritten by any later assembly
+        # on the same domain (e.g. a jno.precond.form auxiliary operator).
+        native_pts = getattr(self, "_native_dof_points", None)
+        if native_pts is None:
+            native_pts = getattr(self.domain, "_fem_native_dof_points", None)
         if native_pts is not None:
             return jnp.asarray(native_pts)
         if self.mesh is not None:
@@ -1216,7 +1220,10 @@ class FEM:
         meshes = getattr(prob, "mesh", None) if prob is not None else None
         if meshes:
             return [jnp.asarray(m.points) for m in meshes]
-        native_all = getattr(self.domain, "_fem_native_dof_points_all", None)
+        # snapshot first (see .points): the live domain attribute is clobbered by later assemblies
+        native_all = getattr(self, "_native_dof_points_all", None)
+        if native_all is None:
+            native_all = getattr(self.domain, "_fem_native_dof_points_all", None)
         if native_all is not None:
             return [jnp.asarray(p) for p in native_all]
         pts = self.points
@@ -2016,6 +2023,11 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         # the constraint-walk order is the fallback for paths that don't run the native assembler.
         fem_obj._block_field_keys = list(getattr(domain, "_fem_native_field_keys", None) or ())
         fem_obj._trial_field_keys = _field_keys(_orig_constraints)
+        # Same snapshot treatment for the DOF coordinates behind .points / .field_points — an
+        # auxiliary assembly (jno.precond.form) would otherwise clobber them mid-solve.
+        fem_obj._native_dof_points = getattr(domain, "_fem_native_dof_points", None)
+        _all = getattr(domain, "_fem_native_dof_points_all", None)
+        fem_obj._native_dof_points_all = list(_all) if _all is not None else None
         if couplings:
             # Fold the coupling into the residual FIRST -- a steady local form is promoted to a nonlinear
             # FemResidualOperator. The periodic reduction below then wraps the *coupled* residual through

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -927,7 +927,7 @@ class FEM:
             return list(self._offsets)
         return getattr(self.problem, "offset", None)
 
-    def solve(self, solve_fn=None, *, adapt=None, **kwargs) -> Any:
+    def solve(self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, **kwargs) -> Any:
         """Differentiable forward solve as a trace node — the inverse-problem entry.
 
         Pass ``adapt=AdaptSpec(...)`` to run the **adaptive** loop
@@ -973,11 +973,45 @@ class FEM:
         ``solve()`` returns the complex solution ``u_r + i·u_i`` via the real-equivalent block
         ``[[A_r,-A_i],[A_i,A_r]]`` (the assembly produces only real systems); pass ``solve_fn=(A, b) -> u``
         to choose the real block solver.
+
+        **Solver slots** (callables-only; alternative to ``solve_fn``, which stays the total
+        override — passing both is an error). The solver space factorises into four orthogonal
+        slots; each takes a configured callable from ``jno.solve`` / ``jno.precond`` (or your
+        own with the same contract, see those modules), and every ``None`` keeps today's
+        default::
+
+            fem.solve(
+                x0        = None,                   # warm start (initial guess / iterate)
+                nonlinear = jno.solve.newton(),     # linearization driver (nonlinear mode)
+                linear    = jno.solve.gmres(),      # inner linear solve
+                precond   = jno.precond.jacobi(),   # v -> M^{-1} v spec, materialized per solve
+            )
+
+        The slots compose into a ``solve_fn`` internally, so each dispatch path below keeps its
+        periodic reduction and implicit-differentiation behaviour; slot solvers receive the
+        **BCOO** operator (no densification). Not yet supported: slots on transient problems,
+        ``x0`` on complex problems, ``precond`` on the (matrix-free) nonlinear path, and slots
+        combined with ``adapt=`` (remeshing invalidates warm starts and cached preconditioner
+        setups — pass ``solve_fn=`` there).
         """
+        has_slots = (x0 is not None) or (nonlinear is not None) or (linear is not None) or (precond is not None)
         if adapt is not None:
+            if has_slots:
+                raise NotImplementedError(
+                    "fem.solve: the solver slots (x0/nonlinear/linear/precond) do not compose with "
+                    "adapt= yet — remeshing changes the DOF layout under a warm start and stales "
+                    "cached form/amg preconditioner setups. Pass solve_fn= for the adaptive loop."
+                )
             from .utils.solver.fem_adapt import run_adaptive_solve
 
             return run_adaptive_solve(self, adapt, solve_fn=solve_fn, **kwargs)
+        if has_slots:
+            solve_fn, kwargs = self._compose_slots(
+                solve_fn, x0=x0, nonlinear=nonlinear, linear=linear, precond=precond, kwargs=kwargs
+            )
+            from_slots = True
+        else:
+            from_slots = False
         if self._mode == "complex":
             return _solve_complex_block(self._op, solve_fn, periodic=self._periodic)
         if self._mode == "complex_transient":
@@ -1012,6 +1046,8 @@ class FEM:
                 return prolong_periodic(self._periodic, u_red)
             if solve_fn is None and hasattr(A, "todense"):
                 return _solve_linear_matrix_free(A, b)
+            if from_slots:
+                return solve_fn(A, b)  # slot-composed solvers take the BCOO operator directly
             A = jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)
             return (solve_fn or (lambda A_, b_: jnp.linalg.solve(A_, b_)))(A, b)
         if self._mode == "linear" and isinstance(self._op, FemLinearSystem):
@@ -1052,6 +1088,41 @@ class FEM:
             # flow to crux; with no parameter it is just a forward solve, so evaluate it to an array.
             return self._op.solve(solve_fn, **kwargs).fn()
         return self._op.solve(solve_fn, **kwargs)
+
+    def _compose_slots(self, solve_fn, *, x0, nonlinear, linear, precond, kwargs):
+        """Compose the solver slots into the mode-appropriate ``solve_fn`` (see :meth:`solve`)."""
+        from .utils.solver.solver_api import compose_linear_solve_fn, compose_nonlinear_solve_fn
+
+        if solve_fn is not None:
+            raise ValueError(
+                "fem.solve: pass either solve_fn= (the total override) or the solver slots "
+                "(x0/nonlinear/linear/precond), not both."
+            )
+        if self._mode in ("transient", "complex_transient"):
+            raise NotImplementedError(
+                "fem.solve solver slots are not threaded into the transient stepper yet -- pass a full "
+                "integrator via solve_fn= (see plans/fem-solver-api.md)."
+            )
+        if self._mode == "nonlinear":
+            fn = compose_nonlinear_solve_fn(nonlinear, linear, precond, self)
+            if x0 is not None:
+                if "u0" in kwargs:
+                    raise ValueError("fem.solve: x0= and u0= are the same initial guess; pass one.")
+                kwargs = {**kwargs, "u0": jnp.asarray(x0).reshape(-1)}
+            return fn, kwargs
+        if nonlinear is not None:
+            raise ValueError(f"fem.solve: nonlinear= given, but this problem is {self._mode} (no linearization).")
+        if self._mode == "complex" and x0 is not None:
+            raise NotImplementedError(
+                "fem.solve: x0= on a complex problem is not supported yet (the solve runs on the "
+                "real-equivalent block, an internal layout)."
+            )
+        if self._periodic is not None and x0 is not None:
+            # the solve runs in the periodic-reduced space; restrict the guess to match
+            from .utils.solver.fem_utils import restrict_state_periodic
+
+            x0 = restrict_state_periodic(self._periodic, jnp.asarray(x0).reshape(-1))
+        return compose_linear_solve_fn(linear, precond, x0, self), kwargs
 
     @property
     def points(self):

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1056,9 +1056,14 @@ class FEM:
         ``precond`` spec is materialized per Newton/Picard linearization against the JVP
         operator — ``form`` / ``inner(...)`` / ``chebyshev`` / pre-built ``amg`` and their
         ``block_diag``/``triangular`` compositions work; ``jacobi`` (needs the assembled
-        diagonal) does not. Not yet supported: slots on transient problems, ``x0`` on complex
-        problems, and slots combined with ``adapt=`` (remeshing invalidates warm starts and
-        cached preconditioner setups — pass ``solve_fn=`` there).
+        diagonal) does not. On a **transient** problem the slots configure the *per-step*
+        solves of the default theta-stepper: ``linear``/``precond`` see the step operator
+        ``M + θ·dt·A`` (materialized once, before the time loop, when the operator is
+        time-independent — an AMG hierarchy / auxiliary form is then reused by every step),
+        ``nonlinear`` drives each implicit step, each step warm-starts from the previous state
+        (``x0`` is rejected — the ICs own the initial state). Not yet supported: slots on
+        complex/complex-transient problems, and slots combined with ``adapt=`` (remeshing
+        invalidates warm starts and cached preconditioner setups — pass ``solve_fn=`` there).
         """
         has_slots = (x0 is not None) or (nonlinear is not None) or (linear is not None) or (precond is not None)
         if adapt is not None:
@@ -1164,11 +1169,30 @@ class FEM:
                 "fem.solve: pass either solve_fn= (the total override) or the solver slots "
                 "(x0/nonlinear/linear/precond), not both."
             )
-        if self._mode in ("transient", "complex_transient"):
+        if self._mode == "complex_transient":
             raise NotImplementedError(
-                "fem.solve solver slots are not threaded into the transient stepper yet -- pass a full "
-                "integrator via solve_fn= (see plans/fem-solver-api.md)."
+                "fem.solve solver slots are not threaded into the complex-transient path yet -- pass a "
+                "full integrator via solve_fn= (see plans/fem-solver-api.md)."
             )
+        if self._mode == "transient":
+            # thread the slots into the default theta-stepper as per-step solvers: the linear
+            # slot/precond see the step operator (M + theta dt A) -- materialized ONCE before the
+            # scan when the operator is time-independent -- and the nonlinear slot drives each
+            # implicit step. The bring-your-own (block, args, save_ts) contract is unchanged.
+            if x0 is not None:
+                raise ValueError(
+                    "fem.solve: x0= on a transient problem -- the initial state comes from the initial "
+                    "conditions, and each step already warm-starts from the previous state."
+                )
+            from .utils.solver.backend_blocks import _default_transient_integrate
+            from .utils.solver.solver_api import compose_transient_step_solvers
+
+            lin_s, nonlin_s = compose_transient_step_solvers(nonlinear, linear, precond, self, self._op)
+
+            def _stepper(block, args, save_ts):
+                return _default_transient_integrate(block, args, save_ts, linear_solve=lin_s, nonlinear_solve=nonlin_s)
+
+            return _stepper, kwargs
         if self._mode == "nonlinear":
             fn = compose_nonlinear_solve_fn(nonlinear, linear, precond, self)
             if x0 is not None:

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -927,6 +927,37 @@ class FEM:
             return list(self._offsets)
         return getattr(self.problem, "offset", None)
 
+    @property
+    def blocks(self):
+        """Per-field DOF ``slice``s into the flat solution (``None`` without block structure).
+
+        The structural handle block preconditioners build on: ``jno.precond.block_diag`` /
+        ``triangular`` resolve their field arguments to these slices (see ``docs/fem.md``)."""
+        off = self.offsets
+        if off is None:
+            return None
+        return [slice(int(off[i]), int(off[i + 1])) for i in range(len(off) - 1)]
+
+    def block_index(self, field) -> int:
+        """Resolve a trial symbol (or plain index) to its position in :attr:`blocks` /
+        :attr:`offsets` — the field order is first appearance in the ``jno.fem`` constraints."""
+        if isinstance(field, int):
+            return field
+        # the native assembler records the keys in assembly (= offsets) order — snapshotted onto
+        # this FEM at finalize time (the domain attribute is overwritten by any later assembly on
+        # the same domain, e.g. an auxiliary jno.precond.form); the constraint-walk order is only
+        # a fallback for paths that don't set it
+        keys = getattr(self, "_block_field_keys", None) or getattr(self, "_trial_field_keys", None)
+        fk = getattr(field, "field_key", None)
+        if keys is None or fk is None:
+            raise TypeError(
+                "FEM.block_index: cannot resolve this object to a field block — pass the trial "
+                "symbol from d.fem_symbols() (or the integer block index)."
+            )
+        if fk not in keys:
+            raise KeyError(f"FEM.block_index: trial field {getattr(field, 'name', fk)!r} is not part of this system.")
+        return keys.index(fk)
+
     def solve(self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, **kwargs) -> Any:
         """Differentiable forward solve as a trace node — the inverse-problem entry.
 
@@ -1949,6 +1980,11 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         fem_obj._term_source = (domain, volume_terms)
         fem_obj._constraints = _orig_constraints
         fem_obj._fem_kwargs = _orig_fem_kwargs
+        # Field-key snapshots for FEM.block_index: the assembler's list is offsets-ordered (and
+        # must be captured NOW — a later assembly on the same domain overwrites the attribute);
+        # the constraint-walk order is the fallback for paths that don't run the native assembler.
+        fem_obj._block_field_keys = list(getattr(domain, "_fem_native_field_keys", None) or ())
+        fem_obj._trial_field_keys = _field_keys(_orig_constraints)
         if couplings:
             # Fold the coupling into the residual FIRST -- a steady local form is promoted to a nonlinear
             # FemResidualOperator. The periodic reduction below then wraps the *coupled* residual through

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -646,50 +646,64 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic
     (memory ``O(nnz)``; robust on the indefinite Helmholtz block). Pass ``solve_fn=(A, b) -> u`` to
     use a dense/direct solver instead -- it receives the densified block.
 
+    Each leg is a raw ``(A, b)`` (forward solve) or a parametric :class:`FemLinearSystem` (the complex
+    *inverse*): when either leg is parametric this returns a differentiable :class:`FunctionCall` trace
+    node instead of an array, so a real ``jno.np.parameter`` recovered through a complex forward solve
+    trains through ``crux`` -- the same real-equivalent block, with ``A(θ), b(θ)`` re-formed and the
+    block re-solved on each call.
+
     A periodic tie reduces *both* legs by the **same** prolongation ``P`` -- Re and Im live on one FE
     space, so one ``P`` -- before the block is formed: ``A -> P^T A P``, ``b -> P^T b`` on each leg.
     Because the same ``P`` hits both, ``blkdiag(P, P)^T [[A_r,-A_i],[A_i,A_r]] blkdiag(P, P)`` preserves
     the real-equivalent structure exactly; the reduced complex solution is prolonged back ``u = P u_red``."""
-    from .trace import FemLinearSystem
+    from .trace import FemLinearSystem, FunctionCall
     from .utils.solver.fem_utils import prolong_periodic, reduce_matrix_periodic, reduce_vector_periodic
 
-    def _ab(op):
-        if isinstance(op, FemLinearSystem):
-            raise NotImplementedError(
-                "Complex FEM with a runtime jno.np.parameter (the complex *inverse*) is a follow-on; "
-                "this path is the forward complex solve. (A real parameter recovered through a complex "
-                "forward works under the same real-equivalent block, but is not wired here yet.)"
-            )
-        A, b = op
+    def _ab(op, args):
+        A, b = op.evaluate(args) if isinstance(op, FemLinearSystem) else op
         b = jnp.asarray(b).reshape(-1)
         if periodic is not None:
             A = reduce_matrix_periodic(periodic, A)  # P^T A P  (stays sparse if A is BCOO)
             b = reduce_vector_periodic(periodic, b)  # P^T b
         return A, b  # keep A sparse (BCOO) -- do NOT densify
 
-    (A_r, b_r), (A_i, b_i) = _ab(ops[0]), _ab(ops[1])
-    n = b_r.shape[0]
-    rhs = jnp.concatenate([b_r, b_i])
-    is_sparse = hasattr(A_r, "indices") and hasattr(A_i, "indices")
+    def _block_solve(args):
+        (A_r, b_r), (A_i, b_i) = _ab(ops[0], args), _ab(ops[1], args)
+        n = b_r.shape[0]
+        rhs = jnp.concatenate([b_r, b_i])
+        is_sparse = hasattr(A_r, "indices") and hasattr(A_i, "indices")
 
-    if solve_fn is not None:
-        # user solver receives the densified block (dense/direct back-compat path)
-        Ar_d = jnp.asarray(A_r.todense() if hasattr(A_r, "todense") else A_r)
-        Ai_d = jnp.asarray(A_i.todense() if hasattr(A_i, "todense") else A_i)
-        sol = jnp.asarray(solve_fn(jnp.block([[Ar_d, -Ai_d], [Ai_d, Ar_d]]), rhs))
-    elif is_sparse:
-        from .utils.solver.linear import sparse_lu_solve
+        if solve_fn is not None:
+            # user solver receives the densified block (dense/direct back-compat path)
+            Ar_d = jnp.asarray(A_r.todense() if hasattr(A_r, "todense") else A_r)
+            Ai_d = jnp.asarray(A_i.todense() if hasattr(A_i, "todense") else A_i)
+            sol = jnp.asarray(solve_fn(jnp.block([[Ar_d, -Ai_d], [Ai_d, Ar_d]]), rhs))
+        elif is_sparse:
+            from .utils.solver.linear import sparse_lu_solve
 
-        sol = sparse_lu_solve(_complex_block_bcoo(A_r, A_i, n), rhs)  # sparse-direct on the 2n block
-    else:
-        Ar_d, Ai_d = jnp.asarray(A_r), jnp.asarray(A_i)  # dense fallback (e.g. 1D / already dense)
-        sol = jnp.linalg.solve(jnp.block([[Ar_d, -Ai_d], [Ai_d, Ar_d]]), rhs)
+            sol = sparse_lu_solve(_complex_block_bcoo(A_r, A_i, n), rhs)  # sparse-direct on the 2n block
+        else:
+            Ar_d, Ai_d = jnp.asarray(A_r), jnp.asarray(A_i)  # dense fallback (e.g. 1D / already dense)
+            sol = jnp.linalg.solve(jnp.block([[Ar_d, -Ai_d], [Ai_d, Ar_d]]), rhs)
 
-    if periodic is None:
-        return sol[:n] + 1j * sol[n:]
-    # Prolong the real and imaginary reduced halves *separately* (real P @ real vector); prolonging the
-    # complex vector directly would cast it to P's real dtype and silently drop the imaginary part.
-    return prolong_periodic(periodic, sol[:n]) + 1j * prolong_periodic(periodic, sol[n:])
+        if periodic is None:
+            return sol[:n] + 1j * sol[n:]
+        # Prolong the real and imaginary reduced halves *separately* (real P @ real vector); prolonging
+        # the complex vector directly would cast it to P's real dtype and silently drop the imaginary part.
+        return prolong_periodic(periodic, sol[:n]) + 1j * prolong_periodic(periodic, sol[n:])
+
+    # Forward (non-parametric): solve eagerly. Inverse: one or both legs are a parametric FemLinearSystem
+    # -> return a trace node over the union of their runtime parameters so ∂u/∂θ flows through crux.
+    rpe: dict = {}
+    for op in ops:
+        if isinstance(op, FemLinearSystem):
+            rpe.update(op.runtime_parameter_exprs)
+    if not rpe:
+        return _block_solve(None)
+    names = list(rpe)
+    return FunctionCall(
+        lambda *vals: _block_solve(dict(zip(names, vals))), [rpe[n] for n in names], name="fem_complex_solve"
+    )
 
 
 def _solve_complex_transient(blocks: Any, save_ts: Any = None, periodic: Optional[dict] = None) -> Any:
@@ -2056,6 +2070,12 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         fem_obj._native_dof_points = getattr(domain, "_fem_native_dof_points", None)
         _all = getattr(domain, "_fem_native_dof_points_all", None)
         fem_obj._native_dof_points_all = list(_all) if _all is not None else None
+        if couplings and periodic_ties and fem_obj.is_transient:
+            # The native periodic *transient* block reduces eagerly into a master-DOF space; the coupling
+            # residual is written in the full nodal space, so the two cannot be composed on that path yet.
+            raise NotImplementedError(
+                "jno.fem: periodic ties combined with a *transient* nonlocal Coupling are not yet supported."
+            )
         if couplings:
             # Fold the coupling into the residual FIRST -- a steady local form is promoted to a nonlinear
             # FemResidualOperator. The periodic reduction below then wraps the *coupled* residual through
@@ -2063,15 +2083,6 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
             fem_obj = _wrap_couplings(domain, fem_obj, couplings)
         if not periodic_ties:
             return fem_obj
-        if fem_obj._mode == "complex_transient":
-            raise NotImplementedError(
-                "jno.fem: periodic ties on a complex *transient* problem are not supported yet "
-                "(the reduction must be applied to both the real and imaginary time blocks)."
-            )
-        if isinstance(fem_obj._op, FemLinearSystem):
-            # The reduction is applied on the non-parametric (A, b) branch of FEM.solve; the
-            # runtime-parametric FemLinearSystem.solve path would silently ignore it.
-            raise NotImplementedError("jno.fem: periodic ties are not yet supported on runtime-parametric linear problems.")
         # Single-field transient was already reduced by the dedicated native branch -> reuse its P.
         if periodic_holder:
             fem_obj._periodic = periodic_holder[0]

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -121,9 +121,10 @@ def lag(expr: Any) -> Any:
     but not exact. Remove ``lag`` (full Newton) when exact parameter gradients matter more than
     per-step solvability.
     """
-    sg = getattr(expr, "stop_gradient", None)
-    if sg is not None and not callable(sg):
-        return sg  # traced view / placeholder: the .stop_gradient property
+    # views and raw trace nodes expose ``.stop_gradient`` as a *property* (its value — a trace
+    # node — is itself callable, so a callable() test cannot distinguish them from methods)
+    if isinstance(getattr(type(expr), "stop_gradient", None), property):
+        return expr.stop_gradient
     return jax.lax.stop_gradient(expr)  # plain arrays inside hand-written residuals
 
 
@@ -1051,10 +1052,13 @@ class FEM:
 
         The slots compose into a ``solve_fn`` internally, so each dispatch path below keeps its
         periodic reduction and implicit-differentiation behaviour; slot solvers receive the
-        **BCOO** operator (no densification). Not yet supported: slots on transient problems,
-        ``x0`` on complex problems, ``precond`` on the (matrix-free) nonlinear path, and slots
-        combined with ``adapt=`` (remeshing invalidates warm starts and cached preconditioner
-        setups — pass ``solve_fn=`` there).
+        **BCOO** operator (no densification). On the (matrix-free) **nonlinear** path a
+        ``precond`` spec is materialized per Newton/Picard linearization against the JVP
+        operator — ``form`` / ``inner(...)`` / ``chebyshev`` / pre-built ``amg`` and their
+        ``block_diag``/``triangular`` compositions work; ``jacobi`` (needs the assembled
+        diagonal) does not. Not yet supported: slots on transient problems, ``x0`` on complex
+        problems, and slots combined with ``adapt=`` (remeshing invalidates warm starts and
+        cached preconditioner setups — pass ``solve_fn=`` there).
         """
         has_slots = (x0 is not None) or (nonlinear is not None) or (linear is not None) or (precond is not None)
         if adapt is not None:

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -95,6 +95,14 @@ class _Form:
         self.quad_degree = quad_degree
         self._op = None  # assembled once; the auxiliary operator is parameter-independent
 
+    def prepare(self, fem):
+        """Eager one-time assembly (called at compose time, OUTSIDE any trace — assembling a
+        fresh ``jno.fem`` inside the Newton/Picard ``while_loop`` entangles with loop tracers)."""
+        if self._op is None:
+            from .utils.solver.solver_api import PrecondContext as _Ctx
+
+            self._op = _Ctx(None, fem).assemble(self.terms, quad_degree=self.quad_degree)
+
     def materialize(self, ctx: PrecondContext):
         if self._op is None:
             self._op = ctx.assemble(self.terms, quad_degree=self.quad_degree)
@@ -184,9 +192,20 @@ def _pairs_to_appliers(pairs, ctx: PrecondContext):
     return appliers
 
 
+def _prepare_pairs(pairs, fem):
+    """Recurse the eager-preparation hook into a block composition's child specs."""
+    for _field, spec in pairs:
+        prep = getattr(spec, "prepare", None)
+        if prep is not None:
+            prep(fem)
+
+
 class _BlockDiag:
     def __init__(self, pairs):
         self.pairs = pairs
+
+    def prepare(self, fem):
+        _prepare_pairs(self.pairs, fem)
 
     def materialize(self, ctx: PrecondContext):
         appliers = _pairs_to_appliers(self.pairs, ctx)
@@ -206,6 +225,9 @@ class _BlockDiag:
 class _Triangular:
     def __init__(self, pairs):
         self.pairs = pairs
+
+    def prepare(self, fem):
+        _prepare_pairs(self.pairs, fem)
 
     def materialize(self, ctx: PrecondContext):
         appliers = _pairs_to_appliers(self.pairs, ctx)

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -26,7 +26,7 @@ import jax.numpy as jnp
 
 from .utils.solver.solver_api import PrecondContext  # noqa: F401  (re-export for user specs)
 
-__all__ = ["PrecondContext", "jacobi"]
+__all__ = ["PrecondContext", "jacobi", "chebyshev"]
 
 
 class _Jacobi:
@@ -42,6 +42,33 @@ class _Jacobi:
         return "jno.precond.jacobi()"
 
 
+class _Chebyshev:
+    """Spec for the fixed-degree Chebyshev polynomial preconditioner; see :func:`chebyshev`."""
+
+    def __init__(self, degree, lmin, lmax, lmin_ratio, safety, bound_iters):
+        self.degree = degree
+        self.lmin, self.lmax = lmin, lmax
+        self.lmin_ratio, self.safety, self.bound_iters = lmin_ratio, safety, bound_iters
+
+    def materialize(self, ctx: PrecondContext):
+        from .utils.solver.krylov import chebyshev_apply, power_iteration_bound
+
+        if ctx.A.shape is None and self.lmax is None:
+            raise TypeError(
+                "jno.precond.chebyshev on a matvec-only operator needs explicit spectrum bounds "
+                "(lmin=, lmax=) — there is no assembled matrix to estimate them from."
+            )
+        hi = self.lmax
+        if hi is None:
+            n = ctx.A.shape[0]
+            hi = self.safety * power_iteration_bound(ctx.A.mv, n, iters=self.bound_iters)
+        lo = self.lmin if self.lmin is not None else self.lmin_ratio * hi
+        return lambda v: chebyshev_apply(ctx.A.mv, v, lmin=lo, lmax=hi, degree=self.degree)
+
+    def __repr__(self):
+        return f"jno.precond.chebyshev(degree={self.degree})"
+
+
 def jacobi() -> _Jacobi:
     """Diagonal (Jacobi) preconditioner ``M^{-1} v = v / diag(A)``.
 
@@ -55,3 +82,25 @@ def jacobi() -> _Jacobi:
     historic steady-linear default exactly.
     """
     return _Jacobi()
+
+
+def chebyshev(
+    *,
+    degree: int = 8,
+    lmin: float | None = None,
+    lmax: float | None = None,
+    lmin_ratio: float = 1.0 / 30.0,
+    safety: float = 1.05,
+    bound_iters: int = 30,
+) -> _Chebyshev:
+    """Fixed-degree Chebyshev **polynomial** preconditioner ``M^{-1} = p_degree(A) ≈ A^{-1}``
+    for SPD operators (Saad 2003, §12.3 / Golub & Varga 1961 — the same recurrence as
+    ``jno.solve.chebyshev``, truncated at ``degree`` with no convergence test, which keeps the
+    application a fixed *linear* map so it may precondition CG and MINRES).
+
+    The GPU-era substitute for Gauss-Seidel/ILU smoothing: only matvecs and AXPYs — no
+    reductions, no triangular solves — ``jit``- and ``vmap``-native. Spectrum bounds of ``A``
+    are taken from ``lmin``/``lmax`` when given, else estimated by power iteration (``safety``
+    inflation, ``lmin = lmin_ratio * lmax``).
+    """
+    return _Chebyshev(degree, lmin, lmax, lmin_ratio, safety, bound_iters)

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -28,7 +28,7 @@ import jax.numpy as jnp
 
 from .utils.solver.solver_api import PrecondContext  # noqa: F401  (re-export for user specs)
 
-__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular"]
+__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg"]
 
 
 class _Jacobi:
@@ -255,6 +255,78 @@ def triangular(*pairs) -> _Triangular:
     *Finite Elements and Fast Iterative Solvers*, 2nd ed., OUP 2014, §9.2). With inexact
     (iterative) block solves the outer Krylov must be flexible: ``jno.solve.fgmres()``."""
     return _Triangular(list(pairs))
+
+
+class _AMG:
+    """Spec for the hybrid (pyamg-setup / pure-JAX-apply) AMG preconditioner; see :func:`amg`."""
+
+    def __init__(self, cycles, max_levels, coarse_size, smoother_degree):
+        self.cycles = cycles
+        self.max_levels = max_levels
+        self.coarse_size = coarse_size
+        self.smoother_degree = smoother_degree
+        self._levels = None
+
+    def build(self, A) -> "_AMG":
+        """Eager one-time setup from a **concrete** operator (BCOO / dense / ``fem.A`` /
+        ``LinearOperator``). Required before use inside traced (jit / vmap / parametric-inverse)
+        solves — pyamg cannot run under a trace; the built hierarchy is then frozen closure data.
+        Returns ``self`` (chainable). Rebuild when the operator values drift far from this one."""
+        from .utils.solver.amg import build_hierarchy
+        from .utils.solver.solver_api import LinearOperator
+
+        if isinstance(A, LinearOperator):
+            A = A.bcoo if A.bcoo is not None else A.dense()
+        self._levels = build_hierarchy(
+            A,
+            max_levels=self.max_levels,
+            coarse_size=self.coarse_size,
+            smoother_degree=self.smoother_degree,
+        )
+        return self
+
+    def materialize(self, ctx: PrecondContext):
+        from .utils.solver.amg import vcycle_apply
+
+        if self._levels is None:
+            A = ctx.A.bcoo if ctx.A.bcoo is not None else ctx.A.dense()
+            self.build(A)  # raises with .build() guidance when A is traced
+        levels, cycles = self._levels, self.cycles
+        A_op = ctx.A
+
+        def apply(r):
+            x = vcycle_apply(levels, r)
+            for _ in range(cycles - 1):
+                x = x + vcycle_apply(levels, r - A_op.mv(x))
+            return x
+
+        return apply
+
+    def __repr__(self):
+        return f"jno.precond.amg(cycles={self.cycles}, built={self._levels is not None})"
+
+
+def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smoother_degree: int = 3) -> _AMG:
+    """Hybrid **algebraic multigrid**: smoothed-aggregation setup by the optional ``pyamg``
+    (Vaněk, Mandel & Brezina, Computing 56, 1996; Bell et al., JOSS 8(87):5495, 2023), applied as
+    a pure-JAX V-cycle with Chebyshev polynomial smoothing (Adams et al., JCP 188, 2003) — see
+    :mod:`jno.utils.solver.amg`.
+
+    The setup runs **once on the host** (eagerly) and freezes fixed-pattern level operators; the
+    per-application V-cycle is then ``jit``/``vmap``-native and a fixed *linear* map, so it may
+    precondition ``cg``/``minres`` as well as ``bicgstab``/``fgmres``. The mesh-independent
+    convergence of multigrid makes this *the* preconditioner for large elliptic blocks — heat,
+    diffusion, elasticity, the (Picard-lagged) velocity block of a saddle system inside
+    :func:`triangular`.
+
+    Inside traced contexts (jit, vmap, a parametric inverse solve) call ``spec.build(fem.A)``
+    once, eagerly, first; the frozen hierarchy is a legitimate preconditioner while operator
+    values change (speed degrades gracefully, correctness never). pyamg is imported lazily —
+    without it, a clear ``ImportError`` explains the install. On a matvec-only sub-block the
+    matrix is recovered via the (dense) block view — fine for moderate blocks; pass a pre-built
+    spec for very large ones.
+    """
+    return _AMG(cycles, max_levels, coarse_size, smoother_degree)
 
 
 def chebyshev(

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -1,0 +1,57 @@
+"""``jno.precond`` -- preconditioner **specs** for ``fem.solve(precond=...)``.
+
+A spec is declarative: it says *what* preconditioner to build, and jno materializes it at solve
+time against a :class:`jno.utils.solver.solver_api.PrecondContext` (the assembled operator; later
+per-field blocks and auxiliary weak-form assembly). The materialized applier is just
+``v -> M^{-1} v`` and composes with any Krylov solver from ``jno.solve``.
+
+Preconditioners change convergence *speed*, never the converged solution, so a spec needs no
+gradient path -- arbitrary (even non-JAX, via a future callback tier) appliers stay compatible
+with differentiable solves. A user spec is any object with ``materialize(ctx)`` or a bare
+``ctx -> (v -> M^{-1} v)`` callable::
+
+    def my_precond(ctx):
+        inv = 1.0 / ctx.diag()
+        return lambda v: inv * v
+
+    fem.solve(linear=jno.solve.cg(), precond=my_precond)
+
+Block/Schur composition and form-based (auxiliary weak-form) specs are the next phase -- see
+``plans/fem-solver-api.md``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from .utils.solver.solver_api import PrecondContext  # noqa: F401  (re-export for user specs)
+
+__all__ = ["PrecondContext", "jacobi"]
+
+
+class _Jacobi:
+    """Spec for the diagonal (Jacobi) preconditioner; see :func:`jacobi`."""
+
+    def materialize(self, ctx: PrecondContext):
+        d = ctx.diag()
+        safe = jnp.where(jnp.abs(d) > 1e-30, d, 1.0)  # zero diagonals (saddle blocks) left unscaled
+        inv = 1.0 / safe
+        return lambda v: inv * v
+
+    def __repr__(self):
+        return "jno.precond.jacobi()"
+
+
+def jacobi() -> _Jacobi:
+    """Diagonal (Jacobi) preconditioner ``M^{-1} v = v / diag(A)``.
+
+    The cheapest useful preconditioner: one elementwise multiply per application, ``jit``- and
+    ``vmap``-native, effective on diagonally-dominant (elliptic) systems -- heat, diffusion,
+    elasticity. Zero/near-zero diagonals (e.g. the pressure block of a saddle-point system) are
+    left unscaled so it never produces ``inf``/``NaN`` -- but it does not *rescue* saddle
+    systems; use ``jno.solve.lu()`` there (block/Schur specs are planned).
+
+    ``fem.solve(linear=jno.solve.bicgstab(), precond=jno.precond.jacobi())`` reproduces the
+    historic steady-linear default exactly.
+    """
+    return _Jacobi()

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -16,8 +16,10 @@ with differentiable solves. A user spec is any object with ``materialize(ctx)`` 
 
     fem.solve(linear=jno.solve.cg(), precond=my_precond)
 
-Block/Schur composition and form-based (auxiliary weak-form) specs are the next phase -- see
-``plans/fem-solver-api.md``.
+Composition: :func:`block_diag` / :func:`triangular` build block preconditioners over the
+per-field DOF blocks (``fem.blocks``); :func:`form` assembles auxiliary weak-form operators
+("preconditioners as weak forms"); :func:`inner` turns any ``jno.solve`` solver into an
+(inexact) ``M^{-1}`` application.
 """
 
 from __future__ import annotations
@@ -26,7 +28,7 @@ import jax.numpy as jnp
 
 from .utils.solver.solver_api import PrecondContext  # noqa: F401  (re-export for user specs)
 
-__all__ = ["PrecondContext", "jacobi", "chebyshev"]
+__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular"]
 
 
 class _Jacobi:
@@ -76,12 +78,183 @@ def jacobi() -> _Jacobi:
     ``vmap``-native, effective on diagonally-dominant (elliptic) systems -- heat, diffusion,
     elasticity. Zero/near-zero diagonals (e.g. the pressure block of a saddle-point system) are
     left unscaled so it never produces ``inf``/``NaN`` -- but it does not *rescue* saddle
-    systems; use ``jno.solve.lu()`` there (block/Schur specs are planned).
+    systems; use ``jno.solve.lu()`` or a :func:`triangular` block/Schur spec there.
 
     ``fem.solve(linear=jno.solve.bicgstab(), precond=jno.precond.jacobi())`` reproduces the
     historic steady-linear default exactly.
     """
     return _Jacobi()
+
+
+class _Form:
+    """Spec assembling an auxiliary weak form as the preconditioner operator; see :func:`form`."""
+
+    def __init__(self, terms, inner_solver, quad_degree):
+        self.terms = list(terms)
+        self.inner = inner_solver
+        self.quad_degree = quad_degree
+        self._op = None  # assembled once; the auxiliary operator is parameter-independent
+
+    def materialize(self, ctx: PrecondContext):
+        if self._op is None:
+            self._op = ctx.assemble(self.terms, quad_degree=self.quad_degree)
+        op = self._op
+        if self.inner is None:
+            from . import solve as _s
+
+            self.inner = _s.lu()
+        solver = self.inner
+        return lambda v: solver(op, v)
+
+    def __repr__(self):
+        return f"jno.precond.form(<{len(self.terms)} terms>, inner={self.inner})"
+
+
+def form(terms, *, inner=None, quad_degree: int = 2) -> _Form:
+    """**Preconditioners as weak forms**: assemble an auxiliary operator ``Â`` from ordinary
+    traced ``jno.fem`` terms and apply ``M^{-1} v = Â^{-1} v`` with ``inner`` (default
+    ``jno.solve.lu()``).
+
+    This is how the classical physics-based preconditioners are written declaratively — in the
+    *same language as the PDE*:
+
+    * a (weighted) **mass matrix** — e.g. the pressure Schur-complement approximation of a
+      Stokes-type saddle system: ``jno.precond.form([w * pi * qi], inner=jno.solve.cg(...))``;
+    * a **local proxy of a nonlocal operator** — assemble only the conduction terms to
+      precondition a conduction+radiation system (the dense view-factor coupling stays in the
+      outer matvec);
+    * a **shifted/damped twin** of an indefinite operator (shifted-Laplacian Helmholtz);
+    * a **low-order proxy** preconditioning a high-order discretisation.
+
+    The auxiliary system is assembled once with the ordinary ``jno.fem`` machinery (cached on
+    the spec — it is parameter-independent) and must be steady linear. Its size must match the
+    (sub-)operator this spec preconditions: a form over one field's symbols preconditions that
+    field's diagonal block inside :func:`block_diag`/:func:`triangular`; a form over all fields
+    preconditions the full system. With an *iterative* ``inner``, drive the outer solve with
+    ``jno.solve.fgmres()`` (flexible preconditioning).
+    """
+    return _Form(terms, inner, quad_degree)
+
+
+class _InnerSolve:
+    """Spec using a configured linear solver as the ``M^{-1}`` application; see :func:`inner`."""
+
+    def __init__(self, solver):
+        self.solver = solver
+
+    def materialize(self, ctx: PrecondContext):
+        solver, op = self.solver, ctx.A
+        return lambda v: solver(op, v)
+
+    def __repr__(self):
+        return f"jno.precond.inner({self.solver})"
+
+
+def inner(solver) -> _InnerSolve:
+    """Use a ``jno.solve`` linear solver as the preconditioner application ``M^{-1} v ≈ A^{-1} v``
+    on whatever operator it is materialized against — the natural way to give a diagonal block of
+    :func:`block_diag`/:func:`triangular` an (inexact) block solve, e.g.
+    ``jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=50))``. With an iterative solver here the
+    outer Krylov must be flexible: ``jno.solve.fgmres()``."""
+    return _InnerSolve(solver)
+
+
+def _pairs_to_appliers(pairs, ctx: PrecondContext):
+    """Resolve ``(field, spec)`` pairs → offsets-ordered ``(slice, applier)`` per diagonal block."""
+    from .utils.solver.solver_api import materialize_precond
+
+    if ctx.fem is None:
+        raise TypeError("Block preconditioners need the owning FEM (use them via fem.solve(precond=...)).")
+    resolved = {}
+    for field, spec in pairs:
+        idx = ctx.fem.block_index(field)
+        if idx in resolved:
+            raise ValueError(f"Block preconditioner: field block {idx} specified twice.")
+        resolved[idx] = spec
+    blocks = ctx.blocks
+    if sorted(resolved) != list(range(len(blocks))):
+        raise ValueError(
+            f"Block preconditioner: got specs for blocks {sorted(resolved)} but the system has "
+            f"{len(blocks)} field blocks — every field needs exactly one (field, spec) pair."
+        )
+    appliers = []
+    for idx in range(len(blocks)):
+        sub_ctx = PrecondContext(ctx.sub(idx), ctx.fem)
+        appliers.append((blocks[idx], materialize_precond(resolved[idx], sub_ctx)))
+    return appliers
+
+
+class _BlockDiag:
+    def __init__(self, pairs):
+        self.pairs = pairs
+
+    def materialize(self, ctx: PrecondContext):
+        appliers = _pairs_to_appliers(self.pairs, ctx)
+
+        def apply(v):
+            out = jnp.zeros_like(v)
+            for s, M in appliers:
+                out = out.at[s].set(M(v[s]))
+            return out
+
+        return apply
+
+    def __repr__(self):
+        return f"jno.precond.block_diag(<{len(self.pairs)} blocks>)"
+
+
+class _Triangular:
+    def __init__(self, pairs):
+        self.pairs = pairs
+
+    def materialize(self, ctx: PrecondContext):
+        appliers = _pairs_to_appliers(self.pairs, ctx)
+        k = len(appliers)
+        subs = {(i, j): ctx.sub(i, j) for i in range(k) for j in range(i + 1, k)}
+
+        def apply(v):
+            # block backward substitution: y_i = M_i^{-1} (v_i - sum_{j>i} A_ij y_j)
+            ys = [None] * k
+            for i in reversed(range(k)):
+                s, M = appliers[i]
+                r = v[s]
+                for j in range(i + 1, k):
+                    r = r - subs[(i, j)].mv(ys[j])
+                ys[i] = M(r)
+            out = jnp.zeros_like(v)
+            for (s, _), y in zip(appliers, ys):
+                out = out.at[s].set(y)
+            return out
+
+        return apply
+
+    def __repr__(self):
+        return f"jno.precond.triangular(<{len(self.pairs)} blocks>)"
+
+
+def block_diag(*pairs) -> _BlockDiag:
+    """Block-**diagonal** preconditioner over the per-field DOF blocks: each ``(field, spec)``
+    pair materializes ``spec`` against that field's diagonal sub-operator (``field`` is the
+    trial symbol from ``d.fem_symbols()``, or the integer block index). Cheaper per application
+    than :func:`triangular` but ignores the coupling blocks — prefer :func:`triangular` for
+    saddle systems."""
+    return _BlockDiag(list(pairs))
+
+
+def triangular(*pairs) -> _Triangular:
+    """Block **upper-triangular** preconditioner ``P = [[Â_1, A_12, …], [0, Â_2, …], …]`` over
+    the per-field blocks — the standard shape for saddle-point systems (Stokes / Taylor–Hood,
+    mixed Poisson, Biot): the last-listed block is solved first, then substituted back through
+    the *actual* off-diagonal coupling matvecs of the assembled operator.
+
+    Each ``(field, spec)`` pair supplies the approximate **diagonal-block inverse** ``Â_i^{-1}``:
+    e.g. ``jno.precond.inner(jno.solve.cg(tol=1e-2))`` (inexact block solve),
+    ``jno.precond.chebyshev(...)`` (polynomial), or ``jno.precond.form([...])`` (auxiliary
+    operator — for Stokes the classic pressure choice is the viscosity-weighted **mass matrix**
+    ``form([(1/mu) * pi * qi])`` as the Schur-complement approximation; Elman, Silvester & Wathen,
+    *Finite Elements and Fast Iterative Solvers*, 2nd ed., OUP 2014, §9.2). With inexact
+    (iterative) block solves the outer Krylov must be flexible: ``jno.solve.fgmres()``."""
+    return _Triangular(list(pairs))
 
 
 def chebyshev(

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -1,0 +1,125 @@
+"""``jno.solve`` -- the callables-only solver namespace for ``fem.solve``'s slots.
+
+Every factory returns a configured **callable** (no strings anywhere): a linear solver
+``(A, b, *, M=None, x0=None) -> x`` or a nonlinear driver ``(residual_fn, u0, *,
+linear_solve=None) -> u``. All shipped solvers are pure JAX -- ``jit``- and ``vmap``-native,
+differentiable through ``lax.custom_linear_solve`` / ``lax.custom_root`` -- and they *reuse*
+existing implementations (``jax.scipy.sparse.linalg`` Krylov, the differentiable sparse-direct
+``spsolve``) rather than re-implementing them. A user-written callable with the same signature
+drops into the same slot; if it is pure JAX it inherits every transform automatically.
+
+Usage::
+
+    fem.solve(linear=jno.solve.cg(tol=1e-10), precond=jno.precond.jacobi())
+    fem.solve(linear=jno.solve.lu())                      # differentiable sparse-direct
+    fem.solve(nonlinear=jno.solve.newton(), x0=u_guess)   # warm-started Newton-Krylov
+
+Defaults when a slot is ``None`` are unchanged from the historic behaviour: Jacobi-preconditioned
+BiCGStab (steady linear) and Jacobian-free Newton-Krylov (nonlinear).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+
+from .utils.solver.solver_api import LinearOperator, LinearSolver, NonlinearSolver, _maybe_residual_check
+
+__all__ = ["LinearOperator", "LinearSolver", "NonlinearSolver", "lu", "dense", "cg", "bicgstab", "gmres", "newton"]
+
+
+def lu() -> LinearSolver:
+    """Differentiable sparse-direct solve (JAX ``spsolve``: cuSolver on GPU, native LU on CPU).
+
+    Wraps the existing :func:`jno.utils.solver.linear.sparse_lu_solve` -- robust on the
+    indefinite saddle-point systems where Jacobi-preconditioned Krylov stalls, reverse-mode
+    differentiable in the matrix entries and the right-hand side. Direct: ignores ``x0`` and
+    rejects a preconditioner. ``jit`` yes; **no vmap batching rule upstream** (trait
+    ``vmap="no"``) -- use a Krylov solver inside vmapped/batched solves.
+    """
+
+    def _fn(op: LinearOperator, b, *, M, x0):
+        from .utils.solver.linear import sparse_lu_solve
+
+        A = op.bcoo if op.bcoo is not None else op.dense()
+        return sparse_lu_solve(A, b)
+
+    return LinearSolver(_fn, name="lu", direct=True, traits={"vmap": "no"})
+
+
+def dense() -> LinearSolver:
+    """Dense LAPACK solve (``jnp.linalg.solve``) on the densified operator.
+
+    ``O(N^2)`` memory / ``O(N^3)`` time -- the right answer for small systems and coarse
+    blocks, and the only shipped direct solver with a native vmap batching rule. Direct:
+    ignores ``x0``, rejects a preconditioner.
+    """
+
+    def _fn(op: LinearOperator, b, *, M, x0):
+        return jnp.linalg.solve(op.dense(), b)
+
+    return LinearSolver(_fn, name="dense", direct=True)
+
+
+def _krylov(name: str, tol: float, atol: float, maxiter: Optional[int], **fixed):
+    def _fn(op: LinearOperator, b, *, M, x0):
+        method = getattr(jax.scipy.sparse.linalg, name)
+        x, _info = method(op.mv, b, x0=x0, tol=tol, atol=atol, maxiter=maxiter, M=M, **fixed)
+        return _maybe_residual_check(op, b, x, name)
+
+    return LinearSolver(_fn, name=name)
+
+
+def cg(*, tol: float = 1e-8, atol: float = 0.0, maxiter: Optional[int] = 20_000) -> LinearSolver:
+    """Conjugate gradients (``jax.scipy.sparse.linalg.cg``) -- **symmetric positive-definite**
+    systems only (Poisson, elasticity, mass matrices). Cheapest per iteration; takes ``M`` and
+    ``x0``. Implicitly differentiable upstream via ``lax.custom_linear_solve``."""
+    return _krylov("cg", tol, atol, maxiter)
+
+
+def bicgstab(*, tol: float = 1e-8, atol: float = 0.0, maxiter: Optional[int] = 20_000) -> LinearSolver:
+    """BiCGStab (``jax.scipy.sparse.linalg.bicgstab``) -- general non-symmetric systems.
+    With ``precond=jno.precond.jacobi()`` this reproduces the historic ``fem.solve()``
+    steady-linear default exactly."""
+    return _krylov("bicgstab", tol, atol, maxiter)
+
+
+def gmres(*, tol: float = 1e-8, atol: float = 0.0, maxiter: Optional[int] = None, restart: int = 30) -> LinearSolver:
+    """Restarted GMRES (``jax.scipy.sparse.linalg.gmres``) -- non-symmetric systems where
+    BiCGStab's erratic convergence hurts; memory grows with ``restart``. For an *iterative*
+    (e.g. multigrid-with-tolerance) preconditioner a flexible variant (FGMRES) is required --
+    planned; see ``plans/fem-solver-api.md``."""
+    return _krylov("gmres", tol, atol, maxiter, restart=restart, solve_method="batched")
+
+
+def newton(
+    *,
+    rtol: float = 1e-8,
+    atol: float = 1e-8,
+    max_steps: int = 100,
+    inner_tol: float = 1e-10,
+    inner_maxit: int = 2000,
+) -> NonlinearSolver:
+    """Jacobian-free Newton-Krylov -- the (unchanged) nonlinear default, as a configurable slot.
+
+    Wraps :func:`jno.utils.solver.newton_krylov.newton_krylov`: ``J @ v`` from a JVP, inner
+    matrix-free solve (default BiCGStab, or the ``linear=`` slot when given), implicit
+    differentiation via ``lax.custom_root`` so gradients reach parameters without unrolling."""
+
+    def _fn(residual_fn, u0, *, linear_solve):
+        from .utils.solver.newton_krylov import newton_krylov
+
+        return newton_krylov(
+            residual_fn,
+            u0,
+            rtol=rtol,
+            atol=atol,
+            max_steps=max_steps,
+            inner_tol=inner_tol,
+            inner_maxit=inner_maxit,
+            linear_solve=linear_solve,
+        )
+
+    return NonlinearSolver(_fn, name="newton")

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -27,7 +27,20 @@ import jax.numpy as jnp
 
 from .utils.solver.solver_api import LinearOperator, LinearSolver, NonlinearSolver, _maybe_residual_check
 
-__all__ = ["LinearOperator", "LinearSolver", "NonlinearSolver", "lu", "dense", "cg", "bicgstab", "gmres", "newton"]
+__all__ = [
+    "LinearOperator",
+    "LinearSolver",
+    "NonlinearSolver",
+    "lu",
+    "dense",
+    "cg",
+    "bicgstab",
+    "gmres",
+    "fgmres",
+    "minres",
+    "chebyshev",
+    "newton",
+]
 
 
 def lu() -> LinearSolver:
@@ -92,6 +105,84 @@ def gmres(*, tol: float = 1e-8, atol: float = 0.0, maxiter: Optional[int] = None
     (e.g. multigrid-with-tolerance) preconditioner a flexible variant (FGMRES) is required --
     planned; see ``plans/fem-solver-api.md``."""
     return _krylov("gmres", tol, atol, maxiter, restart=restart, solve_method="batched")
+
+
+def _firewalled(raw, op: LinearOperator, b, *, M, x0, symmetric: bool, name: str):
+    """Run a raw (non-differentiable) iteration inside ``lax.custom_linear_solve``.
+
+    The differentiability firewall: gradients w.r.t. ``b`` and anything the matvec closes over
+    come from the implicit transpose solve — the loop itself is never differentiated, and the
+    preconditioner needs no gradient path at all. The transpose solve runs the same iteration
+    on ``A^T`` (on ``A`` itself when ``symmetric``), reusing ``M`` (legitimate: a preconditioner
+    only affects convergence speed, never the converged solution).
+    """
+    fwd = lambda _mv, rhs: raw(op.mv, rhs, M=M, x0=x0)
+    rev = fwd if symmetric else (lambda _mv, rhs: raw(op.T.mv, rhs, M=M, x0=None))
+    x = jax.lax.custom_linear_solve(op.mv, b, fwd, transpose_solve=rev, symmetric=symmetric)
+    return _maybe_residual_check(op, b, x, name)
+
+
+def fgmres(*, tol: float = 1e-8, restart: int = 30, maxiter: int = 1000) -> LinearSolver:
+    """Flexible restarted GMRES (Saad 1993, Alg. 2.2; see
+    :func:`jno.utils.solver.krylov.fgmres`) — the outer solver to use when the preconditioner is
+    itself **iterative** (an inner Krylov sweep, a multigrid cycle with a tolerance, a block/Schur
+    recipe with inexact inner solves), which plain GMRES's fixed-``M`` assumption forbids.
+    Memory: two ``(restart, n)`` bases."""
+
+    def _fn(op: LinearOperator, b, *, M, x0):
+        from .utils.solver.krylov import fgmres as _raw
+
+        raw = lambda mv, rhs, M, x0: _raw(mv, rhs, M=M, x0=x0, tol=tol, restart=restart, maxiter=maxiter)
+        return _firewalled(raw, op, b, M=M, x0=x0, symmetric=False, name="fgmres")
+
+    return LinearSolver(_fn, name="fgmres")
+
+
+def minres(*, tol: float = 1e-8, maxiter: int = 2000) -> LinearSolver:
+    """MINRES (Paige & Saunders 1975, §5; see :func:`jno.utils.solver.krylov.minres`) — the
+    Krylov method for **symmetric indefinite** systems: Stokes/Biot saddle points, biharmonic
+    (Argyris/Morley), shifted Helmholtz-like operators. Monotone residual where BiCGStab is
+    erratic; ``O(1)`` memory where GMRES grows with ``restart``. The preconditioner must be
+    symmetric positive definite even when ``A`` is indefinite."""
+
+    def _fn(op: LinearOperator, b, *, M, x0):
+        from .utils.solver.krylov import minres as _raw
+
+        raw = lambda mv, rhs, M, x0: _raw(mv, rhs, M=M, x0=x0, tol=tol, maxiter=maxiter)
+        return _firewalled(raw, op, b, M=M, x0=x0, symmetric=True, name="minres")
+
+    return LinearSolver(_fn, name="minres")
+
+
+def chebyshev(
+    *,
+    lmin: Optional[float] = None,
+    lmax: Optional[float] = None,
+    tol: float = 1e-8,
+    maxiter: int = 500,
+    bound_iters: int = 30,
+    lmin_ratio: float = 1.0 / 30.0,
+    safety: float = 1.05,
+) -> LinearSolver:
+    """Chebyshev semi-iteration for **SPD** systems (Golub & Varga 1961; Saad 2003 §12.3,
+    Alg. 12.1; see :func:`jno.utils.solver.krylov.chebyshev_iteration`). Inner-product free —
+    matvecs and AXPYs only, no reductions — so it shines under ``vmap`` and on GPU where CG's
+    dot products serialise. Needs spectrum bounds of ``M^{-1} A``: pass ``lmin``/``lmax`` when
+    known; otherwise ``lmax`` is estimated by ``bound_iters`` power-iteration steps (inflated by
+    ``safety``) and ``lmin = lmin_ratio * lmax`` — a smoother-style default that converges but
+    slower than true bounds; prefer real bounds for a *solver* use."""
+
+    def _fn(op: LinearOperator, b, *, M, x0):
+        from .utils.solver.krylov import chebyshev_iteration, power_iteration_bound
+
+        hi = lmax
+        if hi is None:
+            hi = safety * power_iteration_bound(op.mv, b.shape[0], dtype=b.dtype, iters=bound_iters, M=M)
+        lo = lmin if lmin is not None else lmin_ratio * hi
+        raw = lambda mv, rhs, M, x0: chebyshev_iteration(mv, rhs, lmin=lo, lmax=hi, M=M, x0=x0, tol=tol, maxiter=maxiter)
+        return _firewalled(raw, op, b, M=M, x0=x0, symmetric=True, name="chebyshev")
+
+    return LinearSolver(_fn, name="chebyshev")
 
 
 def newton(

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -56,8 +56,11 @@ def lu() -> LinearSolver:
     def _fn(op: LinearOperator, b, *, M, x0):
         from .utils.solver.linear import sparse_lu_solve
 
-        A = op.bcoo if op.bcoo is not None else op.dense()
-        return sparse_lu_solve(A, b)
+        if op.bcoo is not None:
+            return sparse_lu_solve(op.bcoo, b)
+        # a dense operator gets the dense direct solve — BCOO.fromdense would need a concrete
+        # nse, which does not exist under jit/vmap tracing
+        return jnp.linalg.solve(op.dense(), b)
 
     return LinearSolver(_fn, name="lu", direct=True, traits={"vmap": "no"})
 

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -40,6 +40,7 @@ __all__ = [
     "minres",
     "chebyshev",
     "newton",
+    "picard",
 ]
 
 
@@ -188,20 +189,7 @@ def chebyshev(
     return LinearSolver(_fn, name="chebyshev")
 
 
-def newton(
-    *,
-    rtol: float = 1e-8,
-    atol: float = 1e-8,
-    max_steps: int = 100,
-    inner_tol: float = 1e-10,
-    inner_maxit: int = 2000,
-) -> NonlinearSolver:
-    """Jacobian-free Newton-Krylov -- the (unchanged) nonlinear default, as a configurable slot.
-
-    Wraps :func:`jno.utils.solver.newton_krylov.newton_krylov`: ``J @ v`` from a JVP, inner
-    matrix-free solve (default BiCGStab, or the ``linear=`` slot when given), implicit
-    differentiation via ``lax.custom_root`` so gradients reach parameters without unrolling."""
-
+def _root_driver(name, *, damping, rtol, atol, max_steps, inner_tol, inner_maxit) -> NonlinearSolver:
     def _fn(residual_fn, u0, *, linear_solve):
         from .utils.solver.newton_krylov import newton_krylov
 
@@ -214,6 +202,55 @@ def newton(
             inner_tol=inner_tol,
             inner_maxit=inner_maxit,
             linear_solve=linear_solve,
+            damping=damping,
         )
 
-    return NonlinearSolver(_fn, name="newton")
+    return NonlinearSolver(_fn, name=name)
+
+
+def newton(
+    *,
+    damping: float = 1.0,
+    rtol: float = 1e-8,
+    atol: float = 1e-8,
+    max_steps: int = 100,
+    inner_tol: float = 1e-10,
+    inner_maxit: int = 2000,
+) -> NonlinearSolver:
+    """Jacobian-free Newton-Krylov -- the (unchanged) nonlinear default, as a configurable slot.
+
+    Wraps :func:`jno.utils.solver.newton_krylov.newton_krylov`: ``J @ v`` from a JVP, inner
+    matrix-free solve (default BiCGStab, or the ``linear=`` slot when given), implicit
+    differentiation via ``lax.custom_root`` so gradients reach parameters without unrolling.
+    ``damping < 1`` relaxes each update for strongly nonlinear residuals."""
+    return _root_driver(
+        "newton", damping=damping, rtol=rtol, atol=atol, max_steps=max_steps, inner_tol=inner_tol, inner_maxit=inner_maxit
+    )
+
+
+def picard(
+    *,
+    damping: float = 1.0,
+    rtol: float = 1e-8,
+    atol: float = 1e-8,
+    max_steps: int = 200,
+    inner_tol: float = 1e-10,
+    inner_maxit: int = 2000,
+) -> NonlinearSolver:
+    """Damped Picard (lagged-coefficient / fixed-point) iteration — pair with :func:`jno.lag`.
+
+    Freeze the troublesome solution-dependent coefficients in the weak form with
+    ``jno.lag(...)``; the linearization of the residual is then the *Picard* operator (the
+    lagged system re-solved at each iterate), and this driver iterates it with optional damping.
+    The classic trade: more outer iterations than Newton's quadratic convergence, but each
+    linearized system keeps the structure (symmetry, definiteness) that block preconditioners
+    and multigrid need — e.g. a non-Newtonian Stokes flow whose full-Newton velocity block is
+    strongly nonsymmetric while its Picard block is a plain symmetric Stokes operator.
+
+    Without any ``jno.lag`` marker in the residual this is exactly damped Newton. The default
+    ``max_steps`` is higher than Newton's — linear (not quadratic) convergence. See the
+    ``jno.lag`` docstring for the inverse-problem (Picard-adjoint) caveat.
+    """
+    return _root_driver(
+        "picard", damping=damping, rtol=rtol, atol=atol, max_steps=max_steps, inner_tol=inner_tol, inner_maxit=inner_maxit
+    )

--- a/jno/utils/solver/amg.py
+++ b/jno/utils/solver/amg.py
@@ -1,0 +1,123 @@
+"""Hybrid algebraic multigrid: **pyamg setup on the host, pure-JAX V-cycle apply**.
+
+The split that makes AMG compatible with ``jit``/``vmap``/AD: the *setup* (strength graphs,
+aggregation, building the prolongators) is dynamic-sparsity graph work — hopeless to trace — so
+it runs once, eagerly, through pyamg's smoothed-aggregation solver [2]. What it produces is a
+frozen hierarchy of **fixed-pattern** sparse operators (`A_l`, `P_l`, `R_l`) plus a dense
+coarse-grid inverse. The *cycle* is then nothing but SpMVs, Chebyshev polynomial smoothing [3],
+and one small dense matmul — pure JAX, ``jit``- and ``vmap``-native (the hierarchy is closure
+data: a shared preconditioner across a batch is legitimate because a preconditioner only affects
+convergence speed, never the converged solution), and needs no gradient path (the
+``custom_linear_solve`` firewall).
+
+The frozen hierarchy is built from one *representative* concrete matrix. Reusing it while the
+operator values change (Picard iterations, parameter updates during an inverse solve) is the
+standard frozen-preconditioner trade: convergence degrades gracefully with the distance from the
+setup matrix, correctness never does. Rebuild (``spec.build(A)``) when it drifts too far.
+
+pyamg is an **optional** dependency (lazily imported here only); everything else is jNO + JAX.
+
+References
+----------
+[1] P. Vaněk, J. Mandel, M. Brezina, *Algebraic Multigrid by Smoothed Aggregation for Second and
+    Fourth Order Elliptic Problems*, Computing 56, 1996 — the SA-AMG setup this delegates to.
+[2] N. Bell, L. N. Olson, J. Schroder, B. Zaman, *PyAMG: Algebraic Multigrid Solvers in Python*,
+    J. Open Source Software 8(87):5495, 2023.
+[3] M. Adams, M. Brezina, J. Hu, R. Tuminaro, *Parallel Multigrid Smoothing: Polynomial versus
+    Gauss-Seidel*, J. Comput. Phys. 188, 2003 — polynomial (Chebyshev) smoothing as the
+    parallel/GPU-friendly substitute for Gauss-Seidel; smoothing window ``[lmax/30, 1.1 lmax]``
+    per pyamg's convention.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .krylov import chebyshev_apply, power_iteration_bound
+
+__all__ = ["build_hierarchy", "vcycle_apply"]
+
+
+def _require_pyamg():
+    try:
+        import pyamg  # noqa: PLC0415
+    except ImportError as e:  # pragma: no cover - exercised only without the optional dep
+        raise ImportError(
+            "jno.precond.amg needs the optional dependency `pyamg` for its host-side setup "
+            "(the apply is pure JAX). Install it with `pip install pyamg` (or use the pixi "
+            "`fem`/`dev` environment, which includes it)."
+        ) from e
+    return pyamg
+
+
+def _to_scipy_csr(A):
+    """Concrete BCOO / dense -> scipy CSR for the pyamg setup."""
+    import scipy.sparse as sp
+
+    if hasattr(A, "todense") and hasattr(A, "indices"):  # BCOO
+        data = np.asarray(A.data)
+        idx = np.asarray(A.indices)
+        return sp.coo_matrix((data, (idx[:, 0], idx[:, 1])), shape=A.shape).tocsr()
+    return sp.csr_matrix(np.asarray(A))
+
+
+def build_hierarchy(
+    A: Any,
+    *,
+    max_levels: int = 10,
+    coarse_size: int = 100,
+    smoother_degree: int = 3,
+    lmin_ratio: float = 1.0 / 30.0,
+    safety: float = 1.1,
+    bound_iters: int = 20,
+) -> List[dict]:
+    """One-time host-side setup: pyamg smoothed aggregation [1,2] -> frozen JAX level data.
+
+    ``A`` must be **concrete** (this runs eagerly, never under a trace). Returns a list of level
+    dicts — fine to coarse: ``{"A", "P", "R", "lmin", "lmax"}`` as BCOO/scalars, the last level
+    ``{"Ainv"}`` a dense inverse — a valid JAX pytree, so a closure over it jits and vmaps.
+    """
+    import jax.experimental.sparse as jsp
+
+    pyamg = _require_pyamg()
+
+    data = getattr(A, "data", None)
+    if isinstance(data, jax.core.Tracer) or isinstance(A, jax.core.Tracer):
+        raise TypeError(
+            "AMG setup needs a concrete matrix but got a traced one (inside jit/grad/vmap or a "
+            "parametric solve). Pre-build eagerly from a representative operator: "
+            "spec = jno.precond.amg(); spec.build(fem.A); then reuse the spec."
+        )
+
+    ml = pyamg.smoothed_aggregation_solver(_to_scipy_csr(A), max_levels=max_levels, max_coarse=coarse_size)
+    levels: List[dict] = []
+    for lvl in ml.levels[:-1]:
+        A_l = jsp.BCOO.from_scipy_sparse(lvl.A.tocoo())
+        P = jsp.BCOO.from_scipy_sparse(lvl.P.tocoo())
+        R = jsp.BCOO.from_scipy_sparse(lvl.R.tocoo())
+        lmax = float(safety * power_iteration_bound(lambda v: A_l @ v, A_l.shape[0], iters=bound_iters))
+        levels.append({"A": A_l, "P": P, "R": R, "lmin": lmin_ratio * lmax, "lmax": lmax, "degree": smoother_degree})
+    A_c = np.asarray(ml.levels[-1].A.todense())
+    levels.append({"Ainv": jnp.asarray(np.linalg.pinv(A_c))})  # pinv: robust to a gauge null space
+    return levels
+
+
+def vcycle_apply(levels: List[dict], r):
+    """One V-cycle on residual ``r`` from a zero initial guess — pure JAX, and a fixed **linear**
+    map in ``r`` (all constituents are linear), so it may precondition CG/MINRES."""
+
+    def _cycle(i, r):
+        lv = levels[i]
+        if "Ainv" in lv:
+            return lv["Ainv"] @ r
+        A = lv["A"]
+        smooth = lambda rhs: chebyshev_apply(lambda v: A @ v, rhs, lmin=lv["lmin"], lmax=lv["lmax"], degree=lv["degree"])
+        x = smooth(r)  # pre-smooth (from zero)
+        x = x + (lv["P"] @ _cycle(i + 1, lv["R"] @ (r - A @ x)))  # coarse-grid correction
+        return x + smooth(r - A @ x)  # post-smooth
+
+    return _cycle(0, jnp.asarray(r).reshape(-1))

--- a/jno/utils/solver/backend_blocks.py
+++ b/jno/utils/solver/backend_blocks.py
@@ -192,7 +192,7 @@ class SemidiscreteTimeBlock:
         """
         return self.mass is not None and self.residual is not None
 
-    def step(self, u, t, dt, args=None, theta=None):
+    def step(self, u, t, dt, args=None, theta=None, *, linear_solve=None, nonlinear_solve=None):
         """Advance the semidiscrete state by one implicit step: ``u(t) -> u(t + dt)``.
 
         The composable one-step primitive behind :func:`_default_transient_integrate` (which is just
@@ -207,6 +207,14 @@ class SemidiscreteTimeBlock:
 
         ``theta`` defaults to ``metadata["theta"]`` (1 backward Euler / 1/2 trapezoidal). Operates in
         the block's (periodic-reduced) DOF space; use :meth:`prolong` for the full nodal field.
+
+        The defaults above are overridable — this is where ``fem.solve``'s solver slots plug in
+        (see ``jno.utils.solver.solver_api.compose_transient_step_solvers``):
+
+        * ``linear_solve(matvec, rhs, x0, diag_fn) -> x`` replaces the theta-step linear solve
+          (``matvec`` applies ``M + theta dt A``; ``diag_fn()`` is its exact diagonal; ``x0`` the
+          previous state as warm start);
+        * ``nonlinear_solve(G, u0) -> u`` replaces the per-step Newton solve.
         """
         import jax
         import jax.numpy as jnp
@@ -228,6 +236,8 @@ class SemidiscreteTimeBlock:
             def G(wn):
                 return (M_t @ (wn - u)) / dt + jnp.asarray(self.residual(wn, t_next, args), dtype).reshape(-1)
 
+            if nonlinear_solve is not None:
+                return nonlinear_solve(G, u)
             return newton_krylov(G, u)
 
         from .linear import matrix_diagonal
@@ -247,6 +257,9 @@ class SemidiscreteTimeBlock:
         f_avg = th * _forcing(t_next) + (1.0 - th) * _forcing(t)
         rhs = M @ u - (1.0 - th) * dt * (A @ u) + dt * c + dt * f_avg
         step_op = lambda wn: M @ wn + th * dt * (A @ wn)  # noqa: E731  the theta-method step operator
+        if linear_solve is not None:
+            # slot-composed per-step solve; the exact step diagonal keeps jacobi-type specs exact
+            return linear_solve(step_op, rhs, u, lambda: matrix_diagonal(M) + th * dt * matrix_diagonal(A))
         # diagonal (Jacobi) preconditioner 1/diag(M + theta dt A); zero diagonals left unscaled
         d = matrix_diagonal(M) + th * dt * matrix_diagonal(A)
         inv = 1.0 / jnp.where(jnp.abs(d) > 1e-30, d, 1.0)
@@ -307,7 +320,7 @@ def _block_time_grid(block):
     return jnp.linspace(t0, t1, n_steps + 1)
 
 
-def _default_transient_integrate(block, args, save_ts):
+def _default_transient_integrate(block, args, save_ts, *, linear_solve=None, nonlinear_solve=None):
     """Default transient integrator: backward Euler at the block's *own* assembled step ``dt``,
     advanced with ``jax.lax.scan`` (reverse-mode differentiable) and sampled at ``save_ts`` by
     linear interpolation, so the integration step is always the assembled ``dt`` and never an
@@ -342,7 +355,9 @@ def _default_transient_integrate(block, args, save_ts):
     theta = float(block.metadata.get("theta", 1.0)) if getattr(block, "metadata", None) else 1.0
 
     def step(w, t_next):
-        wn = block.step(w, t_next - dt, dt, args=args, theta=theta)
+        wn = block.step(
+            w, t_next - dt, dt, args=args, theta=theta, linear_solve=linear_solve, nonlinear_solve=nonlinear_solve
+        )
         return wn, wn
 
     _, ys = jax.lax.scan(step, s0, grid_ts[1:])

--- a/jno/utils/solver/krylov.py
+++ b/jno/utils/solver/krylov.py
@@ -1,0 +1,299 @@
+"""Pure-JAX Krylov solvers absent from the JAX ecosystem: FGMRES, MINRES, Chebyshev.
+
+These are the *only* iteration loops jNO implements itself (design rule: reuse
+``jax.scipy.sparse.linalg`` / ``sparse_lu_solve`` for everything that exists upstream — see
+``plans/fem-solver-api.md``). Each is textbook-grade with a published pseudocode origin, cited in
+its docstring and in ``docs/fem.md``, and is pinned against a scipy/dense oracle in
+``tests/test_fem_solver_krylov.py``.
+
+All three are fixed-shape ``lax.while_loop``/``fori_loop`` implementations: ``jit``- and
+``vmap``-native, GPU-friendly (matvecs and dense small-array work only). Differentiability is
+added one level up (``jno.solve``) via ``lax.custom_linear_solve``, so the loops themselves are
+never differentiated.
+
+Conventions: ``matvec`` is ``v -> A v``; ``M`` is the ``v -> M^{-1} v`` applier (identity when
+``None``); ``x0`` the initial guess (zeros when ``None``); ``tol`` is relative to ``||b||``
+(``atol=0`` semantics, matching ``jax.scipy``).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+__all__ = ["fgmres", "minres", "chebyshev_iteration", "power_iteration_bound"]
+
+_TINY = 1e-300
+
+
+def _ident(v):
+    return v
+
+
+# ---------------------------------------------------------------------------
+# FGMRES
+# ---------------------------------------------------------------------------
+
+
+def fgmres(matvec, b, *, M=None, x0=None, tol=1e-8, restart=30, maxiter=1000):
+    """Flexible restarted GMRES — right preconditioning with a per-iteration-varying ``M``.
+
+    Y. Saad, *A Flexible Inner-Outer Preconditioned GMRES Algorithm*, SIAM J. Sci. Stat.
+    Comput. 14(2), 1993, Algorithm 2.2. Unlike plain GMRES, the preconditioned directions
+    ``z_j = M_j^{-1} v_j`` are stored, so ``M`` may itself be an *iterative* solve (inner Krylov,
+    multigrid-with-tolerance) — the standard outer solver for block/Schur-preconditioned saddle
+    systems. Orthogonalisation is classical Gram-Schmidt with one reorthogonalisation (CGS2):
+    fully vectorised (two ``(m+1, n)`` matvecs per step), the JAX-friendly substitute for
+    sequential MGS at equal numerical quality.
+
+    Memory: two ``(restart, n)`` bases. Each restart cycle runs its ``restart`` inner steps at
+    fixed shape (converged/broken-down steps become masked no-ops); the outer loop re-forms the
+    true residual, so a masked cycle costs work but never accuracy.
+    """
+    M = M or _ident
+    b = jnp.asarray(b)
+    n = b.shape[0]
+    m = int(min(restart, n))
+    x0 = jnp.zeros_like(b) if x0 is None else jnp.asarray(x0).reshape(-1)
+    bnorm = jnp.linalg.norm(b)
+    tol_abs = tol * jnp.maximum(bnorm, _TINY)
+    max_cycles = -(-int(maxiter) // m)  # ceil
+
+    def cycle(x):
+        r0 = b - matvec(x)
+        beta = jnp.linalg.norm(r0)
+        V = jnp.zeros((m + 1, n), b.dtype).at[0].set(r0 / jnp.maximum(beta, _TINY))
+        Z = jnp.zeros((m, n), b.dtype)
+        H = jnp.zeros((m + 1, m), b.dtype)
+        g = jnp.zeros((m + 1,), b.dtype).at[0].set(beta)
+        cs = jnp.zeros((m,), b.dtype)
+        sn = jnp.zeros((m,), b.dtype)
+
+        def step(j, carry):
+            V, Z, H, g, cs, sn, active = carry
+            z = M(V[j])
+            w = matvec(z)
+            # CGS2 against v_0..v_j (mask selects the built part of the basis)
+            mask = (jnp.arange(m + 1) <= j).astype(b.dtype)
+            h = (V @ w) * mask
+            w = w - h @ V
+            h2 = (V @ w) * mask
+            w = w - h2 @ V
+            h = h + h2
+            hj1 = jnp.linalg.norm(w)
+            hcol = h.at[j + 1].set(hj1)
+
+            # apply the stored Givens rotations of columns 0..j-1 to the new column
+            def rot(i, hc):
+                hi, hi1 = hc[i], hc[i + 1]
+                new_i = cs[i] * hi + sn[i] * hi1
+                new_i1 = -sn[i] * hi + cs[i] * hi1
+                return jnp.where(i < j, hc.at[i].set(new_i).at[i + 1].set(new_i1), hc)
+
+            hcol = jax.lax.fori_loop(0, m, rot, hcol)
+
+            # new rotation annihilating the subdiagonal entry
+            denom = jnp.sqrt(hcol[j] ** 2 + hcol[j + 1] ** 2)
+            c_new = hcol[j] / jnp.maximum(denom, _TINY)
+            s_new = hcol[j + 1] / jnp.maximum(denom, _TINY)
+            hcol = hcol.at[j].set(denom).at[j + 1].set(0.0)
+            gj = g[j]
+
+            new = (
+                V.at[j + 1].set(w / jnp.maximum(hj1, _TINY)),
+                Z.at[j].set(z),
+                H.at[:, j].set(hcol),
+                g.at[j].set(c_new * gj).at[j + 1].set(-s_new * gj),
+                cs.at[j].set(c_new),
+                sn.at[j].set(s_new),
+                active & (jnp.abs(s_new * gj) > tol_abs),  # |g[j+1]| is the residual norm
+            )
+            old = (V, Z, H, g, cs, sn, active)
+            return jax.tree_util.tree_map(lambda a, o: jnp.where(active, a, o), new, old)
+
+        active0 = beta > tol_abs
+        V, Z, H, g, cs, sn, _ = jax.lax.fori_loop(0, m, step, (V, Z, H, g, cs, sn, active0))
+
+        # never-written columns are zero: unit diagonal keeps the triangular solve regular,
+        # and their (spurious) y entries multiply the zero rows of Z — harmless by construction
+        Hm = H[:m, :m]
+        written = jnp.abs(jnp.diagonal(Hm)) > 0.0
+        Hm = Hm + jnp.diag(jnp.where(written, 0.0, 1.0))
+        y = jax.scipy.linalg.solve_triangular(Hm, g[:m], lower=False)
+        return x + y @ Z
+
+    def cond(state):
+        x, k = state
+        return (jnp.linalg.norm(b - matvec(x)) > tol_abs) & (k < max_cycles)
+
+    x, _ = jax.lax.while_loop(cond, lambda s: (cycle(s[0]), s[1] + 1), (x0, 0))
+    return x
+
+
+# ---------------------------------------------------------------------------
+# MINRES
+# ---------------------------------------------------------------------------
+
+
+def minres(matvec, b, *, M=None, x0=None, tol=1e-8, maxiter=2000):
+    """MINRES — **symmetric** (possibly indefinite) systems: saddle points, Helmholtz-like shifts.
+
+    C. C. Paige & M. A. Saunders, *Solution of Sparse Indefinite Systems of Linear Equations*,
+    SIAM J. Numer. Anal. 12(4), 1975, §5 (the Lanczos + Givens ``QR`` recurrence; state layout
+    follows the classic reference implementation, e.g. ``scipy.sparse.linalg.minres``).
+    The preconditioner ``M`` must be symmetric **positive definite** even when ``A`` is
+    indefinite (the Lanczos inner products are ``M^{-1}``-weighted); convergence is measured on
+    the ``M^{-1}``-norm residual estimate ``phibar`` relative to its initial value.
+    """
+    M = M or _ident
+    b = jnp.asarray(b)
+    x0 = jnp.zeros_like(b) if x0 is None else jnp.asarray(x0).reshape(-1)
+
+    r1 = b - matvec(x0)
+    y = M(r1)
+    beta1 = jnp.sqrt(jnp.maximum(r1 @ y, 0.0))
+    tol_abs = tol * jnp.maximum(beta1, _TINY)
+
+    # state: x, r1, r2, y, oldb, beta, dbar, epsln, phibar, cs, sn, w, w2, itn
+    zeros = jnp.zeros_like(b)
+    state0 = (
+        x0,
+        r1,
+        r1,
+        y,
+        jnp.array(0.0, b.dtype),
+        beta1,
+        jnp.array(0.0, b.dtype),
+        jnp.array(0.0, b.dtype),
+        beta1,
+        jnp.array(-1.0, b.dtype),
+        jnp.array(0.0, b.dtype),
+        zeros,
+        zeros,
+        0,
+    )
+
+    def cond(s):
+        phibar, itn = s[8], s[13]
+        return (phibar > tol_abs) & (itn < maxiter)
+
+    def body(s):
+        x, r1, r2, y, oldb, beta, dbar, epsln, phibar, cs, sn, w, w2, itn = s
+        v = y / jnp.maximum(beta, _TINY)
+        y = matvec(v)
+        y = y - jnp.where(itn >= 1, beta / jnp.maximum(oldb, _TINY), 0.0) * r1
+        alfa = v @ y
+        y = y - (alfa / jnp.maximum(beta, _TINY)) * r2
+        r1, r2 = r2, y
+        y = M(r2)
+        oldb, beta = beta, jnp.sqrt(jnp.maximum(r2 @ y, 0.0))
+
+        # previous rotation
+        oldeps = epsln
+        delta = cs * dbar + sn * alfa
+        gbar = sn * dbar - cs * alfa
+        epsln = sn * beta
+        dbar = -cs * beta
+        # next rotation
+        gamma = jnp.maximum(jnp.sqrt(gbar**2 + beta**2), _TINY)
+        cs, sn = gbar / gamma, beta / gamma
+        phi = cs * phibar
+        phibar = sn * phibar
+        # solution update
+        w1, w2 = w2, w
+        w = (v - oldeps * w1 - delta * w2) / gamma
+        x = x + phi * w
+        return x, r1, r2, y, oldb, beta, dbar, epsln, phibar, cs, sn, w, w2, itn + 1
+
+    return jax.lax.while_loop(cond, body, state0)[0]
+
+
+# ---------------------------------------------------------------------------
+# Chebyshev
+# ---------------------------------------------------------------------------
+
+
+def power_iteration_bound(matvec, n, *, dtype=None, iters=30, M=None):
+    """Largest-eigenvalue estimate of ``M^{-1} A`` by power iteration (deterministic start).
+
+    ``iters`` fixed steps on a normalized ones-vector; returns the final Rayleigh-quotient
+    magnitude. Cheap (one matvec per step), ``jit``/``vmap``-native, good to a few percent on
+    the FEM operators this preconditions — inflate by a safety factor at the call site.
+    """
+    M = M or _ident
+    dtype = dtype or jnp.result_type(float)
+    v0 = jnp.ones((n,), dtype) / jnp.sqrt(jnp.asarray(n, dtype))
+
+    def step(_, carry):
+        v, _lam = carry
+        w = M(matvec(v))
+        lam = v @ w
+        return w / jnp.maximum(jnp.linalg.norm(w), _TINY), lam
+
+    _, lam = jax.lax.fori_loop(0, iters, step, (v0, jnp.asarray(1.0, dtype)))
+    return jnp.abs(lam)
+
+
+def chebyshev_iteration(matvec, b, *, lmin, lmax, M=None, x0=None, tol=1e-8, maxiter=200):
+    """Chebyshev semi-iteration for SPD systems with spectrum inside ``[lmin, lmax]``.
+
+    Y. Saad, *Iterative Methods for Sparse Linear Systems*, 2nd ed., SIAM 2003, §12.3,
+    Algorithm 12.1 (three-term recurrence; the method originates with Golub & Varga 1961).
+    **Inner-product free** — only matvecs and AXPYs — which is what makes it the GPU-era
+    smoother/preconditioner (no reductions, trivially vmappable) and a fixed *linear* operator
+    in ``b`` for fixed step count (so it can precondition CG). ``M`` (SPD) preconditions the
+    recurrence; ``lmin``/``lmax`` then bound the spectrum of ``M^{-1} A``. Convergence degrades
+    gracefully when the bounds are loose — prefer a small safety margin on ``lmax``.
+    """
+    M = M or _ident
+    b = jnp.asarray(b)
+    x = jnp.zeros_like(b) if x0 is None else jnp.asarray(x0).reshape(-1)
+    theta = 0.5 * (lmax + lmin)
+    delta = 0.5 * (lmax - lmin)
+    sigma1 = theta / delta
+    bnorm = jnp.linalg.norm(b)
+    tol_abs = tol * jnp.maximum(bnorm, _TINY)
+
+    r = b - matvec(x)
+    d = M(r) / theta
+    rho = 1.0 / sigma1
+
+    def cond(s):
+        _x, r, _d, _rho, k = s
+        return (jnp.linalg.norm(r) > tol_abs) & (k < maxiter)
+
+    def body(s):
+        x, r, d, rho, k = s
+        x = x + d
+        r = r - matvec(d)
+        rho_new = 1.0 / (2.0 * sigma1 - rho)
+        d = rho_new * rho * d + (2.0 * rho_new / delta) * M(r)
+        return x, r, d, rho_new, k + 1
+
+    return jax.lax.while_loop(cond, body, (x, r, d, rho, 0))[0]
+
+
+def chebyshev_apply(matvec, v, *, lmin, lmax, degree, M=None):
+    """Fixed-``degree`` Chebyshev polynomial application ``p(A) v ≈ A^{-1} v`` (no convergence
+    test — a *linear* operator in ``v``, usable as a preconditioner for CG/MINRES/FGMRES)."""
+    M = M or _ident
+    theta = 0.5 * (lmax + lmin)
+    delta = 0.5 * (lmax - lmin)
+    sigma1 = theta / delta
+    x = jnp.zeros_like(v)
+    r = v  # x = 0 start
+    d = M(r) / theta
+    rho = 1.0 / sigma1
+
+    def body(_, s):
+        x, r, d, rho = s
+        x = x + d
+        r = r - matvec(d)
+        rho_new = 1.0 / (2.0 * sigma1 - rho)
+        d = rho_new * rho * d + (2.0 * rho_new / delta) * M(r)
+        return x, r, d, rho_new
+
+    return jax.lax.fori_loop(0, degree, body, (x, r, d, rho))[0]
+
+
+__all__.append("chebyshev_apply")

--- a/jno/utils/solver/newton_krylov.py
+++ b/jno/utils/solver/newton_krylov.py
@@ -60,14 +60,28 @@ def _linsolve(matvec, b, *, tol, maxit):
 
 
 def newton_krylov(
-    residual_fn, u0, *, rtol=1e-8, atol=1e-8, max_steps=100, inner_tol=1e-10, inner_maxit=2000, linear_solve=None
+    residual_fn,
+    u0,
+    *,
+    rtol=1e-8,
+    atol=1e-8,
+    max_steps=100,
+    inner_tol=1e-10,
+    inner_maxit=2000,
+    linear_solve=None,
+    damping=1.0,
 ):
     """Root-find ``residual_fn(u) = 0`` from guess ``u0``; differentiable w.r.t. any value
     ``residual_fn`` closes over. Drop-in for the ``(residual_fn, u0) -> u`` solver contract.
 
     ``linear_solve`` overrides the inner matrix-free solve: a ``(matvec, rhs) -> x`` callable
     (e.g. adapted from a ``jno.solve`` Krylov solver); it serves both the Newton step and the
-    implicit-diff tangent solve. Default: BiCGStab wrapped in ``custom_linear_solve``."""
+    implicit-diff tangent solve. Default: BiCGStab wrapped in ``custom_linear_solve``.
+
+    ``damping`` scales each update ``u += damping * delta`` (0 < damping <= 1): a fixed
+    relaxation that trades steps for robustness on strongly nonlinear residuals. With
+    ``jno.lag``-frozen coefficients in the residual the linearization is the *Picard* operator
+    and this loop is the damped Picard iteration (see :func:`jno.solve.picard`)."""
     # residual functions can hand back a plain numpy array for concrete inputs; coerce so the
     # jax.lax.custom_root primitive only ever sees JAX values.
     f0 = lambda u: jnp.asarray(residual_fn(u)).reshape(-1)
@@ -85,7 +99,7 @@ def newton_krylov(
             u, _r, k = state
             ru, jvp = jax.linearize(f, u)  # ru = f(u); jvp(v) = J @ v, reused across inner iters
             delta = inner(jvp, -ru)
-            u = u + delta
+            u = u + damping * delta
             return u, f(u), k + 1
 
         u, _r, _k = jax.lax.while_loop(cond, body, (x0, f(x0), 0))

--- a/jno/utils/solver/newton_krylov.py
+++ b/jno/utils/solver/newton_krylov.py
@@ -59,13 +59,20 @@ def _linsolve(matvec, b, *, tol, maxit):
     return jax.lax.custom_linear_solve(matvec, b, solve, transpose_solve=solve)
 
 
-def newton_krylov(residual_fn, u0, *, rtol=1e-8, atol=1e-8, max_steps=100, inner_tol=1e-10, inner_maxit=2000):
+def newton_krylov(
+    residual_fn, u0, *, rtol=1e-8, atol=1e-8, max_steps=100, inner_tol=1e-10, inner_maxit=2000, linear_solve=None
+):
     """Root-find ``residual_fn(u) = 0`` from guess ``u0``; differentiable w.r.t. any value
-    ``residual_fn`` closes over. Drop-in for the ``(residual_fn, u0) -> u`` solver contract."""
+    ``residual_fn`` closes over. Drop-in for the ``(residual_fn, u0) -> u`` solver contract.
+
+    ``linear_solve`` overrides the inner matrix-free solve: a ``(matvec, rhs) -> x`` callable
+    (e.g. adapted from a ``jno.solve`` Krylov solver); it serves both the Newton step and the
+    implicit-diff tangent solve. Default: BiCGStab wrapped in ``custom_linear_solve``."""
     # residual functions can hand back a plain numpy array for concrete inputs; coerce so the
     # jax.lax.custom_root primitive only ever sees JAX values.
     f0 = lambda u: jnp.asarray(residual_fn(u)).reshape(-1)
     u0 = jnp.asarray(u0).reshape(-1)
+    inner = linear_solve or (lambda mv, rhs: _linsolve(mv, rhs, tol=inner_tol, maxit=inner_maxit))
 
     def solve(f, x0):
         r0n = jnp.linalg.norm(f(x0))
@@ -77,12 +84,12 @@ def newton_krylov(residual_fn, u0, *, rtol=1e-8, atol=1e-8, max_steps=100, inner
         def body(state):
             u, _r, k = state
             ru, jvp = jax.linearize(f, u)  # ru = f(u); jvp(v) = J @ v, reused across inner iters
-            delta = _linsolve(jvp, -ru, tol=inner_tol, maxit=inner_maxit)
+            delta = inner(jvp, -ru)
             u = u + delta
             return u, f(u), k + 1
 
         u, _r, _k = jax.lax.while_loop(cond, body, (x0, f(x0), 0))
         return u
 
-    tangent_solve = lambda g, y: _linsolve(g, y, tol=inner_tol, maxit=inner_maxit)
+    tangent_solve = lambda g, y: inner(g, y)
     return jax.lax.custom_root(f0, u0, solve, tangent_solve)

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -1,0 +1,243 @@
+"""Slot-based solver API: the contracts behind ``fem.solve(x0=, nonlinear=, linear=, precond=)``.
+
+Design (see ``plans/fem-solver-api.md``): the FEM solver space factorises into four orthogonal
+slots -- warm start, linearization driver, inner linear solve, preconditioner. Every slot takes a
+**callable** (no strings); the shipped defaults live in the ``jno.solve`` / ``jno.precond``
+namespaces and are pure JAX (jit- + vmap-native), reusing ``jax.scipy.sparse.linalg`` and the
+existing ``sparse_lu_solve`` rather than re-implementing solvers. ``fem.solve(solve_fn=...)``
+remains the total override and is unchanged.
+
+Contracts
+---------
+* linear solver: ``fn(A, b, *, M=None, x0=None) -> x`` with ``A`` a :class:`LinearOperator`
+  (``.mv(v)``, ``.T.mv(v)``, ``.diag()``, ``.bcoo``, ``.dense()``). Pure-JAX implementations
+  inherit ``jit``/``vmap``/AD; the ``jax.scipy`` Krylov wrappers are built on
+  ``lax.custom_linear_solve`` upstream, so they are implicitly differentiable already.
+* nonlinear driver: ``fn(residual_fn, u0, *, linear_solve=None) -> u`` where ``linear_solve`` is
+  a matrix-free ``(matvec, rhs) -> x`` built from the ``linear`` slot.
+* preconditioner spec: an object with ``materialize(ctx) -> (v -> M^{-1} v)`` (or a bare
+  ``ctx -> apply`` callable). Specs are declarative -- jno materializes them at solve time with a
+  :class:`PrecondContext` carrying the assembled operator. A preconditioner only changes
+  convergence *speed*, never the converged solution, so it needs **no** gradient path
+  (the differentiability firewall of ``custom_linear_solve`` / ``custom_root``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+import jax
+import jax.numpy as jnp
+
+from .linear import matrix_diagonal
+
+__all__ = [
+    "LinearOperator",
+    "LinearSolver",
+    "NonlinearSolver",
+    "PrecondContext",
+    "materialize_precond",
+    "compose_linear_solve_fn",
+    "compose_nonlinear_solve_fn",
+]
+
+
+class LinearOperator:
+    """Uniform handle over an assembled operator (BCOO, dense array, or bare matvec).
+
+    Gives every linear solver one interface regardless of the storage the assembler produced:
+    ``.mv(v)`` (also ``@``), lazy transpose ``.T``, ``.diag()``, ``.dense()``, and ``.bcoo``
+    (``None`` when not sparse). A matvec-only operator (``from_matvec``) supports ``mv`` and a
+    transpose via ``jax.linear_transpose``; ``diag``/``dense`` raise -- direct solvers and
+    diagonal preconditioners need an assembled matrix.
+    """
+
+    def __init__(self, A: Any, *, _transposed: bool = False):
+        if callable(A) and not hasattr(A, "shape"):
+            raise TypeError("Wrap a bare matvec with LinearOperator.from_matvec(fn).")
+        self._A = A
+        self._mv = None
+        self._transposed = _transposed
+
+    @classmethod
+    def from_matvec(cls, mv: Callable, *, _transposed: bool = False) -> "LinearOperator":
+        op = cls.__new__(cls)
+        op._A = None
+        op._mv = mv
+        op._transposed = _transposed
+        return op
+
+    @property
+    def shape(self):
+        if self._A is None:
+            return None
+        s = self._A.shape
+        return (s[1], s[0]) if self._transposed else s
+
+    def mv(self, v):
+        if self._mv is not None:
+            if self._transposed:
+                # transpose of a linear map, via JAX's transposition (exact, not an approximation)
+                (out,) = jax.linear_transpose(self._mv, jnp.zeros_like(v))(v)
+                return out
+            return self._mv(v)
+        # ``v @ A`` is the transposed matvec for both BCOO and dense -- no transpose materialised
+        return (v @ self._A) if self._transposed else (self._A @ v)
+
+    __matmul__ = mv
+    __call__ = mv
+
+    @property
+    def T(self) -> "LinearOperator":
+        if self._mv is not None:
+            return LinearOperator.from_matvec(self._mv, _transposed=not self._transposed)
+        return LinearOperator(self._A, _transposed=not self._transposed)
+
+    def diag(self):
+        if self._A is None:
+            raise TypeError("LinearOperator.diag(): a matvec-only operator has no assembled diagonal.")
+        return matrix_diagonal(self._A)  # transpose shares the diagonal
+
+    def dense(self):
+        if self._A is None:
+            raise TypeError("LinearOperator.dense(): a matvec-only operator cannot densify.")
+        M = self._A.todense() if hasattr(self._A, "todense") else jnp.asarray(self._A)
+        return M.T if self._transposed else M
+
+    @property
+    def bcoo(self):
+        return self._A if hasattr(self._A, "todense") else None
+
+
+def _maybe_residual_check(op: LinearOperator, b, x, who: str, *, rtol: float = 1e-4):
+    """Eager-only convergence guard: raise on a garbage solution when values are concrete.
+
+    Under ``jit``/``vmap``/``grad`` (tracers) it is a no-op -- the check would either fail to
+    concretise or break the transform; there the solver's own iteration cap is the guard.
+    """
+    if any(isinstance(v, jax.core.Tracer) for v in (x, b)):
+        return x
+    import numpy as np
+
+    rel = float(jnp.linalg.norm(b - op.mv(x)) / (jnp.linalg.norm(b) + 1e-30))
+    if not np.isfinite(rel) or rel > rtol:
+        raise RuntimeError(
+            f"jno.solve.{who} did not solve the system (relative residual {rel:.1e}); the problem may be "
+            "singular/ill-posed or need a preconditioner. Try jno.solve.lu(), a precond= spec, or your own solve_fn."
+        )
+    return x
+
+
+class LinearSolver:
+    """A configured linear solver: ``solver(A, b, *, M=None, x0=None) -> x``.
+
+    ``fn`` receives ``(op: LinearOperator, b, M, x0)``. ``traits`` documents transform support
+    (``vmap: "native" | "sequential" | "no"``) so composition layers (and, later, the auto
+    policy) can pick honestly instead of silently host-looping.
+    """
+
+    def __init__(self, fn: Callable, *, name: str, traits: Optional[dict] = None, direct: bool = False):
+        self._fn = fn
+        self.name = name
+        self.traits = {"vmap": "native", "jit": True, **(traits or {})}
+        self.direct = direct  # a direct solver ignores x0 and takes no preconditioner
+
+    def __call__(self, A, b, *, M=None, x0=None):
+        op = A if isinstance(A, LinearOperator) else LinearOperator(A)
+        b = jnp.asarray(b).reshape(-1)
+        if self.direct and M is not None:
+            raise ValueError(f"jno.solve.{self.name} is a direct solver -- it takes no preconditioner (precond=).")
+        return self._fn(op, b, M=M, x0=x0)
+
+    def __repr__(self):
+        return f"jno.solve.{self.name}({', '.join(f'{k}={v}' for k, v in self.traits.items())})"
+
+
+class NonlinearSolver:
+    """A configured nonlinear driver: ``driver(residual_fn, u0, *, linear_solve=None) -> u``."""
+
+    def __init__(self, fn: Callable, *, name: str, traits: Optional[dict] = None):
+        self._fn = fn
+        self.name = name
+        self.traits = {"vmap": "native", "jit": True, **(traits or {})}
+
+    def __call__(self, residual_fn, u0, *, linear_solve=None):
+        return self._fn(residual_fn, u0, linear_solve=linear_solve)
+
+    def __repr__(self):
+        return f"jno.solve.{self.name}()"
+
+
+class PrecondContext:
+    """What a preconditioner spec sees at materialization time.
+
+    ``ctx.A`` is the assembled :class:`LinearOperator` (matvec-only on the Jacobian-free
+    nonlinear path), ``ctx.fem`` the owning :class:`jno.FEM` (``None`` outside ``fem.solve``),
+    and ``ctx.diag()`` the operator diagonal. Block extraction and auxiliary weak-form assembly
+    arrive with the block-preconditioner phase (see ``plans/fem-solver-api.md``).
+    """
+
+    def __init__(self, A: LinearOperator, fem: Any = None):
+        self.A = A
+        self.fem = fem
+
+    def diag(self):
+        return self.A.diag()
+
+
+def materialize_precond(spec: Any, ctx: PrecondContext) -> Callable:
+    """Turn a preconditioner spec into the ``v -> M^{-1} v`` applier for this solve."""
+    if hasattr(spec, "materialize"):
+        return spec.materialize(ctx)
+    if callable(spec):  # duck-typed: a bare ``ctx -> apply`` factory
+        return spec(ctx)
+    raise TypeError(
+        f"precond= expects a jno.precond.* spec or a callable (ctx) -> (v -> M^-1 v); got {type(spec).__name__}."
+    )
+
+
+def compose_linear_solve_fn(linear, precond, x0, fem=None) -> Callable:
+    """Compose the linear-mode slots into the classic ``(A, b) -> x`` ``solve_fn`` contract.
+
+    The composed callable is handed to the *existing* dispatch (plain / periodic-reduced /
+    parametric ``FemLinearSystem`` / complex real-block), so every path keeps its current
+    reduction and implicit-differentiation behaviour. It accepts the assembler's BCOO operator
+    directly -- no densification.
+    """
+    if linear is None:
+        from ... import solve as _solve_ns
+
+        linear = _solve_ns.bicgstab()  # matches the historic matrix-free default
+    x0_flat = None if x0 is None else jnp.asarray(x0).reshape(-1)
+
+    def composed(A, b):
+        op = A if isinstance(A, LinearOperator) else LinearOperator(A)
+        M = materialize_precond(precond, PrecondContext(op, fem)) if precond is not None else None
+        return linear(op, jnp.asarray(b).reshape(-1), M=M, x0=x0_flat)
+
+    return composed
+
+
+def compose_nonlinear_solve_fn(nonlinear, linear, precond, fem=None) -> Callable:
+    """Compose the nonlinear-mode slots into the ``(residual_fn, u0) -> u`` ``solve_fn`` contract.
+
+    The inner Newton/Picard linear solve is matrix-free (a JVP matvec), so a ``precond=`` spec
+    that needs the assembled matrix cannot be materialized here yet -- form-based preconditioners
+    (assembled auxiliary operators) are the planned route; until then this raises.
+    """
+    if precond is not None:
+        raise NotImplementedError(
+            "precond= on the matrix-free nonlinear path needs a form-based preconditioner "
+            "(assembled auxiliary operator) -- not implemented yet; see plans/fem-solver-api.md."
+        )
+    if nonlinear is None:
+        from ... import solve as _solve_ns
+
+        nonlinear = _solve_ns.newton()
+
+    inner = None
+    if linear is not None:
+        # adapt the linear slot to the driver's matrix-free ``(matvec, rhs) -> x`` inner contract
+        inner = lambda matvec, rhs: linear(LinearOperator.from_matvec(matvec), rhs)
+
+    return lambda residual_fn, u0: nonlinear(residual_fn, u0, linear_solve=inner)

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -40,6 +40,7 @@ __all__ = [
     "prepare_precond",
     "compose_linear_solve_fn",
     "compose_nonlinear_solve_fn",
+    "compose_transient_step_solvers",
 ]
 
 
@@ -366,3 +367,72 @@ def compose_nonlinear_solve_fn(nonlinear, linear, precond, fem=None) -> Callable
             return solver(op, rhs, M=M)
 
     return lambda residual_fn, u0: nonlinear(residual_fn, u0, linear_solve=inner)
+
+
+def _add_step_operator(M, A, scale):
+    """Form the theta-step operator ``M + scale * A`` once, eagerly.
+
+    Both BCOO: concatenate triplets (duplicates are legal COO — every consumer sums them:
+    matvec, ``matrix_diagonal``, ``sparse_lu_solve``, the AMG CSR conversion). Anything else:
+    dense addition.
+    """
+    if hasattr(M, "todense") and hasattr(A, "todense"):
+        import jax.experimental.sparse as jsp
+
+        data = jnp.concatenate([M.data, scale * A.data])
+        indices = jnp.concatenate([M.indices, A.indices], axis=0)
+        return jsp.BCOO((data, indices), shape=M.shape)
+    dense = lambda x: x.todense() if hasattr(x, "todense") else jnp.asarray(x)
+    return dense(M) + scale * dense(A)
+
+
+def compose_transient_step_solvers(nonlinear, linear, precond, fem, block):
+    """Compose the slots into per-step solvers for the transient integrator.
+
+    Returns ``(linear_step_solve, nonlinear_step_solve)`` (one is ``None``), matching
+    :meth:`SemidiscreteTimeBlock.step`'s injection points:
+
+    * **nonlinear block** — the per-step implicit solve ``G(u_next) = 0`` gets the same
+      composed driver as the steady nonlinear path (``nonlinear=`` slot + matrix-free inner
+      ``linear``/``precond``), so ``picard(damping=…)`` with ``jno.lag`` coefficients works per
+      time step.
+    * **linear block** — the theta-step system ``(M + θ dt A) u_next = rhs`` is what the
+      ``linear`` solver and ``precond`` spec see. When the operator is **time-independent**
+      (``operator_fn is None``) the step matrix is formed once, eagerly, and the preconditioner
+      is materialized **once before the scan** — the AMG hierarchy / auxiliary ``form`` operator
+      is then reused by every step (the whole point of preconditioning a time loop). A
+      time-dependent ``operator_fn(t, args)`` falls back to per-step materialization against a
+      matvec-only operator that still exposes the exact step diagonal (so ``jacobi`` works).
+    """
+    if block.is_nonlinear():
+        return None, compose_nonlinear_solve_fn(nonlinear, linear, precond, fem)
+    if nonlinear is not None:
+        raise ValueError("fem.solve: nonlinear= given, but this transient block is linear (no linearization).")
+
+    if linear is None:
+        from ... import solve as _solve_ns
+
+        solver = _solve_ns.bicgstab()  # the historic per-step default
+    else:
+        solver = linear
+    if precond is not None:
+        prepare_precond(precond, fem)
+
+    # constant-operator fast path: one step matrix, one preconditioner, reused by every step
+    static_op = None
+    static_M = None
+    if block.operator_fn is None and block.A is not None and block.dt is not None:
+        theta = float(block.metadata.get("theta", 1.0)) if block.metadata else 1.0
+        static_op = LinearOperator(_add_step_operator(block.M, block.A, theta * float(block.dt)))
+        if precond is not None:
+            static_M = materialize_precond(precond, PrecondContext(static_op, fem))
+
+    def step_solve(matvec, rhs, x0, diag_fn):
+        if static_op is not None:
+            op, M = static_op, static_M
+        else:
+            op = LinearOperator.from_matvec(matvec, diag_fn=diag_fn, shape=(rhs.shape[0], rhs.shape[0]))
+            M = materialize_precond(precond, PrecondContext(op, fem)) if precond is not None else None
+        return solver(op, rhs, M=M, x0=x0)
+
+    return step_solve, None

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -37,6 +37,7 @@ __all__ = [
     "NonlinearSolver",
     "PrecondContext",
     "materialize_precond",
+    "prepare_precond",
     "compose_linear_solve_fn",
     "compose_nonlinear_solve_fn",
 ]
@@ -288,6 +289,19 @@ def materialize_precond(spec: Any, ctx: PrecondContext) -> Callable:
     )
 
 
+def prepare_precond(spec: Any, fem: Any) -> None:
+    """Run a spec's eager preparation (optional ``spec.prepare(fem)``) once, at compose time.
+
+    Auxiliary-assembly work (``jno.precond.form``) must happen OUTSIDE any trace: on the
+    matrix-free nonlinear path ``materialize`` runs inside the Newton/Picard ``while_loop``
+    body, where a fresh ``jno.fem`` assembly entangles with the loop tracers (and would
+    re-assemble per re-trace anyway). Specs without a ``prepare`` hook need no eager work.
+    """
+    prep = getattr(spec, "prepare", None)
+    if prep is not None and fem is not None:
+        prep(fem)
+
+
 def compose_linear_solve_fn(linear, precond, x0, fem=None) -> Callable:
     """Compose the linear-mode slots into the classic ``(A, b) -> x`` ``solve_fn`` contract.
 
@@ -300,6 +314,8 @@ def compose_linear_solve_fn(linear, precond, x0, fem=None) -> Callable:
         from ... import solve as _solve_ns
 
         linear = _solve_ns.bicgstab()  # matches the historic matrix-free default
+    if precond is not None:
+        prepare_precond(precond, fem)  # eager auxiliary assembly (safe for traced/parametric solves)
     x0_flat = None if x0 is None else jnp.asarray(x0).reshape(-1)
 
     def composed(A, b):
@@ -313,23 +329,40 @@ def compose_linear_solve_fn(linear, precond, x0, fem=None) -> Callable:
 def compose_nonlinear_solve_fn(nonlinear, linear, precond, fem=None) -> Callable:
     """Compose the nonlinear-mode slots into the ``(residual_fn, u0) -> u`` ``solve_fn`` contract.
 
-    The inner Newton/Picard linear solve is matrix-free (a JVP matvec), so a ``precond=`` spec
-    that needs the assembled matrix cannot be materialized here yet -- form-based preconditioners
-    (assembled auxiliary operators) are the planned route; until then this raises.
+    The inner Newton/Picard linear solve is **matrix-free** -- each outer iteration linearizes
+    the residual into a JVP matvec ``J(u_k) v`` -- so a ``precond=`` spec is materialized *per
+    linearization* against that matvec-only operator (wrapped with the system size, so block
+    slicing and power-iteration bounds work). The same preconditioned solve serves the
+    implicit-differentiation tangent/adjoint solve of ``custom_root``.
+
+    What composes here: ``form`` (auxiliary operators assemble independently -- and are cached,
+    so the assembly happens once even though materialization runs per iteration),
+    ``inner(<krylov>)``, ``chebyshev`` (bounds by power iteration on the JVP), a **pre-built**
+    ``amg`` (``spec.build(A_representative)``), and ``block_diag``/``triangular`` over those.
+    What cannot: specs that need the assembled matrix -- ``jacobi`` (no diagonal on a matvec),
+    an unbuilt ``amg``, ``lu``/``dense`` inner solvers on sub-blocks -- these raise their own
+    targeted errors when materialized.
     """
-    if precond is not None:
-        raise NotImplementedError(
-            "precond= on the matrix-free nonlinear path needs a form-based preconditioner "
-            "(assembled auxiliary operator) -- not implemented yet; see plans/fem-solver-api.md."
-        )
     if nonlinear is None:
         from ... import solve as _solve_ns
 
         nonlinear = _solve_ns.newton()
 
     inner = None
-    if linear is not None:
-        # adapt the linear slot to the driver's matrix-free ``(matvec, rhs) -> x`` inner contract
-        inner = lambda matvec, rhs: linear(LinearOperator.from_matvec(matvec), rhs)
+    if linear is not None or precond is not None:
+        if linear is None:
+            from ... import solve as _solve_ns
+
+            solver = _solve_ns.bicgstab()  # the historic matrix-free inner default
+        else:
+            solver = linear
+        if precond is not None:
+            prepare_precond(precond, fem)  # aux assembly now, NOT inside the traced Newton loop
+
+        def inner(matvec, rhs):
+            n = rhs.shape[0]
+            op = LinearOperator.from_matvec(matvec, shape=(n, n))
+            M = materialize_precond(precond, PrecondContext(op, fem)) if precond is not None else None
+            return solver(op, rhs, M=M)
 
     return lambda residual_fn, u0: nonlinear(residual_fn, u0, linear_solve=inner)

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -57,26 +57,51 @@ class LinearOperator:
             raise TypeError("Wrap a bare matvec with LinearOperator.from_matvec(fn).")
         self._A = A
         self._mv = None
+        self._t_mv = None
+        self._diag_fn = None
+        self._dense_fn = None
+        self._shape = None
         self._transposed = _transposed
 
     @classmethod
-    def from_matvec(cls, mv: Callable, *, _transposed: bool = False) -> "LinearOperator":
+    def from_matvec(
+        cls,
+        mv: Callable,
+        *,
+        t_mv: Optional[Callable] = None,
+        diag_fn: Optional[Callable] = None,
+        dense_fn: Optional[Callable] = None,
+        shape: Optional[tuple] = None,
+        _transposed: bool = False,
+    ) -> "LinearOperator":
+        """Wrap a bare matvec. Optional hooks upgrade it: ``t_mv`` (transposed matvec — else
+        derived exactly via ``jax.linear_transpose``), ``diag_fn``/``dense_fn`` (else those
+        accessors raise), ``shape`` (else ``None``)."""
         op = cls.__new__(cls)
         op._A = None
         op._mv = mv
+        op._t_mv = t_mv
+        op._diag_fn = diag_fn
+        op._dense_fn = dense_fn
+        op._shape = shape
         op._transposed = _transposed
         return op
 
     @property
     def shape(self):
         if self._A is None:
+            s = self._shape
+        else:
+            s = self._A.shape
+        if s is None:
             return None
-        s = self._A.shape
-        return (s[1], s[0]) if self._transposed else s
+        return (s[1], s[0]) if self._transposed else tuple(s)
 
     def mv(self, v):
         if self._mv is not None:
             if self._transposed:
+                if self._t_mv is not None:
+                    return self._t_mv(v)
                 # transpose of a linear map, via JAX's transposition (exact, not an approximation)
                 (out,) = jax.linear_transpose(self._mv, jnp.zeros_like(v))(v)
                 return out
@@ -90,16 +115,29 @@ class LinearOperator:
     @property
     def T(self) -> "LinearOperator":
         if self._mv is not None:
-            return LinearOperator.from_matvec(self._mv, _transposed=not self._transposed)
+            op = LinearOperator.from_matvec(
+                self._mv,
+                t_mv=self._t_mv,
+                diag_fn=self._diag_fn,
+                dense_fn=self._dense_fn,
+                shape=self._shape,
+                _transposed=not self._transposed,
+            )
+            return op
         return LinearOperator(self._A, _transposed=not self._transposed)
 
     def diag(self):
         if self._A is None:
+            if self._diag_fn is not None:
+                return self._diag_fn()  # a (square) block's diagonal is transpose-invariant
             raise TypeError("LinearOperator.diag(): a matvec-only operator has no assembled diagonal.")
         return matrix_diagonal(self._A)  # transpose shares the diagonal
 
     def dense(self):
         if self._A is None:
+            if self._dense_fn is not None:
+                M = self._dense_fn()
+                return M.T if self._transposed else M
             raise TypeError("LinearOperator.dense(): a matvec-only operator cannot densify.")
         M = self._A.todense() if hasattr(self._A, "todense") else jnp.asarray(self._A)
         return M.T if self._transposed else M
@@ -173,8 +211,16 @@ class PrecondContext:
 
     ``ctx.A`` is the assembled :class:`LinearOperator` (matvec-only on the Jacobian-free
     nonlinear path), ``ctx.fem`` the owning :class:`jno.FEM` (``None`` outside ``fem.solve``),
-    and ``ctx.diag()`` the operator diagonal. Block extraction and auxiliary weak-form assembly
-    arrive with the block-preconditioner phase (see ``plans/fem-solver-api.md``).
+    ``ctx.diag()`` the operator diagonal. For multifield systems ``ctx.blocks`` are the
+    per-field DOF slices (from ``fem.offsets``), ``ctx.block_slice(field)`` resolves a trial
+    symbol (or integer index) to its slice, and ``ctx.sub(i, j=None)`` is the ``(i, j)``
+    sub-operator as a :class:`LinearOperator` — applied through the *full* operator's matvec
+    (embed into block ``j``, extract block ``i``), so it stays sparse/matrix-free; ``diag`` and
+    ``dense`` are exact views for ``i == j`` direct/diagonal inner solvers.
+
+    ``ctx.assemble(terms, quad_degree=...)`` assembles an **auxiliary weak form** with the
+    ordinary ``jno.fem`` machinery and returns its operator — the "preconditioners are weak
+    forms" primitive (weighted mass matrices, low-order proxies, shifted operators).
     """
 
     def __init__(self, A: LinearOperator, fem: Any = None):
@@ -183,6 +229,52 @@ class PrecondContext:
 
     def diag(self):
         return self.A.diag()
+
+    @property
+    def blocks(self):
+        blocks = getattr(self.fem, "blocks", None)
+        if blocks is None:
+            raise TypeError("PrecondContext.blocks: no per-field block structure (single field, or no FEM attached).")
+        return blocks
+
+    def block_slice(self, field) -> slice:
+        if isinstance(field, int):  # plain block index
+            return self.blocks[field]
+        if self.fem is None:
+            raise TypeError("PrecondContext.block_slice: resolving a trial symbol needs the owning FEM.")
+        return self.blocks[self.fem.block_index(field)]
+
+    def sub(self, i, j=None) -> LinearOperator:
+        si = self.block_slice(i)
+        sj = si if j is None else self.block_slice(j)
+        A = self.A
+        n = A.shape[0]
+
+        def _embed(v, s):
+            return jnp.zeros((n,), v.dtype).at[s].set(v)
+
+        mv = lambda v: A.mv(_embed(v, sj))[si]
+        t_mv = lambda v: A.T.mv(_embed(v, si))[sj]
+        diag_fn = (lambda: A.diag()[si]) if sj == si else None
+        dense_fn = lambda: A.dense()[si, sj]
+        ni = si.stop - si.start
+        nj = sj.stop - sj.start
+        return LinearOperator.from_matvec(mv, t_mv=t_mv, diag_fn=diag_fn, dense_fn=dense_fn, shape=(ni, nj))
+
+    def assemble(self, terms, *, quad_degree: int = 2) -> LinearOperator:
+        from ... import fem as _fem_entry
+
+        aux = _fem_entry(list(terms), quad_degree=quad_degree)
+        if not aux.is_linear or aux.is_transient or aux.is_complex:
+            raise ValueError("PrecondContext.assemble: the auxiliary preconditioner form must be steady linear.")
+        A = aux.A
+        if not hasattr(A, "todense"):
+            # small systems may assemble dense; convert NOW (concrete) so a sparse-direct inner
+            # solver stays jit-safe when the applier later runs inside a traced Krylov loop
+            import jax.experimental.sparse as jsp
+
+            A = jsp.BCOO.fromdense(jnp.asarray(A))
+        return LinearOperator(A)
 
 
 def materialize_precond(spec: Any, ctx: PrecondContext) -> Callable:

--- a/pixi.lock
+++ b/pixi.lock
@@ -631,6 +631,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5e/c6/82669e70cef67c803852285ba6f59d7e3d102983c0ab4be8269c14756677/tensorstore-0.1.84-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/53/6a81a6ebb1739f19c32002139719d4ee021a349d5bdbe066910feed327a1/optimistix-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/63/f3/c13ae1422434baeefe4d4f306a1cc77f024fe96d2abab3c212cfa1bf3ff8/pyamg-5.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6c/48/c42f657f3d6b4d9d9674c9bc48e763d024511ea4cc1d6e0c68c7b4380c43/diffrax-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/67/9d4ac4b0d683aaa4170da59a1980740b281fd38fc253e1830fde4dac3d4f/pygmsh-7.1.17-py3-none-any.whl
@@ -4302,6 +4303,14 @@ packages:
   - pytest>=8.3.5 ; extra == 'tests'
   - sif2jax ; extra == 'tests'
   requires_python: ~=3.11
+- pypi: https://files.pythonhosted.org/packages/63/f3/c13ae1422434baeefe4d4f306a1cc77f024fe96d2abab3c212cfa1bf3ff8/pyamg-5.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  name: pyamg
+  version: 5.3.0
+  sha256: 5cc223c66a7aca06fba898eb5e8ede6bb7974a9ddf7b8a98f56143c829e63631
+  requires_dist:
+  - numpy
+  - scipy>=1.11.0
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl
   name: nvidia-nccl-cu12
   version: 2.30.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,18 +103,22 @@ ignore = [
 exclude = '^(build/|jNO\.egg-info/|runs/)'
 
 [dependency-groups]
-# Test/tutorial env extras. matplotlib + diffrax are NOT runtime deps (the library
+# Test/tutorial env extras. matplotlib + diffrax + pyamg are NOT runtime deps (the library
 # only imports them lazily, inside try/except); they live here so the tutorial suite
 # and the explainability-callback plotting run unmodified in tests.
 #
 # mmgpy (metric-based local remesher) backs the adaptive-FEM loop in
 # jno.utils.solver.fem_adapt. It is imported lazily inside remesh_with_mmg, so the
 # core install stays lean; it only needs to be present in the fem/dev test envs.
+#
+# pyamg powers the host-side setup of the hybrid AMG preconditioner (jno.precond.amg)
+# — imported lazily there too; the V-cycle apply stays pure JAX.
 fem = [
     "pyfiglet",
     "diffrax",
     "matplotlib",
     "mmgpy>=0.16",
+    "pyamg>=5.0",
 ]
 dev = [
     "pytest-xdist>=3.8.0",

--- a/tests/test_fem_plate_bc.py
+++ b/tests/test_fem_plate_bc.py
@@ -62,9 +62,14 @@ def _plate_center_deflection(space, clamped, mesh_size=0.06):
 def test_clamped_vs_simply_supported_matches_timoshenko(space):
     """The reason the granular BC exists: `u(reg)-g` alone (simply-supported) must give a *different*, and
     larger, deflection than `u(reg)-g` + `u.dn(reg)-0` (clamped) — each matching Timoshenko's coefficient. A
-    silently-still-clamped value BC would give the two the same answer; this is what a grep cannot catch."""
-    w_clamped = _plate_center_deflection(space, clamped=True)
-    w_simple = _plate_center_deflection(space, clamped=False)
+    silently-still-clamped value BC would give the two the same answer; this is what a grep cannot catch.
+
+    Runs on CPU: the C¹-element assembly at this mesh peaks at ~12 GiB in one dense reduce (the
+    known Argyris memory ceiling), which OOMs 8 GiB GPUs — the pin validates the plate BCs, not
+    GPU capacity."""
+    with jax.default_device(jax.devices("cpu")[0]):
+        w_clamped = _plate_center_deflection(space, clamped=True)
+        w_simple = _plate_center_deflection(space, clamped=False)
     assert abs(w_clamped / 0.00126 - 1.0) < 0.06, f"{space} clamped w_max={w_clamped:.5f} (Timoshenko 0.00126)"
     assert abs(w_simple / 0.00406 - 1.0) < 0.06, f"{space} simply-supported w_max={w_simple:.5f} (Timoshenko 0.00406)"
     assert w_simple > 2.5 * w_clamped, "u(reg)-g alone must FREE the rotation (simply-supported ≠ clamped)"

--- a/tests/test_fem_solver_amg.py
+++ b/tests/test_fem_solver_amg.py
@@ -1,0 +1,132 @@
+"""The hybrid AMG preconditioner ``jno.precond.amg``: pyamg smoothed-aggregation setup on the
+host (Vaněk/Mandel/Brezina 1996; PyAMG, Bell et al. 2023), pure-JAX Chebyshev-smoothed V-cycle
+apply (Adams et al. 2003).
+
+Pins: CG+AMG matches the sparse-direct reference on a Poisson system large enough for a real
+multilevel hierarchy; the applier is ``jit``- and ``vmap``-native after an eager ``build`` (the
+batch shares one frozen hierarchy) and is exactly *linear* (CG-legality); the saddle-point
+architecture — FGMRES + triangular(velocity→AMG, pressure→weighted mass) — solves Taylor–Hood
+Stokes; setup under a trace raises with ``.build()`` guidance; and pyamg stays **optional**
+(clear ImportError, ``jno.precond`` imports fine without it)."""
+
+from __future__ import annotations
+
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+pyamg = pytest.importorskip("pyamg", reason="pyamg required for the AMG setup (optional dep)")
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _poisson(mesh_size=0.03):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1 - xi) + yi * (1 - yi))
+    return jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+
+def test_cg_amg_matches_direct_on_poisson():
+    fem = _poisson()
+    assert fem.dofs > 1000  # large enough for a genuine multilevel hierarchy
+    u_ref = np.asarray(fem.solve(linear=jno.solve.lu()))
+    u = np.asarray(fem.solve(linear=jno.solve.cg(tol=1e-10), precond=jno.precond.amg()))
+    assert np.abs(u - u_ref).max() < 1e-8
+
+
+def test_amg_prebuilt_jit_vmap_and_linearity():
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext
+
+    fem = _poisson()
+    u_ref = np.asarray(fem.solve(linear=jno.solve.lu()))
+    spec = jno.precond.amg().build(fem.A)  # eager setup; frozen hierarchy
+    op = LinearOperator(fem.A)
+    M = spec.materialize(PrecondContext(op, fem))
+    solver = jno.solve.cg(tol=1e-10)
+    b = jnp.asarray(fem.b).reshape(-1)
+    x = jax.jit(lambda bb: solver(op, bb, M=M))(b)
+    assert np.abs(np.asarray(x) - u_ref).max() < 1e-8
+    B = jnp.stack([b, 2.0 * b, -b])  # one hierarchy shared across the batch
+    X = jax.vmap(lambda bb: solver(op, bb, M=M))(B)
+    assert np.abs(np.asarray(X[1]) - 2.0 * u_ref).max() < 1e-8
+    # exactly linear in r (fixed cycle from zero guess) -- the CG-legality requirement
+    v, w = b, jnp.roll(b, 3)
+    assert float(jnp.abs(M(2.0 * v + w) - 2.0 * M(v) - M(w)).max()) < 1e-12
+
+
+def test_stokes_fgmres_triangular_with_amg_velocity_block():
+    """The production saddle-point architecture: AMG on the (symmetric) velocity block, weighted
+    pressure mass as the Schur approximation, flexible outer Krylov."""
+    inner_, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+    G, mu, H, Lx = 1.0, 1.0, 1.0, 4.0
+    u_profile = lambda y: (G / (2 * mu)) * y * (H - y)
+    d = jno.domain(box(0.0, 0.0, Lx, H), mesh_size=0.25)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
+    p, q = d.fem_symbols(names=("p", "q"), order=1)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    pp, qq = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+    fem = jno.fem(
+        [
+            mu * inner_(gu, gv, n_contract=2) - pp * trace(gv),
+            -qq * trace(gu),
+            u(xb, yb)[0] - u_profile(yb),
+            u(xb, yb)[1] - 0.0,
+            p.pin(),
+        ]
+    )
+    u_ref = np.asarray(fem.solve(linear=jno.solve.lu()))
+    sol = fem.solve(
+        linear=jno.solve.fgmres(tol=1e-10, restart=40, maxiter=4000),
+        precond=jno.precond.triangular(
+            (u, jno.precond.amg(cycles=2)),  # velocity block via the (dense) block view
+            (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.dense())),
+        ),
+    )
+    assert np.abs(np.asarray(sol) - u_ref).max() < 1e-6
+
+
+def test_traced_setup_raises_with_build_guidance():
+    import jax.experimental.sparse as jsp
+
+    from jno.utils.solver.amg import build_hierarchy
+
+    fem = _poisson(mesh_size=0.2)
+    A = fem.A if hasattr(fem.A, "todense") else jsp.BCOO.fromdense(jnp.asarray(fem.A))
+
+    def traced(data):
+        build_hierarchy(jsp.BCOO((data, A.indices), shape=A.shape))
+        return data.sum()
+
+    with pytest.raises(TypeError, match="spec.build"):
+        jax.jit(traced)(A.data)
+
+
+def test_pyamg_stays_optional(monkeypatch):
+    """Without pyamg: jno.precond imports fine (it already did — lazy import), and using amg
+    raises a clear ImportError naming the install."""
+    monkeypatch.setitem(sys.modules, "pyamg", None)  # a None entry makes `import pyamg` raise
+    fem = _poisson(mesh_size=0.2)
+    with pytest.raises(ImportError, match="pip install pyamg"):
+        jno.precond.amg().build(fem.A)

--- a/tests/test_fem_solver_krylov.py
+++ b/tests/test_fem_solver_krylov.py
@@ -1,0 +1,193 @@
+"""The pure-JAX Krylov trio jNO implements itself (absent from the JAX ecosystem): FGMRES
+(Saad 1993, Alg. 2.2), MINRES (Paige & Saunders 1975), Chebyshev (Saad 2003 §12.3).
+
+Pins: correctness vs dense/scipy oracles on the structure each method targets (non-symmetric for
+FGMRES, symmetric *indefinite* for MINRES, SPD for Chebyshev); FGMRES's distinguishing property
+(an *iterative*, per-call-varying preconditioner — illegal for plain GMRES); restart smaller than
+the Krylov dimension; the Chebyshev polynomial preconditioner accelerating CG; ``jit`` + ``vmap``
+at the contract level; reverse-mode differentiability through the ``custom_linear_solve``
+firewall (vs finite differences, non-symmetric so a transpose bug cannot hide); and end-to-end
+use as ``fem.solve`` slots.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.experimental.sparse as jsp
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import jno
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _spd(n=40, seed=0):
+    rng = np.random.default_rng(seed)
+    Q = rng.standard_normal((n, n))
+    return Q @ Q.T + n * np.eye(n)
+
+
+def _sym_indefinite(n=40, seed=1):
+    """Symmetric with a genuinely mixed spectrum — CG diverges here, MINRES is the method."""
+    rng = np.random.default_rng(seed)
+    D = np.diag(np.concatenate([np.linspace(1.0, 10.0, n // 2), -np.linspace(1.0, 5.0, n - n // 2)]))
+    U, _ = np.linalg.qr(rng.standard_normal((n, n)))
+    return U @ D @ U.T
+
+
+def _nonsym(n=40, seed=2):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((n, n)) + n * np.eye(n)
+
+
+def _op(Ad):
+    return jno.solve.LinearOperator(jsp.BCOO.fromdense(jnp.asarray(Ad)))
+
+
+def _b(n, seed=3):
+    return jnp.asarray(np.random.default_rng(seed).standard_normal(n))
+
+
+# ---------------------------------------------------------------------------
+# correctness vs oracles
+# ---------------------------------------------------------------------------
+
+
+def test_minres_symmetric_indefinite_vs_scipy():
+    Ad = _sym_indefinite()
+    b = _b(Ad.shape[0])
+    x = jno.solve.minres(tol=1e-12)(_op(Ad), b)
+    assert np.abs(np.asarray(x) - np.linalg.solve(Ad, np.asarray(b))).max() < 1e-9
+    sp = pytest.importorskip("scipy.sparse.linalg")
+    x_sp, info = sp.minres(Ad, np.asarray(b), rtol=1e-12)
+    assert info == 0
+    assert np.abs(np.asarray(x) - x_sp).max() < 1e-7
+
+
+def test_minres_spd_preconditioner():
+    Ad = _spd(seed=4) + np.diag(np.linspace(0, 500, 40))  # spread the diagonal so Jacobi bites
+    b = _b(40)
+    op = _op(Ad)
+    inv = 1.0 / jnp.asarray(np.diag(Ad))
+    x = jno.solve.minres(tol=1e-12)(op, b, M=lambda v: inv * v)
+    assert np.abs(np.asarray(x) - np.linalg.solve(Ad, np.asarray(b))).max() < 1e-9
+
+
+def test_fgmres_nonsymmetric_and_restarted():
+    Ad = _nonsym()
+    b = _b(Ad.shape[0])
+    x_ref = np.linalg.solve(Ad, np.asarray(b))
+    x = jno.solve.fgmres(tol=1e-12)(_op(Ad), b)
+    assert np.abs(np.asarray(x) - x_ref).max() < 1e-9
+    # restart << n exercises the outer cycle loop
+    x_r = jno.solve.fgmres(tol=1e-12, restart=7)(_op(Ad), b)
+    assert np.abs(np.asarray(x_r) - x_ref).max() < 1e-9
+
+
+def test_fgmres_flexible_iterative_preconditioner():
+    """The defining FGMRES property: M is itself an inexact Krylov solve (varies per call)."""
+    Ad = _spd(seed=5)
+    b = _b(Ad.shape[0])
+    op = _op(Ad)
+    M_inner = lambda v: jax.scipy.sparse.linalg.cg(op.mv, v, tol=1e-2, maxiter=5)[0]
+    x = jno.solve.fgmres(tol=1e-12)(op, b, M=M_inner)
+    assert np.abs(np.asarray(x) - np.linalg.solve(Ad, np.asarray(b))).max() < 1e-9
+
+
+def test_chebyshev_solver_true_and_estimated_bounds():
+    Ad = _spd(seed=6)
+    b = _b(Ad.shape[0])
+    x_ref = np.linalg.solve(Ad, np.asarray(b))
+    lam = np.linalg.eigvalsh(Ad)
+    x = jno.solve.chebyshev(lmin=float(lam[0]), lmax=float(lam[-1]), tol=1e-12)(_op(Ad), b)
+    assert np.abs(np.asarray(x) - x_ref).max() < 1e-9
+    x_auto = jno.solve.chebyshev(tol=1e-12, maxiter=2000)(_op(Ad), b)  # power-iteration bounds
+    assert np.abs(np.asarray(x_auto) - x_ref).max() < 1e-8
+
+
+def test_chebyshev_polynomial_preconditioner_accelerates_cg():
+    from jno.utils.solver.solver_api import PrecondContext, materialize_precond
+
+    Ad = _spd(seed=7)
+    b = _b(Ad.shape[0])
+    op = _op(Ad)
+    M = materialize_precond(jno.precond.chebyshev(degree=8), PrecondContext(op))
+    x = jno.solve.cg(tol=1e-12)(op, b, M=M)
+    assert np.abs(np.asarray(x) - np.linalg.solve(Ad, np.asarray(b))).max() < 1e-9
+    # the fixed-degree application is linear in v (required for CG): p(A)(a v + w) = a p(A)v + p(A)w
+    v, w = _b(40, seed=8), _b(40, seed=9)
+    lin = np.asarray(M(2.0 * v + w) - 2.0 * M(v) - M(w))
+    assert np.abs(lin).max() < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# transforms: jit, vmap, grad (the custom_linear_solve firewall)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [lambda: jno.solve.fgmres(tol=1e-12), lambda: jno.solve.minres(tol=1e-12)])
+def test_jit_and_vmap(factory):
+    Ad = _sym_indefinite(seed=10)
+    op = _op(Ad)
+    solver = factory()
+    b = _b(Ad.shape[0])
+    x = jax.jit(lambda bb: solver(op, bb))(b)
+    assert np.abs(np.asarray(x) - np.linalg.solve(Ad, np.asarray(b))).max() < 1e-8
+    B = jnp.stack([b, -b, 3.0 * b + 1.0])
+    X = jax.vmap(lambda bb: solver(op, bb))(B)
+    assert np.abs(np.asarray(X) - np.linalg.solve(Ad, np.asarray(B).T).T).max() < 1e-8
+
+
+def test_grad_through_firewall_nonsymmetric():
+    """Reverse-mode through fgmres on a NON-symmetric parametric system vs finite differences —
+    exercises the transpose solve of the custom_linear_solve wrapper."""
+    A0 = jnp.asarray(_nonsym(n=12, seed=11))
+    P = jnp.asarray(np.random.default_rng(12).standard_normal((12, 12)))
+    b = _b(12, seed=13)
+    solver = jno.solve.fgmres(tol=1e-13)
+
+    def loss(theta):
+        op = jno.solve.LinearOperator(A0 + theta * P)
+        return jnp.sum(solver(op, b) ** 2)
+
+    g = float(jax.grad(loss)(0.3))
+    eps = 1e-6
+    g_fd = (float(loss(0.3 + eps)) - float(loss(0.3 - eps))) / (2 * eps)
+    assert abs(g - g_fd) / (abs(g_fd) + 1e-12) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# end-to-end as fem.solve slots
+# ---------------------------------------------------------------------------
+
+
+def test_fem_solve_with_new_krylov_slots():
+    pytest.importorskip("shapely", reason="shapely required for the box domain")
+    from shapely.geometry import box
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.2)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    u_ref = np.asarray(fem.solve())
+    for solver, precond in [
+        (jno.solve.fgmres(), jno.precond.jacobi()),
+        (jno.solve.minres(), jno.precond.jacobi()),  # Poisson stiffness is SPD: MINRES applies
+        (jno.solve.cg(), jno.precond.chebyshev(degree=6)),
+        (jno.solve.chebyshev(maxiter=2000), None),
+    ]:
+        uu = np.asarray(fem.solve(linear=solver, precond=precond))
+        assert np.abs(uu - u_ref).max() < 1e-6, f"{solver.name} deviates on Poisson"

--- a/tests/test_fem_solver_picard.py
+++ b/tests/test_fem_solver_picard.py
@@ -1,0 +1,92 @@
+"""``jno.lag`` (lagged-coefficient marker) + the ``jno.solve.picard`` / damped-Newton drivers.
+
+Pins: on a manufactured nonlinear diffusion problem ``-div((1+u^2) grad u) = f``, Picard on the
+``lag``-frozen form converges to the *same* solution as full Newton on the unlagged form (the
+root is independent of gradient markers); damping converges too; the drivers compose with the
+``linear=`` slot; ``lag`` freezes differentiation (stop-gradient semantics, array fallback
+included) while leaving values untouched; and ``picard`` without any ``lag`` marker is exactly
+damped Newton.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _nonlinear_diffusion(lagged: bool, mesh_size=0.2):
+    """-div((1+u^2) grad u) = f manufactured from u* = x(1-x)y(1-y)."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    us = xi * (1 - xi) * yi * (1 - yi)
+    ux, uy = (1 - 2 * xi) * yi * (1 - yi), xi * (1 - xi) * (1 - 2 * yi)
+    lap = -2 * yi * (1 - yi) - 2 * xi * (1 - xi)
+    f = -((2 * us) * (ux * ux + uy * uy) + (1 + us**2) * lap)
+    k = 1.0 + ui**2
+    kk = jno.lag(k) if lagged else k
+    return jno.fem([kk * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=4)
+
+
+def test_picard_on_lagged_form_matches_full_newton():
+    u_newton = np.asarray(_nonlinear_diffusion(lagged=False).solve())
+    fem_lag = _nonlinear_diffusion(lagged=True)
+    u_picard = np.asarray(fem_lag.solve(nonlinear=jno.solve.picard()))
+    assert np.abs(u_picard - u_newton).max() < 1e-8
+    u_damped = np.asarray(fem_lag.solve(nonlinear=jno.solve.picard(damping=0.7)))
+    assert np.abs(u_damped - u_newton).max() < 1e-7
+
+
+def test_picard_composes_with_linear_slot():
+    u_newton = np.asarray(_nonlinear_diffusion(lagged=False).solve())
+    fem_lag = _nonlinear_diffusion(lagged=True)
+    u = np.asarray(fem_lag.solve(nonlinear=jno.solve.picard(), linear=jno.solve.bicgstab(tol=1e-12)))
+    assert np.abs(u - u_newton).max() < 1e-8
+
+
+def test_damped_newton_converges():
+    fem = _nonlinear_diffusion(lagged=False)
+    u_ref = np.asarray(fem.solve())
+    u = np.asarray(fem.solve(nonlinear=jno.solve.newton(damping=0.5)))
+    assert np.abs(u - u_ref).max() < 1e-8
+
+
+def test_picard_without_lag_is_damped_newton():
+    fem = _nonlinear_diffusion(lagged=False)
+    u_ref = np.asarray(fem.solve())
+    u = np.asarray(fem.solve(nonlinear=jno.solve.picard(damping=1.0)))
+    assert np.abs(u - u_ref).max() < 1e-8
+
+
+def test_lag_freezes_gradients_but_not_values():
+    # array fallback: values pass through, differentiation sees a constant
+    x = jnp.asarray([1.5, -2.0])
+    assert np.allclose(np.asarray(jno.lag(x)), np.asarray(x))
+    g = jax.grad(lambda z: jnp.sum(jno.lag(z) * z))(x)
+    assert np.allclose(np.asarray(g), np.asarray(x))  # d/dz [c*z] = c (not 2z)
+    # traced views return a view (the .stop_gradient property), not a callable
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.5)
+    u, _ = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    ui = u.bind(x=xi, y=yi)
+    lagged = jno.lag(1.0 + ui**2)
+    assert hasattr(lagged, "_expr") or hasattr(lagged, "op_id")

--- a/tests/test_fem_solver_picard.py
+++ b/tests/test_fem_solver_picard.py
@@ -77,6 +77,70 @@ def test_picard_without_lag_is_damped_newton():
     assert np.abs(u - u_ref).max() < 1e-8
 
 
+def test_nonlinear_precond_form_full_system():
+    """precond= on the matrix-free nonlinear path: a form-based (assembled auxiliary) operator
+    is materialized per Newton linearization against the JVP operator."""
+    fem = _nonlinear_diffusion(lagged=False)
+    u_ref = np.asarray(fem.solve())
+    d = fem.domain
+    # the linear part of the operator as the auxiliary preconditioner (fresh symbols, same space)
+    w, s = d.fem_symbols(names=("w_aux", "s_aux"))
+    xi, yi, _ = d.variable("interior", split=True)
+    wi, si = w.bind(x=xi, y=yi), s.bind(x=xi, y=yi)
+    spec = jno.precond.form([wi.x * si.x + wi.y * si.y + wi * si], inner=jno.solve.lu(), quad_degree=4)
+    u = np.asarray(fem.solve(nonlinear=jno.solve.newton(), linear=jno.solve.fgmres(tol=1e-10), precond=spec))
+    assert np.abs(u - u_ref).max() < 1e-7
+
+
+def test_nonlinear_stokes_picard_fgmres_triangular():
+    """The production nonlinear-saddle architecture (the cold-rolling / rigid-plastic pattern):
+    velocity-dependent viscosity frozen with jno.lag, driven by Picard, each lagged Stokes system
+    solved by FGMRES with a block upper-triangular preconditioner (inexact CG velocity block +
+    weighted pressure-mass Schur approximation)."""
+    inner_, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+    G, H, Lx = 1.0, 1.0, 2.0
+    u_profile = lambda y: (G / 2.0) * y * (H - y)
+    d = jno.domain(box(0.0, 0.0, Lx, H), mesh_size=0.3)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
+    p, q = d.fem_symbols(names=("p", "q"), order=1)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    pp, qq = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+    mu_eff = 1.0 + 0.5 * inner_(gu, gu, n_contract=2)  # shear-dependent viscosity
+    fem = jno.fem(
+        [
+            jno.lag(mu_eff) * inner_(gu, gv, n_contract=2) - pp * trace(gv),
+            -qq * trace(gu),
+            u(xb, yb)[0] - u_profile(yb),
+            u(xb, yb)[1] - 0.0,
+            p.pin(),
+        ]
+    )
+
+    # reference: dense Picard on the same lagged residual (same root, brute-force linear algebra)
+    def dense_picard(rf, u0):
+        w = u0
+        for _ in range(60):
+            J = jax.jacfwd(rf)(w)
+            w = w + jnp.linalg.solve(J, -rf(w))
+            if float(jnp.linalg.norm(rf(w))) < 1e-11:
+                break
+        return w
+
+    u_ref = np.asarray(fem.solve(solve_fn=dense_picard))
+
+    sol = fem.solve(
+        nonlinear=jno.solve.picard(),
+        linear=jno.solve.fgmres(tol=1e-10, restart=40, maxiter=4000),
+        precond=jno.precond.triangular(
+            (u, jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=60))),
+            (p, jno.precond.form([pp * qq], inner=jno.solve.dense())),
+        ),
+    )
+    assert np.abs(np.asarray(sol) - u_ref).max() < 1e-6
+
+
 def test_lag_freezes_gradients_but_not_values():
     # array fallback: values pass through, differentiation sees a constant
     x = jnp.asarray([1.5, -2.0])

--- a/tests/test_fem_solver_precond.py
+++ b/tests/test_fem_solver_precond.py
@@ -1,0 +1,191 @@
+"""Structure-aware preconditioner specs: ``jno.precond.form`` (auxiliary weak-form operators),
+``jno.precond.inner`` (a solver as the M⁻¹ application), and per-field block composition
+(``block_diag`` / ``triangular``) over ``fem.blocks``.
+
+Pins: the flagship saddle-point pattern — Taylor–Hood Stokes solved by FGMRES with an
+upper-triangular block preconditioner (inexact CG velocity solve + (1/μ)-weighted pressure-mass
+Schur approximation, Elman/Silvester/Wathen §9.2) against the sparse-direct reference, including
+spec *reuse* across solves (cached auxiliary operator, snapshotted field keys); symbol→block
+resolution in offsets order (`fem.blocks` / `fem.block_index`); sub-operator extraction
+(``ctx.sub``) against dense slices; ``form`` on the full system; and the pair-validation guards.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _stokes(mesh_size=0.25):
+    """Taylor-Hood (P2/P1) Poiseuille channel — the docs/tutorial Stokes system."""
+    inner_, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+    G, mu, H, Lx = 1.0, 1.0, 1.0, 4.0
+    u_profile = lambda y: (G / (2 * mu)) * y * (H - y)
+    d = jno.domain(box(0.0, 0.0, Lx, H), mesh_size=mesh_size)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
+    p, q = d.fem_symbols(names=("p", "q"), order=1)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    pp, qq = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+    fem = jno.fem(
+        [
+            mu * inner_(gu, gv, n_contract=2) - pp * trace(gv),
+            -qq * trace(gu),
+            u(xb, yb)[0] - u_profile(yb),
+            u(xb, yb)[1] - 0.0,
+            p.pin(),
+        ]
+    )
+    return fem, u, p, pp, qq, mu
+
+
+def _poisson(mesh_size=0.2):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    return fem, ui, vi
+
+
+# ---------------------------------------------------------------------------
+# the flagship: Stokes saddle system, FGMRES + block preconditioning
+# ---------------------------------------------------------------------------
+
+
+def test_stokes_fgmres_triangular_schur():
+    fem, u, p, pp, qq, mu = _stokes()
+    u_ref = np.asarray(fem.solve(linear=jno.solve.lu()))
+    tri = jno.precond.triangular(
+        (u, jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=60))),  # inexact velocity block solve
+        (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.dense())),  # μ⁻¹-weighted pressure mass
+    )
+    sol = fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=40, maxiter=4000), precond=tri)
+    assert np.abs(np.asarray(sol) - u_ref).max() < 1e-6
+    # spec reuse: the auxiliary mass operator is cached, the field-key snapshot survives the
+    # auxiliary assembly on the same domain (regression: domain._fem_native_field_keys overwrite)
+    sol2 = fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=40, maxiter=4000), precond=tri)
+    assert np.abs(np.asarray(sol2) - u_ref).max() < 1e-6
+
+
+def test_stokes_block_diag():
+    fem, u, p, pp, qq, mu = _stokes()
+    u_ref = np.asarray(fem.solve(linear=jno.solve.lu()))
+    bd = jno.precond.block_diag(
+        (u, jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=60))),
+        (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.dense())),
+    )
+    sol = fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=40, maxiter=4000), precond=bd)
+    assert np.abs(np.asarray(sol) - u_ref).max() < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# structure handles
+# ---------------------------------------------------------------------------
+
+
+def test_blocks_and_block_index_offsets_order():
+    fem, u, p, *_ = _stokes(mesh_size=0.35)
+    off = fem.offsets
+    assert fem.blocks == [slice(int(off[0]), int(off[1])), slice(int(off[1]), int(off[2]))]
+    iu, ip = fem.block_index(u), fem.block_index(p)
+    assert (iu, ip) == (0, 1)  # P2 vector velocity is the big first block
+    assert (off[1] - off[0]) > (off[2] - off[1])
+    assert fem.block_index(1) == 1  # integer passthrough
+    # a foreign symbol is rejected
+    d2 = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.5)
+    w, _ = d2.fem_symbols(names=("w", "pw"))
+    with pytest.raises(KeyError, match="not part of this system"):
+        fem.block_index(w)
+
+
+def test_single_field_blocks_trivial():
+    """A single-field system has no *useful* block structure: blocks is None (no offsets) or the
+    one whole-vector slice (native path sets offsets [0, N])."""
+    fem, *_ = _poisson()
+    assert fem.blocks is None or fem.blocks == [slice(0, fem.dofs)]
+
+
+def test_sub_operator_matches_dense_slices():
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext
+
+    fem, u, p, *_ = _stokes(mesh_size=0.35)
+    ctx = PrecondContext(LinearOperator(fem.A), fem)
+    Ad = np.asarray(fem.A.todense() if hasattr(fem.A, "todense") else fem.A)
+    su, sp = fem.blocks
+    Auu, Aup = Ad[su, su], Ad[su, sp]
+    vu = jnp.asarray(np.random.default_rng(0).standard_normal(Auu.shape[0]))
+    vp = jnp.asarray(np.random.default_rng(1).standard_normal(Aup.shape[1]))
+    assert np.allclose(np.asarray(ctx.sub(u).mv(vu)), Auu @ np.asarray(vu))
+    assert np.allclose(np.asarray(ctx.sub(u, p).mv(vp)), Aup @ np.asarray(vp))
+    assert np.allclose(np.asarray(ctx.sub(u, p).T.mv(vu)), Aup.T @ np.asarray(vu))
+    assert np.allclose(np.asarray(ctx.sub(u).diag()), np.diag(Auu))
+    assert np.allclose(np.asarray(ctx.sub(u, p).dense()), Aup)
+    assert ctx.sub(u, p).shape == Aup.shape
+
+
+# ---------------------------------------------------------------------------
+# form / inner on the full system
+# ---------------------------------------------------------------------------
+
+
+def test_form_full_system_preconditioner():
+    """The operator's own weak form as the aux operator == an (up to BC rows) exact
+    preconditioner; any Krylov converges immediately to the reference."""
+    fem, ui, vi = _poisson()
+    u_ref = np.asarray(fem.solve())
+    spec = jno.precond.form([ui.x * vi.x + ui.y * vi.y + ui * vi], inner=jno.solve.lu(), quad_degree=3)
+    sol = fem.solve(linear=jno.solve.fgmres(tol=1e-10), precond=spec)
+    assert np.abs(np.asarray(sol) - u_ref).max() < 1e-6
+    # materialization is cached: the second materialize returns without re-assembling
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext
+
+    ctx = PrecondContext(LinearOperator(fem.A), fem)
+    spec.materialize(ctx)
+    op_first = spec._op
+    spec.materialize(ctx)
+    assert spec._op is op_first
+
+
+def test_inner_spec_full_system():
+    fem, *_ = _poisson()
+    u_ref = np.asarray(fem.solve())
+    sol = fem.solve(
+        linear=jno.solve.fgmres(tol=1e-10),
+        precond=jno.precond.inner(jno.solve.cg(tol=1e-1, maxiter=25)),
+    )
+    assert np.abs(np.asarray(sol) - u_ref).max() < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# guards
+# ---------------------------------------------------------------------------
+
+
+def test_block_pair_validation():
+    fem, u, p, pp, qq, mu = _stokes(mesh_size=0.35)
+    jac = jno.precond.jacobi()
+    with pytest.raises(ValueError, match="specified twice"):
+        fem.solve(linear=jno.solve.fgmres(), precond=jno.precond.triangular((u, jac), (u, jac)))
+    with pytest.raises(ValueError, match="every field needs exactly one"):
+        fem.solve(linear=jno.solve.fgmres(), precond=jno.precond.triangular((u, jac)))

--- a/tests/test_fem_solver_precond.py
+++ b/tests/test_fem_solver_precond.py
@@ -88,6 +88,27 @@ def test_stokes_fgmres_triangular_schur():
     assert np.abs(np.asarray(sol2) - u_ref).max() < 1e-6
 
 
+def test_points_survive_aux_assembly():
+    """Regression: fem.points / fem.field_points are snapshots — assembling a jno.precond.form
+    auxiliary operator on the same domain must not clobber them (the raw domain attributes
+    _fem_native_dof_points* ARE overwritten by the aux assembly; the FEM must not care)."""
+    fem, u, p, pp, qq, mu = _stokes(mesh_size=0.35)
+    pts_before = [np.asarray(x) for x in fem.field_points]
+    n_before = np.asarray(fem.points).shape[0]
+    fem.solve(
+        linear=jno.solve.fgmres(tol=1e-8, restart=40, maxiter=4000),
+        precond=jno.precond.triangular(
+            (u, jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=60))),
+            (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.dense())),
+        ),
+    )
+    pts_after = fem.field_points
+    assert len(pts_after) == len(pts_before)
+    for a, b in zip(pts_after, pts_before):
+        assert np.asarray(a).shape == b.shape and np.allclose(np.asarray(a), b)
+    assert np.asarray(fem.points).shape[0] == n_before
+
+
 def test_stokes_block_diag():
     fem, u, p, pp, qq, mu = _stokes()
     u_ref = np.asarray(fem.solve(linear=jno.solve.lu()))

--- a/tests/test_fem_solver_slots.py
+++ b/tests/test_fem_solver_slots.py
@@ -223,11 +223,13 @@ def test_jacobi_on_matrix_free_nonlinear_raises():
         fem.solve(nonlinear=jno.solve.newton(), precond=jno.precond.jacobi())
 
 
-def test_transient_slots_raise():
+def test_complex_transient_slots_raise():
+    # plain-transient slots are supported (see test_fem_solver_transient.py); the complex-
+    # transient path still routes around them
     from jno._fem import FEM
 
-    fem = FEM(None, None, [], mode="transient")
-    with pytest.raises(NotImplementedError, match="transient"):
+    fem = FEM(None, None, [], mode="complex_transient")
+    with pytest.raises(NotImplementedError, match="complex-transient"):
         fem.solve(linear=jno.solve.cg())
 
 

--- a/tests/test_fem_solver_slots.py
+++ b/tests/test_fem_solver_slots.py
@@ -1,0 +1,236 @@
+"""The slot-based solver API: ``fem.solve(x0=, nonlinear=, linear=, precond=)`` composed from the
+callables-only ``jno.solve`` / ``jno.precond`` namespaces (see ``plans/fem-solver-api.md``).
+
+Pins: every shipped linear solver reproduces the historic default on a Poisson system (slot
+solvers receive the BCOO operator -- no densification); ``x0`` warm-starts (exact guess is a
+fixed point); the direct/Krylov contract (``LinearSolver`` rejects ``M`` on direct solvers);
+jit + vmap of the pure-JAX solvers at the contract level; slot composition on the nonlinear
+path (driver + injected inner linear solve) matches the Newton-Krylov default; the parametric
+(inverse) path stays differentiable through slot solvers; and the guard rails (slots xor
+``solve_fn``; transient unsupported; ``precond`` on the matrix-free nonlinear path unsupported).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+
+import jax  # noqa: E402
+import jax.experimental.sparse as jsp  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _poisson(mesh_size=0.2):
+    """Poisson with exact solution u = x(1-x)y(1-y); homogeneous Dirichlet."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    return jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+
+def _nonlinear(mesh_size=0.25):
+    """Reaction-diffusion -lap u + u^3 = f with exact u = sin(pi x) sin(pi y)."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    ss = jno.np.sin(PI * xi) * jno.np.sin(PI * yi)
+    f = 2.0 * PI**2 * ss + ss**3
+    return jno.fem([ui.x * vi.x + ui.y * vi.y + ui**3 * vi - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+
+# ---------------------------------------------------------------------------
+# steady linear slots
+# ---------------------------------------------------------------------------
+
+
+def test_linear_slot_solvers_match_default():
+    fem = _poisson()
+    u_ref = np.asarray(fem.solve())
+    for solver, precond in [
+        (jno.solve.cg(), jno.precond.jacobi()),  # SPD system: CG applies
+        (jno.solve.bicgstab(), jno.precond.jacobi()),  # == the historic default, via slots
+        (jno.solve.gmres(), jno.precond.jacobi()),
+        (jno.solve.gmres(), None),
+        (jno.solve.lu(), None),
+        (jno.solve.dense(), None),
+    ]:
+        u = np.asarray(fem.solve(linear=solver, precond=precond))
+        assert np.abs(u - u_ref).max() < 1e-7, f"{solver.name} (precond={precond}) deviates from the default"
+
+
+def test_x0_warm_start():
+    fem = _poisson()
+    u_ref = jnp.asarray(fem.solve())
+    # the exact solution as warm start is a fixed point of a converged Krylov solve
+    u = fem.solve(linear=jno.solve.bicgstab(), precond=jno.precond.jacobi(), x0=u_ref)
+    assert np.abs(np.asarray(u - u_ref)).max() < 1e-12
+    # a pure warm start (all other slots defaulted) also solves
+    u2 = fem.solve(x0=jnp.zeros_like(u_ref))
+    assert np.abs(np.asarray(u2 - u_ref)).max() < 1e-7
+
+
+def test_user_written_slot_callables():
+    """The documented extension contract: bare callables drop into the slots."""
+    fem = _poisson()
+    u_ref = np.asarray(fem.solve())
+
+    def my_linear(A, b, *, M=None, x0=None):  # LinearOperator in, solution out
+        return jnp.linalg.solve(A.dense(), b)
+
+    def my_precond(ctx):  # ctx -> (v -> M^{-1} v)
+        inv = 1.0 / ctx.diag()
+        return lambda v: inv * v
+
+    assert np.abs(np.asarray(fem.solve(linear=my_linear)) - u_ref).max() < 1e-9
+    u = fem.solve(linear=jno.solve.cg(), precond=my_precond)
+    assert np.abs(np.asarray(u) - u_ref).max() < 1e-7
+
+
+# ---------------------------------------------------------------------------
+# contract level: LinearOperator / LinearSolver under jit + vmap
+# ---------------------------------------------------------------------------
+
+
+def _spd(n=24, seed=0):
+    rng = np.random.default_rng(seed)
+    Q = rng.standard_normal((n, n))
+    Ad = Q @ Q.T + n * np.eye(n)
+    return jsp.BCOO.fromdense(jnp.asarray(Ad)), Ad
+
+
+def test_solver_contract_jit_and_vmap():
+    A, Ad = _spd()
+    solver = jno.solve.cg(tol=1e-12)
+    op = jno.solve.LinearOperator(A)
+    b = jnp.asarray(np.random.default_rng(1).standard_normal(Ad.shape[0]))
+    x = jax.jit(lambda bb: solver(op, bb))(b)
+    assert np.allclose(np.asarray(x), np.linalg.solve(Ad, np.asarray(b)), atol=1e-8)
+    B = jnp.stack([b, 2.0 * b, b - 1.0])
+    X = jax.vmap(lambda bb: solver(op, bb))(B)  # shipped Krylov solvers are vmap-native
+    assert np.allclose(np.asarray(X), np.linalg.solve(Ad, np.asarray(B).T).T, atol=1e-8)
+
+
+def test_linear_operator_transpose_and_diag():
+    A, Ad = _spd(n=8, seed=2)
+    op = jno.solve.LinearOperator(A)
+    v = jnp.arange(8, dtype=jnp.float64)
+    assert np.allclose(np.asarray(op.T.mv(v)), Ad.T @ np.asarray(v))
+    assert np.allclose(np.asarray(op.diag()), np.diag(Ad))
+    mv_op = jno.solve.LinearOperator.from_matvec(lambda w: A @ w)
+    assert np.allclose(np.asarray(mv_op.T.mv(v)), Ad.T @ np.asarray(v))  # via jax.linear_transpose
+    with pytest.raises(TypeError):
+        mv_op.diag()
+
+
+# ---------------------------------------------------------------------------
+# nonlinear slots
+# ---------------------------------------------------------------------------
+
+
+def test_nonlinear_slots_match_default():
+    fem = _nonlinear()
+    u_ref = np.asarray(fem.solve())
+    u = np.asarray(fem.solve(nonlinear=jno.solve.newton()))
+    assert np.abs(u - u_ref).max() < 1e-8
+    # inner linear solve injected from the linear slot (adapted to the matrix-free contract)
+    u2 = np.asarray(fem.solve(nonlinear=jno.solve.newton(), linear=jno.solve.bicgstab(tol=1e-12)))
+    assert np.abs(u2 - u_ref).max() < 1e-7
+    # x0 is the Newton initial guess
+    u3 = np.asarray(fem.solve(nonlinear=jno.solve.newton(), x0=jnp.asarray(u_ref)))
+    assert np.abs(u3 - u_ref).max() < 1e-8
+
+
+# ---------------------------------------------------------------------------
+# parametric (inverse) path stays differentiable through slot solvers
+# ---------------------------------------------------------------------------
+
+
+def test_parametric_linear_differentiable_through_slots():
+    import optax
+
+    alpha = jno.np.parameter((1,), key=jax.random.PRNGKey(1), name="alpha")
+    alpha.initialize(jax.nn.initializers.constant(2.0))
+    alpha.dtype(jnp.float64)
+    alpha.optimizer(optax.adam(5e-2))
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.25)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    fem = jno.fem([alpha * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+    u_obs = jnp.asarray(_poisson(mesh_size=0.25).solve())  # alpha_true = 1 data
+    node = fem.solve(linear=jno.solve.cg(tol=1e-12), precond=jno.precond.jacobi())
+    dummy = jno.domain.from_array({"_": np.zeros((1, 1))})
+    crux = jno.core([(node - u_obs).mse], domain=dummy)
+    crux.solve(120)
+    a = float(np.asarray(crux.eval([alpha])).reshape(-1)[0])
+    assert abs(a - 1.0) < 0.05, f"alpha not recovered through slot solvers: {a}"
+
+
+# ---------------------------------------------------------------------------
+# guard rails
+# ---------------------------------------------------------------------------
+
+
+def test_slots_and_solve_fn_are_exclusive():
+    fem = _poisson()
+    with pytest.raises(ValueError, match="not both"):
+        fem.solve(solve_fn=lambda A, b: b, linear=jno.solve.cg())
+
+
+def test_direct_solver_rejects_preconditioner():
+    fem = _poisson()
+    with pytest.raises(ValueError, match="direct solver"):
+        fem.solve(linear=jno.solve.lu(), precond=jno.precond.jacobi())
+
+
+def test_nonlinear_slot_on_linear_problem_raises():
+    fem = _poisson()
+    with pytest.raises(ValueError, match="no linearization"):
+        fem.solve(nonlinear=jno.solve.newton())
+
+
+def test_precond_on_matrix_free_nonlinear_raises():
+    fem = _nonlinear()
+    with pytest.raises(NotImplementedError, match="form-based"):
+        fem.solve(nonlinear=jno.solve.newton(), precond=jno.precond.jacobi())
+
+
+def test_transient_slots_raise():
+    from jno._fem import FEM
+
+    fem = FEM(None, None, [], mode="transient")
+    with pytest.raises(NotImplementedError, match="transient"):
+        fem.solve(linear=jno.solve.cg())
+
+
+def test_x0_u0_conflict_raises():
+    fem = _nonlinear()
+    z = jnp.zeros(4)
+    with pytest.raises(ValueError, match="same initial guess"):
+        fem.solve(x0=z, u0=z)

--- a/tests/test_fem_solver_slots.py
+++ b/tests/test_fem_solver_slots.py
@@ -215,9 +215,11 @@ def test_nonlinear_slot_on_linear_problem_raises():
         fem.solve(nonlinear=jno.solve.newton())
 
 
-def test_precond_on_matrix_free_nonlinear_raises():
+def test_jacobi_on_matrix_free_nonlinear_raises():
+    """precond= composes with the nonlinear path (materialized per linearization against the JVP
+    operator) — but jacobi needs the assembled diagonal, which a matvec-only operator lacks."""
     fem = _nonlinear()
-    with pytest.raises(NotImplementedError, match="form-based"):
+    with pytest.raises(TypeError, match="matvec-only"):
         fem.solve(nonlinear=jno.solve.newton(), precond=jno.precond.jacobi())
 
 

--- a/tests/test_fem_solver_transient.py
+++ b/tests/test_fem_solver_transient.py
@@ -1,0 +1,140 @@
+"""Solver slots threaded into the transient stepper: ``fem.solve(linear=, precond=, nonlinear=)``
+now configures the per-step solves of the default theta-method integrator.
+
+Pins: on a linear transient block the slot solvers reproduce the default backward-Euler
+trajectory (Krylov+jacobi, sparse-direct, flexible-Krylov with an iterative inner, and AMG —
+whose hierarchy is built ONCE on the step operator ``M + θ·dt·A`` and reused by every step);
+a nonlinear transient block takes the composed Newton driver; the **second-order-in-time**
+(augmented ``[u, v]``) block flows through the same machinery unchanged; a **parametric**
+transient inverse stays differentiable through slot solvers (per-step materialization path,
+``operator_fn(t, args)``); and the guard rails (``x0`` on transient; ``nonlinear=`` on a linear
+block).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _heat(nonlinear=False, mesh_size=0.2, time=(0.0, 0.2, 21)):
+    """Transient heat (optionally + u^3 reaction), homogeneous Dirichlet, sine-bump IC."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size, time=time)
+    u, v = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    ic = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    terms = [ui.t * vi + ui.x * vi.x + ui.y * vi.y, u(xb, yb) - 0.0, u(ci[0], ci[1]) - ic]
+    if nonlinear:
+        terms[0] = ui.t * vi + ui.x * vi.x + ui.y * vi.y + ui**3 * vi
+    return jno.fem(terms)
+
+
+def test_linear_transient_slots_match_default():
+    fem = _heat()
+    ref = np.asarray(fem.solve().fn())
+    for name, kw in [
+        ("cg+jacobi", dict(linear=jno.solve.cg(tol=1e-10), precond=jno.precond.jacobi())),
+        ("lu", dict(linear=jno.solve.lu())),
+        (
+            "fgmres+inner",  # iterative preconditioner per step -> flexible outer required
+            dict(linear=jno.solve.fgmres(tol=1e-10), precond=jno.precond.inner(jno.solve.cg(tol=1e-2, maxiter=30))),
+        ),
+    ]:
+        sol = np.asarray(fem.solve(**kw).fn())
+        assert np.abs(sol - ref).max() < 1e-8, f"{name} trajectory deviates from the default"
+
+
+def test_linear_transient_amg_built_once_on_step_operator():
+    pytest.importorskip("pyamg", reason="pyamg required for the AMG setup (optional dep)")
+    fem = _heat(mesh_size=0.1)
+    ref = np.asarray(fem.solve().fn())
+    spec = jno.precond.amg()
+    sol = np.asarray(fem.solve(linear=jno.solve.cg(tol=1e-10), precond=spec).fn())
+    assert np.abs(sol - ref).max() < 1e-8
+    # the hierarchy was set up eagerly (constant step operator M + theta*dt*A), before the scan
+    assert spec._levels is not None
+
+
+def test_nonlinear_transient_slots_match_default():
+    fem = _heat(nonlinear=True)
+    ref = np.asarray(fem.solve().fn())
+    sol = np.asarray(fem.solve(nonlinear=jno.solve.newton(), linear=jno.solve.fgmres(tol=1e-11)).fn())
+    assert np.abs(sol - ref).max() < 1e-8
+
+
+def test_second_order_time_slots():
+    """The u_tt (wave) path builds an augmented [u, v] linear block — the slots apply unchanged."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.25, time=(0.0, 0.3, 31))
+    u, phi = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    xi0, yi0, ti0 = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), phi.bind(x=xi, y=yi, t=ti)
+    ui0 = u.bind(x=xi0, y=yi0, t=ti0)
+    weak = ui.tt * vi + (ui.x * vi.x + ui.y * vi.y)
+    u0 = u(xi0, yi0) - jno.fn(lambda x, y: jnp.sin(PI * x) * jnp.sin(PI * y), [xi0, yi0])
+    fem = jno.fem([weak, u(xb, yb) - 0.0, u0, ui0.t - 0.0])
+    ref = np.asarray(fem.solve().fn())
+    sol = np.asarray(fem.solve(linear=jno.solve.gmres(tol=1e-11), precond=jno.precond.jacobi()).fn())
+    assert np.abs(sol - ref).max() < 1e-7
+
+
+def test_parametric_transient_inverse_through_slots():
+    """The per-step materialization path: a runtime parameter makes the operator
+    ``operator_fn(t, args)``, so the step system is re-formed per step — the slot solver +
+    jacobi (exact step diagonal via diag_fn) must stay differentiable through the scan."""
+    import optax
+
+    alpha = jno.np.parameter((1,), key=jax.random.PRNGKey(1), name="alpha")
+    alpha.initialize(jax.nn.initializers.constant(2.0))
+    alpha.dtype(jnp.float64)
+    alpha.optimizer(optax.adam(5e-2))
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.25, time=(0.0, 0.2, 11))
+    u, v = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    ic = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    fem = jno.fem([ui.t * vi + alpha * (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - ic])
+    # observations at alpha_true = 1
+    obs_fem = _heat(mesh_size=0.25, time=(0.0, 0.2, 11))
+    u_obs = jnp.asarray(obs_fem.solve().fn())
+
+    node = fem.solve(linear=jno.solve.bicgstab(tol=1e-12), precond=jno.precond.jacobi())
+    dummy = jno.domain.from_array({"_": np.zeros((1, 1))})
+    crux = jno.core([(node - u_obs).mse], domain=dummy)
+    crux.solve(120)
+    a = float(np.asarray(crux.eval([alpha])).reshape(-1)[0])
+    assert abs(a - 1.0) < 0.05, f"alpha not recovered through transient slot solvers: {a}"
+
+
+def test_transient_guards():
+    fem = _heat()
+    with pytest.raises(ValueError, match="initial conditions"):
+        fem.solve(x0=jnp.zeros(4))
+    with pytest.raises(ValueError, match="linear"):
+        fem.solve(nonlinear=jno.solve.newton())

--- a/tests/test_polygon_domain_csg.py
+++ b/tests/test_polygon_domain_csg.py
@@ -57,7 +57,7 @@ def test_boundary_edge_sampling_uses_input_order_and_exact_normals():
     np.random.seed(1)
     dom = jno.domain.csg(SQUARE_A, name="a")
 
-    xb, yb, tb, nx, ny = dom.variable("boundary_a_0", sample=(64, None), normals=True)
+    xb, yb, tb, nx, ny = dom.variable("boundary_a_0", sample=(64, None), normals=True, split=True)
     pts = dom.context[xb.tag][0, 0]
     normals = dom.context[nx.tag][0, 0]
 
@@ -109,7 +109,7 @@ def test_difference_exposes_subtrahend_boundary_as_hole_boundary():
     inner = jno.domain.csg([(0.4, 0.4), (0.6, 0.4), (0.6, 0.6), (0.4, 0.6)], name="hole")
 
     dom = outer - inner
-    xb, yb, tb, nx, ny = dom.variable("boundary_hole_0", sample=(64, None), normals=True)
+    xb, yb, tb, nx, ny = dom.variable("boundary_hole_0", sample=(64, None), normals=True, split=True)
     pts = dom.context[xb.tag][0, 0]
     normals = dom.context[nx.tag][0, 0]
 

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -518,7 +518,7 @@ def test_boundary_normals_updated_after_resample():
 
     # mesh_size=0.1 → ~40 boundary nodes in pool, working set = 20 → 2× ratio.
     domain = 1 * jno.domain(constructor=jno.domain.rect(mesh_size=0.1))
-    b_vars = domain.variable("boundary", sample=(20, None), normals=True, resampling_strategy=strategy)
+    b_vars = domain.variable("boundary", sample=(20, None), normals=True, split=True, resampling_strategy=strategy)
     xb, yb = b_vars[0], b_vars[1]
 
     xi, yi = domain.variable("interior", sample=(40, None))[:2]


### PR DESCRIPTION
## What

Adds a **slot-based solver API** to \`fem.solve\` — four orthogonal, callables-only slots that cover the FEM solver space by composition, while \`fem.solve()\` defaults and \`solve_fn=\` stay byte-compatible:

\`\`\`python
fem.solve(
    x0        = u_guess,                # warm start (previous solve / coarse solve / surrogate)
    nonlinear = jno.solve.picard(damping=0.7),   # linearization driver (newton / picard + jno.lag)
    linear    = jno.solve.fgmres(tol=1e-10),     # lu / dense / cg / bicgstab / gmres / fgmres / minres / chebyshev
    precond   = jno.precond.triangular(          # specs, materialized against the assembled operator
        (u, jno.precond.amg()),                          # hybrid AMG (pyamg setup, pure-JAX V-cycle)
        (p, jno.precond.form([(1.0/mu) * pp * qq])),     # "preconditioners as weak forms"
    ),
)
\`\`\`

Everything shipped is pure JAX — jit/vmap-native, differentiable via the \`custom_linear_solve\`/\`custom_root\` firewall — and reuses \`jax.scipy\`/\`spsolve\` wherever an implementation exists upstream.

## Highlights

- **New Krylov (the only hand-written loops)**: FGMRES (Saad 1993), MINRES (Paige & Saunders 1975), Chebyshev (Saad 2003 §12.3) — scipy/dense-oracle-pinned, FD-verified gradients.
- **Preconditioner specs**: \`jacobi\`, \`chebyshev\` (polynomial), \`inner(solver)\`, \`form([...])\` (auxiliary weak forms), \`block_diag\`/\`triangular\` over \`fem.blocks\` (trial symbols resolve to DOF blocks), and **hybrid AMG** — smoothed-aggregation setup via *optional* pyamg, pure-JAX Chebyshev-smoothed V-cycle apply (jit/vmap-native, exactly linear ⇒ CG-legal).
- **\`jno.lag\` + \`picard\`**: lagged-coefficient (Picard) linearization as first-class API; validated on a nonlinear-viscosity Stokes saddle solve (picard + fgmres + triangular ≡ dense reference).
- **Nonlinear × precond**: specs materialize per Newton/Picard linearization against the JVP operator (eager \`prepare\` stage keeps auxiliary assembly out of traced loops).
- **Transient threading**: slots configure the per-step solves of the theta-stepper; for a time-independent operator the step matrix \`M + θ·dt·A\` is formed once and the preconditioner (e.g. an AMG hierarchy) is **built once and reused by every step**; \`u_tt\` flows through unchanged; parametric transient inverse stays differentiable through the scan.
- **Tutorial migration**: 11 tutorials converted to the slot API (the Stokes channel is now a matrix-free FGMRES + block-triangular showcase, no densification anywhere).

## Fixes

- **Restores #79 work clobbered by the #80 merge**: parametric complex block solve (kept #80's sparse \`_complex_block_bcoo\`, restored the parametric trace-node layer) and the \`_finalize\` periodic guards — un-breaks 8 tests failing on main (\`test_fem_complex_parametric\`, \`test_fem_periodic_parametric\`, \`test_fem_periodic_complex_transient\`).
- \`fem.points\`/\`fem.field_points\`/field-key resolution snapshotted onto the FEM (auxiliary assemblies were clobbering the live domain attributes).
- 3 normals-API test stragglers from #78 (\`split=True\`); plate-Timoshenko tests pinned to CPU (the C¹ assembly's ~12 GiB peak OOMs 8 GiB GPUs).

## Tests

54 new tests across 6 suites (slots, Krylov, precond, picard, AMG, transient) — correctness vs oracles, jit/vmap at the contract level, FD-verified gradients, guard rails. Full suite: 2422 pass; the 13 failures previously on main are fixed here. Docs: new "Choosing the solver" section in \`docs/fem.md\`; all algorithms cited (docstring + docs).