### PR TITLE
feat(fdm): close the 3-D gap — interior tets, cotangent Laplacian, flux BCs, Shape.contains regions

### DIFF
--- a/docs/fdm.md
+++ b/docs/fdm.md
@@ -67,7 +67,9 @@ The built-in stencils (parsed from the scheme string) are:
 
 The `cotangent` Laplacian is the most accurate and is symmetric; the gradient methods trade accuracy
 for locality. The scheme stays on the operator it describes — `ui.d2(x, scheme=…)` — so different
-terms in the same residual can use different stencils.
+terms in the same residual can use different stencils. (`cotangent` is a **2-D** stencil; a
+tetrahedral mesh has no cotangent Laplace–Beltrami, so in 3-D the Laplacian is `gradient_of_gradient`
+— see [3-D tetrahedral meshes](#3-d-tetrahedral-meshes).)
 
 ---
 
@@ -116,10 +118,14 @@ jno.fdm([
 !!! note "How flux BCs differ from `jno.fem`"
     In `jno.fem` a Neumann condition is a *natural* weak term `h·v` carrying the test function. The
     strong form has no test function, so the flux is imposed **directly** on the boundary node's
-    equation. The normal is computed from the mesh boundary segments (exact on axis-aligned edges).
-    A **corner** node shared by two flux edges has no single outward normal, so it falls back to the
-    interior PDE residual — give such a corner an explicit Dirichlet value if it needs anchoring. A
-    condition that is *not* affine in `∂u/∂n` raises rather than returning a wrong answer.
+    equation. In **2-D** the normal is computed from the mesh boundary segments (exact on axis-aligned
+    edges), and a **corner** node shared by two flux edges has no single outward normal, so it falls
+    back to the interior PDE residual — give such a corner an explicit Dirichlet value if it needs
+    anchoring. In **3-D** the normal comes from the region's boundary **faces**, each oriented outward
+    exactly via its owning tetrahedron's apex (a flat face gives an exact axis normal), so face-edge
+    nodes keep their flux row; where a flux face meets a Dirichlet face, the Dirichlet value wins (its
+    row is applied last). A condition that is *not* affine in `∂u/∂n` raises rather than returning a
+    wrong answer.
 
 ---
 
@@ -174,14 +180,52 @@ array eagerly, as in every section above.
 
 ---
 
+## 3-D tetrahedral meshes
+
+Everything above dispatches on `domain.dimension`: give `jno.fdm` a **3-D tetrahedral** domain and the
+same constraint list solves in 3-D. Build the mesh with [`jno.Shape`](shape.md) — a box, sphere,
+cylinder, or any boolean combination — and add the third coordinate:
+
+```python
+d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.1).domain()
+x, y, z, _   = d.variable("interior", split=True)          # note the z coordinate
+xb, yb, zb, _ = d.variable("boundary", split=True)
+u  = d.unknown()
+ui = u.bind(x=x, y=y, z=z)
+
+f = 3.0 * np.pi**2 * jnn.sin(np.pi*x) * jnn.sin(np.pi*y) * jnn.sin(np.pi*z)
+sol = jno.fdm([
+    -ui.d2(x) - ui.d2(y) - ui.d2(z) - f,                   # -Delta u = f on the cube
+    u(xb, yb, zb) - 0.0,                                   # Dirichlet u = 0
+]).solve()
+```
+
+A cube from `jno.Shape.box` auto-names its six faces `left/right/front/back/bottom/top`, so **flux**
+conditions work per face exactly as in 2-D — bind to the face and take the normal derivative
+(`nr = d.variable("right", normals=True)`, then `ui.d(nr) - h` or `ur.d(nr) + alpha*(ur - u_inf)`).
+
+!!! note "3-D accuracy"
+    A tetrahedral mesh has no cotangent Laplace–Beltrami stencil, so the 3-D Laplacian is the
+    first-order `gradient_of_gradient` double-difference (`lsq_of_gradient` is unstable for a *second*
+    derivative on tets — the nested least-squares amplifies — and is not recommended in 3-D). It
+    converges under refinement but is coarser than the 2-D cotangent stencil, so 3-D accuracy leans on
+    mesh refinement.
+
+---
+
 ## Scope and limitations
 
-**Supported (v1):** scalar fields on a 2-D triangular mesh; any mix of steady Dirichlet and
-flux (Neumann / Robin / coordinate-coefficient, affine in `∂u/∂n`) boundary conditions; transient
-problems by the method of lines (`M = I`, unit-coefficient `u.t`); linear and nonlinear residuals;
-differentiable inverse problems.
+**Supported:** scalar fields on a **2-D triangular or 3-D tetrahedral** mesh; any mix of steady
+Dirichlet and flux (Neumann / Robin / coordinate-coefficient, affine in `∂u/∂n`) boundary conditions,
+in 2-D and 3-D; transient problems by the method of lines (`M = I`, unit-coefficient `u.t`); linear
+and nonlinear residuals; differentiable inverse problems. A geometric sub-region for a subdomain /
+domain-decomposition solve (`jno.dd.couple([(problem, region)])`) resolves to a mesh-node subset via
+the analytic, shapely-free [`Shape.contains`](shape.md) — in 2-D **and** 3-D.
 
 **Planned:** transient flux boundary conditions (a flux node keeps `M = 1`, unlike a pinned Dirichlet
 node); periodic boundaries; a general `u.t` mass coefficient; a structured-grid stencil backend; 1-D
-and 3-D meshes. A pure-Neumann problem (no Dirichlet node anywhere) is singular — the solution is
-defined only up to an additive constant — and is solved as-is.
+meshes; a higher-order (cotangent-equivalent) 3-D Laplacian. Authoring a `jno.Shape` sub-region
+through `domain.region(name, shape)` + `d.variable`, and 3-D coupled solves, additionally need
+region-tag support on the base 3-D domain (a separate 3-D domain-decomposition feature). A pure-Neumann
+problem (no Dirichlet node anywhere) is singular — the solution is defined only up to an additive
+constant — and is solved as-is.

--- a/docs/fdm.md
+++ b/docs/fdm.md
@@ -67,9 +67,9 @@ The built-in stencils (parsed from the scheme string) are:
 
 The `cotangent` Laplacian is the most accurate and is symmetric; the gradient methods trade accuracy
 for locality. The scheme stays on the operator it describes — `ui.d2(x, scheme=…)` — so different
-terms in the same residual can use different stencils. (`cotangent` is a **2-D** stencil; a
-tetrahedral mesh has no cotangent Laplace–Beltrami, so in 3-D the Laplacian is `gradient_of_gradient`
-— see [3-D tetrahedral meshes](#3-d-tetrahedral-meshes).)
+terms in the same residual can use different stencils. (`cotangent` is the accurate default in 2-D
+**and** 3-D — the cotangent-weight operator on triangles, and its exact analogue the P1 finite-element
+Laplace–Beltrami operator on tetrahedra; see [3-D tetrahedral meshes](#3-d-tetrahedral-meshes).)
 
 ---
 
@@ -204,12 +204,14 @@ A cube from `jno.Shape.box` auto-names its six faces `left/right/front/back/bott
 conditions work per face exactly as in 2-D — bind to the face and take the normal derivative
 (`nr = d.variable("right", normals=True)`, then `ui.d(nr) - h` or `ur.d(nr) + alpha*(ur - u_inf)`).
 
-!!! note "3-D accuracy"
-    A tetrahedral mesh has no cotangent Laplace–Beltrami stencil, so the 3-D Laplacian is the
-    first-order `gradient_of_gradient` double-difference (`lsq_of_gradient` is unstable for a *second*
-    derivative on tets — the nested least-squares amplifies — and is not recommended in 3-D). It
-    converges under refinement but is coarser than the 2-D cotangent stencil, so 3-D accuracy leans on
-    mesh refinement.
+!!! note "3-D Laplacian stencil"
+    The default `cotangent` Laplacian is the **P1 tetrahedral finite-element** (Laplace–Beltrami)
+    operator — the exact 3-D analogue of the 2-D cotangent weights — so it is symmetric and second-order
+    for the Galerkin solve. `gradient_of_gradient` (first-order, local) is the alternative;
+    `lsq_of_gradient` is unstable for a *second* derivative on tets (the nested least-squares amplifies)
+    and is not recommended in 3-D. As in 2-D, the whole-Laplacian `cotangent` stencil **cannot be split**
+    across directions — write it as the single term `ui.d2(x, scheme="finite_difference:cotangent")`,
+    not summed; the plain `−d2(x) − d2(y) − d2(z)` uses the per-direction `gradient_of_gradient`.
 
 ---
 
@@ -224,7 +226,7 @@ the analytic, shapely-free [`Shape.contains`](shape.md) — in 2-D **and** 3-D.
 
 **Planned:** transient flux boundary conditions (a flux node keeps `M = 1`, unlike a pinned Dirichlet
 node); periodic boundaries; a general `u.t` mass coefficient; a structured-grid stencil backend; 1-D
-meshes; a higher-order (cotangent-equivalent) 3-D Laplacian. Authoring a `jno.Shape` sub-region
+meshes. Authoring a `jno.Shape` sub-region
 through `domain.region(name, shape)` + `d.variable`, and 3-D coupled solves, additionally need
 region-tag support on the base 3-D domain (a separate 3-D domain-decomposition feature). A pure-Neumann
 problem (no Dirichlet node anywhere) is singular — the solution is defined only up to an additive

--- a/jno/dd.py
+++ b/jno/dd.py
@@ -28,16 +28,19 @@ import numpy as np
 
 
 def _region_mask(pts, geom):
-    """Boolean mask of points ``pts`` inside a shapely region ``geom`` (used for nodes and element centroids)."""
-    from shapely.geometry import Point
+    """Boolean mask of points ``pts`` inside a region ``geom`` (nodes or element centroids). A
+    ``jno.Shape`` is tested by the analytic, shapely-free :meth:`Shape.contains` (2-D and 3-D alike — the
+    primary, 3-D-capable path). A shapely geometry falls back to shapely containment; that path survives
+    only for 2-D regions whose mesh is conformed to the region in ``polygon_domain`` (interface /
+    partition tags), which stays shapely by scope."""
+    from jno.geometry import Shape
 
-    g = geom.buffer(1e-9)
-    try:
-        import shapely  # vectorized (shapely >= 2.0.2)
+    p = np.asarray(pts)
+    if isinstance(geom, Shape):
+        return np.asarray(geom.contains(p[:, : geom.dim]))
+    import shapely
 
-        return np.asarray(shapely.contains_xy(g, np.asarray(pts)[:, 0], np.asarray(pts)[:, 1]))
-    except (ImportError, AttributeError):
-        return np.array([g.contains(Point(float(q[0]), float(q[1]))) for q in np.asarray(pts)])
+    return np.asarray(shapely.contains_xy(geom.buffer(1e-9), p[:, 0], p[:, 1]))
 
 
 def _element_partition(pts, tris, geom0):
@@ -73,8 +76,6 @@ def _interface_edge_lengths(pts, tris, gamma):
 def _interface_normal(pts, gamma, into_geom):
     """Unit normal of the (straight) interface line, oriented to point INTO ``into_geom`` (the Neumann
     region). This is the Dirichlet region's outward normal — the direction of the flux it exports."""
-    from shapely.geometry import Point
-
     P = pts[gamma]
     c = P.mean(0)
     if len(gamma) >= 2:
@@ -84,7 +85,8 @@ def _interface_normal(pts, gamma, into_geom):
     else:
         nrm = np.array([1.0, 0.0])
     nrm = nrm / (np.linalg.norm(nrm) + 1e-30)
-    if not into_geom.buffer(1e-9).contains(Point(float(c[0] + 1e-3 * nrm[0]), float(c[1] + 1e-3 * nrm[1]))):
+    probe = np.array([[c[0] + 1e-3 * nrm[0], c[1] + 1e-3 * nrm[1]]])  # a hair into the normal direction
+    if not bool(_region_mask(probe, into_geom)[0]):
         nrm = -nrm
     return nrm
 
@@ -498,8 +500,15 @@ class _Coupled:
         Dirichlet-Neumann vs overlapping Schwarz) is inferred from whether the regions overlap."""
         probs = [p for p, _ in self._subdomains]
         geoms = [g for _, g in self._subdomains]
-        inter = geoms[0].intersection(geoms[1])
-        if float(getattr(inter, "area", 0.0)) > 1e-12:
+        # Overlap vs. single-interface (line-DN) is decided on element CENTROIDS, not nodes: a centroid
+        # never lands exactly on a shared interface line, so a centroid in BOTH regions means a genuine
+        # 2-D overlap band. (Interface nodes lie in both regions under inclusive containment, so a
+        # node-based test would misread a clean partition as an overlap.)
+        dom = probs[0].domain
+        pts = np.asarray(dom.mesh_connectivity["points"])[:, : int(getattr(dom, "dimension", 2))]
+        cells = np.asarray(dom.mesh_connectivity["triangles"])
+        cent = pts[cells].mean(1)
+        if int(np.count_nonzero(_region_mask(cent, geoms[0]) & _region_mask(cent, geoms[1]))) > 0:
             return self._solve_overlap(probs, geoms, tol=tol, max_iter=max_iter, return_info=return_info)
         return self._solve_line(probs, geoms, tol=tol, max_iter=max_iter, return_info=return_info)
 
@@ -609,7 +618,8 @@ def couple(subdomains, interface_conditions=None):
 
     ``subdomains``: a list of ``(problem, region)`` pairs, where ``problem`` is a subdomain solve
     (``jno.fdm([...])`` / ``jno.fem([...])``) authored with its PDE + outer boundary conditions, and
-    ``region`` is the shapely geometry it owns. ``interface_conditions``: optional residuals declaring the
+    ``region`` is the ``jno.Shape`` it owns (resolved to a node subset by ``Shape.contains``, no shapely).
+    ``interface_conditions``: optional residuals declaring the
     coupling in jNO syntax (value ``uA(iface)-uB(iface)`` / flux ``k*uA.d(n)-...`` on an ``interface_*``
     tag). The interface is inferred from the regions: a single line (partitioning tags) is coupled by
     Dirichlet-Neumann, an overlap by Schwarz.

--- a/jno/differential_operators.py
+++ b/jno/differential_operators.py
@@ -689,6 +689,63 @@ class DifferentialOperators:
         return jnp.where(valid, num / safe_det, 0.0)
 
     @staticmethod
+    def compute_laplacian_3d_cotangent(
+        u_values: jnp.ndarray,
+        points: jnp.ndarray,
+        tetrahedra: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """P1 finite-element (Laplace–Beltrami) Laplacian on a tetrahedral mesh — the 3-D analogue of the
+        2-D :meth:`compute_laplacian_2d_cotangent` (in 2-D the cotangent weights **are** the P1 stiffness
+        off-diagonals).
+
+        Each tet's linear basis gradients ``∇φ_a`` are constant, obtained from the inverse of the element
+        Jacobian ``J = [p1-p0 | p2-p0 | p3-p0]`` (``∇λ_{1,2,3}`` are the rows of ``J⁻¹``, ``∇λ_0`` their
+        negated sum). The assembled stiffness applied to ``u`` is, matrix-free,
+        ``(K u)_i = Σ_{T∋i} V_T (∇φ_i · ∇u_T)`` with ``∇u_T = Σ_a u_a ∇φ_a`` the (constant) element
+        gradient and ``V_T`` the tet volume; normalizing by the lumped vertex volume
+        ``M_i = Σ_{T∋i} V_T / 4`` gives the strong Laplacian ``Δu_i = -(K u)_i / M_i``. Symmetric,
+        CG-compatible, and second-order for the Galerkin solution — the accurate default on tets.
+
+        Args:
+            u_values:   Function values, shape ``(N,)``.
+            points:     Coordinates, shape ``(N, 3)``.
+            tetrahedra: Tet connectivity, shape ``(M, 4)``.
+
+        Returns:
+            Laplacian at each node, shape ``(N,)``.
+        """
+        pts = jnp.asarray(points)[:, :3]
+        tets = jnp.asarray(tetrahedra)
+        n = u_values.shape[0]
+        i0, i1, i2, i3 = tets[:, 0], tets[:, 1], tets[:, 2], tets[:, 3]
+        p0 = pts[i0]
+        # Jacobian with columns e1, e2, e3 = p1-p0, p2-p0, p3-p0
+        jac = jnp.stack([pts[i1] - p0, pts[i2] - p0, pts[i3] - p0], axis=2)  # (M, 3, 3)
+        det = jnp.linalg.det(jac)
+        good = jnp.abs(det) > 1e-14  # guard sliver / degenerate tets against a singular inverse
+        vol = jnp.where(good, jnp.abs(det) / 6.0, 0.0)
+        jinv = jnp.linalg.inv(jnp.where(good[:, None, None], jac, jnp.eye(3, dtype=jac.dtype)))
+        g1, g2, g3 = jinv[:, 0, :], jinv[:, 1, :], jinv[:, 2, :]  # ∇λ_1, ∇λ_2, ∇λ_3 (rows of J⁻¹)
+        g0 = -(g1 + g2 + g3)  # ∇λ_0 = -(∇λ_1 + ∇λ_2 + ∇λ_3)  (partition of unity)
+        u0, u1, u2, u3 = u_values[i0], u_values[i1], u_values[i2], u_values[i3]
+        gradu = g0 * u0[:, None] + g1 * u1[:, None] + g2 * u2[:, None] + g3 * u3[:, None]  # ∇u on the tet
+        ku = (
+            jnp.zeros(n)
+            .at[i0]
+            .add(vol * jnp.sum(g0 * gradu, axis=1))
+            .at[i1]
+            .add(vol * jnp.sum(g1 * gradu, axis=1))
+            .at[i2]
+            .add(vol * jnp.sum(g2 * gradu, axis=1))
+            .at[i3]
+            .add(vol * jnp.sum(g3 * gradu, axis=1))
+        )
+        quarter = vol / 4.0
+        mass = jnp.zeros(n).at[i0].add(quarter).at[i1].add(quarter).at[i2].add(quarter).at[i3].add(quarter)
+        safe_mass = jnp.where(mass > 1e-14, mass, 1.0)
+        return jnp.where(mass > 1e-14, -ku / safe_mass, 0.0)
+
+    @staticmethod
     def compute_fd_laplacian_3d_simple(
         u_values: jnp.ndarray,
         points: jnp.ndarray,
@@ -703,12 +760,14 @@ class DifferentialOperators:
             points:     Coordinates, shape ``(N, 3)``.
             tetrahedra: Tet connectivity, shape ``(M, 4)``.
             dims:       Spatial dimensions to sum over, e.g. ``(0, 1, 2)``.
-            method:     ``"gradient_of_gradient"`` (default) or
-                        ``"lsq_of_gradient"``.
+            method:     ``"cotangent"`` (P1 Laplace–Beltrami — accurate, symmetric),
+                        ``"gradient_of_gradient"``, or ``"lsq_of_gradient"``.
 
         Returns:
             Laplacian, shape ``(N,)``.
         """
+        if method == "cotangent":
+            return DifferentialOperators.compute_laplacian_3d_cotangent(u_values, points, tetrahedra)
         if method == "lsq_of_gradient":
             result = jnp.zeros_like(u_values)
             for d in dims:

--- a/jno/fdm.py
+++ b/jno/fdm.py
@@ -17,7 +17,12 @@ u(xi, yi) - u0])`` authored with ``u = domain.unknown()`` exactly as ``jno.fem([
 initial condition is *found from the constraints* (never a config flag) and ``t_span``/step-count are
 inferred from ``domain.time`` — and a low-level **function form** (:class:`FDMSystem`).
 
-v1 scope: scalar, 2-D triangular mesh, and **any mix** of steady boundary conditions — Dirichlet
+Scope: scalar fields on a **2-D triangular or 3-D tetrahedral mesh**. The interior operators
+(``jno.fdm.laplacian`` / ``jno.fdm.gradient``, and the constraint-list ``u.d2(x)+u.d2(y)+u.d2(z)``
+authoring) dispatch on ``domain.dimension``; a tet mesh has no cotangent Laplace-Beltrami, so its
+Laplacian is the first-order ``gradient_of_gradient`` double-difference (accuracy leans on
+refinement). Flux BCs and geometric sub-regions are 2-D for now (3-D face-normal flux and 3-D
+containment are the next extensions). In 2-D, **any mix** of steady boundary conditions — Dirichlet
 ``u(region) - g``, and **any flux BC affine in the normal derivative** ``∂u/∂n`` written with that
 edge's boundary tags: Neumann ``ur.d(n) - h``, Robin ``ur.d(n) + α(u - u∞)``, a coordinate-coefficient
 ``κ(x)·ur.d(n)``, either sign (``ur = u.bind(x=xr, y=yr)``, ``n = domain.variable(region, normals=True)``;
@@ -40,27 +45,45 @@ __all__ = ["fdm", "laplacian", "gradient"]
 
 
 def _mesh(domain):
+    """``(points, cells)`` for the domain — 2-D triangles or 3-D tetrahedra, dispatched on
+    ``domain.dimension``. 1-D is not exposed here (``jno.fdm`` is a 2-D/3-D collocation solver)."""
     mc = domain.mesh_connectivity
     dim = int(getattr(domain, "dimension", 2))
     pts = jnp.asarray(np.asarray(mc["points"])[:, :dim])
-    if dim != 2:
-        raise NotImplementedError("jno.fdm: only 2-D triangular meshes are supported in v1.")
-    return pts, jnp.asarray(mc["triangles"])
+    if dim == 2:
+        return pts, jnp.asarray(mc["triangles"])
+    if dim == 3:
+        return pts, jnp.asarray(mc["tetrahedra"])
+    raise NotImplementedError("jno.fdm: only 2-D triangular and 3-D tetrahedral meshes are supported.")
 
 
 def laplacian(u, domain, method: str = "cotangent"):
-    """FD Laplacian ``Δu`` of the nodal field ``u`` on the domain's mesh. ``method="cotangent"``
-    (symmetric, accurate — CG-compatible) or ``"gradient_of_gradient"`` / ``"lsq_of_gradient"``."""
-    pts, tris = _mesh(domain)
-    return _D.compute_fd_laplacian_2d_simple(u, pts, tris, dims=(0, 1), method=method)
+    """FD Laplacian ``Δu`` of the nodal field ``u`` on the domain's mesh. In 2-D ``method="cotangent"``
+    (symmetric, accurate — CG-compatible) or ``"gradient_of_gradient"`` / ``"lsq_of_gradient"``. A
+    tetrahedral mesh has **no cotangent Laplace-Beltrami**, so the 3-D operator is the
+    ``"gradient_of_gradient"`` double-difference (``"cotangent"`` is accepted as that alias, and is the
+    default): it is first-order and noisier than the 2-D cotangent stencil, so 3-D accuracy leans on
+    mesh refinement. (``"lsq_of_gradient"`` is unstable for the *second* derivative on tetrahedra —
+    the nested least-squares amplifies — and is not recommended in 3-D.)"""
+    pts, cells = _mesh(domain)
+    dim = int(getattr(domain, "dimension", 2))
+    if dim == 3:
+        method = "gradient_of_gradient" if method == "cotangent" else method
+        return _D.compute_fd_laplacian_3d_simple(u, pts, cells, dims=(0, 1, 2), method=method)
+    return _D.compute_fd_laplacian_2d_simple(u, pts, cells, dims=(0, 1), method=method)
 
 
 def gradient(u, domain, method: str = "area_weighted"):
-    """FD gradient ``∇u`` of the nodal field ``u`` — shape ``(N, 2)``. ``method`` selects the stencil
-    (``"area_weighted"`` default, ``"uniform"``, ``"inverse_distance"``, ``"least_squares"``)."""
-    pts, tris = _mesh(domain)
-    gx = _D.compute_fd_gradient_2d_simple(u, pts, tris, 0, method=method)
-    gy = _D.compute_fd_gradient_2d_simple(u, pts, tris, 1, method=method)
+    """FD gradient ``∇u`` of the nodal field ``u`` — shape ``(N, dim)``. ``method`` selects the stencil
+    (``"area_weighted"`` default, ``"uniform"``, ``"inverse_distance"``, ``"least_squares"``); the same
+    names apply on a 2-D triangular or 3-D tetrahedral mesh."""
+    pts, cells = _mesh(domain)
+    dim = int(getattr(domain, "dimension", 2))
+    if dim == 3:
+        comps = [_D.compute_fd_gradient_3d_simple(u, pts, cells, d, method=method) for d in range(3)]
+        return jnp.stack(comps, axis=1)
+    gx = _D.compute_fd_gradient_2d_simple(u, pts, cells, 0, method=method)
+    gy = _D.compute_fd_gradient_2d_simple(u, pts, cells, 1, method=method)
     return jnp.stack([gx, gy], axis=1)
 
 

--- a/jno/fdm.py
+++ b/jno/fdm.py
@@ -254,17 +254,20 @@ def _has_unknown_derivative(node, unknown):
 
 
 def _mesh_nodes_in(pts, geom):
-    """Indices of the mesh nodes ``pts`` inside a shapely region ``geom`` — resolves a geometric region
-    (registered via ``domain.region(name, geom)``) to a node subset for pinning/solving on a subdomain."""
-    from shapely.geometry import Point
+    """Indices of the mesh nodes ``pts`` inside a geometric region ``geom`` (registered via
+    ``domain.region(name, region)``) — resolves the region to a node subset for pinning/solving on a
+    subdomain. A ``jno.Shape`` uses the analytic, shapely-free :meth:`Shape.contains` (2-D and 3-D — the
+    primary path); a shapely geometry falls back to shapely (2-D mesh-conforming regions in
+    ``polygon_domain``, which stay shapely by scope)."""
+    from .geometry import Shape
 
-    g = geom.buffer(1e-9)
-    try:  # vectorized fast path (shapely >= 2.0.2), fall back to per-point containment
+    p = np.asarray(pts)
+    if isinstance(geom, Shape):
+        mask = np.asarray(geom.contains(p[:, : geom.dim]))
+    else:
         import shapely
 
-        mask = np.asarray(shapely.contains_xy(g, np.asarray(pts)[:, 0], np.asarray(pts)[:, 1]))
-    except (ImportError, AttributeError):
-        mask = np.array([g.contains(Point(float(q[0]), float(q[1]))) for q in np.asarray(pts)])
+        mask = np.asarray(shapely.contains_xy(geom.buffer(1e-9), p[:, 0], p[:, 1]))
     return np.nonzero(mask)[0].astype(int)
 
 

--- a/jno/fdm.py
+++ b/jno/fdm.py
@@ -19,9 +19,10 @@ inferred from ``domain.time`` — and a low-level **function form** (:class:`FDM
 
 Scope: scalar fields on a **2-D triangular or 3-D tetrahedral mesh**. The interior operators
 (``jno.fdm.laplacian`` / ``jno.fdm.gradient``, and the constraint-list ``u.d2(x)+u.d2(y)+u.d2(z)``
-authoring) dispatch on ``domain.dimension``; a tet mesh has no cotangent Laplace-Beltrami, so its
-Laplacian is the first-order ``gradient_of_gradient`` double-difference (accuracy leans on
-refinement). **Any mix** of steady boundary conditions — Dirichlet ``u(region) - g``, and **any flux BC
+authoring) dispatch on ``domain.dimension``; the default ``cotangent`` Laplacian is the cotangent-weight
+operator in 2-D and its exact analogue, the **P1 tetrahedral finite-element** Laplace-Beltrami operator,
+in 3-D (symmetric, second-order for the solve; ``gradient_of_gradient`` is the first-order local
+alternative). **Any mix** of steady boundary conditions — Dirichlet ``u(region) - g``, and **any flux BC
 affine in the normal derivative** ``∂u/∂n`` written with that region's boundary tags: Neumann
 ``ur.d(n) - h``, Robin ``ur.d(n) + α(u - u∞)``, a coordinate-coefficient ``κ(x)·ur.d(n)``, either sign
 (``ur = u.bind(x=xr, y=yr[, z=zr])``, ``n = domain.variable(region, normals=True)``). Flux normals come
@@ -60,17 +61,16 @@ def _mesh(domain):
 
 
 def laplacian(u, domain, method: str = "cotangent"):
-    """FD Laplacian ``Δu`` of the nodal field ``u`` on the domain's mesh. In 2-D ``method="cotangent"``
-    (symmetric, accurate — CG-compatible) or ``"gradient_of_gradient"`` / ``"lsq_of_gradient"``. A
-    tetrahedral mesh has **no cotangent Laplace-Beltrami**, so the 3-D operator is the
-    ``"gradient_of_gradient"`` double-difference (``"cotangent"`` is accepted as that alias, and is the
-    default): it is first-order and noisier than the 2-D cotangent stencil, so 3-D accuracy leans on
-    mesh refinement. (``"lsq_of_gradient"`` is unstable for the *second* derivative on tetrahedra —
-    the nested least-squares amplifies — and is not recommended in 3-D.)"""
+    """FD Laplacian ``Δu`` of the nodal field ``u`` on the domain's mesh. ``method="cotangent"`` (the
+    default) is the symmetric, CG-compatible Laplace–Beltrami stencil — the cotangent-weight operator on
+    a 2-D triangular mesh and its exact analogue, the **P1 tetrahedral finite-element** operator, on a
+    3-D tet mesh (second-order for the Galerkin solve). ``"gradient_of_gradient"`` (first-order double
+    difference) and ``"lsq_of_gradient"`` are the local alternatives; ``"lsq_of_gradient"`` is unstable
+    for the *second* derivative on tetrahedra (nested least-squares amplifies) and is not recommended in
+    3-D."""
     pts, cells = _mesh(domain)
     dim = int(getattr(domain, "dimension", 2))
     if dim == 3:
-        method = "gradient_of_gradient" if method == "cotangent" else method
         return _D.compute_fd_laplacian_3d_simple(u, pts, cells, dims=(0, 1, 2), method=method)
     return _D.compute_fd_laplacian_2d_simple(u, pts, cells, dims=(0, 1), method=method)
 

--- a/jno/fdm.py
+++ b/jno/fdm.py
@@ -21,12 +21,14 @@ Scope: scalar fields on a **2-D triangular or 3-D tetrahedral mesh**. The interi
 (``jno.fdm.laplacian`` / ``jno.fdm.gradient``, and the constraint-list ``u.d2(x)+u.d2(y)+u.d2(z)``
 authoring) dispatch on ``domain.dimension``; a tet mesh has no cotangent Laplace-Beltrami, so its
 Laplacian is the first-order ``gradient_of_gradient`` double-difference (accuracy leans on
-refinement). Flux BCs and geometric sub-regions are 2-D for now (3-D face-normal flux and 3-D
-containment are the next extensions). In 2-D, **any mix** of steady boundary conditions — Dirichlet
-``u(region) - g``, and **any flux BC affine in the normal derivative** ``∂u/∂n`` written with that
-edge's boundary tags: Neumann ``ur.d(n) - h``, Robin ``ur.d(n) + α(u - u∞)``, a coordinate-coefficient
-``κ(x)·ur.d(n)``, either sign (``ur = u.bind(x=xr, y=yr)``, ``n = domain.variable(region, normals=True)``;
-corner nodes fall back to the PDE residual). Plus **transient** problems by method-of-lines (``M = I``;
+refinement). **Any mix** of steady boundary conditions — Dirichlet ``u(region) - g``, and **any flux BC
+affine in the normal derivative** ``∂u/∂n`` written with that region's boundary tags: Neumann
+``ur.d(n) - h``, Robin ``ur.d(n) + α(u - u∞)``, a coordinate-coefficient ``κ(x)·ur.d(n)``, either sign
+(``ur = u.bind(x=xr, y=yr[, z=zr])``, ``n = domain.variable(region, normals=True)``). Flux normals come
+from the mesh boundary **segments in 2-D** (a corner node — undefined normal — falls back to the PDE
+residual) and boundary **faces in 3-D** (each oriented outward exactly via its owning tet's apex, so a
+flat face gives an exact axis normal, no corner heuristic). Plus **transient** problems by
+method-of-lines (``M = I``;
 a unit-coefficient ``u.t`` term, e.g. ``ui.t - νΔu``) — all with linear + nonlinear residuals. Transient
 flux BCs, periodic, a general ``u.t`` mass coefficient, and a structured-grid stencil backend are planned
 extensions (see ``plans/fdm-solver.md``). A pure-Neumann problem (no Dirichlet node) is singular
@@ -526,19 +528,25 @@ class _TraceFDM:
         return rows
 
     def _node_normals(self, region):
-        """Unit outward normals for the **smooth-edge** nodes of ``region``, aligned to those nodes.
+        """Unit outward normals for the flux nodes of ``region``, aligned to those nodes.
 
-        Computed from the mesh **boundary segments** (``mesh_connectivity["boundary_edges"]``): each
-        segment's exact perpendicular is averaged over the (two) segments meeting at a node, so an
+        **2-D** — computed from the mesh **boundary segments** (``mesh_connectivity["boundary_edges"]``):
+        each segment's exact perpendicular is averaged over the (two) segments meeting at a node, so an
         axis-aligned edge yields an exact ``(±1, 0)`` / ``(0, ±1)`` — much cleaner than the domain's
         smoothed per-point normal, which bleeds a tangential component near corners and would spoil the
-        flux. Outward orientation is taken (sign only) from ``domain.variable(region, normals=True)``.
-
-        A **corner** node averages two differently-oriented segment normals, so the averaged magnitude
+        flux. Outward orientation is taken (sign only) from ``domain.variable(region, normals=True)``. A
+        **corner** node averages two differently-oriented segment normals, so the averaged magnitude
         drops (≈0.71 at a right angle): the outward normal is undefined there, so corners are **dropped**
         from the flux row and keep their interior PDE residual (give a corner an explicit Dirichlet
-        condition if it needs one). Returns ``(kept_node_indices, unit_n)``."""
+        condition if it needs one).
+
+        **3-D** — see :meth:`_node_normals_3d`: the region's boundary triangles are oriented outward
+        exactly via each face's owning-tet apex, so no corner heuristic is needed.
+
+        Returns ``(kept_node_indices, unit_n)``."""
         dim = self.domain.dimension
+        if dim == 3:
+            return self._node_normals_3d(region)
         pts = np.asarray(self._pts)
         edges = np.asarray(self.domain.mesh_connectivity["boundary_edges"], dtype=int)  # (E, 2) node pairs
         tang = pts[edges[:, 1]] - pts[edges[:, 0]]
@@ -565,6 +573,28 @@ class _TraceFDM:
         idx, raw = idx[smooth], raw[smooth]
         n = raw / (np.linalg.norm(raw, axis=1, keepdims=True) + 1e-30)
         return idx, jnp.asarray(n)
+
+    def _node_normals_3d(self, region):
+        """Outward unit normals for the boundary-face nodes of ``region`` on a **tetrahedral** mesh.
+
+        The region's boundary triangles — the mesh boundary faces (a face shared by exactly one tet)
+        whose three vertices are all tagged ``region`` — are extracted from the tet connectivity
+        (:meth:`MeshUtils._boundary_faces_with_apex`). Each face normal is oriented outward **exactly**
+        via its owning tet's apex, then area-weighted and averaged per node
+        (:meth:`MeshUtils._compute_normals_from_boundary_faces`), so a flat face gives an exact axis
+        normal and a curved region an accurate one. Restricting to the region's **own** faces keeps a
+        region-edge node's normal consistent (all contributing faces are coplanar for a flat face), so —
+        unlike the 2-D path — no corner-dropping is needed. Returns ``(node_indices, unit_n)``."""
+        from .domain.mesh_utils import MeshUtils
+
+        pts = np.asarray(self._pts)
+        tets = np.asarray(self.domain.mesh_connectivity["tetrahedra"], dtype=int)
+        bfaces, bapex = MeshUtils._boundary_faces_with_apex(tets)
+        region_nodes = np.asarray(self._region_nodes(region), dtype=int)
+        on_region = np.isin(bfaces, region_nodes).all(axis=1)  # a face lies on the region ⟺ all 3 verts tagged
+        rfaces, rapex = bfaces[on_region], bapex[on_region]
+        n, idx = MeshUtils._compute_normals_from_boundary_faces(pts, rfaces, apex_points=pts[rapex])
+        return np.asarray(idx, dtype=int), jnp.asarray(n)
 
     def _flux_value_fn(self, constraint, val, extra_params=None):
         """Evaluate the flux constraint over ALL nodes with the normal derivative ``∂u/∂n`` pinned to the
@@ -660,8 +690,8 @@ class _TraceFDM:
         def residual_with_bc(u):
             r = residual_fn(u)
             # Flux rows first (`a·(∇u·n) + b`, with a = F(1)-F(0), b = F(0) — Neumann/Robin/etc.), then
-            # Dirichlet: a node shared by both (a corner touching a Dirichlet edge) resolves to the
-            # essential Dirichlet value.
+            # Dirichlet: a node carrying both (a 2-D corner, or a 3-D edge where a flux face meets a
+            # Dirichlet face) resolves to the essential Dirichlet value — the Dirichlet row is set last.
             for idx, nrm, method, v0, v1 in flux_rows:
                 grad = gradient(u, self.domain, method=method)  # (N, 2), differentiable
                 flux = jnp.sum(grad[idx] * nrm, axis=1)  # ∇u·n at the edge nodes

--- a/jno/geometry/primitives.py
+++ b/jno/geometry/primitives.py
@@ -25,6 +25,8 @@ import math
 from dataclasses import dataclass
 from typing import ClassVar, Optional, Tuple
 
+import numpy as np
+
 # How close a boundary point must be to an analytic curve/surface to lie "on" it.
 TOL = 1e-6
 
@@ -53,6 +55,11 @@ class Rect:
             return "top"
         return None
 
+    def contains(self, pts, tol: float = TOL):
+        """Boolean mask (N,) — which rows of ``pts`` (N, ≥2) lie inside, inclusive within ``tol``."""
+        x, y = pts[:, 0], pts[:, 1]
+        return (x >= self.x0 - tol) & (x <= self.x1 + tol) & (y >= self.y0 - tol) & (y <= self.y1 + tol)
+
 
 @dataclass(frozen=True)
 class Disk:
@@ -70,6 +77,10 @@ class Disk:
         if abs(math.hypot(x - self.cx, y - self.cy) - self.r) < tol:
             return "arc"
         return None
+
+    def contains(self, pts, tol: float = TOL):
+        """Boolean mask (N,) — which rows of ``pts`` (N, ≥2) lie inside, inclusive within ``tol``."""
+        return (pts[:, 0] - self.cx) ** 2 + (pts[:, 1] - self.cy) ** 2 <= (self.r + tol) ** 2
 
 
 @dataclass(frozen=True)
@@ -105,6 +116,18 @@ class Box:
             return "top"
         return None
 
+    def contains(self, pts, tol: float = TOL):
+        """Boolean mask (N,) — which rows of ``pts`` (N, ≥3) lie inside, inclusive within ``tol``."""
+        x, y, z = pts[:, 0], pts[:, 1], pts[:, 2]
+        return (
+            (x >= self.x0 - tol)
+            & (x <= self.x1 + tol)
+            & (y >= self.y0 - tol)
+            & (y <= self.y1 + tol)
+            & (z >= self.z0 - tol)
+            & (z <= self.z1 + tol)
+        )
+
 
 @dataclass(frozen=True)
 class Polygon:
@@ -137,6 +160,22 @@ class Polygon:
                 if -tol <= t <= 1.0 + tol:
                     return f"e{i}"
         return None
+
+    def contains(self, pts, tol: float = TOL):
+        """Boolean mask (N,) — inside test by the even-odd crossing rule (ray-cast). Edge-exact points
+        are ambiguous (the crossing rule is exclusive on edges); ``tol`` is unused here."""
+        x, y = pts[:, 0], pts[:, 1]
+        verts = self.points
+        n = len(verts)
+        inside = np.zeros(x.shape, dtype=bool)
+        j = n - 1
+        for i in range(n):
+            xi, yi = verts[i]
+            xj, yj = verts[j]
+            crosses = ((yi > y) != (yj > y)) & (x < (xj - xi) * (y - yi) / (yj - yi + 1e-30) + xi)
+            inside ^= crosses
+            j = i
+        return inside
 
 
 @dataclass(frozen=True)
@@ -172,6 +211,16 @@ class Cylinder:
             return "side"
         return None
 
+    def contains(self, pts, tol: float = TOL):
+        """Boolean mask (N,) — inside the axial extent [0, |axis|] and within radius ``r`` (± ``tol``)."""
+        axis = np.array([self.dx, self.dy, self.dz])
+        alen = float(np.linalg.norm(axis))
+        u = axis / alen
+        w = pts[:, :3] - np.array([self.x, self.y, self.z])
+        t = w @ u
+        perp2 = np.sum(w * w, axis=1) - t * t
+        return (t >= -tol) & (t <= alen + tol) & (perp2 <= (self.r + tol) ** 2)
+
 
 @dataclass(frozen=True)
 class Sphere:
@@ -190,6 +239,11 @@ class Sphere:
         if abs(math.sqrt((x - self.cx) ** 2 + (y - self.cy) ** 2 + (z - self.cz) ** 2) - self.r) < tol:
             return "surface"
         return None
+
+    def contains(self, pts, tol: float = TOL):
+        """Boolean mask (N,) — which rows of ``pts`` (N, ≥3) lie inside, inclusive within ``tol``."""
+        c = np.array([self.cx, self.cy, self.cz])
+        return np.sum((pts[:, :3] - c) ** 2, axis=1) <= (self.r + tol) ** 2
 
 
 def _on_line(a, b, x, y, tol):

--- a/jno/geometry/shape.py
+++ b/jno/geometry/shape.py
@@ -20,7 +20,29 @@ import math
 from dataclasses import dataclass, field
 from typing import Callable, FrozenSet, Tuple, Union
 
+import numpy as np
+
 from .primitives import Box, Cylinder, Disk, Polygon, Rect, Sphere
+
+
+def _node_contains(node, pts, tol):
+    """Analytic point membership over the CSG tree — leaves + cut/fuse/inter, no gmsh."""
+    kind = node[0]
+    if kind == "leaf":
+        return np.asarray(node[1].contains(pts, tol), dtype=bool)
+    if kind == "cut":
+        return _node_contains(node[1]._node, pts, tol) & ~_node_contains(node[2]._node, pts, tol)
+    if kind == "fuse":
+        return _node_contains(node[1]._node, pts, tol) | _node_contains(node[2]._node, pts, tol)
+    if kind == "inter":
+        return _node_contains(node[1]._node, pts, tol) & _node_contains(node[2]._node, pts, tol)
+    raise NotImplementedError(
+        f"Shape.contains supports the analytic CSG subset — primitive leaves combined by "
+        f"'-'/'|'/'&' (cut/fuse/inter); a {kind!r} solid (extrude/revolve/sweep/fillet/translate/"
+        f"rotate) has no closed-form point membership. Tag that region another way, or add its "
+        f"inverse transform here."
+    )
+
 
 # Unique, identity-stable key per primitive leaf, for provenance (``edges_from``).
 _LEAF_KEYS = itertools.count()
@@ -202,6 +224,19 @@ class Shape:
 
     def keys(self) -> FrozenSet[int]:
         return frozenset(k for _, _, k in self.leaves())
+
+    def contains(self, points, tol: float = 1e-9):
+        """Boolean mask over ``points`` (shape ``(N, dim)``): which lie inside this shape.
+
+        Analytic CSG membership evaluated host-side with numpy — primitive leaves combined by ``-``
+        (cut), ``|`` (fuse), ``&`` (inter) — so it needs no gmsh and works in 2-D and 3-D alike. This is
+        the shapely-free point-in-region test that resolves a geometric ``domain.region(name, shape)`` to
+        a mesh-node subset for a subdomain / domain-decomposition solve. Inclusive within ``tol`` (the
+        analogue of shapely's ``buffer(1e-9)``), so nodes exactly on a face count as inside. A shape
+        carrying a non-CSG transform (``extrude``/``revolve``/``sweep``/``fillet``/``translate``/
+        ``rotate``) has no closed-form membership and raises :class:`NotImplementedError`."""
+        pts = np.asarray(points, dtype=float)
+        return _node_contains(self._node, pts, float(tol))
 
     # ----- boundary selection ----------------------------------------------------
     def edge(self, name: str) -> Selector:

--- a/tests/test_domain_decomposition.py
+++ b/tests/test_domain_decomposition.py
@@ -399,6 +399,7 @@ def test_couple_driver_reproduces_monolithic():
 
     b1, b2 = box(0.0, 0.0, 0.6, 1.0), box(0.4, 0.0, 1.0, 1.0)
     d = jno.domain(b1.union(b2), mesh_size=0.06)
+    sA, sB = jno.Shape.rect(0.0, 0.0, 0.6, 1.0), jno.Shape.rect(0.4, 0.0, 1.0, 1.0)
     p = np.asarray(d.mesh_connectivity["points"])[:, :2]
     exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])
     x, y, _ = d.variable("interior", split=True)
@@ -411,7 +412,7 @@ def test_couple_driver_reproduces_monolithic():
     b = jno.fdm([-ui.d2(x) - ui.d2(y) - f, u(xb, yb) - 0.0])
     mono = np.asarray(jno.fdm([-ui.d2(x) - ui.d2(y) - f, u(xb, yb) - 0.0]).solve()).reshape(-1)
 
-    sol, info = couple([(a, b1), (b, b2)]).solve(tol=1e-7, max_iter=60, return_info=True)
+    sol, info = couple([(a, sA), (b, sB)]).solve(tol=1e-7, max_iter=60, return_info=True)
     assert info["overlap_jump"] < 1e-6, f"driver did not converge: {info}"
     equiv = float(np.linalg.norm(np.asarray(sol) - mono) / np.linalg.norm(mono))
     assert equiv < 1e-5, f"coupled driver must reproduce the monolithic solve, got {equiv:.2e}"
@@ -573,6 +574,7 @@ def test_material_interface_via_overlap_and_kx():
     a, b = 2 * kR / (kL + kR), 2 * kL / (kL + kR)  # analytic slopes: u = 1-a·x (left), u = b·(1-x) (right)
     boxA, boxB = box(0.0, 0.0, 0.6, 1.0), box(0.5, 0.0, 1.0, 1.0)  # FEM covers the jump; overlap [0.5,0.6] uniform kR
     d = jno.domain(boxA.union(boxB), mesh_size=0.05)
+    sA, sB = jno.Shape.rect(0.0, 0.0, 0.6, 1.0), jno.Shape.rect(0.5, 0.0, 1.0, 1.0)
     p = np.asarray(d.mesh_connectivity["points"])[:, :2]
     on = np.abs(p[:, 0] - 0.5) < 1e-6
 
@@ -590,7 +592,7 @@ def test_material_interface_via_overlap_and_kx():
     uiB = u.bind(x=xi, y=yi)
     fdmB = jno.fdm([-kR * (uiB.d2(xi) + uiB.d2(yi)), u(xb, yb) - g(xb, yb)])  # uniform kR (smooth region)
 
-    sol = np.asarray(couple([(femA, boxA), (fdmB, boxB)]).solve(max_iter=200)).reshape(-1)
+    sol = np.asarray(couple([(femA, sA), (fdmB, sB)]).solve(max_iter=200)).reshape(-1)
     iface_val = float(np.mean(sol[on]))
     assert abs(iface_val - kL / (kL + kR)) < 0.03, f"material kink should be {kL / (kL + kR):.2f}, got {iface_val:.3f}"
 
@@ -617,6 +619,7 @@ def test_overlap_coupled_solve_differentiable_in_fem_coefficient():
     kR, fsrc = 3.0, 10.0
     boxA, boxB = box(0.0, 0.0, 0.6, 1.0), box(0.5, 0.0, 1.0, 1.0)  # overlap x∈[0.5,0.6]
     d = jno.domain(boxA.union(boxB), mesh_size=0.08)
+    sA, sB = jno.Shape.rect(0.0, 0.0, 0.6, 1.0), jno.Shape.rect(0.5, 0.0, 1.0, 1.0)
     p = np.asarray(d.mesh_connectivity["points"])[:, :2]
     in_a, in_b = _region_mask(p, boxA), _region_mask(p, boxB)
     overlap = jnp.asarray(in_a & in_b)
@@ -634,7 +637,7 @@ def test_overlap_coupled_solve_differentiable_in_fem_coefficient():
     uiB = u.bind(x=xi, y=yi)
     fdmB = jno.fdm([-kR * (uiB.d2(xi) + uiB.d2(yi)) - fsrc, u(xb, yb) - 0.0])
 
-    node = couple([(femA, boxA), (fdmB, boxB)]).solve(tol=1e-9, max_iter=300)
+    node = couple([(femA, sA), (fdmB, sB)]).solve(tol=1e-9, max_iter=300)
     assert isinstance(node, FunctionCall), "a trainable coefficient must make the coupled solve a differentiable node"
     assert getattr(node, "_domain", None) is d, "the coupled node must carry its domain for jno.core"
 

--- a/tests/test_fdm.py
+++ b/tests/test_fdm.py
@@ -411,3 +411,71 @@ def test_dirichlet_value_from_nodal_field():
 
     assert not isinstance(sol, FunctionCall), "a data-field Dirichlet value must stay an eager solve"
     assert float(np.linalg.norm(np.asarray(sol).reshape(-1) - exact) / np.linalg.norm(exact)) < 1e-2
+
+
+# ==========================================================================
+# 3-D tetrahedral meshes (interior operators — Tier 1)
+# ==========================================================================
+
+
+def _nodes3(d):
+    return np.asarray(d.mesh_connectivity["points"])[:, :3]
+
+
+def _cube(mesh_size):
+    """Unit cube meshed by jno.Shape (gmsh tets) — no shapely."""
+    return jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=mesh_size).domain()
+
+
+def _poisson3d(mesh_size, method="gradient_of_gradient"):
+    """-Δu = f on [0,1]³, u=0 on ∂Ω, exact u = sin(πx)sin(πy)sin(πz) ⇒ f = 3π²u. Returns rel-L2 error."""
+    d = _cube(mesh_size)
+    p = _nodes3(d)
+    exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1]) * np.sin(np.pi * p[:, 2])
+    f = jnp.asarray(3 * np.pi**2 * exact)
+    sys = jno.fdm(d, residual=lambda u: -jno.fdm.laplacian(u, d, method=method) - f, dirichlet={"boundary": 0.0})
+    u = np.asarray(sys.solve()).reshape(-1)
+    return float(np.linalg.norm(u - exact) / np.linalg.norm(exact))
+
+
+def test_gradient_3d_shape():
+    """The FD gradient on a tet mesh is (N, 3) — the flux dot-product ∇u·n stays dimension-agnostic."""
+    d = _cube(0.25)
+    g = jno.fdm.gradient(jnp.asarray(_nodes3(d)[:, 0]), d)  # ∇x = (1,0,0)
+    assert g.shape == (_nodes3(d).shape[0], 3)
+
+
+def test_poisson_3d_dirichlet():
+    assert _poisson3d(0.1) < 0.2
+
+
+def test_poisson_3d_convergence_under_refinement():
+    """Refining the tet mesh reduces the FD error — Tier-1 consistency in 3-D. The gradient-of-gradient
+    Laplacian is only first-order (no cotangent Laplace-Beltrami on tets), so the absolute error is
+    larger than the 2-D case and accuracy leans on refinement — but it converges monotonically."""
+    errs = [_poisson3d(h) for h in (0.20, 0.14, 0.10)]
+    assert errs[0] > errs[1] > errs[2], f"not monotonically converging: {errs}"
+    assert errs[2] < 0.2
+
+
+def test_laplacian_3d_cotangent_aliases_grad_of_grad():
+    """A tet mesh has no cotangent stencil, so `method="cotangent"` (the default) aliases to
+    `"gradient_of_gradient"` rather than raising — the two give the identical solve."""
+    assert abs(_poisson3d(0.14, method="cotangent") - _poisson3d(0.14, method="gradient_of_gradient")) < 1e-12
+
+
+def test_constraint_list_poisson_3d():
+    """fem-style authoring in 3-D: jno.fdm([-u.d2(x)-u.d2(y)-u.d2(z)-f, u(xb,yb,zb)-0]). `split=True`
+    yields (x, y, z, t) on a 3-D domain — the trailing coord is temporal."""
+    import jno.jnp_ops as jnn
+
+    d = _cube(0.14)
+    x, y, z, _ = d.variable("interior", split=True)
+    xb, yb, zb, _ = d.variable("boundary", split=True)
+    p = _nodes3(d)
+    exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1]) * np.sin(np.pi * p[:, 2])
+    u = d.unknown()
+    ui = u.bind(x=x, y=y, z=z)
+    f = 3 * np.pi**2 * jnn.sin(np.pi * x) * jnn.sin(np.pi * y) * jnn.sin(np.pi * z)
+    sol = jno.fdm([-ui.d2(x) - ui.d2(y) - ui.d2(z) - f, u(xb, yb, zb) - 0.0]).solve()
+    assert float(np.linalg.norm(np.asarray(sol).reshape(-1) - exact) / np.linalg.norm(exact)) < 0.35

--- a/tests/test_fdm.py
+++ b/tests/test_fdm.py
@@ -499,3 +499,94 @@ def test_mesh_nodes_in_3d_shape_box():
     hand = np.nonzero(np.all((p >= 0.3 - 1e-9) & (p <= 0.7 + 1e-9), axis=1))[0]
     assert np.array_equal(np.sort(idx), np.sort(hand))
     assert len(idx) > 0, "the central box must capture interior tet nodes"
+
+
+# ---- 3-D flux BCs (Neumann / Robin on a face — Tier 2) ----
+
+
+def test_node_normals_3d_face_is_axis():
+    """The 3-D flux normals of a cube face are the exact outward axis normal — apex orientation +
+    coplanar averaging give (+1,0,0) on the right face and (0,0,1) on the top, for every face node."""
+    from jno.fdm import _TraceFDM
+
+    d = _cube(0.2)
+    x, y, z, _ = d.variable("interior", split=True)
+    xb, yb, zb, _ = d.variable("boundary", split=True)
+    u = d.unknown()
+    ui = u.bind(x=x, y=y, z=z)
+    sysm = _TraceFDM([-ui.d2(x) - ui.d2(y) - ui.d2(z), u(xb, yb, zb) - 0.0])  # a valid system to reach the method
+    for face, axis in (("right", [1.0, 0.0, 0.0]), ("top", [0.0, 0.0, 1.0]), ("front", [0.0, -1.0, 0.0])):
+        idx, n = sysm._node_normals(face)
+        assert len(idx) > 0
+        assert np.allclose(np.asarray(n), np.array(axis), atol=1e-9), f"{face} normal off: {np.asarray(n)[0]}"
+
+
+def _cube_mixed_flux_3d(mesh_size, exact_fn, du_dn_right):
+    """-Δu = 0 on the cube, Dirichlet u = exact on five faces, Neumann ∂u/∂n = h on the right face
+    (x=1). Returns rel-L2 vs the exact solution."""
+    d = _cube(mesh_size)
+    p = _nodes3(d)
+    exact = exact_fn(p[:, 0], p[:, 1], p[:, 2])
+    x, y, z, _ = d.variable("interior", split=True)
+    nr = d.variable("right", normals=True)  # outward normal on the right face (x=1)
+    u = d.unknown()
+    ui = u.bind(x=x, y=y, z=z)
+    cons = [-ui.d2(x) - ui.d2(y) - ui.d2(z), ui.d(nr) - du_dn_right]
+    for face in ("left", "front", "back", "bottom", "top"):
+        xf, yf, zf, _ = d.variable(face, split=True)
+        cons.append(u(xf, yf, zf) - exact_fn(xf, yf, zf))  # Dirichlet on the other five faces
+    sol = jno.fdm(cons).solve()
+    return float(np.linalg.norm(np.asarray(sol).reshape(-1) - exact) / np.linalg.norm(exact))
+
+
+def test_neumann_3d_linear_exact():
+    """u = x + 2y − z is linear ⇒ the tet FD gradient/Laplacian are exact ⇒ mixed Dirichlet+Neumann on
+    the cube recovers it. Right face (x=1) carries ∂u/∂n = ∂u/∂x = 1. Pins the 3-D flux row: apex-
+    oriented face normals, unit-normalization, ∇u·n = h."""
+    err = _cube_mixed_flux_3d(0.2, lambda x, y, z: x + 2 * y - z, du_dn_right=1.0)
+    assert err < 1e-3, f"linear 3-D mixed D+N should be near-exact, got {err}"
+
+
+def test_robin_3d_linear_exact():
+    """Robin ∂u/∂n + α(u − u∞) = 0 on the right face, α=1, u∞=2: for u = x this reads 1 + (1 − 2) = 0.
+    The whole face equation is written with that face's tags (ur = u.bind(x=xr,y=yr,z=zr)) — pins the
+    two-probe (a·∇u·n + b) extraction and the boundary value evaluation in 3-D."""
+    d = _cube(0.2)
+    p = _nodes3(d)
+    exact = p[:, 0]  # u = x
+    x, y, z, _ = d.variable("interior", split=True)
+    xr, yr, zr, _ = d.variable("right", split=True)
+    nr = d.variable("right", normals=True)
+    u = d.unknown()
+    ui = u.bind(x=x, y=y, z=z)
+    ur = u.bind(x=xr, y=yr, z=zr)  # face-bound field for the flux + value terms of the Robin condition
+    cons = [-ui.d2(x) - ui.d2(y) - ui.d2(z), ur.d(nr) + 1.0 * (ur - 2.0)]
+    for face in ("left", "front", "back", "bottom", "top"):
+        xf, yf, zf, _ = d.variable(face, split=True)
+        cons.append(u(xf, yf, zf) - xf)  # Dirichlet u = x
+    sol = jno.fdm(cons).solve()
+    assert float(np.linalg.norm(np.asarray(sol).reshape(-1) - exact) / np.linalg.norm(exact)) < 1e-3
+
+
+def test_flux_dirichlet_shared_edge_precedence_3d():
+    """A right-face (Neumann) node that also lies on an adjacent Dirichlet face gets BOTH a flux row and
+    a Dirichlet row. The assembly applies Dirichlet last, so Dirichlet wins (the well-posed choice — the
+    3-D flux path keeps region-edge nodes rather than dropping them, unlike a 2-D corner). Use an
+    inconsistent flux (∂u/∂n = 3 while Dirichlet pins u = x) and confirm the shared right-face edge nodes
+    take the Dirichlet value x = 1, not the flux-driven value."""
+    d = _cube(0.25)
+    p = _nodes3(d)
+    x, y, z, _ = d.variable("interior", split=True)
+    nr = d.variable("right", normals=True)
+    u = d.unknown()
+    ui = u.bind(x=x, y=y, z=z)
+    cons = [-ui.d2(x) - ui.d2(y) - ui.d2(z), ui.d(nr) - 3.0]  # deliberately inconsistent flux on the right
+    for face in ("left", "front", "back", "bottom", "top"):
+        xf, yf, zf, _ = d.variable(face, split=True)
+        cons.append(u(xf, yf, zf) - xf)  # Dirichlet u = x
+    sol = np.asarray(jno.fdm(cons).solve()).reshape(-1)
+    on_right = np.isclose(p[:, 0], 1.0)
+    on_adj = np.isclose(p[:, 1], 0) | np.isclose(p[:, 1], 1) | np.isclose(p[:, 2], 0) | np.isclose(p[:, 2], 1)
+    shared = on_right & on_adj  # right-face nodes shared with an adjacent Dirichlet face
+    assert shared.sum() > 0, "expected right-face edge nodes shared with adjacent faces"
+    assert np.max(np.abs(sol[shared] - 1.0)) < 1e-9, "Dirichlet must win at a shared flux/Dirichlet edge node"

--- a/tests/test_fdm.py
+++ b/tests/test_fdm.py
@@ -479,3 +479,23 @@ def test_constraint_list_poisson_3d():
     f = 3 * np.pi**2 * jnn.sin(np.pi * x) * jnn.sin(np.pi * y) * jnn.sin(np.pi * z)
     sol = jno.fdm([-ui.d2(x) - ui.d2(y) - ui.d2(z) - f, u(xb, yb, zb) - 0.0]).solve()
     assert float(np.linalg.norm(np.asarray(sol).reshape(-1) - exact) / np.linalg.norm(exact)) < 0.35
+
+
+def test_mesh_nodes_in_3d_shape_box():
+    """Keystone 3-D containment: `jno.fdm._mesh_nodes_in` resolves a `jno.Shape.box` sub-region to the
+    exact tetrahedral-mesh node subset via the analytic 3-D `Shape.contains` — the production path both
+    `_TraceFDM._region_nodes` and `jno.dd._region_mask` route through to turn a geometric sub-region into
+    a node set. This is what shapely could never do (it is 2-D only). (Wiring such a region into a *3-D
+    coupled solve* additionally needs region-tag support on the base 3-D domain — a separate feature.)"""
+    from jno.fdm import _mesh_nodes_in
+
+    d = _cube(0.12)
+    p = _nodes3(d)
+    core = jno.Shape.box(0.3, 0.3, 0.3, 0.7, 0.7, 0.7)
+    idx = _mesh_nodes_in(p, core)
+    # resolves exactly the analytic 3-D containment ...
+    assert np.array_equal(np.sort(idx), np.sort(np.nonzero(core.contains(p))[0]))
+    # ... which is the hand-checkable "all three coords in [0.3, 0.7]" box (inclusive within tol)
+    hand = np.nonzero(np.all((p >= 0.3 - 1e-9) & (p <= 0.7 + 1e-9), axis=1))[0]
+    assert np.array_equal(np.sort(idx), np.sort(hand))
+    assert len(idx) > 0, "the central box must capture interior tet nodes"

--- a/tests/test_fdm.py
+++ b/tests/test_fdm.py
@@ -427,7 +427,7 @@ def _cube(mesh_size):
     return jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=mesh_size).domain()
 
 
-def _poisson3d(mesh_size, method="gradient_of_gradient"):
+def _poisson3d(mesh_size, method="cotangent"):
     """-Δu = f on [0,1]³, u=0 on ∂Ω, exact u = sin(πx)sin(πy)sin(πz) ⇒ f = 3π²u. Returns rel-L2 error."""
     d = _cube(mesh_size)
     p = _nodes3(d)
@@ -446,22 +446,47 @@ def test_gradient_3d_shape():
 
 
 def test_poisson_3d_dirichlet():
-    assert _poisson3d(0.1) < 0.2
+    assert _poisson3d(0.1) < 3e-2  # cotangent (P1 Laplace–Beltrami) default
 
 
 def test_poisson_3d_convergence_under_refinement():
-    """Refining the tet mesh reduces the FD error — Tier-1 consistency in 3-D. The gradient-of-gradient
-    Laplacian is only first-order (no cotangent Laplace-Beltrami on tets), so the absolute error is
-    larger than the 2-D case and accuracy leans on refinement — but it converges monotonically."""
+    """Refining the tet mesh reduces the FD error and does so at ~2nd order — the default cotangent
+    stencil is the P1 tetrahedral Laplace–Beltrami operator (a small-constant Galerkin solve, unlike the
+    first-order gradient-of-gradient)."""
     errs = [_poisson3d(h) for h in (0.20, 0.14, 0.10)]
     assert errs[0] > errs[1] > errs[2], f"not monotonically converging: {errs}"
-    assert errs[2] < 0.2
+    assert errs[2] < 3e-2
 
 
-def test_laplacian_3d_cotangent_aliases_grad_of_grad():
-    """A tet mesh has no cotangent stencil, so `method="cotangent"` (the default) aliases to
-    `"gradient_of_gradient"` rather than raising — the two give the identical solve."""
-    assert abs(_poisson3d(0.14, method="cotangent") - _poisson3d(0.14, method="gradient_of_gradient")) < 1e-12
+def test_laplacian_3d_cotangent_beats_grad_of_grad():
+    """The 3-D cotangent (P1 FEM) Laplacian is a distinct, materially more accurate operator than the
+    local gradient-of-gradient double-difference — on the same tet mesh its Poisson error is several
+    times smaller (this is the whole point of wiring it up)."""
+    h = 0.12
+    cot = _poisson3d(h, method="cotangent")
+    gog = _poisson3d(h, method="gradient_of_gradient")
+    assert cot < 0.4 * gog, f"cotangent ({cot:.3e}) should be << gradient_of_gradient ({gog:.3e})"
+
+
+def test_constraint_list_cotangent_3d():
+    """The constraint-list path reaches the 3-D cotangent stencil too — a SINGLE whole-Laplacian term
+    `ui.d2(x, scheme="finite_difference:cotangent")` (NOT the split −d2(x)−d2(y)−d2(z), which stays
+    per-direction gradient-of-gradient), exactly as in 2-D. It matches the function-form accuracy."""
+    import jno.jnp_ops as jnn
+
+    d = _cube(0.14)
+    p = _nodes3(d)
+    exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1]) * np.sin(np.pi * p[:, 2])
+    x, y, z, _ = d.variable("interior", split=True)
+    xb, yb, zb, _ = d.variable("boundary", split=True)
+    u = d.unknown()
+    ui = u.bind(x=x, y=y, z=z)
+    f = 3 * np.pi**2 * jnn.sin(np.pi * x) * jnn.sin(np.pi * y) * jnn.sin(np.pi * z)
+    sol = jno.fdm([-ui.d2(x, scheme="finite_difference:cotangent") - f, u(xb, yb, zb) - 0.0]).solve()
+    err = float(np.linalg.norm(np.asarray(sol).reshape(-1) - exact) / np.linalg.norm(exact))
+    # ~0.064 at h=0.14 — the function-form cotangent value, and far below the per-direction
+    # gradient_of_gradient (~0.27), proving the whole-Laplacian cotangent stencil took effect.
+    assert err < 0.1, f"whole-cotangent constraint list should match function-form accuracy, got {err}"
 
 
 def test_constraint_list_poisson_3d():

--- a/tests/test_shape_contains.py
+++ b/tests/test_shape_contains.py
@@ -1,0 +1,74 @@
+"""``jno.Shape.contains`` — analytic, shapely-free point-in-region membership (2-D & 3-D).
+
+The point-containment predicate that resolves a geometric ``domain.region(name, shape)`` to a mesh-node
+subset. CSG only (leaf + cut/fuse/inter); non-analytic transforms raise."""
+
+import numpy as np
+import pytest
+
+from jno.geometry import Shape
+
+
+def test_rect_contains():
+    s = Shape.rect(0.0, 0.0, 1.0, 1.0)
+    pts = np.array([[0.5, 0.5], [1.5, 0.5], [-0.1, 0.5], [0.0, 0.0], [1.0, 1.0]])
+    assert list(s.contains(pts)) == [True, False, False, True, True]  # corners inclusive
+
+
+def test_disk_contains():
+    s = Shape.disk(0.0, 0.0, 1.0)
+    pts = np.array([[0.0, 0.0], [0.9, 0.0], [1.1, 0.0], [0.7, 0.7]])
+    assert list(s.contains(pts)) == [True, True, False, True]  # (0.7,0.7): r≈0.99 < 1
+
+
+def test_polygon_contains_triangle():
+    s = Shape.polygon([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)])
+    pts = np.array([[0.2, 0.2], [0.6, 0.6], [0.9, 0.9], [-0.1, 0.5]])
+    assert list(s.contains(pts)) == [True, False, False, False]  # (0.6,0.6) is outside x+y<1
+
+
+def test_box_contains():
+    s = Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+    pts = np.array([[0.5, 0.5, 0.5], [0.5, 0.5, 1.5], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+    assert list(s.contains(pts)) == [True, False, True, True]
+
+
+def test_sphere_contains():
+    s = Shape.sphere(0.0, 0.0, 0.0, 1.0)
+    pts = np.array([[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [1.0, 1.0, 1.0]])
+    assert list(s.contains(pts)) == [True, True, False]  # (.5,.5,.5): r≈0.87<1; (1,1,1): r≈1.73>1
+
+
+def test_cylinder_contains():
+    s = Shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.0)  # axis +z, height 2, radius 1
+    pts = np.array([[0.0, 0.0, 1.0], [0.9, 0.0, 1.0], [1.1, 0.0, 1.0], [0.0, 0.0, 2.5], [0.0, 0.0, -0.1]])
+    assert list(s.contains(pts)) == [True, True, False, False, False]
+
+
+def test_cut_fuse_inter():
+    a = Shape.rect(0.0, 0.0, 0.6, 1.0)
+    b = Shape.rect(0.4, 0.0, 1.0, 1.0)  # overlap x∈[0.4,0.6]
+    pts = np.array([[0.2, 0.5], [0.5, 0.5], [0.8, 0.5]])  # in A only / both / in B only
+    assert list((a - b).contains(pts)) == [True, False, False]  # cut: A minus B
+    assert list((a | b).contains(pts)) == [True, True, True]  # fuse: union
+    assert list((a & b).contains(pts)) == [False, True, False]  # inter: overlap band only
+
+
+def test_difference_matches_shapely():
+    """The cut predicate matches shapely's, node-for-node, on a random cloud — the migration invariant."""
+    shp = pytest.importorskip("shapely")
+    from shapely.geometry import box
+
+    a_s, b_s = box(0.0, 0.0, 0.6, 1.0), box(0.4, 0.0, 1.0, 1.0)
+    diff = a_s.difference(b_s)
+    rng = np.random.default_rng(0)
+    pts = rng.uniform(-0.1, 1.1, size=(500, 2))
+    ours = (Shape.rect(0.0, 0.0, 0.6, 1.0) - Shape.rect(0.4, 0.0, 1.0, 1.0)).contains(pts)
+    theirs = np.asarray(shp.contains_xy(diff.buffer(1e-9), pts[:, 0], pts[:, 1]))
+    assert np.array_equal(ours, theirs)
+
+
+def test_non_csg_transform_raises():
+    solid = Shape.rect(0.0, 0.0, 1.0, 1.0).extrude(1.0)  # a swept solid — no analytic membership
+    with pytest.raises(NotImplementedError, match="closed-form"):
+        solid.contains(np.zeros((1, 3)))


### PR DESCRIPTION
Closes the 3-D gap in `jno.fdm`: the strong-form solver now runs on tetrahedral meshes with the same constraint-list API as 2-D — interior operators, a proper accurate Laplacian, flux boundary conditions, and geometric-region containment — plus a shapely-free `Shape.contains` that works in both dimensions.

## What's in it (5 commits)

| commit | what |
| --- | --- |
| `interior 3-D tetrahedral meshes` | `_mesh`/`laplacian`/`gradient` dispatch on `domain.dimension` onto the tet stencils; both front-ends (function form + `u.d2(x)+u.d2(y)+u.d2(z)`) solve in 3-D. |
| `analytic Shape.contains` | gmsh-free CSG point-membership over the build-plan (leaf + cut/fuse/inter; raises on non-CSG transforms). Works in 2-D **and 3-D** — which shapely cannot. |
| `regions via Shape.contains (no shapely)` | `fdm._mesh_nodes_in` / `dd._region_mask` resolve a `jno.Shape` region analytically; the overlap-vs-line-DN decision moves to an element-centroid mask. |
| `3-D flux boundary conditions` | Neumann/Robin on tet faces — `_node_normals_3d` builds outward normals from the region's boundary faces, oriented exactly via each face's owning-tet apex. |
| `P1 cotangent Laplace–Beltrami stencil` | the accurate 3-D Laplacian (default): the P1 tetrahedral finite-element operator, the exact analogue of the 2-D cotangent weights. |

## Highlights

- **Accuracy**: the P1 cotangent Laplacian is ~**6× more accurate** than the first-order `gradient_of_gradient` at a fixed mesh (unit-cube Poisson rel-L2 **2.3%** vs 14.2% at N≈1200) and converges at ~2nd order. Reached by both `jno.fdm.laplacian(method="cotangent")` and the constraint-list whole-Laplacian term `ui.d2(x, scheme="finite_difference:cotangent")` — full parity with 2-D.
- **`lsq_of_gradient` is unstable in 3-D** (nested least-squares on a second derivative) and is documented not-recommended.
- **Flux BCs** on tet faces use apex-oriented face normals (a flat face gives an exact axis normal, no corner heuristic); at an edge where a flux face meets a Dirichlet face, Dirichlet wins.
- **`Shape.contains`** is validated node-for-node against shapely's `difference()` on a random cloud; the 3-D containment is exercised through the real `_mesh_nodes_in` path.

## Scope boundaries (deliberately out)

- `domain.region(name, Shape)` + `d.variable` authoring on a 2-D `PolygonDomain` stays shapely-bound (that region machinery lives in `polygon_domain`, unchanged). Shape regions are consumed via `jno.dd.couple([(problem, shape)])`, which routes only through the analytic containment.
- Wiring a `Shape` sub-region into a **3-D coupled solve** needs region-tag support on the base 3-D domain — a separate 3-D domain-decomposition feature, not included here.
- shapely remains as the containment fallback for the 2-D mesh-conforming / interface-tag path only.

## Tests & docs

- `test_fdm.py` (31), `test_shape_contains.py` (9), and `test_domain_decomposition.py` all green; new 3-D coverage for interior convergence, the cotangent-vs-gradient comparison, flux normals + Neumann/Robin, the shared flux/Dirichlet edge precedence, and the 3-D containment keystone.
- `docs/fdm.md` gains a "3-D tetrahedral meshes" section and an updated scope block.

Verified on CPU (x64). The full GPU suite was not run in this environment.
