### PR TITLE
fix(fem): transpose the preconditioner for the adjoint solve (M^T, not M)

### DIFF
--- a/jno/precond.py
+++ b/jno/precond.py
@@ -26,7 +26,10 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 
-from .utils.solver.solver_api import PrecondContext  # noqa: F401  (re-export for user specs)
+from .utils.solver.solver_api import (  # noqa: F401  (PrecondContext re-exported for user specs)
+    PrecondApplier,
+    PrecondContext,
+)
 
 __all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg"]
 
@@ -38,7 +41,7 @@ class _Jacobi:
         d = ctx.diag()
         safe = jnp.where(jnp.abs(d) > 1e-30, d, 1.0)  # zero diagonals (saddle blocks) left unscaled
         inv = 1.0 / safe
-        return lambda v: inv * v
+        return PrecondApplier(lambda v: inv * v)  # diagonal => symmetric => M^T == M
 
     def __repr__(self):
         return "jno.precond.jacobi()"
@@ -65,7 +68,11 @@ class _Chebyshev:
             n = ctx.A.shape[0]
             hi = self.safety * power_iteration_bound(ctx.A.mv, n, iters=self.bound_iters)
         lo = self.lmin if self.lmin is not None else self.lmin_ratio * hi
-        return lambda v: chebyshev_apply(ctx.A.mv, v, lmin=lo, lmax=hi, degree=self.degree)
+        # A^T shares the spectrum of A, so the same [lo, hi] bounds the transpose recurrence.
+        return PrecondApplier(
+            lambda v: chebyshev_apply(ctx.A.mv, v, lmin=lo, lmax=hi, degree=self.degree),
+            lambda v: chebyshev_apply(ctx.A.T.mv, v, lmin=lo, lmax=hi, degree=self.degree),
+        )
 
     def __repr__(self):
         return f"jno.precond.chebyshev(degree={self.degree})"
@@ -112,7 +119,9 @@ class _Form:
 
             self.inner = _s.lu()
         solver = self.inner
-        return lambda v: solver(op, v)
+        # M^{-T} v ~ (Â^{-1})^T v = (Â^T)^{-1} v: run the same inner solver on the transposed
+        # auxiliary operator (for a symmetric Â -- e.g. a mass matrix -- op.T behaves like op).
+        return PrecondApplier(lambda v: solver(op, v), lambda v: solver(op.T, v))
 
     def __repr__(self):
         return f"jno.precond.form(<{len(self.terms)} terms>, inner={self.inner})"
@@ -152,7 +161,9 @@ class _InnerSolve:
 
     def materialize(self, ctx: PrecondContext):
         solver, op = self.solver, ctx.A
-        return lambda v: solver(op, v)
+        # transpose applier solves the transposed (sub-)operator, so a non-symmetric block gets a
+        # correctly-preconditioned adjoint solve (else reverse-mode stalls -- see PrecondApplier).
+        return PrecondApplier(lambda v: solver(op, v), lambda v: solver(op.T, v))
 
     def __repr__(self):
         return f"jno.precond.inner({self.solver})"
@@ -188,7 +199,14 @@ def _pairs_to_appliers(pairs, ctx: PrecondContext):
     appliers = []
     for idx in range(len(blocks)):
         sub_ctx = PrecondContext(ctx.sub(idx), ctx.fem)
-        appliers.append((blocks[idx], materialize_precond(resolved[idx], sub_ctx)))
+        m = materialize_precond(resolved[idx], sub_ctx)
+        # Normalize to a PrecondApplier so the block transpose paths (apply_T) always have `.T`.
+        # A bare-callable block precond (e.g. amg) has no structural transpose, so `.T` reuses M
+        # (M^T := M) — correct (a preconditioner never changes the converged solution), just not
+        # transpose-optimal, exactly the firewall's bare-callable fallback one level down.
+        if not isinstance(m, PrecondApplier):
+            m = PrecondApplier(m)
+        appliers.append((blocks[idx], m))
     return appliers
 
 
@@ -216,7 +234,13 @@ class _BlockDiag:
                 out = out.at[s].set(M(v[s]))
             return out
 
-        return apply
+        def apply_T(v):  # block-diagonal transpose = transpose each independent block
+            out = jnp.zeros_like(v)
+            for s, M in appliers:
+                out = out.at[s].set(M.T(v[s]))
+            return out
+
+        return PrecondApplier(apply, apply_T)
 
     def __repr__(self):
         return f"jno.precond.block_diag(<{len(self.pairs)} blocks>)"
@@ -248,7 +272,23 @@ class _Triangular:
                 out = out.at[s].set(y)
             return out
 
-        return apply
+        def apply_T(v):
+            # transpose of an upper-triangular P is lower-triangular P^T: FORWARD substitution
+            # with transposed diagonal blocks (M_i^T) and transposed couplings ((A_ji)^T = sub(j,i)^T):
+            #   y_i = M_i^{-T} (v_i - sum_{j<i} A_ji^T y_j)
+            ys = [None] * k
+            for i in range(k):
+                s, M = appliers[i]
+                r = v[s]
+                for j in range(i):
+                    r = r - subs[(j, i)].T.mv(ys[j])
+                ys[i] = M.T(r)
+            out = jnp.zeros_like(v)
+            for (s, _), y in zip(appliers, ys):
+                out = out.at[s].set(y)
+            return out
+
+        return PrecondApplier(apply, apply_T)
 
     def __repr__(self):
         return f"jno.precond.triangular(<{len(self.pairs)} blocks>)"

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -25,7 +25,13 @@ from typing import Optional
 import jax
 import jax.numpy as jnp
 
-from .utils.solver.solver_api import LinearOperator, LinearSolver, NonlinearSolver, _maybe_residual_check
+from .utils.solver.solver_api import (
+    LinearOperator,
+    LinearSolver,
+    NonlinearSolver,
+    PrecondApplier,
+    _maybe_residual_check,
+)
 
 __all__ = [
     "LinearOperator",
@@ -121,7 +127,18 @@ def _firewalled(raw, op: LinearOperator, b, *, M, x0, symmetric: bool, name: str
     only affects convergence speed, never the converged solution).
     """
     fwd = lambda _mv, rhs: raw(op.mv, rhs, M=M, x0=x0)
-    rev = fwd if symmetric else (lambda _mv, rhs: raw(op.T.mv, rhs, M=M, x0=None))
+    if symmetric:
+        rev = fwd
+    else:
+        # The reverse pass solves A^T y = v and MUST be preconditioned by M^T, not M: a
+        # preconditioner never changes the converged solution, but for a non-symmetric M
+        # (block-triangular Schur, ILU) M approximates A^{-1} and is near-useless for A^T, so the
+        # adjoint Krylov solve runs almost unpreconditioned -- orders of magnitude more iterations
+        # than the forward (empirically ~90x the forward step for a Taylor-Hood Navier-Stokes
+        # step). jno.precond appliers carry a structural transpose (PrecondApplier.T); a bare
+        # callable preconditioner has none, so we fall back to reusing M (correct, maybe slow).
+        M_T = M.T if isinstance(M, PrecondApplier) else M
+        rev = lambda _mv, rhs: raw(op.T.mv, rhs, M=M_T, x0=None)
     x = jax.lax.custom_linear_solve(op.mv, b, fwd, transpose_solve=rev, symmetric=symmetric)
     return _maybe_residual_check(op, b, x, name)
 

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -35,6 +35,7 @@ __all__ = [
     "LinearOperator",
     "LinearSolver",
     "NonlinearSolver",
+    "PrecondApplier",
     "PrecondContext",
     "materialize_precond",
     "prepare_precond",
@@ -42,6 +43,37 @@ __all__ = [
     "compose_nonlinear_solve_fn",
     "compose_transient_step_solvers",
 ]
+
+
+class PrecondApplier:
+    """A preconditioner application ``v -> M^{-1} v`` that also carries its **transpose** applier
+    ``.T`` (``v -> M^{-T} v``).
+
+    The reverse pass of a differentiable solve preconditions ``A^T`` and must use ``M^T``, not
+    ``M``: a preconditioner never changes the converged solution, so reusing ``M`` is *correct*,
+    but for a non-symmetric ``M`` (block-triangular Schur, ILU, ...) ``M`` approximates ``A^{-1}``
+    and is near-useless for ``A^T`` -- the adjoint Krylov solve then runs almost unpreconditioned
+    and dominates reverse-mode cost. Preconditioner specs build the transpose applier structurally
+    (transpose each block, swap the substitution direction, transpose the coupling matvecs), which
+    ``jax.linear_transpose`` cannot do through inner iterative/direct sub-solves.
+
+    ``fwd`` is the forward applier; ``t`` the transpose applier, or ``None`` for a **symmetric**
+    preconditioner (Jacobi, an SPD auxiliary form) -- then ``.T`` is the applier itself. A bare
+    callable preconditioner (no ``.T``) still works: callers fall back to reusing ``M``.
+    """
+
+    __slots__ = ("_fwd", "_t")
+
+    def __init__(self, fwd, t=None):
+        self._fwd = fwd
+        self._t = t
+
+    def __call__(self, v):
+        return self._fwd(v)
+
+    @property
+    def T(self) -> "PrecondApplier":
+        return self if self._t is None else PrecondApplier(self._t, self._fwd)
 
 
 class LinearOperator:


### PR DESCRIPTION
## Summary

The differentiability firewall (`_firewalled`) preconditioned the reverse-pass solve `Aᵀy = v` with the **forward** preconditioner `M`. A preconditioner never changes the converged solution, so this was *correct* — but for a non-symmetric `M` (block-triangular Schur, ILU) `M` approximates `A⁻¹` and is a near-useless preconditioner for `Aᵀ`, so the adjoint Krylov solve ran almost unpreconditioned and dominated reverse-mode cost (empirically ~90× the forward step for a Taylor–Hood Navier–Stokes step; ~1.4–2.3× speedup + a more accurate gradient once fixed).

`jax.linear_transpose` cannot transpose `M` through its inner iterative/direct sub-solves, so the transpose is built **structurally**.

## Changes

- New `PrecondApplier` (`solver_api`): a preconditioner application that also carries its transpose applier `.T` (`v → M⁻ᵀ v`); `.T` is the applier itself for a symmetric preconditioner. A bare-callable precond has no `.T`, so `_firewalled` falls back to reusing `M` (unchanged behaviour).
- Every `jno.precond` spec now returns a `PrecondApplier` with its structural transpose: `jacobi` (symmetric), `chebyshev`/`form`/`inner` (run on the transposed operator `Aᵀ`), `block_diag` (transpose each block), `triangular` (transpose = forward-substitution with transposed diagonal blocks and transposed coupling matvecs `sub(j,i)ᵀ`).
- Block preconditioners normalize each per-block applier to a `PrecondApplier`, so a bare-callable block precond (e.g. `amg`) gets `Mᵀ := M` in the transpose path instead of crashing on a missing `.T`.
- `_firewalled` uses `M.T` for the non-symmetric `transpose_solve`.

Purely a convergence-speed change — the preconditioner cannot alter the gradient.

## Testing

- Targeted solver suite (GPU, `JAX_PLATFORMS=cuda,cpu`): **80 passed** across precond / slots / krylov / amg / picard / transient / newton-krylov / linear-solvers / inverse.
- The AMG-block transpose fallback was surfaced by `test_stokes_fgmres_triangular_with_amg_velocity_block` and now passes.
