### PR TITLE
feat(fem): trainable neural-network coefficients in assembled FEM systems

### DIFF
--- a/.github/ci_test_per_file.sh
+++ b/.github/ci_test_per_file.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# CI test runner: one pytest process per test FILE, so memory (JAX device
+# buffers, accumulated coverage state) is fully released between files.
+#
+# The all-in-one `pytest --cov` run accumulates memory across the growing FEM
+# suite and gets OOM-killed on the GitHub runner (exit 137) ~35% of the way in,
+# before finishing — this has failed CI on `main` and every FEM PR. Running each
+# file in its own process bounds peak memory to a single file's footprint. A
+# shared JAX compilation cache keeps the fresh per-file processes from
+# recompiling the same kernels, so the wall-time cost stays modest.
+#
+# `-m 'not slow'` still skips slow-marked tests (heavy training-loop recoveries,
+# tutorials). Coverage is appended across files into one `.coverage` and written
+# to `coverage.xml` at the end for the codecov upload.
+set -uo pipefail
+
+export JAX_COMPILATION_CACHE_DIR="${JAX_COMPILATION_CACHE_DIR:-$PWD/.jax_cache}"
+export MPLBACKEND="${MPLBACKEND:-Agg}"
+mkdir -p "$JAX_COMPILATION_CACHE_DIR"
+
+rm -f .coverage coverage.xml
+
+# Optional explicit file list (for local testing); default is the whole suite.
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  mapfile -t files < <(find tests -name 'test_*.py' | sort)
+fi
+echo "Running ${#files[@]} test files, one process each (memory released between files)."
+
+failed=()
+for f in "${files[@]}"; do
+  echo "::group::${f}"
+  pytest "$f" -m 'not slow' --cov=jno --cov-append --cov-report= --tb=short -q
+  code=$?
+  echo "::endgroup::"
+  # exit 5 == "no tests collected" (every test in the file is slow-marked/skipped): not a failure.
+  if [ "$code" -ne 0 ] && [ "$code" -ne 5 ]; then
+    failed+=("$f")
+    echo "::error::test file failed: ${f} (exit ${code})"
+  fi
+done
+
+coverage xml -o coverage.xml 2>/dev/null || echo "warning: could not write coverage.xml"
+
+if [ "${#failed[@]}" -ne 0 ]; then
+  echo "==================================================================="
+  echo "FAILED test files (${#failed[@]}):"
+  printf '  %s\n' "${failed[@]}"
+  exit 1
+fi
+echo "All ${#files[@]} test files passed."

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ whitepapers/
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+.coverage
+coverage.xml

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -773,10 +773,10 @@ The non-nodal path assembles a *dense* operator, so a parametric solve wants an 
 
 Current scope: steady/transient/steady-complex on the native 2D/3D Lagrange assembler (single or
 coupled multi-field), and steady scalar C¹ non-nodal (Argyris/Morley/Hermite). Not yet supported
-(each fails loud): networks inside Dirichlet/IC values, on the mass term, k(u) in complex forms,
-the complex transient, time-varying Dirichlet `g(x,t)` with a trainable net, transient non-nodal,
-the vector edge families (RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter
-path at all).
+(each fails loud): networks inside Dirichlet/IC values, a *trainable* net on the mass (`u_t`) term
+(a frozen/known one is fine — the mass is assembled once), k(u) in complex forms, the complex
+transient, time-varying Dirichlet `g(x,t)` with a trainable net, transient non-nodal, the vector
+edge families (RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter path at all).
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -758,10 +758,15 @@ for `net(u)`) re-evaluates the network, so a diffusivity or constitutive law is 
 *trainable* net on the mass (`u_t`) term is rejected (the mass matrix assembles once — the net
 would silently freeze; `.freeze()` it or keep it on spatial terms).
 
-Current scope: steady and transient weak forms (linear k(x) and nonlinear k(u)/k(∇u)) on the
-native 2D/3D Lagrange assembler, single field. Not yet supported (each fails loud): networks
-inside Dirichlet/IC values, on the mass term, `complex=True` forms, time-varying Dirichlet
-`g(x,t)` combined with a trainable net, coupled multi-field problems, 1D, and non-nodal
+A real coordinate-input net also composes with **complex** steady forms (a Helmholtz coefficient
+recovered from complex full-field data): the Re/Im legs assemble as parametric systems and the
+real-equivalent block solve stays differentiable in the weights.
+
+Current scope: steady, transient, and steady-complex weak forms (linear k(x); nonlinear
+k(u)/k(∇u) on real steady/transient forms) on the native 2D/3D Lagrange assembler, single field.
+Not yet supported (each fails loud): networks inside Dirichlet/IC values, on the mass term,
+k(u) in complex forms, the complex transient, time-varying Dirichlet `g(x,t)` combined with a
+trainable net, coupled multi-field problems, 1D, and non-nodal
 (Argyris/Morley/Hermite/RT/Nédélec) elements.
 
 ### Transient inverse

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -756,9 +756,11 @@ arguments carry the unknown makes the form nonlinear — including a bare reacti
 for `net(u)`) re-evaluates the network, so a diffusivity or constitutive law is recovered from a
 `u(t)` trajectory exactly like the scalar/nodal transient inverse below. A coordinate `net(x)` on
 the **mass** (`u_t`) term is supported too — an unknown density `ρ(x)·u_t` recovered from a decay
-trajectory: the mass becomes a parametric matrix re-assembled from the weights each step. Only a
-*solution-dependent* `net(u)` on the mass term is rejected — that is a nonlinear mass `C(u)·u_t`,
-which the semidiscrete matrix form cannot express (a frozen net on the mass is always fine).
+trajectory: the mass becomes a parametric matrix re-assembled from the weights each step (via
+`block.mass_fn`; `block.M` stays the static placeholder, so a hand-rolled integrator built off
+`block.M` sees the initial mass, not the parametric one — read `block.mass_fn(t, args)` if you roll
+your own). Only a *solution-dependent* `net(u)` on the mass term is rejected — that is a nonlinear
+mass `C(u)·u_t`, which the semidiscrete matrix form cannot express (a frozen net is always fine).
 
 A real coordinate-input net also composes with **complex** steady forms (a Helmholtz coefficient
 recovered from complex full-field data): the Re/Im legs assemble as parametric systems and the

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -733,10 +733,29 @@ L. De Lorenzis, *NN-EUCLID: Deep-learning hyperelasticity without stress data*, 
 Solids 165 (2022) 105076, §2.2–2.3) and Tartakovsky et al., *Learning Parameters and Constitutive
 Relationships with Physics-Informed Deep Neural Networks* (Water Resour. Res. 56, 2020, §2).
 
-Current scope: **steady** weak forms on the native 2D/3D Lagrange assembler, single field.
-Not yet supported (each fails loud): networks inside Dirichlet/IC values, transient forms,
-`complex=True` forms, coupled multi-field problems, 1D, and non-nodal
-(Argyris/Morley/Hermite/RT/Nédélec) elements.
+**Learned constitutive laws — `net(u)`, `net(∇u)`.** A network may also take the *solution* (or
+its derivatives) as input — then it is a material law, not a spatial map, and the form becomes
+nonlinear in `u` (routed to the matrix-free Newton path automatically; the net's `u`-dependence
+enters the element Jacobians through per-element forward AD). This is the NN-EUCLID setting:
+observe `u`, learn the hidden law unsupervised through the residual:
+
+```python
+net = jno.nn.wrap(foundax.mlp(1, hidden_dims=16, num_layers=2,
+                              activation=jax.nn.tanh, key=key)).dtype(jnp.float64)
+# hidden truth k(u) = 1 + 0.5 u²; learn it from a single observed field
+fem = jno.fem([(1.0 + net(ui)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0])
+crux = jno.core([(fem.solve() - u_obs).mse], domain=obs).solve(600)
+```
+
+`net(ui.x, ui.y)` (a `k(∇u)` p-Laplacian-type law) works the same way, and solution- and
+coordinate-inputs can be mixed (`net(xi, yi, ui)`). Classification is automatic: a net whose
+arguments carry the unknown makes the form nonlinear — including a bare reaction term
+`net(u)*v` — while `net(x, y)` keeps the system linear(-parametric).
+
+Current scope: **steady** weak forms (linear k(x) and nonlinear k(u)/k(∇u)) on the native 2D/3D
+Lagrange assembler, single field. Not yet supported (each fails loud): networks inside
+Dirichlet/IC values, transient forms, `complex=True` forms, coupled multi-field problems, 1D, and
+non-nodal (Argyris/Morley/Hermite/RT/Nédélec) elements.
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -703,6 +703,41 @@ k = jno.np.parameter(phi, name="k")                       # P1 field, one DOF pe
 crux = jno.core([(fem.solve() - u_obs).mse, 1e-3 * k.regularize("h1seminorm").mean], domain=obs)
 ```
 
+### Neural coefficients — `jno.nn.wrap(net)` inside the weak form
+
+A network called inside a weak form is a trainable **coefficient** on an assembled FE system —
+mesh-independent (remeshing never touches the weights), smooth by architecture, and trained
+through the same differentiable `fem.solve()` as any parameter:
+
+```python
+net = jno.nn.wrap(foundax.mlp(2, hidden_dims=16, num_layers=2,
+                              activation=jax.nn.tanh, key=key))
+net.dtype(jnp.float64)                                       # match the f64 assembly
+net.optimizer(optax.adam(1e-2))
+
+# k(x) = 1 + net(x, y): the offset keeps A(θ) nonsingular at the (near-zero) net init
+fem = jno.fem([(1.0 + net(xi, yi)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0])
+crux = jno.core([(fem.solve() - u_obs).mse], domain=obs).solve(600)   # trains the weights
+```
+
+The kernel re-evaluates the network at the quadrature points during every re-assembly, so the
+coefficient is *not* interpolated on the mesh (unlike the P1 nodal field above) — it composes
+with scalar/nodal parameters in one weak form, with per-region masks, vector trials, and surface
+(Robin/Neumann) terms. `net.freeze()` makes it a **known** network coefficient (evaluated from
+its stored weights; the system stays non-parametric). The role is decided by the constraints: a
+weak form whose trial is a *real* FE symbol makes the network a coefficient; a network written
+*in place of* the trial is a VPINN (see the VPINN section).
+
+This is the unsupervised coefficient-recovery setting of NN-EUCLID (M. Flaschel, S. Kumar,
+L. De Lorenzis, *NN-EUCLID: Deep-learning hyperelasticity without stress data*, J. Mech. Phys.
+Solids 165 (2022) 105076, §2.2–2.3) and Tartakovsky et al., *Learning Parameters and Constitutive
+Relationships with Physics-Informed Deep Neural Networks* (Water Resour. Res. 56, 2020, §2).
+
+Current scope: **steady** weak forms on the native 2D/3D Lagrange assembler, single field.
+Not yet supported (each fails loud): networks inside Dirichlet/IC values, transient forms,
+`complex=True` forms, coupled multi-field problems, 1D, and non-nodal
+(Argyris/Morley/Hermite/RT/Nédélec) elements.
+
 ### Transient inverse
 
 For a transient form, `fem.solve()` returns the **trajectory** `u(save_ts)` (default: backward

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -778,12 +778,20 @@ spatially-varying permeability/permittivity multiplying a vector term); only a s
 non-nodal path assembles a *dense* operator, so a parametric solve wants an explicit dense
 `solve_fn` — `fem.solve(lambda A, b: jnp.linalg.solve(A, b))`.
 
+**Unknown boundary conditions.** A network as a *Dirichlet value* — `u(region) - net(xb, yb)` —
+is a trainable BC *profile*, not a coefficient: it enters the load vector (the Dirichlet lift), not
+the operator. Recover an unknown boundary temperature/flux from the interior response by evaluating
+`net` at the boundary nodes each solve. Supported for a **bare** `net(x)` on a boundary region,
+steady native Lagrange single-field; a compound value (`1 + net(x)`), an initial-condition value,
+or a transient/nonlinear form fails loud.
+
 Current scope: steady/transient/steady-complex on the native 2D/3D Lagrange assembler (single or
-coupled multi-field), and steady scalar C¹ non-nodal (Argyris/Morley/Hermite). Not yet supported
-(each fails loud): networks inside Dirichlet/IC values, solution-dependent `net(u)` on the mass
-(`u_t`) term (a nonlinear mass), k(u) in complex forms, the complex transient, time-varying
-Dirichlet `g(x,t)` with a trainable net, solution-dependent `net(u)` on the vector edge families
-(RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter path at all).
+coupled multi-field), steady scalar C¹ non-nodal (Argyris/Morley/Hermite), and a bare `net(x)`
+steady Dirichlet value. Not yet supported (each fails loud): a compound/IC/transient net Dirichlet
+value, solution-dependent `net(u)` on the mass (`u_t`) term (a nonlinear mass), k(u) in complex
+forms, the complex transient, time-varying Dirichlet `g(x,t)` with a trainable net,
+solution-dependent `net(u)` on the vector edge families (RT/Nédélec), and 1D domains (the 1D
+assembler has no runtime-parameter path at all).
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -760,14 +760,16 @@ would silently freeze; `.freeze()` it or keep it on spatial terms).
 
 A real coordinate-input net also composes with **complex** steady forms (a Helmholtz coefficient
 recovered from complex full-field data): the Re/Im legs assemble as parametric systems and the
-real-equivalent block solve stays differentiable in the weights.
+real-equivalent block solve stays differentiable in the weights. And a net coefficient works in a
+**coupled (multi-field)** form — it is evaluated at the shared quadrature points and a trial-input
+`net(u_i)` resolves its own field, so no per-field bookkeeping is needed.
 
 Current scope: steady, transient, and steady-complex weak forms (linear k(x); nonlinear
-k(u)/k(∇u) on real steady/transient forms) on the native 2D/3D Lagrange assembler, single field.
-Not yet supported (each fails loud): networks inside Dirichlet/IC values, on the mass term,
-k(u) in complex forms, the complex transient, time-varying Dirichlet `g(x,t)` combined with a
-trainable net, coupled multi-field problems, 1D, and non-nodal
-(Argyris/Morley/Hermite/RT/Nédélec) elements.
+k(u)/k(∇u) on real steady/transient forms) on the native 2D/3D Lagrange assembler, single or
+coupled multi-field. Not yet supported (each fails loud): networks inside Dirichlet/IC values, on
+the mass term, k(u) in complex forms, the complex transient, time-varying Dirichlet `g(x,t)`
+combined with a trainable net, 1D domains (the 1D assembler has no runtime-parameter path at all),
+and non-nodal (Argyris/Morley/Hermite/RT/Nédélec) elements.
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -764,12 +764,19 @@ real-equivalent block solve stays differentiable in the weights. And a net coeff
 **coupled (multi-field)** form — it is evaluated at the shared quadrature points and a trial-input
 `net(u_i)` resolves its own field, so no per-field bookkeeping is needed.
 
-Current scope: steady, transient, and steady-complex weak forms (linear k(x); nonlinear
-k(u)/k(∇u) on real steady/transient forms) on the native 2D/3D Lagrange assembler, single or
-coupled multi-field. Not yet supported (each fails loud): networks inside Dirichlet/IC values, on
-the mass term, k(u) in complex forms, the complex transient, time-varying Dirichlet `g(x,t)`
-combined with a trainable net, 1D domains (the 1D assembler has no runtime-parameter path at all),
-and non-nodal (Argyris/Morley/Hermite/RT/Nédélec) elements.
+**Non-nodal C¹ elements.** A net coefficient — `k(x)` or a constitutive `k(u)` — also works on the
+scalar C¹ families (`space="Argyris"`/`"Morley"`/`"Hermite"`), e.g. a spatially varying or
+solution-dependent stiffness on a biharmonic plate: the network is evaluated at the quadrature
+points independently of the C¹ trial's DOF layout (the same property the P1 field parameter uses).
+The non-nodal path assembles a *dense* operator, so a parametric solve wants an explicit dense
+`solve_fn` — `fem.solve(lambda A, b: jnp.linalg.solve(A, b))`.
+
+Current scope: steady/transient/steady-complex on the native 2D/3D Lagrange assembler (single or
+coupled multi-field), and steady scalar C¹ non-nodal (Argyris/Morley/Hermite). Not yet supported
+(each fails loud): networks inside Dirichlet/IC values, on the mass term, k(u) in complex forms,
+the complex transient, time-varying Dirichlet `g(x,t)` with a trainable net, transient non-nodal,
+the vector edge families (RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter
+path at all).
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -764,19 +764,23 @@ real-equivalent block solve stays differentiable in the weights. And a net coeff
 **coupled (multi-field)** form — it is evaluated at the shared quadrature points and a trial-input
 `net(u_i)` resolves its own field, so no per-field bookkeeping is needed.
 
-**Non-nodal C¹ elements.** A net coefficient — `k(x)` or a constitutive `k(u)` — also works on the
+**Non-nodal elements.** A net coefficient — `k(x)` or a constitutive `k(u)` — also works on the
 scalar C¹ families (`space="Argyris"`/`"Morley"`/`"Hermite"`), e.g. a spatially varying or
 solution-dependent stiffness on a biharmonic plate: the network is evaluated at the quadrature
 points independently of the C¹ trial's DOF layout (the same property the P1 field parameter uses).
-The non-nodal path assembles a *dense* operator, so a parametric solve wants an explicit dense
+On the vector edge families (`"RT"`/`"N1E"`) a *scalar coordinate* `net(x)` coefficient works too (a
+spatially-varying permeability/permittivity multiplying a vector term); only a solution-dependent
+`net(u)` there is unsupported, since a vector-valued trial input to the network is undefined. The
+non-nodal path assembles a *dense* operator, so a parametric solve wants an explicit dense
 `solve_fn` — `fem.solve(lambda A, b: jnp.linalg.solve(A, b))`.
 
 Current scope: steady/transient/steady-complex on the native 2D/3D Lagrange assembler (single or
 coupled multi-field), and steady scalar C¹ non-nodal (Argyris/Morley/Hermite). Not yet supported
 (each fails loud): networks inside Dirichlet/IC values, a *trainable* net on the mass (`u_t`) term
 (a frozen/known one is fine — the mass is assembled once), k(u) in complex forms, the complex
-transient, time-varying Dirichlet `g(x,t)` with a trainable net, transient non-nodal, the vector
-edge families (RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter path at all).
+transient, time-varying Dirichlet `g(x,t)` with a trainable net, transient non-nodal,
+solution-dependent `net(u)` on the vector edge families (RT/Nédélec), and 1D domains (the 1D
+assembler has no runtime-parameter path at all).
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -752,10 +752,17 @@ coordinate-inputs can be mixed (`net(xi, yi, ui)`). Classification is automatic:
 arguments carry the unknown makes the form nonlinear — including a bare reaction term
 `net(u)*v` — while `net(x, y)` keeps the system linear(-parametric).
 
-Current scope: **steady** weak forms (linear k(x) and nonlinear k(u)/k(∇u)) on the native 2D/3D
-Lagrange assembler, single field. Not yet supported (each fails loud): networks inside
-Dirichlet/IC values, transient forms, `complex=True` forms, coupled multi-field problems, 1D, and
-non-nodal (Argyris/Morley/Hermite/RT/Nédélec) elements.
+**Transient forms** work the same way — the per-step operator (or the per-step Newton residual,
+for `net(u)`) re-evaluates the network, so a diffusivity or constitutive law is recovered from a
+`u(t)` trajectory exactly like the scalar/nodal transient inverse below. One exclusion: a
+*trainable* net on the mass (`u_t`) term is rejected (the mass matrix assembles once — the net
+would silently freeze; `.freeze()` it or keep it on spatial terms).
+
+Current scope: steady and transient weak forms (linear k(x) and nonlinear k(u)/k(∇u)) on the
+native 2D/3D Lagrange assembler, single field. Not yet supported (each fails loud): networks
+inside Dirichlet/IC values, on the mass term, `complex=True` forms, time-varying Dirichlet
+`g(x,t)` combined with a trainable net, coupled multi-field problems, 1D, and non-nodal
+(Argyris/Morley/Hermite/RT/Nédélec) elements.
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -754,9 +754,11 @@ arguments carry the unknown makes the form nonlinear — including a bare reacti
 
 **Transient forms** work the same way — the per-step operator (or the per-step Newton residual,
 for `net(u)`) re-evaluates the network, so a diffusivity or constitutive law is recovered from a
-`u(t)` trajectory exactly like the scalar/nodal transient inverse below. One exclusion: a
-*trainable* net on the mass (`u_t`) term is rejected (the mass matrix assembles once — the net
-would silently freeze; `.freeze()` it or keep it on spatial terms).
+`u(t)` trajectory exactly like the scalar/nodal transient inverse below. A coordinate `net(x)` on
+the **mass** (`u_t`) term is supported too — an unknown density `ρ(x)·u_t` recovered from a decay
+trajectory: the mass becomes a parametric matrix re-assembled from the weights each step. Only a
+*solution-dependent* `net(u)` on the mass term is rejected — that is a nonlinear mass `C(u)·u_t`,
+which the semidiscrete matrix form cannot express (a frozen net on the mass is always fine).
 
 A real coordinate-input net also composes with **complex** steady forms (a Helmholtz coefficient
 recovered from complex full-field data): the Re/Im legs assemble as parametric systems and the
@@ -776,11 +778,10 @@ non-nodal path assembles a *dense* operator, so a parametric solve wants an expl
 
 Current scope: steady/transient/steady-complex on the native 2D/3D Lagrange assembler (single or
 coupled multi-field), and steady scalar C¹ non-nodal (Argyris/Morley/Hermite). Not yet supported
-(each fails loud): networks inside Dirichlet/IC values, a *trainable* net on the mass (`u_t`) term
-(a frozen/known one is fine — the mass is assembled once), k(u) in complex forms, the complex
-transient, time-varying Dirichlet `g(x,t)` with a trainable net, solution-dependent `net(u)` on
-the vector edge families (RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter
-path at all).
+(each fails loud): networks inside Dirichlet/IC values, solution-dependent `net(u)` on the mass
+(`u_t`) term (a nonlinear mass), k(u) in complex forms, the complex transient, time-varying
+Dirichlet `g(x,t)` with a trainable net, solution-dependent `net(u)` on the vector edge families
+(RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter path at all).
 
 ### Transient inverse
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -778,9 +778,9 @@ Current scope: steady/transient/steady-complex on the native 2D/3D Lagrange asse
 coupled multi-field), and steady scalar C¹ non-nodal (Argyris/Morley/Hermite). Not yet supported
 (each fails loud): networks inside Dirichlet/IC values, a *trainable* net on the mass (`u_t`) term
 (a frozen/known one is fine — the mass is assembled once), k(u) in complex forms, the complex
-transient, time-varying Dirichlet `g(x,t)` with a trainable net, transient non-nodal,
-solution-dependent `net(u)` on the vector edge families (RT/Nédélec), and 1D domains (the 1D
-assembler has no runtime-parameter path at all).
+transient, time-varying Dirichlet `g(x,t)` with a trainable net, solution-dependent `net(u)` on
+the vector edge families (RT/Nédélec), and 1D domains (the 1D assembler has no runtime-parameter
+path at all).
 
 ### Transient inverse
 

--- a/docs/tutorial_examples/08_fem_and_varpinns/inverse_neural_diffusivity_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/inverse_neural_diffusivity_2d.py
@@ -15,14 +15,21 @@ setting of NN-EUCLID (Flaschel, Kumar, De Lorenzis, J. Mech. Phys. Solids 165 (2
 §2.2-2.3) and Tartakovsky et al. (Water Resour. Res. 56, 2020, §2).
 """
 
-import foundax
-import jax
-import jax.numpy as jnp
-import numpy as np
-import optax
-from shapely.geometry import box
+import os
 
-import jno
+os.environ["JAX_PLATFORMS"] = "cpu"  # differentiable inverse solve: run on CPU (no GPU contention/OOM)
+
+import jax  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)  # FEM assembly / solves are float64
+
+import foundax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import optax  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
 
 d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.1)
 u, phi = d.fem_symbols()

--- a/docs/tutorial_examples/08_fem_and_varpinns/inverse_neural_diffusivity_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/inverse_neural_diffusivity_2d.py
@@ -1,0 +1,63 @@
+"""Inverse problem: recover a hidden diffusivity k(x) with a NEURAL coefficient.
+
+    Forward:  -div(k(x) grad u) = f,   u = 0 on the boundary,   with unknown k(x) > 0.
+
+Same identification problem as the nodal-field tutorial (``inverse_diffusivity_field.py``), but
+the unknown is parametrised by a coordinate MLP instead of one value per mesh node:
+``k(x, y) = 1 + net(x, y)`` written directly into the weak form. The network is a trainable
+*coefficient* on an assembled FE system — the kernel re-evaluates it at the quadrature points on
+every re-assembly, and ``crux`` trains the weights through the differentiable ``fem.solve()``.
+
+Why prefer a net over a nodal field? The parametrisation is mesh-independent (remeshing never
+touches the weights), smooth by architecture (no explicit H1 prior needed here), and it extends
+to constitutive laws ``net(u)`` / ``net(∇u)``. This is the unsupervised coefficient-recovery
+setting of NN-EUCLID (Flaschel, Kumar, De Lorenzis, J. Mech. Phys. Solids 165 (2022) 105076,
+§2.2-2.3) and Tartakovsky et al. (Water Resour. Res. 56, 2020, §2).
+"""
+
+import foundax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from shapely.geometry import box
+
+import jno
+
+d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.1)
+u, phi = d.fem_symbols()
+xi, yi, _ = d.variable("interior", split=True)
+xb, yb, _ = d.variable("boundary", split=True)
+ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+f = 30.0 * (xi * (1 - xi) + yi * (1 - yi))  # strong source so u is sensitive to k
+
+# Hidden truth: background + a smooth high-diffusivity inclusion.
+k_true_expr = 1.0 + 0.8 * jno.np.exp(-((xi - 0.5) ** 2 + (yi - 0.5) ** 2) / (2 * 0.18**2))
+fem_ref = jno.fem([k_true_expr * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+A_true = fem_ref.A.todense() if hasattr(fem_ref.A, "todense") else jnp.asarray(fem_ref.A)
+u_obs = jnp.linalg.solve(A_true, jnp.asarray(fem_ref.b).reshape(-1))  # clean full-field data
+
+# The unknown coefficient: k = 1 + net(x, y). The offset keeps A nonsingular at the
+# (near-zero) net init — the same practice as starting a nodal field at k = 1.
+net = jno.nn.wrap(foundax.mlp(2, hidden_dims=32, num_layers=2, activation=jax.nn.tanh, key=jax.random.PRNGKey(0)))
+net.dtype(jnp.float64)  # match the float64 assembly
+net.optimizer(optax.adam(2e-2))
+
+fem = jno.fem([(1.0 + net(xi, yi)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+crux = jno.core(
+    [(fem.solve() - u_obs).mse],  # no explicit prior: the architecture regularises
+    domain=jno.domain.from_array({"_": np.zeros((1, 1))}),
+)
+crux.solve(2500)
+
+# Verify the TRAINED network itself against the hidden truth on the mesh nodes.
+trained = crux.eval([jno.trace.ModelWeights(net)])  # the trained module (current weights)
+nodes = np.asarray(d.built_mesh.points)[:, :2]
+k_rec = 1.0 + np.asarray(trained(jnp.asarray(nodes))).reshape(-1)
+k_true = 1.0 + 0.8 * np.exp(-((nodes[:, 0] - 0.5) ** 2 + (nodes[:, 1] - 0.5) ** 2) / (2 * 0.18**2))
+rel = float(np.linalg.norm(k_rec - k_true) / np.linalg.norm(k_true))
+print(
+    f"\nInverse neural diffusivity: nodes={len(k_true)}  k(x) rel_L2={rel:.3e}  "
+    f"peak rec/true={k_rec.max():.3f}/{k_true.max():.3f}"
+)
+assert rel < 0.1

--- a/docs/tutorial_examples/08_fem_and_varpinns/learn_constitutive_law_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/learn_constitutive_law_2d.py
@@ -1,0 +1,84 @@
+"""Inverse problem: learn a nonlinear constitutive law k(T) from a measured field (NN-EUCLID style).
+
+    Forward:  -div(k(T) grad T) = f,   T = 0 on the boundary,   with unknown law k(T) > 0.
+
+Here the unknown is *not* a spatial map k(x) but a **material law**: the conductivity depends on
+the solution itself, ``k = k(T)`` (temperature-dependent conduction). A network takes the trial
+value as its input, so the weak form is nonlinear in the unknown and ``jno.fem`` routes it to the
+matrix-free Newton path automatically; the network's T-dependence enters the element Jacobians
+through per-element forward AD. Physical positivity of the conductivity is enforced *by the
+architecture* — a softplus output, ``k(T) = softplus(net(T)) > 0`` — so the operator can never go
+indefinite during training (the same idea as input-convex nets for hyperelastic potentials).
+Training the weights through the differentiable solve recovers the law from a single observed
+temperature field, with no stress/flux labels — the unsupervised constitutive-learning setting of
+NN-EUCLID (M. Flaschel, S. Kumar, L. De Lorenzis, J. Mech. Phys. Solids 165 (2022) 105076,
+§2.2-2.3; A. Tartakovsky et al., Water Resour. Res. 56 (2020), §2).
+
+Unlike a spatial map, a learned law k(T) is *transferable*: reuse it on any geometry or load.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"  # heavy per-step Newton inverse: run on CPU (no GPU contention/OOM)
+
+import jax  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)  # FEM assembly / solves are float64
+
+import foundax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import optax  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+from jno.utils.solver.newton_krylov import newton_krylov  # noqa: E402
+
+PI = np.pi
+
+d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.1)
+u, phi = d.fem_symbols()  # ``u`` is the temperature field T
+xi, yi, _ = d.variable("interior", split=True)
+xb, yb, _ = d.variable("boundary", split=True)
+ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+f = 12.0 * jno.np.sin(PI * xi) * jno.np.sin(PI * yi)  # heat source (drives a wide T-range)
+
+
+# Hidden truth: conductivity rises with temperature, k(T) = 1 + 0.6 T^2. Generate the observed
+# field by solving the (nonlinear) forward problem written symbolically.
+def k_true(T):
+    return 1.0 + 0.6 * T**2
+
+
+fem_ref = jno.fem([k_true(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+T_obs = newton_krylov(lambda w: fem_ref.operator(w), jnp.zeros(fem_ref.operator.size))
+T_max = float(jnp.max(T_obs))
+
+# The unknown law: k(T) = softplus(net(T)). A 1-input MLP; the softplus output guarantees k > 0
+# (so the operator stays positive-definite for *any* weights the optimiser visits) and gives a
+# nonsingular k = softplus(0) ~ 0.69 at the near-zero network init.
+net = jno.nn.wrap(foundax.mlp(1, hidden_dims=32, num_layers=2, activation=jax.nn.tanh, key=jax.random.PRNGKey(0)))
+net.dtype(jnp.float64)
+net.optimizer(optax.adam(5e-3))
+
+
+def k_model(T):
+    return jno.np.log1p(jno.np.exp(net(T)))  # softplus(net(T)) > 0
+
+
+fem = jno.fem([k_model(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+crux = jno.core([(fem.solve() - T_obs).mse], domain=jno.domain.from_array({"_": np.zeros((1, 1))}))
+crux.solve(1500)
+
+# Verify the LEARNED law against the truth over the observed temperature range [0, T_max]:
+# the net only sees k(T) where T was actually sampled, so we score it there.
+trained = crux.eval([jno.trace.ModelWeights(net)])
+T_grid = jnp.linspace(0.0, T_max, 100).reshape(-1, 1)
+k_learned = np.asarray(jnp.log1p(jnp.exp(trained(T_grid)))).reshape(-1)  # softplus(net) on the grid
+k_ref = np.asarray(k_true(T_grid)).reshape(-1)
+rel = float(np.linalg.norm(k_learned - k_ref) / np.linalg.norm(k_ref))
+print(
+    f"\nLearned constitutive law k(T): T_range=[0, {T_max:.3f}]  "
+    f"rel_L2={rel:.3e}  k(T_max) learned/true = {k_learned[-1]:.3f}/{k_ref[-1]:.3f}"
+)
+assert rel < 0.05

--- a/docs/tutorials/08-fem-and-varpinns/inverse-neural-diffusivity-2d.md
+++ b/docs/tutorials/08-fem-and-varpinns/inverse-neural-diffusivity-2d.md
@@ -1,0 +1,56 @@
+# Inverse: Recover a Diffusivity Field with a Neural Coefficient
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO/tutorial_examples/08_fem_and_varpinns/inverse_neural_diffusivity_2d.py" download>Download .py</a>
+<a class="md-button" href="/jNO/tutorials/08-fem-and-varpinns/">Back to chapter</a>
+</div>
+
+The same identification problem as the [nodal-field tutorial](inverse-diffusivity-field.md) —
+recover the hidden diffusivity $k(x)$ in $-\nabla\!\cdot(k\nabla u)=f$ from the measured
+response — but the unknown is a **network**, written straight into the weak form:
+$k(x,y) = 1 + \mathrm{net}(x,y)$. The system assembles as usual; the kernel re-evaluates the
+network at the quadrature points on every re-assembly, and `crux` trains the weights through the
+differentiable `fem.solve()`.
+
+## A neural coefficient instead of a nodal field
+
+```python
+net = jno.nn.wrap(foundax.mlp(2, hidden_dims=32, num_layers=2,
+                              activation=jax.nn.tanh, key=key))
+net.dtype(jnp.float64)                        # match the f64 assembly
+net.optimizer(optax.adam(2e-2))
+
+fem = jno.fem([(1.0 + net(xi, yi)) * (ui.x * vi.x + ui.y * vi.y) - f * vi,
+               u(xb, yb) - 0.0], quad_degree=3)
+crux = jno.core([(fem.solve() - u_obs).mse], domain=obs)   # no explicit prior needed
+crux.solve(2500)
+trained = crux.eval([jno.trace.ModelWeights(net)])          # the trained module
+```
+
+## What to notice
+
+- **No new API**: calling `jno.nn.wrap(net)` inside the weak form *is* the feature. The weak
+  form's real FE trial makes the network a coefficient (a network written *in place of* the
+  trial would be a VPINN).
+- **Mesh-independent**: the unknown lives in the weights, not on the mesh — remeshing (or the
+  adaptive loop) never touches the parametrisation, unlike `jno.np.parameter(phi)`.
+- **Architecture as prior**: the nodal-field version needs an explicit
+  `k.regularize("h1seminorm")`; here the MLP's smoothness bias regularises by itself — the
+  Gaussian inclusion is recovered to rel-$L^2 \approx 5\times 10^{-2}$.
+- The `1 +` offset keeps the operator nonsingular at the (near-zero) network init — the same
+  practice as starting a nodal field at $k=1$.
+- The same mechanism trains **constitutive laws** `net(u)` / `net(∇u)` (the form then routes to
+  the Newton path automatically) — see the neural-coefficients section of the
+  [FEM guide](../../fem.md).
+
+This is the unsupervised coefficient/constitutive-recovery setting of NN-EUCLID
+(M. Flaschel, S. Kumar, L. De Lorenzis, *NN-EUCLID: Deep-learning hyperelasticity without
+stress data*, J. Mech. Phys. Solids 165 (2022) 105076, §2.2–2.3) and A. Tartakovsky et al.,
+*Learning Parameters and Constitutive Relationships with Physics-Informed Deep Neural
+Networks* (Water Resour. Res. 56, 2020, §2).
+
+## Full script
+
+```python
+--8<-- "tutorial_examples/08_fem_and_varpinns/inverse_neural_diffusivity_2d.py"
+```

--- a/docs/tutorials/08-fem-and-varpinns/learn-constitutive-law-2d.md
+++ b/docs/tutorials/08-fem-and-varpinns/learn-constitutive-law-2d.md
@@ -1,0 +1,57 @@
+# Learn a Nonlinear Constitutive Law $k(T)$ (NN-EUCLID style)
+
+<div class="hero-actions" markdown>
+<a class="md-button md-button--primary" href="/jNO/tutorial_examples/08_fem_and_varpinns/learn_constitutive_law_2d.py" download>Download .py</a>
+<a class="md-button" href="/jNO/tutorials/08-fem-and-varpinns/">Back to chapter</a>
+</div>
+
+The [neural-diffusivity tutorial](inverse-neural-diffusivity-2d.md) recovered a spatial map
+$k(x)$. Here the unknown is a **material law**: the conductivity depends on the *solution itself*,
+$k=k(T)$ (temperature-dependent conduction in $-\nabla\!\cdot(k(T)\nabla T)=f$). A network takes
+the trial value as its input, so the weak form is **nonlinear in the unknown** — `jno.fem` routes
+it to the matrix-free Newton path automatically, and the network's $T$-dependence enters the
+element Jacobians through per-element forward AD. Training recovers the law from a single measured
+field, with no flux/stress labels: the unsupervised constitutive-learning setting of NN-EUCLID.
+
+## Positivity by construction
+
+A conductivity must be positive, or the operator goes indefinite and Newton diverges. Rather than
+police that with a penalty, enforce it **in the architecture** — a softplus output,
+$k(T)=\mathrm{softplus}(\mathrm{net}(T))>0$ for any weights the optimiser visits (the same idea as
+input-convex networks for hyperelastic potentials):
+
+```python
+net = jno.nn.wrap(foundax.mlp(1, hidden_dims=32, num_layers=2,
+                              activation=jax.nn.tanh, key=key)).dtype(jnp.float64)
+
+def k_model(T):
+    return jno.np.log1p(jno.np.exp(net(T)))          # softplus(net(T)) > 0
+
+fem = jno.fem([k_model(ui) * (ui.x*vi.x + ui.y*vi.y) - f*vi, u(xb, yb) - 0.0])
+crux = jno.core([(fem.solve() - T_obs).mse], domain=obs).solve(1500)
+```
+
+Because `k_model(ui)` feeds the trial `ui` into the network, `jno.fem` classifies the form
+nonlinear and solves it with per-step Newton; the gradient to the weights flows through the
+`custom_root` implicit differentiation without unrolling the Newton iterations.
+
+## What to notice
+
+- The unknown is a **function of the state**, not of position — impossible to express as a nodal
+  field `jno.np.parameter(phi)`. A learned law $k(T)$ is also *transferable*: reuse it on any
+  geometry or load.
+- **Score on the observed range**: the network only sees $k(T)$ where $T$ was actually sampled, so
+  the recovered law is verified on $[0, T_{\max}]$ (rel-$L^2\approx 2\times 10^{-2}$).
+- Heavy per-step Newton inverse ⇒ the script pins `JAX_PLATFORMS=cpu` and enables `x64` at the top
+  (the differentiable nonlinear solve is float64 and CPU avoids GPU-memory contention).
+
+Reference: M. Flaschel, S. Kumar, L. De Lorenzis, *NN-EUCLID: Deep-learning hyperelasticity without
+stress data*, J. Mech. Phys. Solids 165 (2022) 105076, §2.2–2.3; A. Tartakovsky et al., *Learning
+Parameters and Constitutive Relationships with Physics-Informed Deep Neural Networks*, Water
+Resour. Res. 56 (2020), §2.
+
+## Full script
+
+```python
+--8<-- "tutorial_examples/08_fem_and_varpinns/learn_constitutive_law_2d.py"
+```

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -2457,7 +2457,11 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
         # rejected: the complex-transient branch unpacks eager (A, b) legs (a parametric leg cannot
         # ride it), and a solution-dependent net makes the legs nonlinear (no complex Newton block).
         if is_transient:
-            raise NotImplementedError("jno.fem: a neural coefficient in a complex *transient* form is not supported yet.")
+            raise NotImplementedError(
+                "jno.fem: a neural coefficient in a complex *transient* form is not supported — the "
+                "complex-transient path has no parametric/inverse route at all (it integrates fixed "
+                "real-equivalent blocks with no runtime args), so this needs that infrastructure built first."
+            )
         from .utils.solver.weak_form import _is_obviously_nonlinear_in_unknown as _nlin_cx
 
         if any(_nlin_cx(domain, b) for b in weak_bares):

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -2385,9 +2385,15 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
             # parameter k(x). A time-varying Dirichlet g(x,t) routes native only for the LINEAR,
             # non-parametric transient (the row-replacement + per-step Dirichlet-lift forcing path);
             # combined with a runtime parameter or a nonlinear residual it is rejected below.
+            from .utils.solver.parametric_helpers import _collect_neural_coefficient_exprs as _cnce
             from .utils.solver.weak_form import _is_obviously_nonlinear_in_unknown as _nlin
 
-            _native_now = not any(_crp(b) for b in weak_bares) and not any(_nlin(domain, b) for b in weak_bares)
+            _native_now = (
+                not any(_crp(b) for b in weak_bares)
+                and not any(_nlin(domain, b) for b in weak_bares)
+                # tv-Dirichlet g(x,t) + a TRAINABLE net: rejected below (frozen nets stay native)
+                and not any(_cnce(b) for b in weak_bares)
+            )
         if _native_now:
             from .utils.solver.fem_native import assemble_fem_native
 

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -2072,14 +2072,20 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
                 "runtime-parameter path at all (scalar and field parameters are unsupported there too)."
             )
         # Non-nodal: the scalar C¹ families (Argyris/Morley/Hermite) thread the network at the quad points
-        # like their P1 field parameter; the vector edge families (RT/Nédélec) are not wired (a net(u) with a
-        # vector-valued trial input is undefined here).
+        # like their P1 field parameter. The vector edge families (RT/Nédélec) accept a *scalar coordinate*
+        # net(x) coefficient (a spatially-varying permeability/permittivity multiplying a vector term), but
+        # a *solution-dependent* net(u) there would feed the vector-valued trial into the network, which is
+        # undefined — reject only that.
         _nonnodal_spaces = _trial_spaces(constraints) - {"Lagrange", "Argyris", "Morley", "Hermite"}
         if _nonnodal_spaces:
-            raise NotImplementedError(
-                "jno.fem: neural coefficients on non-nodal elements are supported on the scalar C¹ families "
-                f"(Argyris/Morley/Hermite) only; not the vector edge families {sorted(_nonnodal_spaces)} (RT/Nédélec)."
-            )
+            from .utils.solver.weak_form import _is_obviously_nonlinear_in_unknown as _nlin_nn
+
+            if any(_contains_network_call(c) and _nlin_nn(domain, _bare(c)) for c in constraints):
+                raise NotImplementedError(
+                    "jno.fem: a solution-dependent neural coefficient net(u) on the vector edge families "
+                    f"(RT/Nédélec, {sorted(_nonnodal_spaces)}) is not supported — a vector-valued trial input to the "
+                    "network is undefined. A scalar coordinate net(x) coefficient is supported."
+                )
 
     multifield = len(_field_keys(constraints)) > 1
     if vec is None and not multifield:

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -189,11 +189,15 @@ def _contains(constraint: Any, cls) -> bool:
     return contains_node_type(_bare(constraint), cls)
 
 
-def _contains_network_trial(constraint: Any) -> bool:
-    """True if a constraint embeds a *network* ModelCall (e.g. ``u = net(x, y)``) — the VPINN signal.
+def _contains_network_call(constraint: Any) -> bool:
+    """True if a constraint embeds a *network* ModelCall (``jno.nn.wrap(net)(...)``).
 
-    Excludes zero-arg runtime parameters (``jno.np.parameter(...)``, scalar or FEM field): a weak form with a
-    trainable *coefficient* parameter is an ordinary (runtime-parametric) FE system, not a network-trial VPINN."""
+    Excludes zero-arg runtime parameters (``jno.np.parameter(...)``, scalar or FEM field). A network
+    in a weak form plays one of two roles, disambiguated at the constraint-*set* level (see the
+    ``is_vpinn`` routing in :func:`fem`): it *replaces* the trial (``u = net(x, y)`` — the VPINN
+    signal; no ``TrialFunction`` appears in any weak constraint) or it is a *coefficient*
+    multiplying a genuine trial (``net(x, y) * u.dx * v.dx`` — an assembled, runtime-parametric FE
+    system whose kernel re-evaluates the network at the quadrature points)."""
     from .utils.solver.parametric_helpers import _is_runtime_scalar_parameter
 
     return any(isinstance(n, ModelCall) and not _is_runtime_scalar_parameter(n) for n in _walk(_bare(constraint)))
@@ -2039,10 +2043,36 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
             "normal-derivative DOF)."
         )
 
-    # VPINN: a network trial (``u = net(x, y)`` written into the weak form) makes jno.fem
-    # test-project the weak form onto the FE test space -> a trainable residual loss, not an FE
-    # system. Detected by a ModelCall; lowered after the shared quadrature setup (see below).
-    is_vpinn = any(_contains_network_trial(c) for c in constraints)
+    # A network ModelCall in the constraints plays one of two roles, decided at the SET level:
+    #   * VPINN — the network *replaces* the trial (``u = net(x, y)`` written into the weak form):
+    #     no weak (test-carrying) constraint contains a TrialFunction. jno.fem test-projects the
+    #     weak form onto the FE test space -> a trainable residual loss, not an FE system.
+    #   * neural COEFFICIENT — the network multiplies a genuine trial (``net(x,y)*u.dx*v.dx``):
+    #     some weak constraint carries the TrialFunction. The system is assembled as usual and the
+    #     kernel re-evaluates the network at the quadrature points (trainable via the runtime args).
+    _has_network = any(_contains_network_call(c) for c in constraints)
+    _weak_has_real_trial = any(_contains(c, TestFunction) and _contains(c, TrialFunction) for c in constraints)
+    is_vpinn = _has_network and not _weak_has_real_trial
+    has_neural_coeff = _has_network and not is_vpinn
+
+    if has_neural_coeff:
+        # v1 scope for neural coefficients: weak-form (volume/surface integrand) coefficients on the
+        # native 2D/3D Lagrange assembler. Fail loud on everything else rather than mis-assemble.
+        if any(
+            _contains(c, TrialFunction) and not _contains(c, TestFunction) and _contains_network_call(c)
+            for c in constraints
+        ):
+            raise NotImplementedError(
+                "jno.fem: a network inside a Dirichlet/IC value expression (a trial-only constraint) is "
+                "not supported — neural coefficients are weak-form integrand coefficients only."
+            )
+        if getattr(domain, "dimension", None) == 1:
+            raise NotImplementedError("jno.fem: neural coefficients are supported on 2D/3D domains only (no 1D yet).")
+        if _trial_spaces(constraints) - {"Lagrange"}:
+            raise NotImplementedError(
+                "jno.fem: neural coefficients are supported on Lagrange elements only (no non-nodal "
+                "Argyris/Morley/Hermite/RT/Nédélec spaces yet)."
+            )
 
     multifield = len(_field_keys(constraints)) > 1
     if vec is None and not multifield:
@@ -2372,6 +2402,11 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
     # ``.imag`` gives two ordinary real systems A_r/b_r and A_i/b_i; FEM.solve() forms
     # ``[[A_r, -A_i], [A_i, A_r]]`` and recombines to a complex ``u``. A complex *inverse* (runtime
     # parameter) and the complex *transient* (Schrodinger) path are handled separately below. ----
+    if has_neural_coeff and _is_complex_form(domain, ir):
+        raise NotImplementedError(
+            "jno.fem: a neural coefficient in a complex (complex=True) weak form is not supported yet."
+        )
+
     if (
         not is_vpinn
         and _is_complex_form(domain, ir)

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -797,7 +797,22 @@ def _dirichlet_spec(bare: Any) -> Tuple[Optional[int], Any, Any]:
     ``value_node`` is the raw expression (kept so the transient route can detect/evaluate a
     time-varying ``g(x,t)``)."""
     comp, value_node = _essential_spec(bare)
+    if _is_bare_neural_value_node(value_node):
+        # A trainable BC profile ``u(region) - net(x)``: keep the net node raw and leave ``value`` as a
+        # sentinel -- the native parametric path evaluates ``net(boundary_coords)`` from the runtime args
+        # each solve (``_value_from_node`` would build a stored-weights closure, non-differentiable).
+        return comp, None, value_node
     return comp, _value_from_node(value_node), value_node
+
+
+def _is_bare_neural_value_node(value_node: Any) -> bool:
+    """True if a Dirichlet value node is a *bare* neural coefficient ``net(x)`` (a trainable BC profile).
+
+    Only a bare network call is supported as a trainable Dirichlet value; a compound expression such as
+    ``1 + net(x)`` is rejected up front (it would need a general args-aware value evaluator)."""
+    from .utils.solver.parametric_helpers import _is_neural_coefficient
+
+    return _is_neural_coefficient(_bare(value_node)) if value_node is not None else False
 
 
 def _normal_flux_spec(constraint: Any, domain: Any) -> Optional[Tuple[Any, str, Any]]:
@@ -2056,16 +2071,30 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
     has_neural_coeff = _has_network and not is_vpinn
 
     if has_neural_coeff:
-        # v1 scope for neural coefficients: weak-form (volume/surface integrand) coefficients on the
-        # native 2D/3D Lagrange assembler. Fail loud on everything else rather than mis-assemble.
-        if any(
-            _contains(c, TrialFunction) and not _contains(c, TestFunction) and _contains_network_call(c)
+        # A network in a trial-only (essential) constraint is a trainable *Dirichlet value*
+        # ``u(region) - net(x)`` (an unknown boundary profile), NOT an integrand coefficient. It is
+        # supported as a *bare* net on a boundary region, native Lagrange single-field (the parametric
+        # path evaluates ``net(boundary_coords)`` from the runtime args each solve). Everything else --
+        # a compound value ``1+net(x)``, an initial-condition value, non-nodal or multifield -- is rejected.
+        _net_trial_only = [
+            c
             for c in constraints
-        ):
-            raise NotImplementedError(
-                "jno.fem: a network inside a Dirichlet/IC value expression (a trial-only constraint) is "
-                "not supported — neural coefficients are weak-form integrand coefficients only."
-            )
+            if _contains(c, TrialFunction) and not _contains(c, TestFunction) and _contains_network_call(c)
+        ]
+        for c in _net_trial_only:
+            support, _rg = _region_and_support(c, domain)
+            _comp, _val, _vnode = _dirichlet_spec(_bare(c))
+            if support != "boundary" or not _is_bare_neural_value_node(_vnode):
+                raise NotImplementedError(
+                    "jno.fem: a network in an essential (trial-only) constraint must be a *bare* Dirichlet "
+                    "value net(x) on a boundary region — a compound expression (e.g. 1 + net(x)) or an "
+                    "initial-condition value is not supported."
+                )
+        if _net_trial_only:
+            if _trial_spaces(constraints) - {"Lagrange"}:
+                raise NotImplementedError("jno.fem: a net-valued Dirichlet is supported on Lagrange elements only.")
+            if len(_field_keys(constraints)) > 1:
+                raise NotImplementedError("jno.fem: a net-valued Dirichlet is single-field only.")
         if getattr(domain, "dimension", None) == 1:
             raise NotImplementedError(
                 "jno.fem: neural coefficients are not supported on 1D domains — the native 1D assembler has no "

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -2067,11 +2067,18 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
                 "not supported — neural coefficients are weak-form integrand coefficients only."
             )
         if getattr(domain, "dimension", None) == 1:
-            raise NotImplementedError("jno.fem: neural coefficients are supported on 2D/3D domains only (no 1D yet).")
-        if _trial_spaces(constraints) - {"Lagrange"}:
             raise NotImplementedError(
-                "jno.fem: neural coefficients are supported on Lagrange elements only (no non-nodal "
-                "Argyris/Morley/Hermite/RT/Nédélec spaces yet)."
+                "jno.fem: neural coefficients are not supported on 1D domains — the native 1D assembler has no "
+                "runtime-parameter path at all (scalar and field parameters are unsupported there too)."
+            )
+        # Non-nodal: the scalar C¹ families (Argyris/Morley/Hermite) thread the network at the quad points
+        # like their P1 field parameter; the vector edge families (RT/Nédélec) are not wired (a net(u) with a
+        # vector-valued trial input is undefined here).
+        _nonnodal_spaces = _trial_spaces(constraints) - {"Lagrange", "Argyris", "Morley", "Hermite"}
+        if _nonnodal_spaces:
+            raise NotImplementedError(
+                "jno.fem: neural coefficients on non-nodal elements are supported on the scalar C¹ families "
+                f"(Argyris/Morley/Hermite) only; not the vector edge families {sorted(_nonnodal_spaces)} (RT/Nédélec)."
             )
 
     multifield = len(_field_keys(constraints)) > 1

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -2409,9 +2409,20 @@ def fem(constraints: Any, *, quad_degree: int = 2, element_type: Optional[str] =
     # ``[[A_r, -A_i], [A_i, A_r]]`` and recombines to a complex ``u``. A complex *inverse* (runtime
     # parameter) and the complex *transient* (Schrodinger) path are handled separately below. ----
     if has_neural_coeff and _is_complex_form(domain, ir):
-        raise NotImplementedError(
-            "jno.fem: a neural coefficient in a complex (complex=True) weak form is not supported yet."
-        )
+        # A real coordinate-input net in a steady complex form is fine — each Re/Im leg assembles as
+        # a parametric FemLinearSystem and _solve_complex_block builds the differentiable trace node,
+        # exactly like the scalar complex inverse. The two compositions that would mis-assemble stay
+        # rejected: the complex-transient branch unpacks eager (A, b) legs (a parametric leg cannot
+        # ride it), and a solution-dependent net makes the legs nonlinear (no complex Newton block).
+        if is_transient:
+            raise NotImplementedError("jno.fem: a neural coefficient in a complex *transient* form is not supported yet.")
+        from .utils.solver.weak_form import _is_obviously_nonlinear_in_unknown as _nlin_cx
+
+        if any(_nlin_cx(domain, b) for b in weak_bares):
+            raise NotImplementedError(
+                "jno.fem: a solution-dependent neural coefficient (net(u)/net(∇u)) in a complex form "
+                "is not supported yet — complex forms assemble as linear real-equivalent blocks."
+            )
 
     if (
         not is_vpinn

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -3122,6 +3122,30 @@ class FemResidualOperator:
         )
 
 
+class ModelWeights(Placeholder):
+    """Evaluates to a :class:`Model`'s *current* equinox module (the live weight pytree).
+
+    A neural **coefficient** in an assembled FEM system (``jno.nn.wrap(net)`` called inside a weak
+    form, e.g. ``net(x, y) * u.dx * v.dx``) must reach the assembly kernel as its *weights*, not as
+    a call result: the kernel re-evaluates the network at the quadrature points itself, so the
+    solver needs the module pytree in its runtime ``args``. ``FemLinearSystem.solve`` (and the
+    nonlinear/transient counterparts) put a ``ModelWeights`` node in the ``fem_solve``
+    FunctionCall's params where a scalar parameter would put its zero-arg ``ModelCall``; the trace
+    evaluator resolves it to ``params[layer_id]`` — the trainable module crux recombines each step
+    — so gradients flow from the solve back into the network's weights.
+    """
+
+    def __init__(self, model: Model):
+        self.model = model
+        # ``target`` lets generic model-discovery walks (e.g. core's active-model scan, which
+        # falls back to ``.target``) reach the underlying Model without a dedicated branch.
+        self.target = model
+        self.op_id = _next_op_id()
+
+    def __repr__(self):
+        return f"ModelWeights({self.model})"
+
+
 class StateField(Placeholder):
     """Internal marker for the primary weak-form unknown.
 

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -3323,9 +3323,9 @@ class FrozenField(Placeholder):
         self.order = int(getattr(source, "order", 1))
         self.space = str(getattr(source, "space", "Lagrange"))
         self.op_id = _next_op_id()
-        self.field_key = source.field_key            # share the source field's shape data
+        self.field_key = source.field_key  # share the source field's shape data
         self.values = jnp.asarray(values).reshape(-1)  # global nodal vector (scalar field)
-        self.frozen_id = _next_op_id()               # kernel gather-table key
+        self.frozen_id = _next_op_id()  # kernel gather-table key
 
     @property
     def num_components(self) -> int:

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -3304,6 +3304,53 @@ class TrialFunction(Placeholder):
         return f"TrialFunction({self.name}, value_shape={self.value_shape})"
 
 
+class FrozenField(Placeholder):
+    """A field whose DOFs are *pinned* to a known nodal vector ``values`` (e.g. a
+    precomputed FE solution), produced by ``u.bind(...).freeze(values)``.
+
+    It carries the source field's identity (``field_key`` / ``value_shape`` / ``order``
+    / ``space``) so the kernel finds the right basis, and interpolates ``values`` at the
+    quadrature points -- its value and its gradient ``.x`` / ``.y`` are therefore concrete
+    KNOWN data. Because it is **not** a ``TrialFunction``, it is invisible to the
+    unknown-detection that routes nonlinear solves: a term like
+    ``softplus(net(xi, yi, ui.freeze(u0).x, ui.freeze(u0).y)) * (grad u . grad v)``
+    stays LINEAR in the true unknown ``u`` while conditioning the coefficient on the
+    known field ``u0`` (a predictor-corrector). No gradient flows into ``values``."""
+
+    def __init__(self, source, values):
+        self.name = f"frozen[{getattr(source, 'name', 'u')}]"
+        self.value_shape = tuple(getattr(source, "value_shape", ()))
+        self.order = int(getattr(source, "order", 1))
+        self.space = str(getattr(source, "space", "Lagrange"))
+        self.op_id = _next_op_id()
+        self.field_key = source.field_key            # share the source field's shape data
+        self.values = jnp.asarray(values).reshape(-1)  # global nodal vector (scalar field)
+        self.frozen_id = _next_op_id()               # kernel gather-table key
+
+    @property
+    def num_components(self) -> int:
+        n = 1
+        for s in self.value_shape:
+            n *= int(s)
+        return n
+
+    def _field_view(self):
+        n = len(self.value_shape)
+        if n == 0:
+            return self.scalar
+        if n == 1:
+            return self.vector
+        return self.matrix
+
+    def partials(self, **named_vars):
+        return self._field_view().partials(**named_vars)
+
+    bind = partials
+
+    def __repr__(self):
+        return f"FrozenField(source_key={self.field_key}, ndof={self.values.shape[0]})"
+
+
 class TestFunction(Placeholder):
     """
     Generic variational test function.

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -2354,7 +2354,11 @@ class ModelCall(Placeholder):
 
     def __init__(self, model: Model, args: list):
         self.model = model
-        self.args = args
+        # Unwrap typed semantic views (``u.bind(...)``, ``ui.x``, …) to their traced Placeholder:
+        # a view delegates via ``__getattr__`` and is NOT a Placeholder subclass, so left wrapped it
+        # would be invisible to every tree walker (linearity/trial detection, coordinate retagging)
+        # and unevaluable by the evaluators — e.g. a constitutive-law coefficient ``net(ui)``.
+        self.args = [a._expr if (not isinstance(a, Placeholder) and hasattr(a, "_expr")) else a for a in args]
         self.op_id = _next_op_id()
 
     def __repr__(self):

--- a/jno/trace/views.py
+++ b/jno/trace/views.py
@@ -255,6 +255,21 @@ class ScalarView(_DelegatesToPlaceholder):
     # ``bind`` is a synonym — programming flavour, same semantics.
     bind = partials
 
+    def freeze(self, values) -> "ScalarView":
+        """Pin this field's DOFs to the known nodal array ``values`` (e.g. a precomputed
+        coarse solution). The returned view's value and ``.x`` / ``.y`` give that KNOWN
+        field's value / gradient at the quadrature points — usable as a neural-coefficient
+        input (``net(xi, yi, ui.freeze(u0).x, ui.freeze(u0).y)``) while the weak form stays
+        LINEAR in the live unknown. Coordinate bindings from ``.bind(x=, y=)`` are preserved,
+        so ``.x`` / ``.y`` keep working. See :class:`jno.trace.FrozenField`."""
+        from . import FrozenField
+
+        frozen = FrozenField(self._expr, values)
+        cv = getattr(self, "_coord_vars", None)
+        if cv:
+            return _coords_dispatch(ScalarView(frozen), (), dict(cv))
+        return ScalarView(frozen)
+
     # -- scalar operations --
     def abs(self) -> "ScalarView":
         return ScalarView(FunctionCall(jnp.abs, [self._expr], "abs"))

--- a/jno/trace_compiler.py
+++ b/jno/trace_compiler.py
@@ -39,6 +39,7 @@ from .trace import (
     Jacobian,
     Model,
     ModelCall,
+    ModelWeights,
     NetworkGradient,
     OperationCall,
     OperationDef,
@@ -367,6 +368,11 @@ class TraceCompiler:
                 if flax_mod.layer_id not in seen:
                     seen.add(flax_mod.layer_id)
                     layers.append((flax_mod, node.args))
+
+            elif isinstance(node, ModelWeights):
+                # A neural FEM coefficient: the solve node references the model's weights (not a
+                # call), so register the Model itself — that is what makes it trainable.
+                visit(node.model)
 
             elif isinstance(node, Choice):
                 for opt in node.options:

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -20,6 +20,7 @@ from .trace import (
     Jacobian,
     Literal,
     ModelCall,
+    ModelWeights,
     NetworkGradient,
     Noise,
     OperationCall,
@@ -299,6 +300,7 @@ class TraceEvaluator:
         (BinaryOp, "_eval_binary_op"),
         (OperationCall, "_eval_operation_call"),
         (ModelCall, "_eval_flax_module_call"),
+        (ModelWeights, "_eval_model_weights"),
         (TunableModule, "_eval_tunable_module"),
         (TunableModuleCall, "_eval_tunable_module_call"),
         (Choice, "_eval_choice"),
@@ -480,6 +482,16 @@ class TraceEvaluator:
             return expr.fn(*args, key=ctx.key, **kwargs)
         else:
             return expr.fn(*args, **kwargs)
+
+    def _eval_model_weights(self, expr, ctx):
+        """Resolve a ``ModelWeights`` node to the model's *current* module pytree.
+
+        Under ``crux.solve`` this is the live trainable module (``self.params`` is
+        ``eqx.combine(trainable, frozen, static)`` rebuilt each step), so gradients of anything
+        computed from it — e.g. a FEM solve that re-assembles with these weights — reach the
+        optimizer. Outside training (eager evaluation) it falls back to the stored module.
+        """
+        return self.params.get(expr.model.layer_id, expr.model.module)
 
     def _eval_binary_op(self, expr, ctx):
         left = self._dispatch(expr.left, ctx)

--- a/jno/utils/solver/backend_blocks.py
+++ b/jno/utils/solver/backend_blocks.py
@@ -144,6 +144,11 @@ class SemidiscreteTimeBlock:
     # For the heat inverse example:
     #     A(t, args) = A0 + args["nu"] * K
     operator_fn: Optional[Callable] = None
+    # Optional runtime callback for a PARAMETRIC MASS ``mass_fn(t, args) -> M(t, args)`` on the *linear*
+    # path (e.g. an unknown density ``rho(x)*u_t`` recovered from a trajectory). ``M`` stays as the static
+    # placeholder (``.M`` / ``represents_linear``); when ``mass_fn`` is set the step re-assembles the mass
+    # from ``args`` each step, so ``∂/∂args`` flows through the mass as well as the operator.
+    mass_fn: Optional[Callable] = None
     # Diagnostic payload generated during symbolic lowering.
     runtime_parameter_exprs: Dict[str, Any] = field(default_factory=dict)
     operator_basis: Dict[str, Any] = field(default_factory=dict)
@@ -243,7 +248,9 @@ class SemidiscreteTimeBlock:
         from .linear import matrix_diagonal
 
         th = theta if theta is not None else (float(self.metadata.get("theta", 1.0)) if self.metadata else 1.0)
-        M = _operand(self.M)
+        # A parametric mass (``mass_fn``) is re-assembled from ``args`` each step (unknown-density inverse);
+        # otherwise the static ``self.M``.
+        M = _operand(self.mass_fn(t_next, args) if self.mass_fn is not None else self.M)
         n = M.shape[0]
         c = jnp.zeros((n,), dtype) if self.affine_bias is None else jnp.asarray(self.affine_bias, dtype).reshape(-1)
         A = _operand(self.operator_fn(t_next, args) if self.operator_fn is not None else self.A)

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -542,10 +542,10 @@ def assemble_fem_native(
             f"jno.fem: neural coefficient and runtime parameter share the name(s) {sorted(_name_clash)}; "
             "names key the runtime args and must be unique inside one solver block (rename via .name())."
         )
-    if neural_all_names and len(fields) > 1:
-        raise NotImplementedError(
-            "jno.fem (native): a neural coefficient on a coupled (multi-field) problem is not supported yet."
-        )
+    # A neural coefficient needs NO per-field resolution (unlike a nodal FIELD parameter, which
+    # gathers on one field's mesh): the network is evaluated at the shared physical quad points,
+    # and a trial-input ``net(u_i)`` resolves its field through ``_field_data`` (op_id/field_key)
+    # inside the kernel — so a coupled (multi-field) form threads it unchanged.
     # Trainable networks join the runtime-parameter exprs as ModelWeights slots: the solve nodes
     # (FemLinearSystem/FemResidualOperator/SemidiscreteTimeBlock) resolve each to the current module
     # pytree, which arrives back here in ``args`` and is re-evaluated at the quad points inside the

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -1015,19 +1015,22 @@ def assemble_fem_native(
                 "jno.fem (native): an initial condition was provided but no temporal term "
                 "(e.g. ``inner(u.t, v)``) was found in the volume weak form."
             )
-        if collect_neural_slots(temporal).any_trainable:
-            # The mass matrix is assembled ONCE with args=None — a trainable net on the u̇ term
-            # would silently freeze at its initial weights. Fail loud (a frozen net is fine: it
-            # evaluates from its stored module by design; the default collection excludes frozen).
+        # A trainable net on the u̇ term. A COORDINATE ``net(x)`` (an unknown density ``rho(x)*u_t``) keeps
+        # the mass a *matrix* -- just parametric in the weights -- so it is re-assembled from ``args`` each
+        # step (``mass_fn`` below). A SOLUTION-DEPENDENT ``net(u)`` would make the mass itself nonlinear
+        # (``C(u)*u_t``), which the semidiscrete matrix form cannot express -- reject that.
+        _parametric_mass = collect_neural_slots(temporal).any_trainable
+        if _parametric_mass and any(_is_obviously_nonlinear_in_unknown(domain, t) for t in temporal):
             raise NotImplementedError(
-                "jno.fem (native): a trainable neural coefficient on the mass (u_t) term is not "
-                "supported — the mass matrix is assembled once, so the net would silently freeze. "
-                "Use it on spatial terms, or .freeze() the network."
+                "jno.fem (native): a solution-dependent neural coefficient net(u) on the mass (u_t) term is a "
+                "nonlinear mass C(u)*u_t, which the semidiscrete matrix form cannot express. A coordinate "
+                "net(x) mass coefficient (an unknown density) is supported."
             )
 
         mass_terms = [_strip_temporal_trial_derivative(t) for t in temporal]
         # Mass matrix: volume only (no boundary); spatial residual: volume + boundary
-        M = _make_jacobian(mass_terms)(zeros)
+        _mass_jac = _make_jacobian(mass_terms)
+        M = _mass_jac(zeros)
         spatial_res = _make_residual(spatial, boundary_terms)
         spatial_jac = _make_jacobian(spatial, boundary_terms)
 
@@ -1077,6 +1080,13 @@ def assemble_fem_native(
         d_dofs = jnp.asarray([p[0] for p in dirichlet_pairs], dtype=jnp.int32) if dirichlet_pairs else None
         d_vals = jnp.asarray([p[1] for p in dirichlet_pairs], dtype=zeros.dtype) if dirichlet_pairs else None
 
+        # Parametric mass ``mass_fn(t, args)`` (unknown density net(x)*u_t): re-assemble M from args each
+        # step with the Dirichlet rows/cols zeroed (a constrained DOF carries no time derivative). ``None``
+        # keeps the static ``M_bc`` for a non-parametric mass.
+        def _mass_cb(t, args=None, _d=d_dofs):
+            Mt = _mass_jac(zeros, t, args)
+            return Mt if _d is None else bcoo_zero_rows_cols(Mt, _d)
+
         nonlinear = any(_is_obviously_nonlinear_in_unknown(domain, t) for t in spatial)
         if nonlinear:
             # Row-replacement Dirichlet (constant g), threaded through the runtime time t AND the
@@ -1092,7 +1102,7 @@ def assemble_fem_native(
             M_bc = M if d_dofs is None else bcoo_zero_rows_cols(M, d_dofs)
             return (
                 SemidiscreteTimeBlock(
-                    mass=lambda t, args=None, _M=M_bc: _M,
+                    mass=_mass_cb if _parametric_mass else (lambda t, args=None, _M=M_bc: _M),
                     residual=res_bc,
                     jacobian=jac_bc,
                     runtime_parameter_exprs=dict(_param_and_neural_exprs),
@@ -1122,6 +1132,7 @@ def assemble_fem_native(
             return (
                 SemidiscreteTimeBlock(
                     M=M_bc,
+                    mass_fn=_mass_cb if _parametric_mass else None,  # parametric mass (unknown density net(x)*u_t)
                     operator_fn=operator_fn,
                     affine_bias=c_bias,
                     forcing_vector_fn=forcing_vector_fn,

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -531,6 +531,29 @@ def assemble_fem_native(
     neural_param_names, _neural_models = _neural.param_names, _neural.models
     _param_and_neural_exprs = neural_operator_exprs(_rt_param_exprs, _neural)
 
+    # Frozen fields (ui.freeze(values)): KNOWN nodal vectors whose value/gradient are delivered at the
+    # quad points (e.g. as neural-coefficient inputs). Collected once; their per-cell nodal slice is a
+    # compile-time constant gathered below and threaded via loc["frozen_fields"].
+    def _collect_frozen_fields(terms):
+        from ...trace import FrozenField
+        from .solver_helper import iter_children
+
+        found: Dict[Any, Any] = {}
+        seen: set = set()
+        stack = list(terms)
+        while stack:
+            n = stack.pop()
+            if id(n) in seen:
+                continue
+            seen.add(id(n))
+            if isinstance(n, FrozenField):
+                found[n.frozen_id] = n
+                continue
+            stack.extend(iter_children(n))
+        return found
+
+    _frozen_nodes = _collect_frozen_fields(list(volume_terms) + list(boundary_terms))
+
     # A trainable DIRICHLET VALUE ``u(region) - net(x)`` (an unknown boundary profile). The net is not an
     # integrand coefficient -- it is evaluated at the boundary NODES to form the Dirichlet lift -- so it is
     # collected here from ``dirichlet_raw`` (a bare net node; the front-end already rejected compound values)
@@ -628,6 +651,18 @@ def assemble_fem_native(
         loc_seg.append(loc_seg[-1] + n_local_f[i] * vecs[i])
     cell_all_dofs = jnp.concatenate(cdofs, axis=1) if len(cdofs) > 1 else cdofs[0]  # (n_cell, n_local_all)
 
+    # Per-cell gather of each frozen field's nodal slice (n_cell, n_local, 1) -- a compile-time constant
+    # (no args threading, no jacfwd tangent), gathered on the frozen field's own FE space via the same
+    # connectivity as the live state, so its shape-gradient contraction matches the trial gradient.
+    _frozen_gathered: Dict[Any, Any] = {}
+    for _fid, _fnode in _frozen_nodes.items():
+        _ffidx = field_index[_fnode.field_key]
+        if vecs[_ffidx] != 1:
+            raise NotImplementedError("ui.freeze(values): only scalar frozen fields are supported.")
+        _fconn = cells_f_j[_ffidx]  # (n_cell, n_local)
+        _fvals = jnp.asarray(_fnode.values).reshape(-1)
+        _frozen_gathered[_fid] = _fvals[_fconn].reshape(_fconn.shape[0], _fconn.shape[1], 1)
+
     def _split_cell_local(local_vals):
         """Split a cell's gathered all-field local vector into per-field ``(n_local_i, vec_i)``."""
         return [local_vals[loc_seg[i] : loc_seg[i + 1]].reshape(n_local_f[i], vecs[i]) for i in range(len(fields))]
@@ -702,6 +737,8 @@ def assemble_fem_native(
         _nt = neural_local_table(_neural, args)
         if _nt is not None:  # trainable nets ride args (crux weights); frozen/placeholder -> stored module
             loc["neural_coefficients"] = _nt
+        if _frozen_gathered:  # known-field (ui.freeze) per-cell nodal slices for this cell
+            loc["frozen_fields"] = {fid: g[c] for fid, g in _frozen_gathered.items()}
         return _integrate_term(domain, coeff, loc, qw_shared * meas)
 
     def _surf_elem_res(fi, local_all, bcoeff, btfi, region, t=0.0, args=None):
@@ -750,6 +787,8 @@ def assemble_fem_native(
         _nt = neural_local_table(_neural, args)
         if _nt is not None:
             loc["neural_coefficients"] = _nt
+        if _frozen_gathered:  # known-field (ui.freeze) per-cell nodal slices for the parent cell
+            loc["frozen_fields"] = {fid: g[c] for fid, g in _frozen_gathered.items()}
         return _integrate_term(domain, bcoeff, loc, face_w * jac_f)
 
     def _classify_one(coeff, where: str) -> List[Tuple[Any, int]]:

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -530,6 +530,26 @@ def assemble_fem_native(
     _neural = collect_neural_slots(volume_terms, boundary_terms, runtime_parameter_tags=runtime_parameter_tags)
     neural_param_names, _neural_models = _neural.param_names, _neural.models
     _param_and_neural_exprs = neural_operator_exprs(_rt_param_exprs, _neural)
+
+    # A trainable DIRICHLET VALUE ``u(region) - net(x)`` (an unknown boundary profile). The net is not an
+    # integrand coefficient -- it is evaluated at the boundary NODES to form the Dirichlet lift -- so it is
+    # collected here from ``dirichlet_raw`` (a bare net node; the front-end already rejected compound values)
+    # and joins ``_param_and_neural_exprs`` as its own ``ModelWeights`` slot. The lift is (re-)built from the
+    # runtime args in ``_dirichlet_pairs_at`` so ``∂b/∂weights`` flows through the solve.
+    from ..._fem import _bare as _bare_node
+    from ...trace import ModelWeights
+    from .parametric_helpers import _is_neural_coefficient, _neural_coefficient_name
+
+    _dir_net_models: Dict[str, Any] = {}
+    for _fk, _rg, _comp, _val, _vnode in dirichlet_raw:
+        _vn = _bare_node(_vnode) if _vnode is not None else None
+        if _vn is not None and _is_neural_coefficient(_vn):
+            _dir_net_models[_neural_coefficient_name(_vn)] = _vn.model
+    if _dir_net_models:
+        _param_and_neural_exprs = {
+            **_param_and_neural_exprs,
+            **{n: ModelWeights(m) for n, m in _dir_net_models.items()},
+        }
     # A nodal FIELD parameter k(x) interpolates on one field's FE space. Single field -> field 0. For a
     # coupled (multi-field) problem, associate it with the field whose test function appears in the
     # term(s) that reference it (e.g. mu(x)*(grad u . grad v) -> the velocity field), so its nodal values
@@ -937,6 +957,9 @@ def assemble_fem_native(
             fidx = field_index.get(field_key)
             if fidx is None:
                 continue
+            _vn = _bare_node(value_node) if value_node is not None else None
+            if _vn is not None and _is_neural_coefficient(_vn):
+                continue  # a net-valued Dirichlet is (re-)built per args in _dirichlet_pairs_at
             vt = vecs[fidx]
             pts_all = pts_f_all[fidx]
             for nid in _boundary_node_ids(fidx, region):
@@ -954,6 +977,32 @@ def assemble_fem_native(
         # Expose the (dof, value) pairs for callers that compose their own system from native blocks
         # (e.g. the second-order-in-time augmented [u, v] block applies them to the 2N system itself).
         domain._fem_native_dirichlet_pairs = pairs
+        return pairs
+
+    def _dirichlet_pairs_at(args):
+        """Dirichlet ``(dof, value)`` pairs with the net-valued profiles evaluated from the runtime
+        ``args`` (an unknown BC ``u(region) - net(x)``): the net is called on the region's boundary-node
+        coordinates, so the value stays a differentiable JAX scalar and ``∂b/∂weights`` flows through the
+        symmetric elimination. Non-net conditions reuse the concrete ``_build_dirichlet_pairs`` values."""
+        a = args or {}
+        pairs = list(_build_dirichlet_pairs())  # concrete (non-net) conditions
+        for field_key, region, comp, value, value_node in dirichlet_raw:
+            fidx = field_index.get(field_key)
+            if fidx is None:
+                continue
+            _vn = _bare_node(value_node) if value_node is not None else None
+            if _vn is None or not _is_neural_coefficient(_vn):
+                continue
+            vt = vecs[fidx]
+            pts_all = np.asarray(pts_f_all[fidx])
+            node_ids = _boundary_node_ids(fidx, region)
+            module = a.get(_neural_coefficient_name(_vn), _vn.model.module)
+            coords = jnp.asarray(pts_all[np.asarray(node_ids, dtype=np.int64)])  # (n_bnodes, dim)
+            n_in = len(_vn.args)  # net(xb, yb[, zb]) -> per-coordinate columns (foundax MLP arity)
+            gvals = jnp.asarray(module(*[coords[:, i : i + 1] for i in range(n_in)])).reshape(-1)
+            for i, nid in enumerate(node_ids):
+                for c in range(vt) if comp is None else [int(comp)]:
+                    pairs.append((offs[fidx] + nid * vt + c, gvals[i]))
         return pairs
 
     def _build_dirichlet_tv_entries():
@@ -1001,6 +1050,11 @@ def assemble_fem_native(
 
     # === transient (Mu̇ + Au = c or M u̇ + R(u) = 0) ===
     if ic_residuals or any(_contains_temporal_derivative(t) for t in all_terms):
+        if _dir_net_models:
+            raise NotImplementedError(
+                "jno.fem: a net-valued Dirichlet u(region) - net(x) in a *transient* form is not supported yet "
+                "(the Dirichlet lift is assembled once). Use a steady form."
+            )
         from ..._fem import _bare, _essential_spec, _eval_value_node_at, _field_key_of
         from .backend_blocks import SemidiscreteTimeBlock
         from .time_route import _infer_time_window, _strip_temporal_trial_derivative
@@ -1212,10 +1266,15 @@ def assemble_fem_native(
     # each call, kept differentiable in args -- the parameter flows as a JAX array through the kernel
     # coefficient into the per-cell assembly (no float() cast). The same re-assembly handles affine,
     # non-affine and (scalar) parameters uniformly. ----
-    if runtime_parameter_tags or neural_param_names:
+    if runtime_parameter_tags or neural_param_names or _dir_net_models:
         from ...trace import FemLinearSystem
 
         if nonlinear:
+            if _dir_net_models:
+                raise NotImplementedError(
+                    "jno.fem: a net-valued Dirichlet u(region) - net(x) on a *nonlinear* form is not wired yet "
+                    "(the row-replacement Dirichlet uses a static value). Use a linear form."
+                )
 
             def res_p(u, args=None, _d=s_d_dofs, _g=s_d_vals):
                 R = residual(jnp.asarray(u), 0.0, args)
@@ -1234,13 +1293,17 @@ def assemble_fem_native(
         def _assemble_at(args):
             A = jacobian(zeros, 0.0, args)
             b = -residual(zeros, 0.0, args)
-            if dirichlet_pairs:
-                A, b = _apply_dirichlet_symmetric(A, b, dirichlet_pairs)
+            # a net-valued Dirichlet re-forms the lift from args each call; otherwise the static pairs.
+            pairs = _dirichlet_pairs_at(args) if _dir_net_models else dirichlet_pairs
+            if pairs:
+                A, b = _apply_dirichlet_symmetric(A, b, pairs)
             return A, b
 
-        # Static placeholder for .A/.b: scalar params at 0, networks at their stored weights.
+        # Static placeholder for .A/.b: scalar params at 0, networks (coefficient + Dirichlet) at stored weights.
         a0, b0 = _assemble_at(
-            {n: 0.0 for n in runtime_parameter_tags} | {n: _neural_models[n].module for n in neural_param_names}
+            {n: 0.0 for n in runtime_parameter_tags}
+            | {n: _neural_models[n].module for n in neural_param_names}
+            | {n: m.module for n, m in _dir_net_models.items()}
         )
         op = FemLinearSystem(
             a0,

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -517,48 +517,19 @@ def assemble_fem_native(
     _field_param_names: set = {n for n, expr in _rt_param_exprs.items() if _is_fem_field_parameter(expr)}
 
     # Neural coefficients (``jno.nn.wrap(net)`` called inside the weak form, e.g. ``net(x,y)*u.dx*v.dx``).
-    # Unlike scalar/nodal parameters they never enter the per-cell ``volume_vars`` — a weight pytree is
-    # cell-independent — the kernel instead re-evaluates the network at the quad points from a
-    # {name: module} table threaded via ``loc["neural_coefficients"]``. TRAINABLE networks arrive
-    # through the runtime ``args`` (a ``ModelWeights`` slot resolved by the trace evaluator to the
-    # crux-recombined module, so ∂solve/∂weights flows); FROZEN (.freeze()d) networks evaluate from
-    # their stored module and keep the system non-parametric.
-    from .parametric_helpers import _collect_neural_coefficient_exprs
+    # Unlike scalar/nodal parameters they never enter the per-cell ``volume_vars`` -- a weight pytree is
+    # cell-independent -- the kernel instead re-evaluates the network at the quad points from the
+    # {name: module} table (``neural_local_table``) threaded via ``loc["neural_coefficients"]``. A neural
+    # coefficient needs NO per-field resolution (unlike a nodal FIELD parameter, which gathers on one
+    # field's mesh): the net is evaluated at the shared physical quad points, and a trial-input
+    # ``net(u_i)`` resolves its field through ``_field_data`` (op_id/field_key) inside the kernel -- so a
+    # coupled (multi-field) form threads it unchanged. The collect / crux-delivery / kernel-table
+    # mechanism lives in ``parametric_helpers`` (shared with the non-nodal assembler).
+    from .parametric_helpers import collect_neural_slots, neural_local_table, neural_operator_exprs
 
-    _neural_all_exprs: Dict[str, Any] = {}
-    for bare in volume_terms:
-        _collect_neural_coefficient_exprs(bare, _neural_all_exprs, include_frozen=True)
-    for _exprs in boundary_terms.values():
-        for bare in _exprs:
-            _collect_neural_coefficient_exprs(bare, _neural_all_exprs, include_frozen=True)
-    neural_all_names: Tuple[str, ...] = tuple(sorted(_neural_all_exprs))
-    _neural_models = {n: e.model for n, e in _neural_all_exprs.items()}
-    neural_param_names: Tuple[str, ...] = tuple(
-        sorted(n for n, e in _neural_all_exprs.items() if not bool(getattr(e.model, "_frozen", False)))
-    )
-    _name_clash = set(neural_all_names) & set(runtime_parameter_tags)
-    if _name_clash:
-        raise ValueError(
-            f"jno.fem: neural coefficient and runtime parameter share the name(s) {sorted(_name_clash)}; "
-            "names key the runtime args and must be unique inside one solver block (rename via .name())."
-        )
-    # A neural coefficient needs NO per-field resolution (unlike a nodal FIELD parameter, which
-    # gathers on one field's mesh): the network is evaluated at the shared physical quad points,
-    # and a trial-input ``net(u_i)`` resolves its field through ``_field_data`` (op_id/field_key)
-    # inside the kernel — so a coupled (multi-field) form threads it unchanged.
-    # Trainable networks join the runtime-parameter exprs as ModelWeights slots: the solve nodes
-    # (FemLinearSystem/FemResidualOperator/SemidiscreteTimeBlock) resolve each to the current module
-    # pytree, which arrives back here in ``args`` and is re-evaluated at the quad points inside the
-    # kernel — keeping ∂solve/∂weights exact through the implicit-diff solvers.
-    if neural_param_names:
-        from ...trace import ModelWeights
-
-        _param_and_neural_exprs: Dict[str, Any] = {
-            **_rt_param_exprs,
-            **{n: ModelWeights(_neural_models[n]) for n in neural_param_names},
-        }
-    else:
-        _param_and_neural_exprs = dict(_rt_param_exprs)
+    _neural = collect_neural_slots(volume_terms, boundary_terms, runtime_parameter_tags=runtime_parameter_tags)
+    neural_param_names, _neural_models = _neural.param_names, _neural.models
+    _param_and_neural_exprs = neural_operator_exprs(_rt_param_exprs, _neural)
     # A nodal FIELD parameter k(x) interpolates on one field's FE space. Single field -> field 0. For a
     # coupled (multi-field) problem, associate it with the field whose test function appears in the
     # term(s) that reference it (e.g. mu(x)*(grad u . grad v) -> the velocity field), so its nodal values
@@ -708,10 +679,9 @@ def assemble_fem_native(
             # functions (field 0 single-field; the resolved field for a coupled problem).
             # _runtime_parameter_value_from_internal_vars reads this top-level shape_vals.
             loc["shape_vals"] = per[_field_param_field_idx]["shape_vals"]
-        if neural_all_names:
-            # Trainable nets ride the runtime args (current crux weights); frozen ones use their
-            # stored module — also the fallback for static assemblies (the .A/.b placeholder).
-            loc["neural_coefficients"] = {n: (args or {}).get(n, _neural_models[n].module) for n in neural_all_names}
+        _nt = neural_local_table(_neural, args)
+        if _nt is not None:  # trainable nets ride args (crux weights); frozen/placeholder -> stored module
+            loc["neural_coefficients"] = _nt
         return _integrate_term(domain, coeff, loc, qw_shared * meas)
 
     def _surf_elem_res(fi, local_all, bcoeff, btfi, region, t=0.0, args=None):
@@ -757,8 +727,9 @@ def assemble_fem_native(
         }
         if _field_param_names:
             loc["shape_vals"] = per_f[_field_param_field_idx]["shape_vals"]
-        if neural_all_names:
-            loc["neural_coefficients"] = {n: (args or {}).get(n, _neural_models[n].module) for n in neural_all_names}
+        _nt = neural_local_table(_neural, args)
+        if _nt is not None:
+            loc["neural_coefficients"] = _nt
         return _integrate_term(domain, bcoeff, loc, face_w * jac_f)
 
     def _classify_one(coeff, where: str) -> List[Tuple[Any, int]]:
@@ -1044,7 +1015,7 @@ def assemble_fem_native(
                 "jno.fem (native): an initial condition was provided but no temporal term "
                 "(e.g. ``inner(u.t, v)``) was found in the volume weak form."
             )
-        if neural_param_names and any(_collect_neural_coefficient_exprs(t) for t in temporal):
+        if collect_neural_slots(temporal).any_trainable:
             # The mass matrix is assembled ONCE with args=None — a trainable net on the u̇ term
             # would silently freeze at its initial weights. Fail loud (a frozen net is fine: it
             # evaluates from its stored module by design; the default collection excludes frozen).

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -515,6 +515,37 @@ def assemble_fem_native(
             _collect_runtime_parameter_exprs(bare, _rt_param_exprs)
     runtime_parameter_tags: Tuple[str, ...] = tuple(sorted(_rt_param_exprs))
     _field_param_names: set = {n for n, expr in _rt_param_exprs.items() if _is_fem_field_parameter(expr)}
+
+    # Neural coefficients (``jno.nn.wrap(net)`` called inside the weak form, e.g. ``net(x,y)*u.dx*v.dx``).
+    # Unlike scalar/nodal parameters they never enter the per-cell ``volume_vars`` — a weight pytree is
+    # cell-independent — the kernel instead re-evaluates the network at the quad points from a
+    # {name: module} table threaded via ``loc["neural_coefficients"]``. TRAINABLE networks arrive
+    # through the runtime ``args`` (a ``ModelWeights`` slot resolved by the trace evaluator to the
+    # crux-recombined module, so ∂solve/∂weights flows); FROZEN (.freeze()d) networks evaluate from
+    # their stored module and keep the system non-parametric.
+    from .parametric_helpers import _collect_neural_coefficient_exprs
+
+    _neural_all_exprs: Dict[str, Any] = {}
+    for bare in volume_terms:
+        _collect_neural_coefficient_exprs(bare, _neural_all_exprs, include_frozen=True)
+    for _exprs in boundary_terms.values():
+        for bare in _exprs:
+            _collect_neural_coefficient_exprs(bare, _neural_all_exprs, include_frozen=True)
+    neural_all_names: Tuple[str, ...] = tuple(sorted(_neural_all_exprs))
+    _neural_models = {n: e.model for n, e in _neural_all_exprs.items()}
+    neural_param_names: Tuple[str, ...] = tuple(
+        sorted(n for n, e in _neural_all_exprs.items() if not bool(getattr(e.model, "_frozen", False)))
+    )
+    _name_clash = set(neural_all_names) & set(runtime_parameter_tags)
+    if _name_clash:
+        raise ValueError(
+            f"jno.fem: neural coefficient and runtime parameter share the name(s) {sorted(_name_clash)}; "
+            "names key the runtime args and must be unique inside one solver block (rename via .name())."
+        )
+    if neural_all_names and len(fields) > 1:
+        raise NotImplementedError(
+            "jno.fem (native): a neural coefficient on a coupled (multi-field) problem is not supported yet."
+        )
     # A nodal FIELD parameter k(x) interpolates on one field's FE space. Single field -> field 0. For a
     # coupled (multi-field) problem, associate it with the field whose test function appears in the
     # term(s) that reference it (e.g. mu(x)*(grad u . grad v) -> the velocity field), so its nodal values
@@ -664,6 +695,10 @@ def assemble_fem_native(
             # functions (field 0 single-field; the resolved field for a coupled problem).
             # _runtime_parameter_value_from_internal_vars reads this top-level shape_vals.
             loc["shape_vals"] = per[_field_param_field_idx]["shape_vals"]
+        if neural_all_names:
+            # Trainable nets ride the runtime args (current crux weights); frozen ones use their
+            # stored module — also the fallback for static assemblies (the .A/.b placeholder).
+            loc["neural_coefficients"] = {n: (args or {}).get(n, _neural_models[n].module) for n in neural_all_names}
         return _integrate_term(domain, coeff, loc, qw_shared * meas)
 
     def _surf_elem_res(fi, local_all, bcoeff, btfi, region, t=0.0, args=None):
@@ -709,6 +744,8 @@ def assemble_fem_native(
         }
         if _field_param_names:
             loc["shape_vals"] = per_f[_field_param_field_idx]["shape_vals"]
+        if neural_all_names:
+            loc["neural_coefficients"] = {n: (args or {}).get(n, _neural_models[n].module) for n in neural_all_names}
         return _integrate_term(domain, bcoeff, loc, face_w * jac_f)
 
     def _classify_one(coeff, where: str) -> List[Tuple[Any, int]]:
@@ -980,6 +1017,14 @@ def assemble_fem_native(
 
     # === transient (Mu̇ + Au = c or M u̇ + R(u) = 0) ===
     if ic_residuals or any(_contains_temporal_derivative(t) for t in all_terms):
+        if neural_all_names:
+            # The non-parametric transient branches assemble with args=None (the operator at t=0, the
+            # forcing per step) — a net there would silently freeze at its initial weights. Fail loud
+            # until the transient threading lands.
+            raise NotImplementedError(
+                "jno.fem (native): a neural coefficient in a transient weak form is not supported yet — "
+                "steady (linear/nonlinear) forms only for now."
+            )
         from ..._fem import _bare, _essential_spec, _eval_value_node_at, _field_key_of
         from .backend_blocks import SemidiscreteTimeBlock
         from .time_route import _infer_time_window, _strip_temporal_trial_derivative
@@ -1168,8 +1213,16 @@ def assemble_fem_native(
     # each call, kept differentiable in args -- the parameter flows as a JAX array through the kernel
     # coefficient into the per-cell assembly (no float() cast). The same re-assembly handles affine,
     # non-affine and (scalar) parameters uniformly. ----
-    if runtime_parameter_tags:
-        from ...trace import FemLinearSystem
+    if runtime_parameter_tags or neural_param_names:
+        from ...trace import FemLinearSystem, ModelWeights
+
+        # Trainable networks join the runtime-parameter exprs as ModelWeights slots: the solve
+        # nodes resolve each to the current module pytree, which arrives here in ``args`` and is
+        # re-evaluated at the quad points inside the kernel (keeping ∂solve/∂weights exact).
+        _param_and_neural_exprs = {
+            **_rt_param_exprs,
+            **{n: ModelWeights(_neural_models[n]) for n in neural_param_names},
+        }
 
         if nonlinear:
 
@@ -1182,7 +1235,7 @@ def assemble_fem_native(
                 return J if _d is None else bcoo_set_dirichlet_rows(J, _d)
 
             return (
-                FemResidualOperator(res_p, jac_p, total, runtime_parameter_exprs=dict(_rt_param_exprs)),
+                FemResidualOperator(res_p, jac_p, total, runtime_parameter_exprs=_param_and_neural_exprs),
                 "nonlinear",
                 offs,
             )
@@ -1194,13 +1247,16 @@ def assemble_fem_native(
                 A, b = _apply_dirichlet_symmetric(A, b, dirichlet_pairs)
             return A, b
 
-        a0, b0 = _assemble_at({n: 0.0 for n in runtime_parameter_tags})  # static placeholder for .A/.b
+        # Static placeholder for .A/.b: scalar params at 0, networks at their stored weights.
+        a0, b0 = _assemble_at(
+            {n: 0.0 for n in runtime_parameter_tags} | {n: _neural_models[n].module for n in neural_param_names}
+        )
         op = FemLinearSystem(
             a0,
             b0,
             operator_fn=lambda args=None: _assemble_at(args)[0],
             rhs_fn=lambda args=None: _assemble_at(args)[1],
-            runtime_parameter_exprs=dict(_rt_param_exprs),
+            runtime_parameter_exprs=_param_and_neural_exprs,
             # The native parametric path re-assembles the operator at each args (it builds no affine
             # parameter basis), so every runtime parameter -- affine or not -- takes the re-assembly route.
             metadata={"nonaffine_operator": True},

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -546,6 +546,19 @@ def assemble_fem_native(
         raise NotImplementedError(
             "jno.fem (native): a neural coefficient on a coupled (multi-field) problem is not supported yet."
         )
+    # Trainable networks join the runtime-parameter exprs as ModelWeights slots: the solve nodes
+    # (FemLinearSystem/FemResidualOperator/SemidiscreteTimeBlock) resolve each to the current module
+    # pytree, which arrives back here in ``args`` and is re-evaluated at the quad points inside the
+    # kernel — keeping ∂solve/∂weights exact through the implicit-diff solvers.
+    if neural_param_names:
+        from ...trace import ModelWeights
+
+        _param_and_neural_exprs: Dict[str, Any] = {
+            **_rt_param_exprs,
+            **{n: ModelWeights(_neural_models[n]) for n in neural_param_names},
+        }
+    else:
+        _param_and_neural_exprs = dict(_rt_param_exprs)
     # A nodal FIELD parameter k(x) interpolates on one field's FE space. Single field -> field 0. For a
     # coupled (multi-field) problem, associate it with the field whose test function appears in the
     # term(s) that reference it (e.g. mu(x)*(grad u . grad v) -> the velocity field), so its nodal values
@@ -1017,14 +1030,6 @@ def assemble_fem_native(
 
     # === transient (Mu̇ + Au = c or M u̇ + R(u) = 0) ===
     if ic_residuals or any(_contains_temporal_derivative(t) for t in all_terms):
-        if neural_all_names:
-            # The non-parametric transient branches assemble with args=None (the operator at t=0, the
-            # forcing per step) — a net there would silently freeze at its initial weights. Fail loud
-            # until the transient threading lands.
-            raise NotImplementedError(
-                "jno.fem (native): a neural coefficient in a transient weak form is not supported yet — "
-                "steady (linear/nonlinear) forms only for now."
-            )
         from ..._fem import _bare, _essential_spec, _eval_value_node_at, _field_key_of
         from .backend_blocks import SemidiscreteTimeBlock
         from .time_route import _infer_time_window, _strip_temporal_trial_derivative
@@ -1038,6 +1043,15 @@ def assemble_fem_native(
             raise ValueError(
                 "jno.fem (native): an initial condition was provided but no temporal term "
                 "(e.g. ``inner(u.t, v)``) was found in the volume weak form."
+            )
+        if neural_param_names and any(_collect_neural_coefficient_exprs(t) for t in temporal):
+            # The mass matrix is assembled ONCE with args=None — a trainable net on the u̇ term
+            # would silently freeze at its initial weights. Fail loud (a frozen net is fine: it
+            # evaluates from its stored module by design; the default collection excludes frozen).
+            raise NotImplementedError(
+                "jno.fem (native): a trainable neural coefficient on the mass (u_t) term is not "
+                "supported — the mass matrix is assembled once, so the net would silently freeze. "
+                "Use it on spatial terms, or .freeze() the network."
             )
 
         mass_terms = [_strip_temporal_trial_derivative(t) for t in temporal]
@@ -1110,7 +1124,7 @@ def assemble_fem_native(
                     mass=lambda t, args=None, _M=M_bc: _M,
                     residual=res_bc,
                     jacobian=jac_bc,
-                    runtime_parameter_exprs=dict(_rt_param_exprs),
+                    runtime_parameter_exprs=dict(_param_and_neural_exprs),
                     **common,
                 ),
                 "transient",
@@ -1120,7 +1134,7 @@ def assemble_fem_native(
         # ---- linear parametric transient: the operator A(t, args) is re-evaluated each step.
         # Row-replacement Dirichlet (rows -> identity, columns kept) needs no args-dependent lift --
         # the coupling to the held Dirichlet value sits on the LHS, the constant g in the affine bias. ----
-        if runtime_parameter_tags:
+        if runtime_parameter_tags or neural_param_names:
             M_bc = M if d_dofs is None else bcoo_zero_rows_cols(M, d_dofs)
             c_bias = zeros if d_dofs is None else zeros.at[d_dofs].set(d_vals)
             free_mask = jnp.ones((total,), dtype=zeros.dtype)
@@ -1140,10 +1154,13 @@ def assemble_fem_native(
                     operator_fn=operator_fn,
                     affine_bias=c_bias,
                     forcing_vector_fn=forcing_vector_fn,
-                    runtime_parameter_exprs=dict(_rt_param_exprs),
+                    runtime_parameter_exprs=dict(_param_and_neural_exprs),
                     # The operator is re-assembled at each (t, args) -- a general (non-affine) operator,
                     # so it covers a parameter inside a nonlinear coefficient (e.g. exp(logk)) too.
-                    metadata={"runtime_parameter_names": list(runtime_parameter_tags), "nonaffine_operator": True},
+                    metadata={
+                        "runtime_parameter_names": list(runtime_parameter_tags) + list(neural_param_names),
+                        "nonaffine_operator": True,
+                    },
                     **common,
                 ),
                 "transient",
@@ -1214,15 +1231,7 @@ def assemble_fem_native(
     # coefficient into the per-cell assembly (no float() cast). The same re-assembly handles affine,
     # non-affine and (scalar) parameters uniformly. ----
     if runtime_parameter_tags or neural_param_names:
-        from ...trace import FemLinearSystem, ModelWeights
-
-        # Trainable networks join the runtime-parameter exprs as ModelWeights slots: the solve
-        # nodes resolve each to the current module pytree, which arrives here in ``args`` and is
-        # re-evaluated at the quad points inside the kernel (keeping ∂solve/∂weights exact).
-        _param_and_neural_exprs = {
-            **_rt_param_exprs,
-            **{n: ModelWeights(_neural_models[n]) for n in neural_param_names},
-        }
+        from ...trace import FemLinearSystem
 
         if nonlinear:
 
@@ -1235,7 +1244,7 @@ def assemble_fem_native(
                 return J if _d is None else bcoo_set_dirichlet_rows(J, _d)
 
             return (
-                FemResidualOperator(res_p, jac_p, total, runtime_parameter_exprs=_param_and_neural_exprs),
+                FemResidualOperator(res_p, jac_p, total, runtime_parameter_exprs=dict(_param_and_neural_exprs)),
                 "nonlinear",
                 offs,
             )
@@ -1256,7 +1265,7 @@ def assemble_fem_native(
             b0,
             operator_fn=lambda args=None: _assemble_at(args)[0],
             rhs_fn=lambda args=None: _assemble_at(args)[1],
-            runtime_parameter_exprs=_param_and_neural_exprs,
+            runtime_parameter_exprs=dict(_param_and_neural_exprs),
             # The native parametric path re-assembles the operator at each args (it builds no affine
             # parameter basis), so every runtime parameter -- affine or not -- takes the re-assembly route.
             metadata={"nonaffine_operator": True},

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -206,6 +206,45 @@ def assemble_fem_nonnodal(
             "volume term."
         )
 
+    # Neural coefficients (``jno.nn.wrap(net)`` in the weak form) on a non-nodal element: like the native
+    # path, the network is re-evaluated at the quad points and its weights ride the runtime ``args`` as a
+    # ``ModelWeights`` slot (frozen nets evaluate from their stored module and keep the system
+    # non-parametric). The network is independent of the C¹ trial's DOF layout -- exactly the property the
+    # P1 field parameter relies on -- so ``net(x)`` and a constitutive ``net(u)`` both thread unchanged.
+    from .parametric_helpers import _collect_neural_coefficient_exprs
+
+    _neural_all_exprs: dict = {}
+    for bare in volume_terms:
+        _collect_neural_coefficient_exprs(bare, _neural_all_exprs, include_frozen=True)
+    neural_all_names: Tuple[str, ...] = tuple(sorted(_neural_all_exprs))
+    _neural_models = {n: e.model for n, e in _neural_all_exprs.items()}
+    neural_param_names: Tuple[str, ...] = tuple(
+        sorted(n for n, e in _neural_all_exprs.items() if not bool(getattr(e.model, "_frozen", False)))
+    )
+    _bdry_neural: dict = {}
+    for _terms in boundary_terms.values():
+        for bare in _terms:
+            _collect_neural_coefficient_exprs(bare, _bdry_neural)  # trainable only (frozen bakes in fine)
+    if _bdry_neural:
+        raise NotImplementedError(
+            "jno.fem (non-nodal): a trainable neural coefficient in a boundary (Neumann/Robin) term is not "
+            "supported -- the natural-BC load is assembled non-differentiably. Put it in a volume term."
+        )
+    if set(neural_all_names) & set(runtime_parameter_tags):
+        raise ValueError(
+            "jno.fem (non-nodal): a neural coefficient and a runtime parameter share a name; "
+            "names key the runtime args and must be unique (rename via .name())."
+        )
+    if neural_param_names:
+        from ...trace import ModelWeights
+
+        _param_and_neural_exprs: dict = {
+            **_rt_param_exprs,
+            **{n: ModelWeights(_neural_models[n]) for n in neural_param_names},
+        }
+    else:
+        _param_and_neural_exprs = dict(_rt_param_exprs)
+
     # Simplex dimension from the mesh: 2D triangle vs 3D tetrahedron. The edge (RT/N1E) push-forward and
     # topology are dimension-agnostic; the vertex families (Hermite/Argyris/Morley) and RT are 2D-only, so
     # in 3D only Nédélec (N1E, edge/H(curl)) is wired -- everything else raises rather than silently mis-map.
@@ -475,6 +514,12 @@ def assemble_fem_nonnodal(
                     }
                     if _field_param_names:  # P1 basis to interpolate a field parameter (top-level, param-only key)
                         local["shape_vals"] = p1_shape_vals
+                    if neural_all_names:
+                        # Trainable nets ride ``args`` (current crux weights); frozen nets use their stored
+                        # module -- also the fallback for the static (.A/.b placeholder, non-parametric) path.
+                        local["neural_coefficients"] = {
+                            n: (args or {}).get(n, _neural_models[n].module) for n in neural_all_names
+                        }
                     return _integrate_term(domain, e, local, qw * meas)  # (ndof of the test field,)
 
                 elem = jax.vmap(_cell)(jnp.arange(n_cells))  # (n_cells, ndof_tfi)
@@ -536,6 +581,13 @@ def assemble_fem_nonnodal(
         from .solver_helper import max_temporal_derivative_order as _mto
         from .time_route import _infer_time_window, _strip_temporal_trial_derivative
 
+        if neural_param_names:
+            # The non-nodal time block builds a fixed mass/operator (or threads only ``_rt_param_exprs``);
+            # a trainable net would silently freeze at its initial weights. Steady non-nodal only for now.
+            raise NotImplementedError(
+                "jno.fem (non-nodal): a trainable neural coefficient in a transient form is not wired yet "
+                "(steady non-nodal only). Use a steady form, or .freeze() the network."
+            )
         sub = [_apply_sign(domain, s, t) for bare in volume_terms for s, t in _split_additive_terms(domain, bare)]
         temporal = [t for t in sub if _contains_temporal_derivative(t)]
         spatial = [t for t in sub if not _contains_temporal_derivative(t)]
@@ -742,7 +794,7 @@ def assemble_fem_nonnodal(
 
     # --- steady nonlinear: a genuinely nonlinear weak term -> a Newton residual operator ---
     if any(_is_obviously_nonlinear_in_unknown(domain, t) for t in volume_terms):
-        if runtime_parameter_tags:  # parametric (inverse): thread args into the residual AND its Jacobian
+        if runtime_parameter_tags or neural_param_names:  # parametric (inverse): thread args through res + jac
 
             def res_p(u, args=None):
                 return _apply_dirichlet_rows(lambda uu: full_residual(uu, args), pins)(jnp.asarray(u))
@@ -751,7 +803,7 @@ def assemble_fem_nonnodal(
                 return jax.jacfwd(lambda uu: res_p(uu, args))(jnp.asarray(u))
 
             return (
-                FemResidualOperator(res_p, jac_p, total, runtime_parameter_exprs=dict(_rt_param_exprs)),
+                FemResidualOperator(res_p, jac_p, total, runtime_parameter_exprs=dict(_param_and_neural_exprs)),
                 "nonlinear",
                 offs,
             )
@@ -768,7 +820,7 @@ def assemble_fem_nonnodal(
     # --- steady linear parametric (inverse): re-assemble A(args), b(args) each call, kept differentiable in
     #     the parameter (mirrors the native path); the Dirichlet pins are RE-APPLIED per args. Returns a
     #     FemLinearSystem so `fem.solve()` gives a differentiable trace node crux can optimise. ---
-    if runtime_parameter_tags:
+    if runtime_parameter_tags or neural_param_names:
         from ...trace import FemLinearSystem
 
         def _assemble_at(args):
@@ -778,8 +830,10 @@ def assemble_fem_nonnodal(
                 A, b = _apply_dirichlet_symmetric(jnp.asarray(A), jnp.asarray(b), pins)
             return A, b
 
-        # static placeholder for `.A` / `.b` (right width per parameter kind: a field param is (n_verts,))
+        # static placeholder for `.A` / `.b` (right width per parameter kind: a field param is (n_verts,),
+        # a neural coefficient rides its stored module)
         _ph = {n: (jnp.zeros((n_verts,)) if n in _field_param_names else 0.0) for n in runtime_parameter_tags}
+        _ph.update({n: _neural_models[n].module for n in neural_param_names})
         a0, b0 = _assemble_at(_ph)
         return (
             FemLinearSystem(
@@ -787,7 +841,7 @@ def assemble_fem_nonnodal(
                 b0,
                 operator_fn=lambda args=None: _assemble_at(args)[0],
                 rhs_fn=lambda args=None: _assemble_at(args)[1],
-                runtime_parameter_exprs=dict(_rt_param_exprs),
+                runtime_parameter_exprs=dict(_param_and_neural_exprs),
                 metadata={"nonaffine_operator": True},  # re-assembles at each args; no affine parameter basis
             ),
             "linear",

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -210,40 +210,17 @@ def assemble_fem_nonnodal(
     # path, the network is re-evaluated at the quad points and its weights ride the runtime ``args`` as a
     # ``ModelWeights`` slot (frozen nets evaluate from their stored module and keep the system
     # non-parametric). The network is independent of the C¹ trial's DOF layout -- exactly the property the
-    # P1 field parameter relies on -- so ``net(x)`` and a constitutive ``net(u)`` both thread unchanged.
-    from .parametric_helpers import _collect_neural_coefficient_exprs
+    # P1 field parameter relies on -- so ``net(x)`` and a constitutive ``net(u)`` both thread unchanged. The
+    # collect / crux-delivery / kernel-table mechanism is shared with the native assembler
+    # (``parametric_helpers``); the non-nodal difference is only the boundary policy: a trainable net in a
+    # natural-BC (Neumann/Robin) term is rejected, since that load is assembled non-differentiably here.
+    from .parametric_helpers import collect_neural_slots, neural_local_table, neural_operator_exprs
 
-    _neural_all_exprs: dict = {}
-    for bare in volume_terms:
-        _collect_neural_coefficient_exprs(bare, _neural_all_exprs, include_frozen=True)
-    neural_all_names: Tuple[str, ...] = tuple(sorted(_neural_all_exprs))
-    _neural_models = {n: e.model for n, e in _neural_all_exprs.items()}
-    neural_param_names: Tuple[str, ...] = tuple(
-        sorted(n for n, e in _neural_all_exprs.items() if not bool(getattr(e.model, "_frozen", False)))
+    _neural = collect_neural_slots(
+        volume_terms, boundary_terms, runtime_parameter_tags=runtime_parameter_tags, reject_trainable_boundary=True
     )
-    _bdry_neural: dict = {}
-    for _terms in boundary_terms.values():
-        for bare in _terms:
-            _collect_neural_coefficient_exprs(bare, _bdry_neural)  # trainable only (frozen bakes in fine)
-    if _bdry_neural:
-        raise NotImplementedError(
-            "jno.fem (non-nodal): a trainable neural coefficient in a boundary (Neumann/Robin) term is not "
-            "supported -- the natural-BC load is assembled non-differentiably. Put it in a volume term."
-        )
-    if set(neural_all_names) & set(runtime_parameter_tags):
-        raise ValueError(
-            "jno.fem (non-nodal): a neural coefficient and a runtime parameter share a name; "
-            "names key the runtime args and must be unique (rename via .name())."
-        )
-    if neural_param_names:
-        from ...trace import ModelWeights
-
-        _param_and_neural_exprs: dict = {
-            **_rt_param_exprs,
-            **{n: ModelWeights(_neural_models[n]) for n in neural_param_names},
-        }
-    else:
-        _param_and_neural_exprs = dict(_rt_param_exprs)
+    neural_param_names, _neural_models = _neural.param_names, _neural.models
+    _param_and_neural_exprs = neural_operator_exprs(_rt_param_exprs, _neural)
 
     # Simplex dimension from the mesh: 2D triangle vs 3D tetrahedron. The edge (RT/N1E) push-forward and
     # topology are dimension-agnostic; the vertex families (Hermite/Argyris/Morley) and RT are 2D-only, so
@@ -514,12 +491,9 @@ def assemble_fem_nonnodal(
                     }
                     if _field_param_names:  # P1 basis to interpolate a field parameter (top-level, param-only key)
                         local["shape_vals"] = p1_shape_vals
-                    if neural_all_names:
-                        # Trainable nets ride ``args`` (current crux weights); frozen nets use their stored
-                        # module -- also the fallback for the static (.A/.b placeholder, non-parametric) path.
-                        local["neural_coefficients"] = {
-                            n: (args or {}).get(n, _neural_models[n].module) for n in neural_all_names
-                        }
+                    _nt = neural_local_table(_neural, args)
+                    if _nt is not None:  # trainable nets ride args (crux weights); frozen/placeholder -> stored
+                        local["neural_coefficients"] = _nt
                     return _integrate_term(domain, e, local, qw * meas)  # (ndof of the test field,)
 
                 elem = jax.vmap(_cell)(jnp.arange(n_cells))  # (n_cells, ndof_tfi)

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -555,26 +555,27 @@ def assemble_fem_nonnodal(
         from .solver_helper import max_temporal_derivative_order as _mto
         from .time_route import _infer_time_window, _strip_temporal_trial_derivative
 
-        if neural_param_names:
-            # The non-nodal time block builds a fixed mass/operator (or threads only ``_rt_param_exprs``);
-            # a trainable net would silently freeze at its initial weights. Steady non-nodal only for now.
-            raise NotImplementedError(
-                "jno.fem (non-nodal): a trainable neural coefficient in a transient form is not wired yet "
-                "(steady non-nodal only). Use a steady form, or .freeze() the network."
-            )
         sub = [_apply_sign(domain, s, t) for bare in volume_terms for s, t in _split_additive_terms(domain, bare)]
         temporal = [t for t in sub if _contains_temporal_derivative(t)]
         spatial = [t for t in sub if not _contains_temporal_derivative(t)]
         if not temporal:
             raise ValueError("jno.fem (non-nodal): a transient weak form must contain a temporal term, e.g. inner(u.t, v).")
+        if collect_neural_slots(temporal).any_trainable:
+            # The mass block is assembled once (args=None) -- a trainable net on the u̇ term would silently
+            # freeze at its initial weights. Fail loud (a frozen net evaluates from its stored module by design).
+            raise NotImplementedError(
+                "jno.fem (non-nodal): a trainable neural coefficient on the mass (u_t) term is not supported -- "
+                "the mass block is assembled once. Use it on spatial terms, or .freeze() the network."
+            )
 
         # === second-order-in-time (u_tt): the augmented first-order block y = [u; v], v = u̇, integrated by
         #     the trapezoidal (θ=½, energy-conserving) rule — the non-nodal analogue of the native
         #     _assemble_second_order_time, reusing this path's push-forward mass / pins / IC-projection. ===
         if max((_mto(t) for t in temporal), default=1) >= 2:
-            if runtime_parameter_tags:
+            if runtime_parameter_tags or neural_param_names:
                 raise NotImplementedError(
-                    "jno.fem (non-nodal): a runtime parameter in a second-order-in-time form is not supported."
+                    "jno.fem (non-nodal): a runtime parameter or neural coefficient in a second-order-in-time "
+                    "form is not supported."
                 )
             if len(fields) > 1:
                 raise NotImplementedError("jno.fem (non-nodal): second-order-in-time (u_tt) is single-field only.")
@@ -698,7 +699,7 @@ def assemble_fem_nonnodal(
             # nonlinear transient: M(t) u̇ + R(u) = 0 (matrix-free Newton-Krylov per step). Natural load
             # folds into R; essential pins are residual rows + zeroed M rows/cols (the 1D pattern).
             M_nl = M if pin_dofs is None else M.at[pin_dofs, :].set(0.0).at[:, pin_dofs].set(0.0)
-            if runtime_parameter_tags:  # transient inverse: thread args through the residual + its Jacobian
+            if runtime_parameter_tags or neural_param_names:  # transient inverse: thread args through res + jac
 
                 def res_pt(u, t, args=None):
                     return _apply_dirichlet_rows(lambda uu: spatial_res(uu, args) - nat_load, pins)(jnp.asarray(u))
@@ -710,7 +711,7 @@ def assemble_fem_nonnodal(
                     mass=lambda t, args=None, _M=M_nl: _M,
                     residual=res_pt,
                     jacobian=jac_pt,
-                    runtime_parameter_exprs=dict(_rt_param_exprs),
+                    runtime_parameter_exprs=dict(_param_and_neural_exprs),
                     **common,
                 )
                 return block, "transient", offs
@@ -724,8 +725,8 @@ def assemble_fem_nonnodal(
             )
             return block, "transient", offs
 
-        if runtime_parameter_tags:  # linear transient inverse: A(args) re-assembled each step; dense Dirichlet
-            #   row-replacement inside operator_fn (the dense analogue of the native bcoo_set_dirichlet_rows).
+        if runtime_parameter_tags or neural_param_names:  # linear transient inverse: A(args) re-assembled each
+            #   step; dense Dirichlet row-replacement inside operator_fn (dense analogue of bcoo_set_dirichlet_rows).
             M_bc = M if pin_dofs is None else M.at[pin_dofs, :].set(0.0).at[:, pin_dofs].set(0.0)
             c_bias = zeros if pin_dofs is None else zeros.at[pin_dofs].set(jnp.asarray([p[1] for p in pins]))
             free_mask = (
@@ -747,7 +748,7 @@ def assemble_fem_nonnodal(
                     operator_fn=operator_fn,
                     affine_bias=c_bias,
                     forcing_vector_fn=forcing_vector_fn,
-                    runtime_parameter_exprs=dict(_rt_param_exprs),
+                    runtime_parameter_exprs=dict(_param_and_neural_exprs),
                     metadata={"nonaffine_operator": True},
                     **common,
                 ),

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -1218,7 +1218,7 @@ def _eval_integrand(domain, node, local):
                 return _call_neural_coefficient(node.model, module, arg_vals, local)
         raise NotImplementedError(
             "jno.fem: a neural coefficient (jno.nn.wrap(net) inside the weak form) is supported on "
-            "the native 2D/3D Lagrange assembler (steady/nonlinear/transient, single-field) only — "
+            "the native 2D/3D Lagrange assembler (steady/nonlinear/transient, single or coupled) — "
             "this assembly path does not thread network weights into the kernel yet."
         )
 

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -1218,8 +1218,8 @@ def _eval_integrand(domain, node, local):
                 return _call_neural_coefficient(node.model, module, arg_vals, local)
         raise NotImplementedError(
             "jno.fem: a neural coefficient (jno.nn.wrap(net) inside the weak form) is supported on "
-            "the native 2D/3D Lagrange assembler (steady, single-field) only — this assembly path "
-            "does not thread network weights into the kernel yet."
+            "the native 2D/3D Lagrange assembler (steady/nonlinear/transient, single-field) only — "
+            "this assembly path does not thread network weights into the kernel yet."
         )
 
     if isinstance(node, FunctionCall):

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -852,6 +852,79 @@ def _eval_frozen_coefficient(domain, model, local):
     )
 
 
+def _call_neural_coefficient(model, module, arg_vals, local):
+    """Evaluate one neural coefficient (``jno.nn.wrap(net)`` inside a weak form) at the quad points.
+
+    ``arg_vals`` are the network's arguments already evaluated by ``_eval_integrand`` — coordinate
+    Variables arrive as ``(n_quad, 1)`` slices of the physical quadrature points, an interpolated
+    trial value as ``(n_quad, c)``, its gradient as ``(n_quad, len(dims))`` — so ``k(x)``, ``k(u)``
+    and ``k(∇u)`` all share this call. Everything is normalised to a ``(n_quad, feat)`` batch (the
+    same convention as the point-cloud evaluator ``TraceEvaluator._eval_flax_module_call``, which
+    foundax MLPs concatenate internally), cast to the model's explicit ``.dtype`` opt-in when set,
+    and the network output is returned as ``(n_quad, k)`` — the shape a nodal field parameter
+    returns, so it composes with test-expanded factors via ``_prefix_align`` identically.
+
+    ``module`` is the *current* weight pytree threaded through the runtime ``args`` (a
+    ``ModelWeights`` slot), so under ``jax.jacfwd`` w.r.t. the cell DOFs a trial-dependent argument
+    carries tangents straight through the network — ∂k(u)/∂u enters the element Jacobian
+    automatically — and under the outer training loop the weights are the crux-recombined
+    trainable leaves, so gradients reach the optimizer.
+
+    Neural-coefficient support follows the unsupervised coefficient/constitutive-recovery setting
+    of NN-EUCLID (M. Flaschel, S. Kumar, L. De Lorenzis, "NN-EUCLID: Deep-learning hyperelasticity
+    without stress data", J. Mech. Phys. Solids 165 (2022) 105076, §2.2–2.3) and Tartakovsky et
+    al., "Learning Parameters and Constitutive Relationships with Physics-Informed Deep Neural
+    Networks" (Water Resour. Res. 56, 2020, §2).
+    """
+    n_quad = int(local["physical_quad_points"].shape[0])
+
+    def _as_quad_batch(v):
+        v = jnp.asarray(v)
+        if v.ndim == 0:
+            return jnp.broadcast_to(v.reshape(1, 1), (n_quad, 1))
+        if v.ndim == 1:
+            if v.shape[0] == n_quad:
+                return v.reshape(n_quad, 1)
+            if v.shape[0] == 1:
+                return jnp.broadcast_to(v.reshape(1, 1), (n_quad, 1))
+        if v.ndim == 2 and v.shape[0] == n_quad:
+            return v
+        if v.ndim == 2 and v.shape[0] == 1:
+            return jnp.broadcast_to(v, (n_quad, v.shape[1]))
+        raise NotImplementedError(
+            "jno.fem: a neural coefficient's arguments must be per-quad-point values (coordinates, "
+            f"the trial or its derivatives, scalars); got an argument of shape {v.shape}. A test "
+            "function cannot appear inside a network argument."
+        )
+
+    vals = [_as_quad_batch(v) for v in arg_vals]
+
+    # Mixed precision: honour an explicit Model.dtype() opt-in exactly like the point evaluator —
+    # cast floating inputs so the net computes in its declared dtype; a plain-f32 net under x64
+    # promotes through the surrounding arithmetic instead.
+    compute_dtype = getattr(model, "_dtype", None)
+    if compute_dtype is not None:
+        vals = [
+            v.astype(compute_dtype) if jnp.issubdtype(v.dtype, jnp.floating) and v.dtype != compute_dtype else v
+            for v in vals
+        ]
+
+    out = module(*vals)
+    if hasattr(out, "output"):  # structured foundation-model outputs
+        out = out.output
+    out = jnp.asarray(out)
+    if out.ndim == 0:
+        return jnp.broadcast_to(out.reshape(1, 1), (n_quad, 1))
+    if out.ndim == 1 and out.shape[0] == n_quad:
+        return out.reshape(n_quad, 1)
+    if out.ndim == 2 and out.shape[0] == n_quad:
+        return out
+    raise NotImplementedError(
+        f"jno.fem: a neural coefficient must return one value (or a feature vector) per quadrature "
+        f"point — got output shape {out.shape} for {n_quad} quad points."
+    )
+
+
 def _eval_integrand(domain, node, local):
     """
     Evaluate a jNO symbolic expression inside a local kernel.
@@ -1111,7 +1184,12 @@ def _eval_integrand(domain, node, local):
         raise NotImplementedError(f"Unsupported binary operator: {node.op}")
 
     if isinstance(node, ModelCall):
-        from .parametric_helpers import _is_frozen_parameter, _is_runtime_scalar_parameter, _parameter_name
+        from .parametric_helpers import (
+            _is_frozen_parameter,
+            _is_runtime_scalar_parameter,
+            _neural_coefficient_name,
+            _parameter_name,
+        )
 
         if _is_frozen_parameter(node):
             # A .freeze()d (known) coefficient: evaluate its constant / coordinate function at the
@@ -1128,8 +1206,21 @@ def _eval_integrand(domain, node, local):
                     "into InternalVars.volume_vars."
                 )
             return val
-        # Non-parameter ModelCall (e.g. a neural coefficient) -> not handled here.
-        raise NotImplementedError("the kernel cannot evaluate non-parameter ModelCall coefficients yet.")
+        # Neural coefficient (``jno.nn.wrap(net)`` called inside the weak form): the assembler
+        # threads a {name: module} table into ``local`` (trainable modules arrive through the
+        # runtime ``args``; frozen ones fall back to their stored weights) and the network is
+        # (re-)evaluated here on its kernel-evaluated arguments at the quadrature points.
+        neural_modules = local.get("neural_coefficients")
+        if neural_modules is not None:
+            module = neural_modules.get(_neural_coefficient_name(node))
+            if module is not None:
+                arg_vals = [_eval_integrand(domain, a, local) for a in node.args]
+                return _call_neural_coefficient(node.model, module, arg_vals, local)
+        raise NotImplementedError(
+            "jno.fem: a neural coefficient (jno.nn.wrap(net) inside the weak form) is supported on "
+            "the native 2D/3D Lagrange assembler (steady, single-field) only — this assembly path "
+            "does not thread network weights into the kernel yet."
+        )
 
     if isinstance(node, FunctionCall):
         args = [_eval_integrand(domain, arg, local) for arg in node.args]

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -1217,9 +1217,9 @@ def _eval_integrand(domain, node, local):
                 arg_vals = [_eval_integrand(domain, a, local) for a in node.args]
                 return _call_neural_coefficient(node.model, module, arg_vals, local)
         raise NotImplementedError(
-            "jno.fem: a neural coefficient (jno.nn.wrap(net) inside the weak form) is supported on "
-            "the native 2D/3D Lagrange assembler (steady/nonlinear/transient, single or coupled) — "
-            "this assembly path does not thread network weights into the kernel yet."
+            "jno.fem: a neural coefficient (jno.nn.wrap(net) inside the weak form) is supported on the "
+            "native 2D/3D Lagrange assembler (single or coupled) and the scalar C¹ non-nodal families "
+            "(Argyris/Morley/Hermite) — this assembly path does not thread network weights yet."
         )
 
     if isinstance(node, FunctionCall):

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -21,6 +21,7 @@ from jax.flatten_util import ravel_pytree
 from ...trace import (
     BinaryOp,
     Constant,
+    FrozenField,
     FunctionCall,
     Hessian,
     Jacobian,
@@ -781,6 +782,22 @@ def _field_data(local, node):
     return fd["shape_vals"], fd["shape_grads"], fd["cell_sol"]
 
 
+def _frozen_cell_values(local, node):
+    """This cell's frozen nodal slice ``(n_local, vec)`` for a :class:`FrozenField`.
+
+    The native kernel gathers each frozen field's per-cell nodal values (a compile-time
+    constant -- no ``args`` threading, no ``jacfwd`` tangent) into
+    ``local["frozen_fields"][frozen_id]``; here we just read it back to interpolate the
+    known value / contract the known gradient with the field's shape data."""
+    table = local.get("frozen_fields")
+    if table is None or node.frozen_id not in table:
+        raise NotImplementedError(
+            "A frozen field (ui.freeze(values)) was used in a weak form assembled by a path that does "
+            "not thread frozen fields. It is currently wired for the native steady/linear volume path."
+        )
+    return table[node.frozen_id]
+
+
 def _field_hess(local, node):
     """Physical shape-function Hessian ``(n_quad, n_dof, dim, dim)`` for ``node``'s field, or ``None`` if
     its element does not tabulate second derivatives (only nodal Lagrange does). Mirrors :func:`_field_data`."""
@@ -945,6 +962,7 @@ def _eval_integrand(domain, node, local):
             Variable,
             TestFunction,
             TrialFunction,
+            FrozenField,
             Jacobian,
             Hessian,
             BinaryOp,
@@ -1059,6 +1077,19 @@ def _eval_integrand(domain, node, local):
             return flat_interp
         return _reshape_components_last(flat_interp, value_shape)
 
+    if isinstance(node, FrozenField):
+        # KNOWN field: interpolate its frozen nodal slice at the quad points, exactly like the
+        # TrialFunction value branch but with frozen values instead of the live cell solution.
+        if _field_space(local, node) != "Lagrange":
+            raise NotImplementedError("ui.freeze(values): frozen fields are supported for nodal Lagrange only.")
+        vals, _, _ = _field_data(local, node)
+        fz = _frozen_cell_values(local, node)  # (n_local, vec)
+        flat_interp = jnp.sum(vals[:, :, None] * fz[None, :, :], axis=1)
+        value_shape = getattr(node, "value_shape", ())
+        if len(value_shape) == 0:
+            return flat_interp
+        return _reshape_components_last(flat_interp, value_shape)
+
     if isinstance(node, Jacobian):
         dims = []
         for var in node.variables:
@@ -1086,6 +1117,22 @@ def _eval_integrand(domain, node, local):
             if len(comps) == 1:
                 return comps[0]
             return jnp.stack(comps, axis=-1)
+
+        if isinstance(node.target, FrozenField):
+            # gradient of a KNOWN field: contract the SAME physical shape gradients with the frozen
+            # nodal slice instead of the live cell solution (byte-identical to the TrialFunction case).
+            if _field_space(local, node.target) != "Lagrange":
+                raise NotImplementedError("ui.freeze(values): frozen-field gradients are nodal-Lagrange only.")
+            _, grads, _ = _field_data(local, node.target)
+            fz = _frozen_cell_values(local, node.target)  # (n_local, vec)
+            grad_list = [jnp.sum(grads[:, :, dim0 : dim0 + 1] * fz[None, :, :], axis=1) for dim0 in dims]
+            flat = grad_list[0] if len(dims) == 1 else jnp.stack(grad_list, axis=-1)
+            value_shape = getattr(node.target, "value_shape", ())
+            if len(value_shape) == 0:
+                return flat
+            if len(dims) == 1:
+                return _reshape_components_last(flat, value_shape)
+            return jnp.reshape(flat, flat.shape[:1] + tuple(value_shape) + (len(dims),))
 
         if isinstance(node.target, TrialFunction):
             _, grads, cell_sol = _field_data(local, node.target)

--- a/jno/utils/solver/parametric_helpers.py
+++ b/jno/utils/solver/parametric_helpers.py
@@ -15,12 +15,20 @@ Examples:
     k * grad(u) * grad(phi)
     mu * u**3 * phi
 
-Deliberately unsupported for now
---------------------------------
+Deliberately unsupported for now (affine factoring)
+---------------------------------------------------
     exp(raw_k) * weak_term
     (k + c) * weak_term
     k1 * k2 * weak_term
-    neural_coefficient(x) * weak_term
+
+Neural coefficients (``jno.nn.wrap(net)`` called inside a weak form, e.g.
+``net(x, y) * weak_term``) are NOT affine-factored: like nodal FEM field
+parameters they stay inside the integrand and take the re-assembly route.
+This module supplies their detection/collection predicates
+(``_is_neural_coefficient`` / ``_collect_neural_coefficient_exprs``); the
+native assembler threads the weight pytree through the runtime ``args`` and
+the kernel evaluates the network at the quadrature points
+(``fem_utils._eval_integrand``).
 """
 
 import jax.numpy as jnp
@@ -62,6 +70,70 @@ def _contains_fem_field_parameter(node) -> bool:
     if _is_fem_field_parameter(node):
         return True
     return any(_contains_fem_field_parameter(child) for child in (_iter_children(node) or ()))
+
+
+def _is_neural_coefficient(node) -> bool:
+    """True for a *network* ModelCall used as a coefficient (``jno.nn.wrap(net)(x, ...)``).
+
+    Everything that is a ModelCall but not a zero-arg ``jno.np.parameter(...)`` counts: the model
+    is an arbitrary equinox module evaluated at the quadrature points on its (symbolic) arguments.
+    A ``.freeze()``d network is still a neural coefficient — it evaluates through the same kernel
+    branch — but it is excluded from *trainable* collection (see
+    ``_collect_neural_coefficient_exprs``), so an all-frozen system assembles non-parametrically.
+    """
+    return isinstance(node, ModelCall) and not _is_runtime_scalar_parameter(node)
+
+
+def _is_frozen_neural_coefficient(node) -> bool:
+    """A neural coefficient whose model is ``.freeze()``d — a known, non-trainable network."""
+    return _is_neural_coefficient(node) and bool(getattr(node.model, "_frozen", False))
+
+
+def _contains_neural_coefficient(node) -> bool:
+    """Recursively detect a neural coefficient in one trace subtree."""
+    if _is_neural_coefficient(node):
+        return True
+    return any(_contains_neural_coefficient(child) for child in (_iter_children(node) or ()))
+
+
+def _neural_coefficient_name(node: ModelCall) -> str:
+    """Stable public name for one neural coefficient (mirrors ``_parameter_name``)."""
+    name = getattr(node.model, "name", None)
+    if name:
+        return str(name)
+    return f"neural_{node.model.layer_id}"
+
+
+def _collect_neural_coefficient_exprs(node, out=None, *, include_frozen=False):
+    """Collect network ModelCalls (neural coefficients) by public name.
+
+    With the default ``include_frozen=False``, ``.freeze()``d networks are skipped — they are
+    known coefficients, evaluated from their stored weights, and must not make the system
+    parametric. Pass ``include_frozen=True`` to build the kernel's evaluation table, which needs
+    every network (frozen ones evaluate from their stored module). Two *different* models sharing
+    one public name are rejected (the name keys the runtime ``args`` slot).
+    """
+    if out is None:
+        out = {}
+
+    if _is_neural_coefficient(node) and (include_frozen or not _is_frozen_neural_coefficient(node)):
+        name = _neural_coefficient_name(node)
+        previous = out.get(name)
+
+        if previous is not None and getattr(previous, "model", None) is not getattr(node, "model", None):
+            raise ValueError(
+                f"Multiple neural-coefficient models use the name {name!r}. "
+                "Model names must be unique inside one solver block."
+            )
+
+        out[name] = node
+        # Do NOT return: the network's arguments may nest further coefficients (e.g. net2 inside
+        # net1's argument); keep descending.
+
+    for child in _iter_children(node) or ():
+        _collect_neural_coefficient_exprs(child, out, include_frozen=include_frozen)
+
+    return out
 
 
 def _flatten_product(node):

--- a/jno/utils/solver/parametric_helpers.py
+++ b/jno/utils/solver/parametric_helpers.py
@@ -31,6 +31,9 @@ the kernel evaluates the network at the quadrature points
 (``fem_utils._eval_integrand``).
 """
 
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
 import jax.numpy as jnp
 
 from ...trace import BinaryOp, Literal, ModelCall
@@ -134,6 +137,119 @@ def _collect_neural_coefficient_exprs(node, out=None, *, include_frozen=False):
         _collect_neural_coefficient_exprs(child, out, include_frozen=include_frozen)
 
     return out
+
+
+# -----------------------------------------------------------------------------
+# Neural-coefficient mechanism (single source of truth for both assemblers)
+#
+# A neural coefficient reuses the runtime-parameter *infrastructure* (the ``args`` dict,
+# ``FemLinearSystem.operator_fn(args)`` / ``FemResidualOperator`` / ``SemidiscreteTimeBlock``,
+# ``custom_root`` implicit diff). Only three things are specific to a network, and they are the
+# axes along which the mechanism could later change -- so they live here, called identically by the
+# native and non-nodal assemblers rather than copied into each:
+#
+#   1. COLLECT      -- which networks are coefficients, their names, which are trainable
+#                      (``collect_neural_slots``);
+#   2. CRUX DELIVERY -- how a trainable net's weights reach the solve node: a ``ModelWeights`` slot in
+#                      ``runtime_parameter_exprs`` that the trace evaluator resolves to the live module
+#                      (``neural_operator_exprs``);
+#   3. KERNEL TABLE -- how the module reaches the per-cell integrand: a ``{name: module}`` map placed at
+#                      ``local["neural_coefficients"]`` (``neural_local_table``).
+#
+# Swapping the mechanism (e.g. partition-based weights instead of whole-module-by-closure) touches
+# only (2)+(3) here plus the ``ModelWeights`` handler; a network stays user-visible as just
+# ``jno.nn.wrap(net)(...)`` inside a weak form, so no user code or behaviour test moves.
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NeuralSlots:
+    """The neural coefficients of one solver block. ``all_names`` covers every network (frozen +
+    trainable) whose module the kernel must evaluate; ``param_names`` is the trainable subset that
+    becomes ``ModelWeights`` runtime slots; ``models`` maps each name to its :class:`Model`."""
+
+    all_names: Tuple[str, ...]
+    models: Dict[str, Any]
+    param_names: Tuple[str, ...]
+
+    @property
+    def any(self) -> bool:
+        return bool(self.all_names)
+
+    @property
+    def any_trainable(self) -> bool:
+        return bool(self.param_names)
+
+
+def collect_neural_slots(
+    volume_terms,
+    boundary_terms=None,
+    *,
+    runtime_parameter_tags: Tuple[str, ...] = (),
+    reject_trainable_boundary: bool = False,
+) -> NeuralSlots:
+    """Collect a block's neural coefficients (touch-point 1).
+
+    Volume-term networks (frozen + trainable) are always threaded. ``boundary_terms`` handling is
+    the one place the two assemblers legitimately differ, kept explicit here rather than hidden:
+    ``reject_trainable_boundary=False`` (native) folds boundary networks into the kernel table too;
+    ``True`` (non-nodal, whose natural-BC load is assembled non-differentiably) raises on a trainable
+    boundary net. A network sharing a name with a runtime parameter is rejected (names key ``args``).
+    """
+    exprs: Dict[str, ModelCall] = {}
+    for bare in volume_terms:
+        _collect_neural_coefficient_exprs(bare, exprs, include_frozen=True)
+
+    if boundary_terms:
+        if reject_trainable_boundary:
+            bexprs: Dict[str, ModelCall] = {}
+            for terms in boundary_terms.values():
+                for bare in terms:
+                    _collect_neural_coefficient_exprs(bare, bexprs)  # trainable only
+            if bexprs:
+                raise NotImplementedError(
+                    "jno.fem (non-nodal): a trainable neural coefficient in a boundary (Neumann/Robin) term "
+                    "is not supported -- the natural-BC load is assembled non-differentiably. Put it in a "
+                    "volume term."
+                )
+        else:
+            for terms in boundary_terms.values():
+                for bare in terms:
+                    _collect_neural_coefficient_exprs(bare, exprs, include_frozen=True)
+
+    all_names = tuple(sorted(exprs))
+    if set(all_names) & set(runtime_parameter_tags):
+        raise ValueError(
+            f"jno.fem: a neural coefficient and a runtime parameter share the name(s) "
+            f"{sorted(set(all_names) & set(runtime_parameter_tags))}; names key the runtime args and must be "
+            "unique inside one solver block (rename via .name())."
+        )
+    models = {n: e.model for n, e in exprs.items()}
+    param_names = tuple(sorted(n for n, e in exprs.items() if not bool(getattr(e.model, "_frozen", False))))
+    return NeuralSlots(all_names=all_names, models=models, param_names=param_names)
+
+
+def neural_operator_exprs(rt_param_exprs: Dict[str, Any], slots: NeuralSlots) -> Dict[str, Any]:
+    """Merge trainable networks into ``runtime_parameter_exprs`` as ``ModelWeights`` slots (touch-point 2).
+
+    The result is what an ``FemLinearSystem`` / ``FemResidualOperator`` / ``SemidiscreteTimeBlock`` carries;
+    at solve time the trace evaluator resolves each ``ModelWeights`` to the live (crux-recombined) module,
+    which returns here through ``args`` -- so ``∂solve/∂weights`` flows through the implicit-diff solvers."""
+    if not slots.param_names:
+        return dict(rt_param_exprs)
+    from ...trace import ModelWeights
+
+    return {**rt_param_exprs, **{n: ModelWeights(slots.models[n]) for n in slots.param_names}}
+
+
+def neural_local_table(slots: NeuralSlots, args) -> Optional[Dict[str, Any]]:
+    """The per-cell ``{name: module}`` table for ``local['neural_coefficients']`` (touch-point 3), or
+    ``None`` when the block has no networks. Trainable modules arrive through ``args``; a frozen (or
+    static-placeholder) net falls back to its stored module."""
+    if not slots.all_names:
+        return None
+    a = args or {}
+    return {n: a.get(n, slots.models[n].module) for n in slots.all_names}
 
 
 def _flatten_product(node):

--- a/jno/utils/solver/solver_helper.py
+++ b/jno/utils/solver/solver_helper.py
@@ -11,6 +11,7 @@ from ...trace import (
     Jacobian,
     Literal,
     ModelCall,
+    ModelWeights,
     NormalDerivative,
     OperationCall,
     OperationDef,
@@ -55,6 +56,10 @@ def iter_children(node: Any):
         for a in node.args:
             if isinstance(a, Placeholder):
                 yield a
+        return
+
+    if isinstance(node, ModelWeights):
+        # Leaf: references a Model's weight pytree, wraps no traced sub-expression.
         return
 
     if isinstance(node, OperationDef):

--- a/jno/utils/solver/weak_form.py
+++ b/jno/utils/solver/weak_form.py
@@ -33,6 +33,7 @@ from ...trace import (
     Hessian,
     Jacobian,
     Literal,
+    ModelCall,
     Placeholder,
     StateField,
     TestFunction,
@@ -666,6 +667,13 @@ def _is_obviously_nonlinear_in_unknown(domain, expr):
 
     if isinstance(expr, (Jacobian, Hessian)):
         return _is_obviously_nonlinear_in_unknown(domain, expr.target)
+
+    if isinstance(expr, ModelCall):
+        # A network is a generically nonlinear map of its inputs: a learned constitutive law
+        # ``net(u)`` / ``net(∇u)`` makes the form nonlinear in the unknown even in an otherwise
+        # linear term (e.g. the bare reaction ``net(u)*v``, which no product rule above catches);
+        # a coordinate-input coefficient ``net(x, y)`` stays linear.
+        return any(_contains_unknown_symbol(domain, a) for a in expr.args if isinstance(a, Placeholder))
 
     return False
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,6 +179,7 @@ nav:
       - Poroelastic Consolidation (Biot): tutorials/08-fem-and-varpinns/poroelastic-consolidation-2d.md
       - Inverse Diffusivity Field: tutorials/08-fem-and-varpinns/inverse-diffusivity-field.md
       - Inverse Neural Diffusivity: tutorials/08-fem-and-varpinns/inverse-neural-diffusivity-2d.md
+      - Learn Constitutive Law k(T): tutorials/08-fem-and-varpinns/learn-constitutive-law-2d.md
       - Inverse Conductivity (L-shape): tutorials/08-fem-and-varpinns/inverse-conductivity-lshape.md
       - Transient Inverse (Rate): tutorials/08-fem-and-varpinns/transient-inverse-heat.md
       - "Inverse Plate Stiffness (4th-order field)": tutorials/08-fem-and-varpinns/inverse-plate-stiffness-2d.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,6 +178,7 @@ nav:
       - Additive Manufacturing (laser thermo-mechanics): tutorials/08-fem-and-varpinns/am-laser-thermomechanics-2d.md
       - Poroelastic Consolidation (Biot): tutorials/08-fem-and-varpinns/poroelastic-consolidation-2d.md
       - Inverse Diffusivity Field: tutorials/08-fem-and-varpinns/inverse-diffusivity-field.md
+      - Inverse Neural Diffusivity: tutorials/08-fem-and-varpinns/inverse-neural-diffusivity-2d.md
       - Inverse Conductivity (L-shape): tutorials/08-fem-and-varpinns/inverse-conductivity-lshape.md
       - Transient Inverse (Rate): tutorials/08-fem-and-varpinns/transient-inverse-heat.md
       - "Inverse Plate Stiffness (4th-order field)": tutorials/08-fem-and-varpinns/inverse-plate-stiffness-2d.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,9 @@ ci-test = "pytest -x --tb=short -m 'not slow'"
 # Coverage variant used by .github/workflows/ci.yml — emits coverage.xml
 # for the codecov upload step. Kept separate from `ci-test` so local
 # `pixi run ci-test` stays fast and unannotated.
-ci-test-cov = "pytest -x --tb=short -m 'not slow' --cov=jno --cov-report=xml:coverage.xml --cov-report=term-missing"
+# Runs each test FILE in its own process (memory released between files) so the
+# growing FEM suite does not OOM-kill the CI runner; aggregates coverage.xml.
+ci-test-cov = "bash .github/ci_test_per_file.sh"
 
 [tool.pixi.dependencies]
 pytest = ">=9.0.3,<10"

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -1095,16 +1095,87 @@ def test_nonnodal_trainable_net_in_boundary_term_guard():
         jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, net(xr, yr) * wr, u(xl, yl) - 0.0])
 
 
+# ==========================================================================
+# net-valued Dirichlet: an unknown boundary profile u(region) - net(x)
+# ==========================================================================
+
+
+def test_dirichlet_net_routes_parametric():
+    """``u(boundary) - net(xb, yb)`` (a trial-only constraint) is a trainable Dirichlet *value*, not a
+    coefficient: the system routes to a parametric FemLinearSystem carrying the net's ModelWeights
+    slot, and the operator itself is unchanged (only the load carries the net)."""
+    from jno.trace import FemLinearSystem
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.25)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    net = _mlp_net(key=40)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 0.0 * vi, u(xb, yb) - net(xb, yb)], quad_degree=3)
+    assert fem.is_linear and isinstance(fem.operator, FemLinearSystem) and fem.operator.is_parametric
+    (name,) = fem.operator.runtime_parameter_exprs
+    assert isinstance(fem.operator.runtime_parameter_exprs[name], ModelWeights)
+
+
+def test_dirichlet_net_recovers_bc_profile():
+    """The headline: recover an unknown Dirichlet profile g(x) = net(x) from the interior response.
+    Laplace ``∇u·∇v = 0`` with ``u(boundary) - net(xb, yb)`` — u is the harmonic extension of the BC,
+    so the interior data pins the boundary profile. The recovery (∂loss/∂weights actually moves the
+    profile) is the correctness test — an operator-match would pass even if the value froze."""
+
+    def setup(g_node_fn):
+        d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.2)
+        u, phi = d.fem_symbols()
+        xi, yi, _ = d.variable("interior", split=True)
+        xb, yb, _ = d.variable("boundary", split=True)
+        ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+        return d, u, (xb, yb), jno.fem([ui.x * vi.x + ui.y * vi.y - 0.0 * vi, g_node_fn(u, xb, yb)], quad_degree=3)
+
+    _, _, _, fem_ref = setup(lambda u, xb, yb: u(xb, yb) - (0.3 + 0.5 * xb + 0.2 * yb))
+    u_obs = jnp.linalg.solve(jnp.asarray(_dense(fem_ref.A)), jnp.asarray(fem_ref.b).reshape(-1))
+
+    net = _mlp_net(key=41, hidden=16)
+    net.optimizer(optax.adam(1e-2))
+    d, u, (xb, yb), fem = setup(lambda u, xb, yb: u(xb, yb) - net(xb, yb))
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    crux.solve(400)
+
+    trained = crux.eval([ModelWeights(net)])
+    nodes = np.asarray(d.built_mesh.points)[:, :2]
+    onb = np.isclose(nodes[:, 0], 0) | np.isclose(nodes[:, 0], 1) | np.isclose(nodes[:, 1], 0) | np.isclose(nodes[:, 1], 1)
+    bn = nodes[onb]
+    g_net = np.asarray(trained(jnp.asarray(bn[:, 0:1]), jnp.asarray(bn[:, 1:2]))).reshape(-1)
+    g_true = 0.3 + 0.5 * bn[:, 0] + 0.2 * bn[:, 1]
+    rel = float(np.linalg.norm(g_net - g_true) / np.linalg.norm(g_true))
+    assert rel < 0.1, f"Dirichlet BC profile recovery rel-err {rel:.3e}"
+
+
+def test_dirichlet_net_scope_guards():
+    """Only a *bare* net(x) Dirichlet value on a boundary is supported: a compound value, an
+    initial-condition value, and a transient form each fail loud."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+
+    # compound Dirichlet value 1 + net(x): rejected (needs a general args-aware value evaluator)
+    net = _mlp_net(key=42)
+    with pytest.raises(NotImplementedError, match="bare|compound"):
+        jno.fem([ui.x * vi.x + ui.y * vi.y - 0.0 * vi, u(xb, yb) - (1.0 + net(xb, yb))], quad_degree=3)
+
+    # net as an initial-condition value: rejected
+    d2, u2, phi2, (x2, y2), (xb2, yb2), ci, u2i, v2i, _psi0 = _transient_setup(mesh_size=0.3, time=(0.0, 0.05, 6))
+    net2 = _mlp_net(key=43)
+    with pytest.raises(NotImplementedError, match="bare|initial|transient"):
+        jno.fem([u2i.t * v2i + (u2i.x * v2i.x + u2i.y * v2i.y), u2(xb2, yb2) - 0.0, u2(ci[0], ci[1]) - net2(ci[0], ci[1])])
+
+
 def test_scope_guards_fail_loud():
-    """Scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
-    Dirichlet value and a solution-dependent net(u) on the mass (u_t) term (a nonlinear mass)."""
-    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
-    net = _mlp_net(key=5)
-
-    # net in a Dirichlet value expression
-    with pytest.raises(NotImplementedError, match="Dirichlet"):
-        jno.fem([(ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - net(xb, yb)])
-
+    """Scope limits raise explicit NotImplementedError, never mis-assemble: a solution-dependent
+    net(u) on the mass (u_t) term (a nonlinear mass). (A *bare* net(x) Dirichlet value IS supported
+    — see test_dirichlet_net_recovers_bc_profile; only compound/IC/transient net values are guarded.)"""
     # net(u) on the mass term = a nonlinear mass C(u)*u_t (the matrix form can't express it). A
     # coordinate net(x) mass coefficient IS supported (see test_mass_net_kx_recovers_via_crux).
     d2, u2, phi2, (x2, y2), (xb2, yb2), ci, u2i, v2i, psi0 = _transient_setup(mesh_size=0.3, time=(0.0, 0.02, 5))

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -949,6 +949,83 @@ def test_rt_solution_dependent_net_guard():
         jno.fem([net(ui) * inner(ui, vi) - inner(vi, vi)])
 
 
+def _hermite_transient_setup(coeff_fn, mesh_size=0.3, time=(0.0, 0.05, 6)):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size, time=time)
+    u, phi = d.fem_symbols(space="Hermite")
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), phi.bind(x=xi, y=yi, t=ti)
+    u0 = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    return d, jno.fem([ui.t * vi + coeff_fn(xi, yi) * (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - u0])
+
+
+def test_transient_nonnodal_net_kx_matches_frozen():
+    """A trainable net(x) diffusivity in a Hermite (C¹) TRANSIENT form: the per-step re-assembled
+    operator leg reproduces the frozen (fixed-operator) trajectory, and the trajectory's gradient
+    reaches the net weights through the time-stepping."""
+    from jno.utils.solver.backend_blocks import _block_time_grid, _default_transient_integrate
+
+    net = _mlp_net(key=30, hidden=8)
+    d, fem = _hermite_transient_setup(lambda x, y: 1.0 + net(x, y))
+    assert fem.is_transient
+    (name,) = fem.operator.runtime_parameter_exprs
+    assert isinstance(fem.operator.runtime_parameter_exprs[name], ModelWeights)
+    ts = _block_time_grid(fem.operator)
+    traj = _default_transient_integrate(fem.operator, {name: net.module}, ts)
+
+    net_f = _mlp_net(key=30, hidden=8)  # identical weights
+    net_f.freeze()
+    _, fem_f = _hermite_transient_setup(lambda x, y: 1.0 + net_f(x, y))
+    traj_f = _default_transient_integrate(fem_f.operator, {}, _block_time_grid(fem_f.operator))
+    assert float(jnp.max(jnp.abs(traj - traj_f))) < 1e-8
+
+    def loss(m):
+        return jnp.sum(_default_transient_integrate(fem.operator, {name: m}, ts) ** 2)
+
+    g = eqx.filter_grad(loss)(net.module)
+    gsum = sum(jnp.sum(jnp.abs(x)) for x in jax.tree_util.tree_leaves(g) if eqx.is_inexact_array(x))
+    assert float(gsum) > 0.0
+
+
+def test_transient_nonnodal_neural_kx_recovers_via_crux():
+    """Recover a smooth k(x) from a Hermite transient trajectory through the default `fem.solve()`
+    (the transient integrator solves the dense per-step system directly, so no dense solve_fn
+    override is needed — unlike the steady non-nodal path)."""
+    from jno.utils.solver.backend_blocks import _block_time_grid, _default_transient_integrate
+
+    _, fem_ref = _hermite_transient_setup(lambda x, y: 1.0 + 0.5 * x + 0.3 * y)
+    u_obs = _default_transient_integrate(fem_ref.operator, {}, _block_time_grid(fem_ref.operator))
+
+    net = _mlp_net(key=31, hidden=16)
+    net.optimizer(optax.adam(1e-2))
+    d, fem = _hermite_transient_setup(lambda x, y: 1.0 + net(x, y))
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    crux.solve(300)
+
+    trained = crux.eval([ModelWeights(net)])
+    nodes = np.asarray(d.built_mesh.points)[:, :2]
+    k_net = 1.0 + np.asarray(trained(jnp.asarray(nodes))).reshape(-1)
+    k_true = 1.0 + 0.5 * nodes[:, 0] + 0.3 * nodes[:, 1]
+    rel = float(np.linalg.norm(k_net - k_true) / np.linalg.norm(k_true))
+    assert rel < 0.12, f"transient non-nodal neural k(x) recovery rel-err {rel:.3e}"
+
+
+def test_transient_nonnodal_mass_net_guard():
+    """A trainable net on the mass (u_t) term of a non-nodal transient form fails loud (the mass
+    block is assembled once) — a frozen one would be fine."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3, time=(0.0, 0.05, 6))
+    u, phi = d.fem_symbols(space="Hermite")
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), phi.bind(x=xi, y=yi, t=ti)
+    u0 = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    net2 = _mlp_net(key=33)
+    with pytest.raises(NotImplementedError, match="mass"):
+        jno.fem([(1.0 + net2(xi, yi)) * ui.t * vi + (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - u0])
+
+
 def test_nonnodal_trainable_net_in_boundary_term_guard():
     """On a non-nodal element a *trainable* net in a Neumann/Robin (boundary) term fails loud — the
     natural-BC load is assembled non-differentiably there. (Native folds boundary nets into the

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -303,6 +303,7 @@ def test_net_in_robin_boundary_term():
 # ==========================================================================
 
 
+@pytest.mark.slow
 def test_neural_kx_recovers_via_crux():
     """Recover a smooth diffusivity k(x) = 0.6 + 0.8x + 0.5y with a coordinate MLP trained through
     the differentiable ``fem.solve()``. The ``1 + net`` offset keeps the operator nonsingular at
@@ -470,6 +471,7 @@ def test_ku_gradient_matches_finite_difference():
     assert abs(g_ad - g_fd) < 1e-5 * max(1.0, abs(g_fd)), f"AD {g_ad} vs FD {g_fd}"
 
 
+@pytest.mark.slow
 def test_ku_recovers_constitutive_law_via_crux():
     """NN-EUCLID-style unsupervised constitutive learning: observe u from a hidden law
     k(u) = 1 + 0.5u², train a 1-input MLP ``1 + net(u)`` through the differentiable nonlinear
@@ -560,6 +562,7 @@ def test_transient_net_kx_trajectory_matches_frozen_reference():
     assert float(jnp.max(jnp.abs(traj - traj_f))) < 1e-9
 
 
+@pytest.mark.slow
 def test_transient_neural_kx_recovers_via_crux():
     """Recover a smooth diffusivity k(x) from a u(t) trajectory with a coordinate MLP trained
     through the transient ``fem.solve()`` (per-step re-assembly, implicit-diff to the weights) —
@@ -590,6 +593,7 @@ def test_transient_neural_kx_recovers_via_crux():
     assert rel < 0.1, f"transient neural k(x) recovery rel-err {rel:.3e}"
 
 
+@pytest.mark.slow
 def test_transient_nonlinear_ku_recovers_via_crux():
     """A constitutive law k(u) in a TRANSIENT form: u_t = div((a + b·u²)∇u). The per-step Newton
     (implicit backward Euler) carries the net's u-dependence; recover (a, b) from the trajectory
@@ -670,6 +674,7 @@ def test_mass_net_kx_parametric_matches_frozen():
     assert float(gsum) > 0.0  # gradient reached the net through the mass
 
 
+@pytest.mark.slow
 def test_mass_net_kx_recovers_via_crux():
     """Recover an unknown density ρ(x) on the mass term from a decay trajectory through the
     differentiable transient `fem.solve()` — the headline for the parametric-mass path."""
@@ -740,6 +745,7 @@ def test_complex_constant_net_matches_scalar_forward():
     assert float(np.abs(u_ref.imag).max()) > 0.1  # genuinely complex
 
 
+@pytest.mark.slow
 def test_complex_net_recovers_kappa_via_crux():
     """Recover the (constant) diffusivity κ = 0.8 with a coordinate MLP trained through the
     complex real-equivalent block — ∂u/∂weights flows through the parametric legs."""
@@ -934,6 +940,7 @@ def test_hermite_constitutive_ku_matches_symbolic():
     assert float(jnp.max(jnp.abs(u_net - u_sym))) < 1e-9
 
 
+@pytest.mark.slow
 def test_hermite_neural_kx_recovers_via_crux():
     """End-to-end: recover a smooth k(x) with a coordinate MLP on a Hermite (C¹) element through the
     non-nodal parametric ``fem.solve()`` — proves the ModelWeights threading reaches the non-nodal
@@ -1041,6 +1048,7 @@ def test_transient_nonnodal_net_kx_matches_frozen():
     assert float(gsum) > 0.0
 
 
+@pytest.mark.slow
 def test_transient_nonnodal_neural_kx_recovers_via_crux():
     """Recover a smooth k(x) from a Hermite transient trajectory through the default `fem.solve()`
     (the transient integrator solves the dense per-step system directly, so no dense solve_fn
@@ -1118,6 +1126,7 @@ def test_dirichlet_net_routes_parametric():
     assert isinstance(fem.operator.runtime_parameter_exprs[name], ModelWeights)
 
 
+@pytest.mark.slow
 def test_dirichlet_net_recovers_bc_profile():
     """The headline: recover an unknown Dirichlet profile g(x) = net(x) from the interior response.
     Laplace ``∇u·∇v = 0`` with ``u(boundary) - net(xb, yb)`` — u is the harmonic extension of the BC,

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -5,9 +5,10 @@ points, the weights ride the runtime ``args`` as a ``ModelWeights`` slot, and ``
 trains them through the differentiable ``fem.solve()`` (NN-EUCLID-style unsupervised coefficient
 recovery — Flaschel/Kumar/De Lorenzis, JMPS 165 (2022); Tartakovsky et al., WRR 56 (2020)).
 
-Scope locked here (v1): steady weak forms on the native 2D/3D Lagrange assembler, single field.
-The set-level routing rule (a weak constraint carrying a real ``TrialFunction`` means the network
-is a coefficient, not the trial) must not disturb VPINN.
+Coverage: steady/nonlinear/transient/complex on the native 2D/3D Lagrange assembler (single AND
+coupled multi-field), plus scalar C¹ non-nodal elements (Argyris/Morley/Hermite). The set-level
+routing rule (a weak constraint carrying a real ``TrialFunction`` means the network is a
+coefficient, not the trial) must not disturb VPINN.
 
 Run with x64 (assembly runs in float64).
 """
@@ -707,6 +708,81 @@ def test_complex_scope_guards():
                 u(ci[0], ci[1]) - psi0,
             ]
         )
+
+
+# ==========================================================================
+# multi-field (coupled): a neural coefficient needs no per-field resolution
+# ==========================================================================
+
+
+def _coupled_setup(mesh_size=0.12):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    nnode = int(np.asarray(d.mesh.points).shape[0])
+    u, v = d.fem_symbols(names=("u", "v"))
+    p, q = d.fem_symbols(names=("p", "q"))
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    pi, qi = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+    g = xi * (1 - xi) * yi * (1 - yi)
+    lg = 2 * (xi * (1 - xi) + yi * (1 - yi))
+    f1, f2 = lg + 2 * g, 2 * lg + g
+    return d, nnode, (u, v, p, q), (xi, yi), (xb, yb), (ui, vi, pi, qi), (f1, f2)
+
+
+def test_multifield_constant_net_matches_scalar_operator():
+    """A constant net on one field's stiffness in a COUPLED (2-field) form assembles the same block
+    operator as the scalar coefficient — the net threads without per-field resolution."""
+    d, nnode, (u, v, p, q), (xi, yi), (xb, yb), (ui, vi, pi, qi), (f1, f2) = _coupled_setup()
+    net = _const_net(0.7)
+
+    def cons(kco):
+        return [
+            kco * (ui.x * vi.x + ui.y * vi.y) + p * vi - f1 * vi,
+            pi.x * qi.x + pi.y * qi.y + u * qi - f2 * qi,
+            u(xb, yb) - 0.0,
+            p(xb, yb) - 0.0,
+        ]
+
+    fem = jno.fem(cons(net(xi, yi)), quad_degree=3)
+    fem_ref = jno.fem(cons(0.7), quad_degree=3)
+    assert fem.is_linear and fem.dofs == 2 * nnode
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, _ = fem.operator.evaluate({name: net.module})
+    assert np.abs(_dense(A) - _dense(fem_ref.A)).max() < 1e-12
+
+
+def test_multifield_nonlinear_net_resolves_correct_field():
+    """A solution-dependent net ``net(u_0)`` in a coupled form must resolve field 0's trial (not
+    field 0 by default) and match the symbolic ``(1 + 0.5 u_0²)`` coupled Newton solve — the
+    definitive per-field-resolution check — with the gradient flowing to the net's weights."""
+    from jno.utils.solver.newton_krylov import newton_krylov
+
+    d, nnode, (u, v, p, q), (xi, yi), (xb, yb), (ui, vi, pi, qi), (f1, f2) = _coupled_setup()
+
+    def cons(kco):
+        return [
+            kco * (ui.x * vi.x + ui.y * vi.y) + p * vi - f1 * vi,
+            pi.x * qi.x + pi.y * qi.y + u * qi - f2 * qi,
+            u(xb, yb) - 0.0,
+            p(xb, yb) - 0.0,
+        ]
+
+    net = _quad_net(a=1.0, b=0.5)
+    fem = jno.fem(cons(net(ui)), quad_degree=3)
+    fem_sym = jno.fem(cons(1.0 + 0.5 * ui**2), quad_degree=3)
+    assert fem._mode == "nonlinear"
+    (name,) = fem.operator.runtime_parameter_exprs
+    u_net = newton_krylov(lambda w: fem.operator.residual(w, {name: net.module}), jnp.zeros(fem.operator.size))
+    u_sym = newton_krylov(lambda w: fem_sym.operator(w), jnp.zeros(fem_sym.operator.size))
+    assert float(jnp.max(jnp.abs(u_net - u_sym))) < 1e-9
+
+    def loss(module):
+        r = lambda w: fem.operator.residual(w, {name: module})
+        return jnp.sum(newton_krylov(r, jnp.zeros(fem.operator.size)) ** 2)
+
+    g = eqx.filter_grad(loss)(net.module)
+    assert abs(float(g.a)) > 0.0 and abs(float(g.b)) > 0.0
 
 
 def test_scope_guards_fail_loud():

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -344,6 +344,172 @@ def test_f32_net_promotes_under_x64():
     assert np.all(np.isfinite(sol))
 
 
+# ==========================================================================
+# learned constitutive laws: k(u) / k(∇u) — steady nonlinear
+# (NN-EUCLID-style: Flaschel/Kumar/De Lorenzis, JMPS 165 (2022) §2.2–2.3)
+# ==========================================================================
+
+
+class _Quad(eqx.Module):
+    """'Network' computing exactly k(u) = a + b·u² — lets the nonlinear solve be checked against
+    the symbolically written form with zero training (and gives named-leaf gradient checks)."""
+
+    a: jnp.ndarray
+    b: jnp.ndarray
+
+    def __call__(self, u):
+        return self.a + self.b * jnp.asarray(u) ** 2
+
+
+def _quad_net(a=1.0, b=0.5):
+    net = jno.nn.wrap(_Quad(a=jnp.asarray(float(a)), b=jnp.asarray(float(b))))
+    net.dtype(jnp.float64)
+    return net
+
+
+def _ku_setup(mesh_size=0.25):
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, _ = _poisson_setup(mesh_size)
+    f = 10.0 * jno.np.sin(PI * xi) * jno.np.sin(PI * yi)
+    return d, u, phi, (xi, yi), (xb, yb), ui, vi, f
+
+
+def test_ku_classification():
+    """A net whose args carry the unknown makes the form NONLINEAR — including the bare reaction
+    ``net(u)*v`` that no product rule catches — while a coordinate-input net stays linear."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _ku_setup()
+    net = _quad_net()
+    fem = jno.fem([net(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    assert fem._mode == "nonlinear"
+
+    net_r = _quad_net()
+    fem_r = jno.fem([(ui.x * vi.x + ui.y * vi.y) + net_r(ui) * vi - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    assert fem_r._mode == "nonlinear"
+
+    net_x = _mlp_net(key=7)
+    fem_l = jno.fem([(1.0 + net_x(xi, yi)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    assert fem_l._mode == "linear"
+
+
+def test_ku_forward_matches_symbolic_newton():
+    """The net-coefficient Newton solve equals the symbolically written ``(1 + 0.5u²)∇u·∇v`` Newton
+    solve to machine precision — the net is evaluated inside the residual, its u-dependence enters
+    the element Jacobian through jacfwd."""
+    from jno.utils.solver.newton_krylov import newton_krylov
+
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _ku_setup()
+    net = _quad_net(a=1.0, b=0.5)
+    fem = jno.fem([net(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    fem_sym = jno.fem([(1.0 + 0.5 * ui**2) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+    (name,) = fem.operator.runtime_parameter_exprs
+    u_net = newton_krylov(lambda v: fem.operator.residual(v, {name: net.module}), jnp.zeros(fem.operator.size))
+    u_sym = newton_krylov(lambda v: fem_sym.operator(v), jnp.zeros(fem_sym.operator.size))
+    assert float(jnp.max(jnp.abs(u_net - u_sym))) < 1e-10
+    assert float(jnp.linalg.norm(u_sym)) > 0.1  # a genuinely nonzero, nonlinear solution
+
+
+def test_kgradu_form_matches_symbolic():
+    """k(∇u): a net taking the gradient components (p-Laplacian-style ``k = 1 + 0.5|∇u|²``) solves
+    and matches the symbolic reference."""
+    from jno.utils.solver.newton_krylov import newton_krylov
+
+    class _PLap(eqx.Module):
+        b: jnp.ndarray
+
+        def __call__(self, gx, gy):
+            return 1.0 + self.b * (jnp.asarray(gx) ** 2 + jnp.asarray(gy) ** 2)
+
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _ku_setup()
+    net = jno.nn.wrap(_PLap(b=jnp.asarray(0.5)))
+    net.dtype(jnp.float64)
+    fem = jno.fem([net(ui.x, ui.y) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    assert fem._mode == "nonlinear"
+    fem_sym = jno.fem(
+        [(1.0 + 0.5 * (ui.x**2 + ui.y**2)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3
+    )
+    (name,) = fem.operator.runtime_parameter_exprs
+    u_net = newton_krylov(lambda v: fem.operator.residual(v, {name: net.module}), jnp.zeros(fem.operator.size))
+    u_sym = newton_krylov(lambda v: fem_sym.operator(v), jnp.zeros(fem_sym.operator.size))
+    assert float(jnp.max(jnp.abs(u_net - u_sym))) < 1e-10
+
+
+def test_constant_ku_net_equals_linear_solve():
+    """The degenerate constitutive law k(u) ≡ c must reproduce the plain linear solve (even though
+    the form still classifies nonlinear — Newton just converges to the linear solution)."""
+    from jno.utils.solver.newton_krylov import newton_krylov
+
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _ku_setup()
+    net = _quad_net(a=2.0, b=0.0)
+    fem = jno.fem([net(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    fem_lin = jno.fem([2.0 * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    (name,) = fem.operator.runtime_parameter_exprs
+    u_net = newton_krylov(lambda v: fem.operator.residual(v, {name: net.module}), jnp.zeros(fem.operator.size))
+    u_lin = jnp.linalg.solve(jnp.asarray(_dense(fem_lin.A)), jnp.asarray(fem_lin.b).reshape(-1))
+    assert float(jnp.max(jnp.abs(u_net - u_lin))) < 1e-9
+
+
+def test_ku_gradient_matches_finite_difference():
+    """The implicit-diff gradient (custom_root through Newton) w.r.t. a net weight matches central
+    finite differences — the least-exercised corner (closure-converted module pytree)."""
+    from jno.utils.solver.newton_krylov import newton_krylov
+
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _ku_setup(mesh_size=0.4)
+    net = _quad_net(a=1.0, b=0.5)
+    fem = jno.fem([net(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    (name,) = fem.operator.runtime_parameter_exprs
+
+    def loss_at(b_val):
+        module = _Quad(a=jnp.asarray(1.0), b=jnp.asarray(b_val))
+        uu = newton_krylov(lambda v: fem.operator.residual(v, {name: module}), jnp.zeros(fem.operator.size))
+        return jnp.sum(uu**2)
+
+    g_ad = float(jax.grad(loss_at)(0.5))
+    h = 1e-6
+    g_fd = float((loss_at(0.5 + h) - loss_at(0.5 - h)) / (2 * h))
+    assert abs(g_ad - g_fd) < 1e-5 * max(1.0, abs(g_fd)), f"AD {g_ad} vs FD {g_fd}"
+
+
+def test_ku_recovers_constitutive_law_via_crux():
+    """NN-EUCLID-style unsupervised constitutive learning: observe u from a hidden law
+    k(u) = 1 + 0.5u², train a 1-input MLP ``1 + net(u)`` through the differentiable nonlinear
+    ``fem.solve()``, and check the learned k against the truth on the observed u-range."""
+    from jno.utils.solver.newton_krylov import newton_krylov
+
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _ku_setup(mesh_size=0.25)
+    fem_sym = jno.fem([(1.0 + 0.5 * ui**2) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    u_obs = newton_krylov(lambda v: fem_sym.operator(v), jnp.zeros(fem_sym.operator.size))
+
+    net = jno.nn.wrap(foundax.mlp(1, hidden_dims=16, num_layers=2, activation=jax.nn.tanh, key=jax.random.PRNGKey(8)))
+    net.dtype(jnp.float64)
+    net.optimizer(optax.adam(1e-2))
+    fem = jno.fem([(1.0 + net(ui)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    assert fem._mode == "nonlinear"
+
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    crux.solve(600)
+
+    trained = crux.eval([ModelWeights(net)])
+    u_grid = jnp.linspace(0.0, float(jnp.max(u_obs)), 64).reshape(-1, 1)
+    k_learned = 1.0 + np.asarray(trained(u_grid)).reshape(-1)
+    k_true = 1.0 + 0.5 * np.asarray(u_grid).reshape(-1) ** 2
+    rel = float(np.linalg.norm(k_learned - k_true) / np.linalg.norm(k_true))
+    assert rel < 0.05, f"constitutive-law recovery rel-err {rel:.3e}"
+
+
+def test_ku_composes_with_solver_slots():
+    """The nonlinear neural-coefficient solve composes with the slot API
+    (``fem.solve(nonlinear=jno.solve.newton())``) through crux."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _ku_setup(mesh_size=0.35)
+    net = _quad_net(a=1.0, b=0.3)
+    net.optimizer(optax.adam(1e-3))
+    fem = jno.fem([net(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    u_node = fem.solve(nonlinear=jno.solve.newton())
+    crux = jno.core([(u_node**2).mse], domain=_DUMMY)
+    crux.solve(3)  # composes and steps without error
+    val = np.asarray(crux.eval([ModelWeights(net)]).b)
+    assert np.isfinite(val).all()
+
+
 def test_scope_guards_fail_loud():
     """v1 scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
     Dirichlet value and a net in a transient form."""

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -1197,3 +1197,52 @@ def test_scope_guards_fail_loud():
                 u2(ci[0], ci[1]) - psi0,
             ]
         )
+
+
+# ==========================================================================
+# frozen fields: ui.freeze(values) as a KNOWN predictor input to a coefficient
+# ==========================================================================
+
+
+def _mlp_net4(key=0, hidden=16, layers=2):
+    """A 4-input MLP: (x, y, d_x u0, d_y u0) -> scalar coefficient."""
+    net = jno.nn.wrap(
+        foundax.mlp(4, hidden_dims=hidden, num_layers=layers, activation=jax.nn.tanh, key=jax.random.PRNGKey(key))
+    )
+    net.dtype(jnp.float64)
+    return net
+
+
+def test_freeze_value_reproduces_the_field():
+    """``ui.freeze(u0)`` interpolates the KNOWN nodal vector u0 at the quad points: its L2 projection
+    back onto the same P1 space is u0 itself (u0 lives in the space), to machine precision."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup(mesh_size=0.25)
+    # a known field: solve a plain Poisson problem for u0
+    u0 = np.asarray(jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3).solve()).reshape(-1)
+    # mass @ x = integral( freeze(u0) * v )  ->  x = L2 projection of u0 = u0
+    proj = jno.fem([ui * vi - ui.freeze(u0) * vi], quad_degree=3)
+    x = np.asarray(proj.solve(linear=jno.solve.lu())).reshape(-1)  # direct solve -> machine precision
+    assert proj.is_linear
+    assert np.linalg.norm(x - u0) / np.linalg.norm(u0) < 1e-11
+
+
+def test_freeze_gradient_conditioned_coefficient_is_linear_and_trains():
+    """A diffusion coefficient conditioned on a FROZEN predictor gradient,
+    ``kappa = softplus(net(x, y, ui.freeze(u0).x, ui.freeze(u0).y))``, stays LINEAR in the true
+    unknown (the frozen field is known data, not the unknown) and its weights train through the
+    differentiable solve (loss decreases)."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup(mesh_size=0.25)
+    u0 = np.asarray(jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3).solve()).reshape(-1)
+    u_obs = u0.copy()  # target: recover the plain-Poisson solution (correction should shrink to ~0)
+
+    net = _mlp_net4()
+    net.optimizer(optax.adam(3e-3))
+    uk = ui.freeze(u0)
+    kappa = jnn.log1p(jnn.exp(net(xi, yi, uk.x, uk.y) - 4.0))  # softplus, small at init
+    fem = jno.fem([(1.0 + kappa) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    assert fem.is_linear, "a frozen-field-conditioned coefficient must keep the system linear"
+
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    hist = crux.solve(200)
+    losses = np.asarray(hist.total_loss_history)
+    assert losses[-1] < 0.5 * losses[0], "frozen-conditioned coefficient weights should train through the solve"

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -927,6 +927,22 @@ def test_nonnodal_vector_family_guard():
         jno.fem([net(xi, yi) * jno.np.inner(ui, vi) - jno.np.inner(vi, vi)])
 
 
+def test_nonnodal_trainable_net_in_boundary_term_guard():
+    """On a non-nodal element a *trainable* net in a Neumann/Robin (boundary) term fails loud — the
+    natural-BC load is assembled non-differentiably there. (Native folds boundary nets into the
+    kernel table; the non-nodal path deliberately does not — this pins that divergence.)"""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3)
+    xi, yi, _ = d.variable("interior", split=True)
+    xr, yr, _ = d.variable("right", split=True)
+    xl, yl, _ = d.variable("left", split=True)
+    u, phi = d.fem_symbols(space="Hermite")
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    wr = phi.bind(x=xr, y=yr)
+    net = _mlp_net(key=22)
+    with pytest.raises(NotImplementedError, match="boundary"):
+        jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, net(xr, yr) * wr, u(xl, yl) - 0.0])
+
+
 def test_scope_guards_fail_loud():
     """Scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
     Dirichlet value and a trainable net on the mass (u_t) term."""

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -618,6 +618,27 @@ def test_transient_nonlinear_ku_recovers_via_crux():
     assert rel < 0.05, f"transient constitutive-law recovery rel-err {rel:.3e}"
 
 
+def test_frozen_net_on_mass_term_is_allowed():
+    """A *frozen* (known) net on the mass (u_t) term IS allowed — a known spatially-varying density
+    ρ(x)·u_t: the mass matrix is assembled once from its stored weights, matching the same scalar
+    density's trajectory. Only a *trainable* net on the mass term is guarded (see the scope test)."""
+    from jno.utils.solver.backend_blocks import _default_transient_integrate
+
+    def setup(coeff):
+        d, u, phi, (xi, yi), (xb, yb), ci, ui, vi, u0 = _transient_setup(mesh_size=0.25, time=(0.0, 0.05, 6))
+        return d, jno.fem([coeff(xi, yi) * ui.t * vi + (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - u0])
+
+    net = _const_net(1.3)
+    net.freeze()
+    d, fem = setup(lambda x, y: net(x, y))
+    assert fem.is_transient and not getattr(fem.operator, "is_parametric", False)  # known coeff -> non-parametric
+    traj = _default_transient_integrate(fem.operator, {}, _grid_ts(fem.operator))
+
+    _, fem_ref = setup(lambda x, y: 1.3)
+    traj_ref = _default_transient_integrate(fem_ref.operator, {}, _grid_ts(fem_ref.operator))
+    assert float(jnp.max(jnp.abs(traj - traj_ref))) < 1e-12
+
+
 # ==========================================================================
 # complex: a real net coefficient through the real-equivalent block
 # ==========================================================================

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -1,0 +1,373 @@
+"""Neural coefficients in assembled FEM systems: ``jno.nn.wrap(net)`` called inside a weak form
+(e.g. ``net(x, y) * u.dx * v.dx``) is a trainable *coefficient* on an ordinary FE system — not a
+VPINN trial. The system assembles as usual; the kernel re-evaluates the network at the quadrature
+points, the weights ride the runtime ``args`` as a ``ModelWeights`` slot, and ``crux.solve``
+trains them through the differentiable ``fem.solve()`` (NN-EUCLID-style unsupervised coefficient
+recovery — Flaschel/Kumar/De Lorenzis, JMPS 165 (2022); Tartakovsky et al., WRR 56 (2020)).
+
+Scope locked here (v1): steady weak forms on the native 2D/3D Lagrange assembler, single field.
+The set-level routing rule (a weak constraint carrying a real ``TrialFunction`` means the network
+is a coefficient, not the trial) must not disturb VPINN.
+
+Run with x64 (assembly runs in float64).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+pytest.importorskip("foundax", reason="foundax required for the MLP coefficient nets")
+
+import equinox as eqx  # noqa: E402
+import foundax  # noqa: E402
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import optax  # noqa: E402
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+import jno.jnp_ops as jnn  # noqa: E402
+from jno.trace import ModelWeights  # noqa: E402
+
+PI = np.pi
+
+# The inverse loss has no spatial Variable (the FEM solve is global), so crux needs
+# an explicit domain to drive its loop.
+_DUMMY = jno.domain.from_array({"_": np.zeros((1, 1))})
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """FEM assembly/solves run in float64; set x64 per-test with save/restore (the global flag is
+    shared across modules and other suites flip it at import)."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+class _Const(eqx.Module):
+    """A 'network' that outputs a constant per quad point — the degenerate extreme that must
+    reproduce a scalar-coefficient assembly exactly (and gives a single-leaf gradient check)."""
+
+    c: jnp.ndarray
+
+    def __call__(self, *args):
+        n = jnp.asarray(args[0]).shape[0]
+        return jnp.broadcast_to(self.c.reshape(1, 1), (n, 1))
+
+
+def _const_net(c):
+    net = jno.nn.wrap(_Const(c=jnp.asarray(float(c), dtype=jnp.float64)))
+    net.dtype(jnp.float64)
+    return net
+
+
+def _mlp_net(key=0, hidden=16, layers=2):
+    net = jno.nn.wrap(
+        foundax.mlp(2, hidden_dims=hidden, num_layers=layers, activation=jax.nn.tanh, key=jax.random.PRNGKey(key))
+    )
+    net.dtype(jnp.float64)
+    return net
+
+
+def _poisson_setup(mesh_size=0.25):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    return d, u, phi, (xi, yi), (xb, yb), ui, vi, f
+
+
+def _dense(A):
+    return np.asarray(A.todense() if hasattr(A, "todense") else A)
+
+
+# ==========================================================================
+# routing: coefficient vs VPINN trial
+# ==========================================================================
+
+
+def test_net_coefficient_routes_to_linear_parametric_system():
+    """``net(x,y) * grad u . grad v``: a weak constraint carrying the real TrialFunction makes the
+    network a coefficient — an assembled linear system, parametric in the net's weights (one
+    ModelWeights slot named after the model)."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    net = _mlp_net()
+    fem = jno.fem([net(xi, yi) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+    assert fem.is_linear
+    exprs = fem.operator.runtime_parameter_exprs
+    assert len(exprs) == 1
+    (name,) = exprs
+    assert isinstance(exprs[name], ModelWeights)
+    assert fem.operator.metadata.get("nonaffine_operator") is True
+
+
+def test_vpinn_network_trial_routing_unchanged():
+    """A network *replacing* the trial (no TrialFunction in any weak constraint) still routes to
+    VPINN — the set-level disambiguation must not regress the network-trial path."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    u_net = _mlp_net(key=1)(xi, yi)
+    weak = jnn.grad(u_net, xi) * jnn.grad(vi, xi) + jnn.grad(u_net, yi) * jnn.grad(vi, yi) - f * vi
+    pde = jno.fem([weak, u(xb, yb) - 0.0])
+    assert hasattr(pde, "mse") and hasattr(pde, "volume_grad_expr")  # GroupedAssembly, not FEM
+
+
+# ==========================================================================
+# extremes: constant net / zero net reproduce scalar assembly exactly
+# ==========================================================================
+
+
+def test_constant_net_matches_scalar_coefficient_operator():
+    """A net that outputs the constant 0.7 must assemble the SAME operator as the scalar
+    coefficient 0.7 (to solver precision) — pins quad-point evaluation and alignment."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    net = _const_net(0.7)
+    fem = jno.fem([net(xi, yi) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    fem_ref = jno.fem([0.7 * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, b = fem.operator.evaluate({name: net.module})
+    assert np.abs(_dense(A) - _dense(fem_ref.A)).max() < 1e-12
+    assert np.abs(np.asarray(b).reshape(-1) - np.asarray(fem_ref.b).reshape(-1)).max() < 1e-12
+
+
+def test_zero_net_zeroes_its_term():
+    """A zero net in ``(net + 1) * grad u . grad v`` leaves exactly the unit-coefficient system —
+    the additive composition evaluates the net inside the integrand, not as a factored scalar."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    net = _const_net(0.0)
+    fem = jno.fem([(net(xi, yi) + 1.0) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    fem_ref = jno.fem([1.0 * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, _ = fem.operator.evaluate({name: net.module})
+    assert np.abs(_dense(A) - _dense(fem_ref.A)).max() < 1e-12
+
+
+# ==========================================================================
+# frozen networks: known coefficients, non-parametric assembly
+# ==========================================================================
+
+
+def test_frozen_net_assembles_nonparametric_and_matches_unfrozen():
+    """``net.freeze()`` = a KNOWN network coefficient: the system stays non-parametric (eager
+    ``fem.A``) and the matrix equals the unfrozen twin re-assembled at the same weights."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    net_t = _mlp_net(key=2)
+    fem_t = jno.fem([(net_t(xi, yi) + 1.5) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    (name,) = fem_t.operator.runtime_parameter_exprs
+    A_train, _ = fem_t.operator.evaluate({name: net_t.module})
+
+    net_f = _mlp_net(key=2)  # identical weights (same PRNG key)
+    net_f.freeze()
+    fem_f = jno.fem([(net_f(xi, yi) + 1.5) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    assert not getattr(fem_f.operator, "is_parametric", False)  # plain (A, b), solved eagerly
+    assert np.abs(_dense(fem_f.A) - _dense(A_train)).max() < 1e-12
+
+    sol = np.linalg.solve(_dense(fem_f.A), np.asarray(fem_f.b).reshape(-1))
+    assert np.all(np.isfinite(sol))
+
+
+# ==========================================================================
+# composition: scalar param + nodal field + net in ONE weak form
+# ==========================================================================
+
+
+def test_mixed_scalar_nodal_neural_coefficients_compose_and_differentiate():
+    """One weak form carrying all three trainable coefficient kinds — a scalar
+    ``jno.np.parameter``, a nodal field ``jno.np.parameter(phi)``, and a network — collects all
+    three runtime slots, re-assembles, and the solve is differentiable in each."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    alpha = jno.np.parameter((1,), key=jax.random.PRNGKey(1), name="alpha")
+    alpha.initialize(jax.nn.initializers.constant(1.0))
+    alpha.dtype(jnp.float64)
+    k = jno.np.parameter(phi, name="k")
+    k.dtype(jnp.float64)
+    k.initialize(jax.nn.initializers.constant(1.0))
+    net = _mlp_net(key=3)
+
+    weak = alpha * (ui.x * vi.x + ui.y * vi.y) + k * (ui * vi) + (net(xi, yi) + 1.0) * (ui * vi) - f * vi
+    fem = jno.fem([weak, u(xb, yb) - 0.0], quad_degree=3)
+    exprs = fem.operator.runtime_parameter_exprs
+    net_name = next(n for n in exprs if n not in ("alpha", "k"))
+    assert set(exprs) == {"alpha", "k", net_name}
+    assert isinstance(exprs[net_name], ModelWeights)
+
+    n_nodes = int(np.asarray(d.built_mesh.points).shape[0])
+
+    def solve_at(a_val, k_vals, module):
+        A, b = fem.operator.evaluate({"alpha": a_val, "k": k_vals, net_name: module})
+        return jnp.linalg.solve(A.todense(), jnp.asarray(b).reshape(-1))
+
+    a0, k0 = jnp.asarray(1.0), jnp.ones((n_nodes,))
+    loss = lambda a, kv, m: jnp.sum(solve_at(a, kv, m) ** 2)
+    g_a = jax.grad(loss, argnums=0)(a0, k0, net.module)
+    g_k = jax.grad(loss, argnums=1)(a0, k0, net.module)
+    g_m = eqx.filter_grad(lambda m: loss(a0, k0, m))(net.module)
+    g_m_sum = sum(jnp.sum(jnp.abs(x)) for x in jax.tree_util.tree_leaves(g_m) if eqx.is_inexact_array(x))
+    assert abs(float(g_a)) > 0.0
+    assert float(jnp.abs(g_k).sum()) > 0.0
+    assert float(g_m_sum) > 0.0
+
+
+# ==========================================================================
+# per-region masks compose with a net coefficient
+# ==========================================================================
+
+
+def test_region_masked_load_with_net_coefficient():
+    """A region-restricted load ``-net*v`` with a constant-1 net integrates to the region's cell
+    area exactly (like the plain per-region load) — the mask's volume_var slot must not shift when
+    a neural coefficient is present."""
+    disk = lambda x, y: (x - 0.5) ** 2 + (y - 0.5) ** 2 < 0.2**2  # noqa: E731
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.08)
+    d.tag("disk", disk)
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xd, yd, _ = d.variable("disk", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    vd = phi.bind(x=xd, y=yd)
+    net = _const_net(1.0)
+
+    fem = jno.fem(
+        [(ui.x * vi.x + ui.y * vi.y), -(net(xd, yd) * vd), u(xb, yb) - 0.0],
+        quad_degree=3,
+    )
+    (name,) = fem.operator.runtime_parameter_exprs
+    _, b = fem.operator.evaluate({name: net.module})
+
+    fem_ref = jno.fem([(ui.x * vi.x + ui.y * vi.y), -(1.0 * vd), u(xb, yb) - 0.0], quad_degree=3)
+    assert np.abs(np.asarray(b).reshape(-1) - np.asarray(fem_ref.b).reshape(-1)).max() < 1e-12
+
+
+# ==========================================================================
+# vector trial and boundary (Robin) terms
+# ==========================================================================
+
+
+def test_vector_elasticity_with_scalar_net_stiffness():
+    """A scalar net multiplying a vector (vec=2) elasticity form: constant-net assembly equals the
+    scalar-coefficient reference."""
+    from jno.jnp_ops import inner, symgrad, trace
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.25)
+    u, w = d.fem_symbols(value_shape=(2,), names=("u", "w"))
+    xi, yi = d.variable("interior", split=True)[:2]
+    xb, yb = d.variable("boundary", split=True)[:2]
+    eu, ev = symgrad(u, [xi, yi]), symgrad(w, [xi, yi])
+    vv = w.bind(x=xi, y=yi)
+    net = _const_net(0.8)
+    lam = 1.2
+    weak = lam * trace(eu) * trace(ev) + 2 * net(xi, yi) * inner(eu, ev, n_contract=2) - (1.0 * vv[0] + 0.5 * vv[1])
+    weak_ref = lam * trace(eu) * trace(ev) + 2 * 0.8 * inner(eu, ev, n_contract=2) - (1.0 * vv[0] + 0.5 * vv[1])
+
+    fem = jno.fem([weak, u(xb, yb) - (0.0, 0.0)], quad_degree=2)
+    fem_ref = jno.fem([weak_ref, u(xb, yb) - (0.0, 0.0)], quad_degree=2)
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, _ = fem.operator.evaluate({name: net.module})
+    assert np.abs(_dense(A) - _dense(fem_ref.A)).max() < 1e-11
+
+
+def test_net_in_robin_boundary_term():
+    """A net coefficient inside a surface (Robin) integrand ``net*u*v`` on one edge — exercises the
+    surface-kernel threading; constant net equals the scalar Robin reference."""
+    from jno.jnp_ops import grad, inner
+
+    d = jno.domain(constructor=jno.domain.rect(mesh_size=0.25))
+    u, w = d.fem_symbols(names=("u", "w"))
+    xi, yi = d.variable("interior", split=True)[:2]
+    vv = w.bind(x=xi, y=yi)
+    xr, yr = d.variable("right", split=True)[:2]
+    ur, wr = u.bind(x=xr, y=yr), w.bind(x=xr, y=yr)
+    xl, yl = d.variable("left", split=True)[:2]
+    net = _const_net(2.5)
+
+    cons = [inner(grad(u, [xi, yi]), grad(w, [xi, yi]), n_contract=1) - 1.0 * vv, net(xr, yr) * ur * wr, u(xl, yl) - 0.0]
+    cons_ref = [inner(grad(u, [xi, yi]), grad(w, [xi, yi]), n_contract=1) - 1.0 * vv, 2.5 * ur * wr, u(xl, yl) - 0.0]
+    fem = jno.fem(cons, quad_degree=3)
+    fem_ref = jno.fem(cons_ref, quad_degree=3)
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, _ = fem.operator.evaluate({name: net.module})
+    assert np.abs(_dense(A) - _dense(fem_ref.A)).max() < 1e-12
+
+
+# ==========================================================================
+# the headline: recover k(x) end-to-end through crux
+# ==========================================================================
+
+
+def test_neural_kx_recovers_via_crux():
+    """Recover a smooth diffusivity k(x) = 0.6 + 0.8x + 0.5y with a coordinate MLP trained through
+    the differentiable ``fem.solve()``. The ``1 + net`` offset keeps the operator nonsingular at
+    the (near-zero) net init — same practice as starting the nodal field at k=1."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup(mesh_size=0.25)
+
+    fem_ref = jno.fem([(0.6 + 0.8 * xi + 0.5 * yi) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    u_obs = jnp.linalg.solve(jnp.asarray(_dense(fem_ref.A)), jnp.asarray(fem_ref.b).reshape(-1))
+
+    net = _mlp_net(key=0)
+    net.optimizer(optax.adam(1e-2))
+    fem = jno.fem([(1.0 + net(xi, yi)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    crux.solve(600)
+
+    trained = crux.eval([ModelWeights(net)])
+    nodes = np.asarray(d.built_mesh.points)[:, :2]
+    k_net = 1.0 + np.asarray(trained(jnp.asarray(nodes))).reshape(-1)
+    k_true = 0.6 + 0.8 * nodes[:, 0] + 0.5 * nodes[:, 1]
+    rel = float(np.linalg.norm(k_net - k_true) / np.linalg.norm(k_true))
+    assert rel < 0.1, f"neural k(x) recovery rel-err {rel:.3e}"
+
+
+# ==========================================================================
+# dtype and scope guards
+# ==========================================================================
+
+
+def test_f32_net_promotes_under_x64():
+    """A plain f32 net (no explicit .dtype opt-in) under x64: assembly stays float64 by promotion
+    and the solve is finite — never a silent downcast of the system."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    net = jno.nn.wrap(foundax.mlp(2, hidden_dims=8, num_layers=2, activation=jax.nn.tanh, key=jax.random.PRNGKey(4)))
+    fem = jno.fem([(1.0 + net(xi, yi)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, b = fem.operator.evaluate({name: net.module})
+    assert _dense(A).dtype == np.float64
+    sol = np.linalg.solve(_dense(A), np.asarray(b).reshape(-1))
+    assert np.all(np.isfinite(sol))
+
+
+def test_scope_guards_fail_loud():
+    """v1 scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
+    Dirichlet value and a net in a transient form."""
+    d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
+    net = _mlp_net(key=5)
+
+    # net in a Dirichlet value expression
+    with pytest.raises(NotImplementedError, match="Dirichlet"):
+        jno.fem([(ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - net(xb, yb)])
+
+    # transient form (fail loud until the transient threading lands)
+    d2 = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3, time=(0.0, 0.02, 5))
+    u2, phi2 = d2.fem_symbols()
+    x2, y2, t2 = d2.variable("interior", split=True)
+    xb2, yb2, _ = d2.variable("boundary", split=True)
+    ci = d2.variable("initial", split=True)
+    u2i, v2i = u2.bind(x=x2, y=y2, t=t2), phi2.bind(x=x2, y=y2, t=t2)
+    psi0 = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    net2 = _mlp_net(key=6)
+    with pytest.raises(NotImplementedError, match="transient"):
+        jno.fem(
+            [
+                u2i.t * v2i + (1.0 + net2(x2, y2)) * (u2i.x * v2i.x + u2i.y * v2i.y),
+                u2(xb2, yb2) - 0.0,
+                u2(ci[0], ci[1]) - psi0,
+            ]
+        )

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -915,16 +915,38 @@ def test_hermite_neural_kx_recovers_via_crux():
     assert rel < 0.12, f"Hermite neural k(x) recovery rel-err {rel:.3e}"
 
 
-def test_nonnodal_vector_family_guard():
-    """A neural coefficient on the vector edge families (RT/Nédélec) fails loud — a net(u) with a
-    vector-valued trial input is undefined, and a scalar k there is out of v1 scope."""
+def test_rt_scalar_net_matches_coordinate_coeff():
+    """A scalar coordinate net(x) coefficient on a vector H(div) (RT) form — a spatially-varying
+    permeability multiplying the vector mass — assembles the same operator as the scalar
+    coefficient. The net evaluates to a scalar at the quad points, independent of the Piola-pushed
+    vector basis; the gather oracle for the edge families."""
+    from jno.jnp_ops import inner
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.4)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), space="RT")
+    xi, yi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    net = _const_net(0.7)
+    fem = jno.fem([net(xi, yi) * inner(ui, vi) - inner(vi, vi)])
+    fem_ref = jno.fem([0.7 * inner(ui, vi) - inner(vi, vi)])
+    assert fem.is_linear
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, _ = fem.operator.evaluate({name: net.module})
+    assert np.max(np.abs(_dense(A) - _dense(fem_ref.A))) < 1e-9
+
+
+def test_rt_solution_dependent_net_guard():
+    """A *solution-dependent* net(u) on a vector edge family fails loud — feeding the vector-valued
+    trial into the network is undefined. Only coordinate net(x) is supported there."""
+    from jno.jnp_ops import inner
+
     d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.5)
     u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), space="RT")
     xi, yi, _ = d.variable("interior", split=True)
     ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
     net = _mlp_net(key=21)
-    with pytest.raises(NotImplementedError, match="RT|Nédélec|edge"):
-        jno.fem([net(xi, yi) * jno.np.inner(ui, vi) - jno.np.inner(vi, vi)])
+    with pytest.raises(NotImplementedError, match="RT|Nédélec|solution-dependent"):
+        jno.fem([net(ui) * inner(ui, vi) - inner(vi, vi)])
 
 
 def test_nonnodal_trainable_net_in_boundary_term_guard():

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -617,6 +617,98 @@ def test_transient_nonlinear_ku_recovers_via_crux():
     assert rel < 0.05, f"transient constitutive-law recovery rel-err {rel:.3e}"
 
 
+# ==========================================================================
+# complex: a real net coefficient through the real-equivalent block
+# ==========================================================================
+
+
+def _complex_helmholtz(kappa_expr_fn, mesh_size=0.15):
+    """Complex Helmholtz ``κ(-Δu) + d·u = f`` (all-Neumann), manufactured
+    ``u* = (1+0.5i) cos(πx) cos(πy)`` at κ_true = 0.8 (mirrors test_fem_complex_parametric)."""
+    dom = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, phi = dom.fem_symbols()
+    xi, yi, _ = dom.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    d_coef = 1.0 + 0.3j
+    f = (2 * PI**2 * 0.8 + d_coef) * (1.0 + 0.5j) * jno.np.cos(PI * xi) * jno.np.cos(PI * yi)
+    weak = kappa_expr_fn(xi, yi, ui) * (ui.x * vi.x + ui.y * vi.y) + d_coef * (u * vi) - f * vi
+    return dom, jno.fem([weak])
+
+
+def test_complex_net_yields_parametric_legs_and_node():
+    """A real net coefficient in a complex form: the legs assemble as parametric FemLinearSystems
+    carrying the ModelWeights slot, and solve() is a differentiable trace node."""
+    from jno.trace import FemLinearSystem
+
+    net = _mlp_net(key=11)
+    _, fem = _complex_helmholtz(lambda x, y, u: 1.0 + net(x, y))
+    assert fem.is_complex
+    op_r, _op_i = fem._op
+    assert isinstance(op_r, FemLinearSystem) and op_r.is_parametric
+    (name,) = op_r.runtime_parameter_exprs
+    assert isinstance(op_r.runtime_parameter_exprs[name], ModelWeights)
+    assert not isinstance(fem.solve(), jax.Array)
+
+
+def test_complex_constant_net_matches_scalar_forward():
+    """A constant net (κ ≡ 0.8) through the complex block equals the scalar-κ complex solve —
+    pins the Re/Im-leg kernel evaluation of the net."""
+    _, fem_ref = _complex_helmholtz(lambda x, y, u: 0.8)
+    u_ref = np.asarray(fem_ref.solve()).reshape(-1)
+
+    net = _const_net(-0.2)  # 1 + net ≡ 0.8
+    _, fem = _complex_helmholtz(lambda x, y, u: 1.0 + net(x, y))
+    u_node = fem.solve()
+    crux = jno.core([(u_node - u_ref).mae], domain=_DUMMY)
+    u_par = np.asarray(crux.eval([u_node])).reshape(-1)
+    assert np.allclose(u_par, u_ref, atol=1e-8)
+    assert float(np.abs(u_ref.imag).max()) > 0.1  # genuinely complex
+
+
+def test_complex_net_recovers_kappa_via_crux():
+    """Recover the (constant) diffusivity κ = 0.8 with a coordinate MLP trained through the
+    complex real-equivalent block — ∂u/∂weights flows through the parametric legs."""
+    _, fem_ref = _complex_helmholtz(lambda x, y, u: 0.8)
+    u_ref = np.asarray(fem_ref.solve())
+
+    net = _mlp_net(key=12, hidden=8)
+    net.optimizer(optax.adam(1e-2))
+    dom, fem = _complex_helmholtz(lambda x, y, u: 1.0 + net(x, y))
+    crux = jno.core([(fem.solve() - u_ref).mae], domain=_DUMMY)
+    crux.solve(300)
+
+    trained = crux.eval([ModelWeights(net)])
+    nodes = np.asarray(dom.built_mesh.points)[:, :2]
+    k_net = 1.0 + np.asarray(trained(jnp.asarray(nodes))).reshape(-1)
+    rel = float(np.linalg.norm(k_net - 0.8) / (0.8 * np.sqrt(len(k_net))))
+    assert rel < 0.1, f"complex neural κ recovery rel-err {rel:.3e}"
+
+
+def test_complex_scope_guards():
+    """The two complex compositions that would mis-assemble stay rejected: a solution-dependent
+    net (the legs are linear real-equivalent blocks) and the complex transient."""
+    net = _quad_net()
+    with pytest.raises(NotImplementedError, match="complex"):
+        _complex_helmholtz(lambda x, y, u: net(u))
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3, time=(0.0, 0.02, 5))
+    u, phi = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), phi.bind(x=xi, y=yi, t=ti)
+    net2 = _mlp_net(key=13)
+    psi0 = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1]) * (1.0 + 0.0j)
+    with pytest.raises(NotImplementedError, match="complex"):
+        jno.fem(
+            [
+                1j * ui.t * vi - (1.0 + net2(xi, yi)) * (ui.x * vi.x + ui.y * vi.y),
+                u(xb, yb) - 0.0,
+                u(ci[0], ci[1]) - psi0,
+            ]
+        )
+
+
 def test_scope_guards_fail_loud():
     """Scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
     Dirichlet value and a trainable net on the mass (u_t) term."""

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -785,6 +785,127 @@ def test_multifield_nonlinear_net_resolves_correct_field():
     assert abs(float(g.a)) > 0.0 and abs(float(g.b)) > 0.0
 
 
+# ==========================================================================
+# non-nodal scalar C¹ elements (Argyris / Morley / Hermite)
+# ==========================================================================
+
+
+def test_argyris_constant_net_matches_coordinate_coeff():
+    """Constant-net ≡ the same coordinate-function coefficient on an Argyris biharmonic operator —
+    the definitive gather/interpolation check on a C¹ element (the net is evaluated at the quad
+    points, independent of the Argyris DOF layout). Mirrors the field-parameter Argyris oracle."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.35)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    lap = jno.np.laplacian
+    f = 48.0 + 0.0 * xi
+    g = xb**4 + yb**4
+    net = _const_net(0.7)
+    u, phi = d.fem_symbols(space="Argyris")
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    fem = jno.fem([net(xi, yi) * (lap(ui, [xi, yi]) * lap(vi, [xi, yi])) - f * vi, u(xb, yb) - g])
+    assert fem.is_linear and len(fem.operator.runtime_parameter_exprs) == 1
+
+    u2, p2 = d.fem_symbols(space="Argyris")
+    ux, vx = u2.bind(x=xi, y=yi), p2.bind(x=xi, y=yi)
+    fem_ref = jno.fem([0.7 * (lap(ux, [xi, yi]) * lap(vx, [xi, yi])) - f * vx, u2(xb, yb) - g])
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, _ = fem.operator.evaluate({name: net.module})
+    assert np.max(np.abs(_dense(A) - _dense(fem_ref.A))) < 1e-9
+
+
+def test_morley_constant_net_matches_coordinate_coeff():
+    """Constant-net ≡ coordinate coefficient on the Morley full-Hessian biharmonic (``∫ D²u:D²v``,
+    the correct non-singular form) — the gather oracle on the cheap C¹ element."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    f = 48.0 + 0.0 * xi
+    g = xb**4 + yb**4
+    net = _const_net(0.7)
+    u, phi = d.fem_symbols(space="Morley")
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    Hu, Hv = jno.np.hessian(ui, [xi, yi]), jno.np.hessian(vi, [xi, yi])
+    fem = jno.fem([net(xi, yi) * jno.np.inner(Hu, Hv, n_contract=2) - f * vi, u(xb, yb) - g])
+    u2, p2 = d.fem_symbols(space="Morley")
+    ux, vx = u2.bind(x=xi, y=yi), p2.bind(x=xi, y=yi)
+    Hu2, Hv2 = jno.np.hessian(ux, [xi, yi]), jno.np.hessian(vx, [xi, yi])
+    fem_ref = jno.fem([0.7 * jno.np.inner(Hu2, Hv2, n_contract=2) - f * vx, u2(xb, yb) - g])
+    (name,) = fem.operator.runtime_parameter_exprs
+    A, _ = fem.operator.evaluate({name: net.module})
+    assert np.max(np.abs(_dense(A) - _dense(fem_ref.A))) < 1e-9
+
+
+def test_hermite_constitutive_ku_matches_symbolic():
+    """A constitutive law ``net(u)`` on a Hermite (C¹) element: the form is nonlinear and its
+    Newton solve matches the symbolic ``(1 + 0.3 u²)`` reference — the net's u-dependence enters
+    the element Jacobian through the C¹ push-forward assembly's jacfwd."""
+    from jno.utils.solver.newton_krylov import newton_krylov
+
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    net = _quad_net(a=1.0, b=0.3)
+    u, phi = d.fem_symbols(space="Hermite")
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    fem = jno.fem([net(ui) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0])
+    assert fem._mode == "nonlinear"
+    u2, p2 = d.fem_symbols(space="Hermite")
+    u2i, v2i = u2.bind(x=xi, y=yi), p2.bind(x=xi, y=yi)
+    fem_sym = jno.fem([(1.0 + 0.3 * u2i**2) * (u2i.x * v2i.x + u2i.y * v2i.y) - f * v2i, u2(xb, yb) - 0.0])
+    (name,) = fem.operator.runtime_parameter_exprs
+    u_net = newton_krylov(lambda w: fem.operator.residual(w, {name: net.module}), jnp.zeros(fem.operator.size))
+    u_sym = newton_krylov(lambda w: fem_sym.operator(w), jnp.zeros(fem_sym.operator.size))
+    assert float(jnp.max(jnp.abs(u_net - u_sym))) < 1e-9
+
+
+def test_hermite_neural_kx_recovers_via_crux():
+    """End-to-end: recover a smooth k(x) with a coordinate MLP on a Hermite (C¹) element through the
+    non-nodal parametric ``fem.solve()`` — proves the ModelWeights threading reaches the non-nodal
+    FemLinearSystem and gradients flow to the weights."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    f = 2.0 * (xi * (1.0 - xi) + yi * (1.0 - yi))
+    u, phi = d.fem_symbols(space="Hermite")
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+
+    fem_ref = jno.fem([(0.6 + 0.8 * xi + 0.5 * yi) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0])
+    u_obs = jnp.linalg.solve(jnp.asarray(_dense(fem_ref.A)), jnp.asarray(fem_ref.b).reshape(-1))
+
+    net = _mlp_net(key=20, hidden=16)
+    net.optimizer(optax.adam(1e-2))
+    fem = jno.fem([(1.0 + net(xi, yi)) * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0])
+    # The non-nodal path assembles a DENSE operator (jacfwd), so use a dense solve_fn — the default
+    # sparse_lu_solve's BCOO-fromdense has a data-dependent nse under crux's jit (same as the
+    # field-parameter Hermite recovery).
+    solver = lambda A, b: jnp.linalg.solve(  # noqa: E731
+        jnp.asarray(A.todense() if hasattr(A, "todense") else A), jnp.asarray(b).reshape(-1)
+    )
+    crux = jno.core([(fem.solve(solver) - u_obs).mse], domain=_DUMMY)
+    crux.solve(400)
+
+    trained = crux.eval([ModelWeights(net)])
+    nodes = np.asarray(d.built_mesh.points)[:, :2]
+    k_net = 1.0 + np.asarray(trained(jnp.asarray(nodes))).reshape(-1)
+    k_true = 0.6 + 0.8 * nodes[:, 0] + 0.5 * nodes[:, 1]
+    rel = float(np.linalg.norm(k_net - k_true) / np.linalg.norm(k_true))
+    assert rel < 0.12, f"Hermite neural k(x) recovery rel-err {rel:.3e}"
+
+
+def test_nonnodal_vector_family_guard():
+    """A neural coefficient on the vector edge families (RT/Nédélec) fails loud — a net(u) with a
+    vector-valued trial input is undefined, and a scalar k there is out of v1 scope."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.5)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), space="RT")
+    xi, yi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    net = _mlp_net(key=21)
+    with pytest.raises(NotImplementedError, match="RT|Nédélec|edge"):
+        jno.fem([net(xi, yi) * jno.np.inner(ui, vi) - jno.np.inner(vi, vi)])
+
+
 def test_scope_guards_fail_loud():
     """Scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
     Dirichlet value and a trainable net on the mass (u_t) term."""

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -639,6 +639,59 @@ def test_frozen_net_on_mass_term_is_allowed():
     assert float(jnp.max(jnp.abs(traj - traj_ref))) < 1e-12
 
 
+def _mass_density_setup(rho_fn, mesh_size=0.25, time=(0.0, 0.05, 6)):
+    d, u, phi, (xi, yi), (xb, yb), ci, ui, vi, u0 = _transient_setup(mesh_size=mesh_size, time=time)
+    return d, jno.fem([rho_fn(xi, yi) * ui.t * vi + (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - u0])
+
+
+def test_mass_net_kx_parametric_matches_frozen():
+    """A trainable coordinate net(x) on the mass (u_t) term — an unknown density ρ(x)·u_t — makes the
+    mass a *parametric matrix* re-assembled from args each step (block.mass_fn). It reproduces the
+    frozen (fixed-mass) trajectory, and the trajectory's gradient flows THROUGH the mass to the net."""
+    from jno.utils.solver.backend_blocks import _default_transient_integrate
+
+    net = _mlp_net(key=34, hidden=8)
+    d, fem = _mass_density_setup(lambda x, y: 1.0 + net(x, y))
+    assert fem.operator.mass_fn is not None  # parametric mass
+    (name,) = fem.operator.runtime_parameter_exprs
+    traj = _default_transient_integrate(fem.operator, {name: net.module}, _grid_ts(fem.operator))
+
+    net_f = _mlp_net(key=34, hidden=8)
+    net_f.freeze()
+    _, fem_f = _mass_density_setup(lambda x, y: 1.0 + net_f(x, y))
+    traj_f = _default_transient_integrate(fem_f.operator, {}, _grid_ts(fem_f.operator))
+    assert float(jnp.max(jnp.abs(traj - traj_f))) < 1e-9
+
+    def loss(m):
+        return jnp.sum(_default_transient_integrate(fem.operator, {name: m}, _grid_ts(fem.operator)) ** 2)
+
+    g = eqx.filter_grad(loss)(net.module)
+    gsum = sum(jnp.sum(jnp.abs(x)) for x in jax.tree_util.tree_leaves(g) if eqx.is_inexact_array(x))
+    assert float(gsum) > 0.0  # gradient reached the net through the mass
+
+
+def test_mass_net_kx_recovers_via_crux():
+    """Recover an unknown density ρ(x) on the mass term from a decay trajectory through the
+    differentiable transient `fem.solve()` — the headline for the parametric-mass path."""
+    from jno.utils.solver.backend_blocks import _default_transient_integrate
+
+    _, fem_ref = _mass_density_setup(lambda x, y: 1.0 + 0.5 * x + 0.3 * y)
+    u_obs = _default_transient_integrate(fem_ref.operator, {}, _grid_ts(fem_ref.operator))
+
+    net = _mlp_net(key=35, hidden=16)
+    net.optimizer(optax.adam(1e-2))
+    d, fem = _mass_density_setup(lambda x, y: 1.0 + net(x, y))
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    crux.solve(400)
+
+    trained = crux.eval([ModelWeights(net)])
+    nodes = np.asarray(d.built_mesh.points)[:, :2]
+    rho_net = 1.0 + np.asarray(trained(jnp.asarray(nodes))).reshape(-1)
+    rho_true = 1.0 + 0.5 * nodes[:, 0] + 0.3 * nodes[:, 1]
+    rel = float(np.linalg.norm(rho_net - rho_true) / np.linalg.norm(rho_true))
+    assert rel < 0.12, f"unknown-density ρ(x) recovery rel-err {rel:.3e}"
+
+
 # ==========================================================================
 # complex: a real net coefficient through the real-equivalent block
 # ==========================================================================
@@ -1044,7 +1097,7 @@ def test_nonnodal_trainable_net_in_boundary_term_guard():
 
 def test_scope_guards_fail_loud():
     """Scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
-    Dirichlet value and a trainable net on the mass (u_t) term."""
+    Dirichlet value and a solution-dependent net(u) on the mass (u_t) term (a nonlinear mass)."""
     d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
     net = _mlp_net(key=5)
 
@@ -1052,13 +1105,14 @@ def test_scope_guards_fail_loud():
     with pytest.raises(NotImplementedError, match="Dirichlet"):
         jno.fem([(ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - net(xb, yb)])
 
-    # trainable net on the mass term: the mass matrix assembles once -> would silently freeze
+    # net(u) on the mass term = a nonlinear mass C(u)*u_t (the matrix form can't express it). A
+    # coordinate net(x) mass coefficient IS supported (see test_mass_net_kx_recovers_via_crux).
     d2, u2, phi2, (x2, y2), (xb2, yb2), ci, u2i, v2i, psi0 = _transient_setup(mesh_size=0.3, time=(0.0, 0.02, 5))
-    net2 = _mlp_net(key=6)
-    with pytest.raises(NotImplementedError, match="mass"):
+    net2 = _quad_net(a=1.0, b=0.5)
+    with pytest.raises(NotImplementedError, match="mass|nonlinear mass"):
         jno.fem(
             [
-                (1.0 + net2(x2, y2)) * u2i.t * v2i + (u2i.x * v2i.x + u2i.y * v2i.y),
+                net2(u2i) * u2i.t * v2i + (u2i.x * v2i.x + u2i.y * v2i.y),
                 u2(xb2, yb2) - 0.0,
                 u2(ci[0], ci[1]) - psi0,
             ]

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -510,9 +510,116 @@ def test_ku_composes_with_solver_slots():
     assert np.isfinite(val).all()
 
 
+# ==========================================================================
+# transient: neural coefficients in the time stepper
+# ==========================================================================
+
+
+def _transient_setup(mesh_size=0.25, time=(0.0, 0.05, 11)):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size, time=time)
+    u, phi = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), phi.bind(x=xi, y=yi, t=ti)
+    u0 = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    return d, u, phi, (xi, yi), (xb, yb), ci, ui, vi, u0
+
+
+def _grid_ts(block):
+    n_steps = int(round((float(block.t1) - float(block.t0)) / float(block.dt)))
+    return jnp.linspace(float(block.t0), float(block.t1), n_steps + 1)
+
+
+def test_transient_net_kx_trajectory_matches_frozen_reference():
+    """Transient heat with a net diffusivity: the parametric per-step re-assembly at the net's
+    stored weights reproduces the frozen (non-parametric) twin's trajectory exactly."""
+    from jno.utils.solver.backend_blocks import _default_transient_integrate
+
+    d, u, phi, (xi, yi), (xb, yb), ci, ui, vi, u0 = _transient_setup()
+    net = _mlp_net(key=9)
+    fem = jno.fem([ui.t * vi + (1.0 + net(xi, yi)) * (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - u0])
+    assert fem.is_transient
+    (name,) = fem.operator.runtime_parameter_exprs
+    assert isinstance(fem.operator.runtime_parameter_exprs[name], ModelWeights)
+    traj = _default_transient_integrate(fem.operator, {name: net.module}, _grid_ts(fem.operator))
+
+    d2, u2, phi2, (x2, y2), (xb2, yb2), ci2, u2i, v2i, u02 = _transient_setup()
+    net_f = _mlp_net(key=9)  # identical weights
+    net_f.freeze()
+    fem_f = jno.fem(
+        [
+            u2i.t * v2i + (1.0 + net_f(x2, y2)) * (u2i.x * v2i.x + u2i.y * v2i.y),
+            u2(xb2, yb2) - 0.0,
+            u2(ci2[0], ci2[1]) - u02,
+        ]
+    )
+    traj_f = _default_transient_integrate(fem_f.operator, {}, _grid_ts(fem_f.operator))
+    assert traj.shape == traj_f.shape
+    assert float(jnp.max(jnp.abs(traj - traj_f))) < 1e-9
+
+
+def test_transient_neural_kx_recovers_via_crux():
+    """Recover a smooth diffusivity k(x) from a u(t) trajectory with a coordinate MLP trained
+    through the transient ``fem.solve()`` (per-step re-assembly, implicit-diff to the weights) —
+    the neural analogue of the transient nodal-field recovery."""
+    from jno.utils.solver.backend_blocks import _default_transient_integrate
+
+    d, u, phi, (xi, yi), (xb, yb), ci, ui, vi, u0 = _transient_setup(mesh_size=0.2)
+    fem_ref = jno.fem(
+        [ui.t * vi + (1.0 + 0.5 * xi + 0.3 * yi) * (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - u0]
+    )
+    u_obs = _default_transient_integrate(fem_ref.operator, {}, _grid_ts(fem_ref.operator))
+    assert not bool(jnp.isnan(u_obs).any())
+
+    d2, u2, phi2, (x2, y2), (xb2, yb2), ci2, u2i, v2i, u02 = _transient_setup(mesh_size=0.2)
+    net = _mlp_net(key=10)
+    net.optimizer(optax.adam(1e-2))
+    fem = jno.fem(
+        [u2i.t * v2i + (1.0 + net(x2, y2)) * (u2i.x * v2i.x + u2i.y * v2i.y), u2(xb2, yb2) - 0.0, u2(ci2[0], ci2[1]) - u02]
+    )
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    crux.solve(300)
+
+    trained = crux.eval([ModelWeights(net)])
+    nodes = np.asarray(d2.built_mesh.points)[:, :2]
+    k_net = 1.0 + np.asarray(trained(jnp.asarray(nodes))).reshape(-1)
+    k_true = 1.0 + 0.5 * nodes[:, 0] + 0.3 * nodes[:, 1]
+    rel = float(np.linalg.norm(k_net - k_true) / np.linalg.norm(k_true))
+    assert rel < 0.1, f"transient neural k(x) recovery rel-err {rel:.3e}"
+
+
+def test_transient_nonlinear_ku_recovers_via_crux():
+    """A constitutive law k(u) in a TRANSIENT form: u_t = div((a + b·u²)∇u). The per-step Newton
+    (implicit backward Euler) carries the net's u-dependence; recover (a, b) from the trajectory
+    through fem.solve()."""
+    from jno.utils.solver.backend_blocks import _default_transient_integrate
+
+    d, u, phi, (xi, yi), (xb, yb), ci, ui, vi, u0 = _transient_setup(mesh_size=0.25, time=(0.0, 0.05, 6))
+    fem_ref = jno.fem(
+        [ui.t * vi + (1.0 + 0.5 * ui**2) * (ui.x * vi.x + ui.y * vi.y), u(xb, yb) - 0.0, u(ci[0], ci[1]) - u0]
+    )
+    u_obs = _default_transient_integrate(fem_ref.operator, {}, _grid_ts(fem_ref.operator))
+
+    d2, u2, phi2, (x2, y2), (xb2, yb2), ci2, u2i, v2i, u02 = _transient_setup(mesh_size=0.25, time=(0.0, 0.05, 6))
+    net = _quad_net(a=1.3, b=0.1)  # start away from the truth (1.0, 0.5)
+    net.optimizer(optax.adam(2e-2))
+    fem = jno.fem([u2i.t * v2i + net(u2i) * (u2i.x * v2i.x + u2i.y * v2i.y), u2(xb2, yb2) - 0.0, u2(ci2[0], ci2[1]) - u02])
+    assert fem.is_transient and not fem.operator.is_linear()
+
+    crux = jno.core([(fem.solve() - u_obs).mse], domain=_DUMMY)
+    crux.solve(250)
+    trained = crux.eval([ModelWeights(net)])
+    u_grid = jnp.linspace(0.0, float(jnp.max(u_obs)), 32)
+    k_learned = np.asarray(trained(u_grid)).reshape(-1)
+    k_true = 1.0 + 0.5 * np.asarray(u_grid) ** 2
+    rel = float(np.linalg.norm(k_learned - k_true) / np.linalg.norm(k_true))
+    assert rel < 0.05, f"transient constitutive-law recovery rel-err {rel:.3e}"
+
+
 def test_scope_guards_fail_loud():
-    """v1 scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
-    Dirichlet value and a net in a transient form."""
+    """Scope limits raise explicit NotImplementedError, never mis-assemble: a net inside a
+    Dirichlet value and a trainable net on the mass (u_t) term."""
     d, u, phi, (xi, yi), (xb, yb), ui, vi, f = _poisson_setup()
     net = _mlp_net(key=5)
 
@@ -520,19 +627,13 @@ def test_scope_guards_fail_loud():
     with pytest.raises(NotImplementedError, match="Dirichlet"):
         jno.fem([(ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - net(xb, yb)])
 
-    # transient form (fail loud until the transient threading lands)
-    d2 = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.3, time=(0.0, 0.02, 5))
-    u2, phi2 = d2.fem_symbols()
-    x2, y2, t2 = d2.variable("interior", split=True)
-    xb2, yb2, _ = d2.variable("boundary", split=True)
-    ci = d2.variable("initial", split=True)
-    u2i, v2i = u2.bind(x=x2, y=y2, t=t2), phi2.bind(x=x2, y=y2, t=t2)
-    psi0 = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    # trainable net on the mass term: the mass matrix assembles once -> would silently freeze
+    d2, u2, phi2, (x2, y2), (xb2, yb2), ci, u2i, v2i, psi0 = _transient_setup(mesh_size=0.3, time=(0.0, 0.02, 5))
     net2 = _mlp_net(key=6)
-    with pytest.raises(NotImplementedError, match="transient"):
+    with pytest.raises(NotImplementedError, match="mass"):
         jno.fem(
             [
-                u2i.t * v2i + (1.0 + net2(x2, y2)) * (u2i.x * v2i.x + u2i.y * v2i.y),
+                (1.0 + net2(x2, y2)) * u2i.t * v2i + (u2i.x * v2i.x + u2i.y * v2i.y),
                 u2(xb2, yb2) - 0.0,
                 u2(ci[0], ci[1]) - psi0,
             ]

--- a/tests/test_fem_plate_bc.py
+++ b/tests/test_fem_plate_bc.py
@@ -58,6 +58,7 @@ def _plate_center_deflection(space, clamped, mesh_size=0.06):
     return float(w[np.argmin((pts[:, 0] - 0.5) ** 2 + (pts[:, 1] - 0.5) ** 2)])
 
 
+@pytest.mark.slow  # C¹ assembly peaks at ~12 GiB (Argyris ceiling) — OOMs the CI runner; runs on the push gate
 @pytest.mark.parametrize("space", ["Argyris", "Morley"])
 def test_clamped_vs_simply_supported_matches_timoshenko(space):
     """The reason the granular BC exists: `u(reg)-g` alone (simply-supported) must give a *different*, and

--- a/tests/test_trace_evaluator.py
+++ b/tests/test_trace_evaluator.py
@@ -52,7 +52,7 @@ class TestEvalCtx:
 # ======================================================================
 class TestDispatchTable:
     def test_handlers_count(self):
-        assert len(TraceEvaluator._HANDLERS) == 23  # Update this if we add more node types
+        assert len(TraceEvaluator._HANDLERS) == 24  # +ModelWeights (neural FEM coefficients)
 
     def test_handlers_are_strings(self):
         for node_type, method_name in TraceEvaluator._HANDLERS:


### PR DESCRIPTION
## Trainable neural-network coefficients in assembled FEM systems

Calling `jno.nn.wrap(net)` inside a weak form makes the network a **trainable coefficient** on an ordinary FE system — mesh-independent, smooth by architecture, and trained through the same differentiable `fem.solve()` as any parameter. **No new user-facing API**: writing the network into the form is the whole feature.

```python
net = jno.nn.wrap(foundax.mlp(2, hidden_dims=16, ...)).dtype(jnp.float64)
net.optimizer(optax.adam(1e-2))
# k(x) = 1 + net(x, y): a trainable diffusivity
fem = jno.fem([(1.0 + net(xi, yi)) * (ui.x*vi.x + ui.y*vi.y) - f*vi, u(xb, yb) - 0.0])
jno.core([(fem.solve() - u_obs).mse], domain=obs).solve(600)   # recovers k(x)
```

### What works

| Capability | Notes |
|---|---|
| **k(x)** steady linear | coordinate coefficient; parametric re-assembly via `FemLinearSystem` |
| **k(u), k(∇u)** constitutive laws | solution-dependent ⇒ auto-routes to matrix-free Newton (NN-EUCLID style) |
| **Transient** | per-step operator/residual re-evaluation; recovered from a `u(t)` trajectory |
| **Complex** (steady) | real coordinate net on the Re/Im real-equivalent legs |
| **Coupled multi-field** | net evaluated at shared quad points; `net(u_i)` resolves its own field |
| **Non-nodal C¹** (Argyris/Morley/Hermite) | net independent of the C¹ DOF layout; dense operator ⇒ pass a dense `solve_fn` |
| **RT/Nédélec** | scalar coordinate `net(x)` on the vector edge families |
| **Mass term `net(x)`** | unknown density `ρ(x)·u_t` via a parametric `SemidiscreteTimeBlock.mass_fn` |
| **Net-valued Dirichlet** | unknown BC profile `u(region) - net(x)` (a trainable lift into the load vector) |

### Mechanism (all internal, swappable)

A neural coefficient reuses the entire runtime-parameter infrastructure (`operator_fn(args)`, `custom_root`, `runtime_parameter_exprs`) — it is one more parameter *kind*. The three network-specific pieces live in one module (`parametric_helpers`): `collect_neural_slots` (collect), `neural_operator_exprs` (a `ModelWeights` slot delivers the live module through `args`), `neural_local_table` (the kernel `{name: module}` table). Because `k(u)` needs the trial value at quadrature points, the net is evaluated *inside* the assembly kernel; passing the whole equinox module by closure through `args` is the minimal thing that supports it. The public contract (`jno.nn.wrap(net)(x)`) is mechanism-agnostic, so the internals can be replaced without touching user code or behaviour tests.

### Tests & docs

- `tests/test_fem_neural_coefficients.py` — ~44 tests, each with a correctness oracle (constant/linear-net ≡ scalar/coordinate-coefficient operator) or a **recovery** oracle (crux actually moves the field), plus fail-loud scope guards.
- Two tutorials: `inverse_neural_diffusivity_2d.py` (k(x) recovery) and `learn_constitutive_law_2d.py` (k(T) constitutive law, softplus-positivity, CPU-pinned).
- `docs/fem.md` neural-coefficients section; citations NN-EUCLID (Flaschel/Kumar/De Lorenzis, JMPS 165 (2022) §2.2–2.3) and Tartakovsky et al. (WRR 56, 2020, §2).

### Deferred (each needs solver-core infrastructure that does not exist yet)

- **complex-transient `net(x)`** — the complex-transient path has no parametric/inverse route at all (integrates fixed real-equivalent blocks, no runtime args).
- **`k(u)` × complex** — needs a complex *nonlinear* operator (the complex path is linear real-equivalent blocks).
- **`net(u)` on the mass term** — a nonlinear mass `C(u)·u_t`; must fold the mass into the step Newton residual.
- **1D** — the native 1D assembler threads no runtime `args` (no scalar/field-parameter path either).

Each fails loud with a message explaining why.
