### PR TITLE
jno.rcwa: optional RCWA backend — constraint-list inference, differentiable vector & anisotropic Maxwell, Jones output

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -14,6 +14,10 @@ The finite-element assembler additionally needs `fenics-basix` (imports as `basi
 `pip install jax-neural-operators fenics-basix`, or use the pixi `fem` environment below
 (which pulls it in).
 
+The optional [RCWA solver](rcwa.md) (`jno.rcwa`, periodic-layered electromagnetics) needs `fmmax`.
+It is imported lazily, so install it only when needed via the `rcwa` extra —
+`pip install jax-neural-operators[rcwa]`, or use the pixi `rcwa` environment.
+
 GPU support is included by default — `jax-neural-operators` depends on
 `jax[cuda]>=0.10.1,<0.11`, so a standard `pip install` already pulls a
 CUDA-capable JAX wheel. The pin is tight on purpose: jNO tracks a single

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -18,12 +18,11 @@ pip install jax-neural-operators[rcwa]      # or:  pixi run -e rcwa ...
 ## The front door — infer the problem from a jNO constraint list
 
 Hand `jno.rcwa` the **same constraint list you would give [`jno.fem`](fem.md)** (or an already-built
-`FEM`) together with the permittivity expression `eps`; it reads everything else out of the traced
-problem:
+`FEM`). Nothing else is required — it reads everything out of the traced problem:
 
 ```python
-rc  = jno.rcwa(constraints, eps, orders=300, wavelength=1.0)
-sol = rc.solve()                 # period, layers, ambients, source, incidence all inferred
+rc  = jno.rcwa(constraints, orders=300)
+sol = rc.solve()                 # period, layers, permittivity, wavelength, incidence all inferred
 sol.efficiency("T")              # transmitted power fraction
 sol.order(+1, 0)                 # a specific diffraction order
 
@@ -36,16 +35,16 @@ What is inferred from the problem, and from where:
 |---|---|
 | **periodicity + period `(Px,Py)`** | the Floquet ties `u(left)-u(right)`, `u(front)-u(back)` — **absent ⇒ raise**, never assumed |
 | **super/substrate ambients** | the two z-normal radiation faces |
-| **layer stack** | `eps` sampled along z, then grouped by [`detect_layers`](#layer-detection) |
+| **permittivity** | the `K0²·ε` coefficient recovered from the scalar Helmholtz volume term, sampled along z, then grouped by [`detect_layers`](#layer-detection) |
+| **wavelength / `k0`** | the coefficient's value in the vacuum superstrate (`k0 = √coeff`); pass `wavelength=` to override |
 | **incident wave** (lit face + angle `k_in`) | the assembled forcing `b` — a constant-phase source ⇒ normal incidence |
 
-Two arguments stay explicit, on purpose:
-
-- **`eps`** — isolating one coefficient sub-tree from an *assembled* weak form is not supported yet, so
-  the permittivity expression is passed directly (you already hold it — it is the design variable).
-  Because it is the same traced `eps`, its dependence on a trainable `jno.np.parameter` carries through,
-  so inverse design flows unchanged.
-- **`wavelength`** — a bare-float `k0` is not an identifiable node in the trace, so `λ` is passed in.
+The permittivity is recovered by splitting the volume weak form `∇u·∇v − K0²·ε·u·v`: the stiffness
+summands carry trial/test inside `Jacobian` nodes, the mass summand carries them as bare values, so
+dropping the `u·v` factor leaves `K0²·ε`. Because it is the same traced coefficient, its dependence on
+a trainable `jno.np.parameter` carries through, so inverse design flows unchanged. Only `orders` (a
+numerical truncation choice) is genuinely the user's; `wavelength` is an optional override for the case
+where no ambient is vacuum.
 
 Because RCWA solves the *infinitely periodic* problem, a finite aperture (absorbing side walls, no
 ties) is **rejected** rather than silently periodicised — exactly the difference between a supercell
@@ -95,7 +94,9 @@ a-Si). Correctness is checked against the analytic Fresnel/transfer-matrix trans
 
 - an `as_precond` path so RCWA can serve as the layered-background preconditioner `M⁻¹ = A₀⁻¹` for the
   large 3-D FEM complex-Helmholtz solve, once the FEM↔grid transfer is wired;
-- auto-inference of `eps` (a general `eps.at(coords)` primitive) and of `k0`, so both become optional.
+- a differentiable sampling path (currently the permittivity is evaluated on the grid with the
+  parameter's current value; threading the gradient through would let RCWA drive inverse design directly);
+- support beyond the scalar isotropic Helmholtz volume term (vector/anisotropic media).
 
 ## References
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -4,74 +4,98 @@
 canonical case being an extruded metasurface unit cell (a patterned dielectric slab between two
 semi-infinite ambients). Unlike [`jno.fem`](fem.md), which discretises the whole volume, RCWA is
 *semi-analytic in the propagation direction*: each layer is expanded in a truncated in-plane Fourier
-basis, solved by an eigenmode decomposition, and the layers are stitched together with a scattering
-matrix. For a periodic slab that is far cheaper than a full 3-D complex-Helmholtz solve.
+basis, solved by an eigenmode decomposition, and the layers are stitched with a scattering matrix. For
+a periodic slab that is far cheaper than a full 3-D complex-Helmholtz solve.
 
 It is built on [`fmmax`](https://github.com/facebookresearch/fmmax), a differentiable JAX Fourier
-Modal Method, which is imported **lazily** — the core `jno` install does not pull it in. Enable the
-backend with the `rcwa` extra:
+Modal Method, imported **lazily** — the core `jno` install does not pull it in. Enable the backend with
+the `rcwa` extra:
 
 ```bash
 pip install jax-neural-operators[rcwa]      # or:  pixi run -e rcwa ...
 ```
 
-Constructing an `Rcwa` without `fmmax` installed raises a clear `ImportError` telling you to install
-the extra — it never silently no-ops.
+## The front door — infer the problem from a jNO constraint list
 
-## Usage
+Hand `jno.rcwa` the **same constraint list you would give [`jno.fem`](fem.md)** (or an already-built
+`FEM`) together with the permittivity expression `eps`; it reads everything else out of the traced
+problem:
+
+```python
+rc  = jno.rcwa(constraints, eps, orders=300, wavelength=1.0)
+sol = rc.solve()                 # period, layers, ambients, source, incidence all inferred
+sol.efficiency("T")              # transmitted power fraction
+sol.order(+1, 0)                 # a specific diffraction order
+
+rc.spec                          # the inferred RcwaSpec — inspectable WITHOUT fmmax
+```
+
+What is inferred from the problem, and from where:
+
+| inferred | source in the list / domain |
+|---|---|
+| **periodicity + period `(Px,Py)`** | the Floquet ties `u(left)-u(right)`, `u(front)-u(back)` — **absent ⇒ raise**, never assumed |
+| **super/substrate ambients** | the two z-normal radiation faces |
+| **layer stack** | `eps` sampled along z, then grouped by [`detect_layers`](#layer-detection) |
+| **incident wave** (lit face + angle `k_in`) | the assembled forcing `b` — a constant-phase source ⇒ normal incidence |
+
+Two arguments stay explicit, on purpose:
+
+- **`eps`** — isolating one coefficient sub-tree from an *assembled* weak form is not supported yet, so
+  the permittivity expression is passed directly (you already hold it — it is the design variable).
+  Because it is the same traced `eps`, its dependence on a trainable `jno.np.parameter` carries through,
+  so inverse design flows unchanged.
+- **`wavelength`** — a bare-float `k0` is not an identifiable node in the trace, so `λ` is passed in.
+
+Because RCWA solves the *infinitely periodic* problem, a finite aperture (absorbing side walls, no
+ties) is **rejected** rather than silently periodicised — exactly the difference between a supercell
+and a finite metasurface.
+
+## The backend — explicit layers
+
+`jno.Rcwa` takes a hand-built stack directly; this is what the front door constructs internally:
 
 ```python
 import numpy as np
-import jno
-
 inf = np.inf
-# a uniform slab (n = 2) between air ambients — the simplest sanity case
-rc = jno.rcwa(
-    [(inf, 1.0), (0.4, 4.0), (inf, 1.0)],   # [(thickness, eps), ...] super -> substrate
-    period=(0.6, 0.6),                      # in-plane unit-cell period
-    orders=200,                             # Fourier truncation (high contrast needs hundreds)
-    wavelength=1.03,
-    assume_periodic=True,                   # you must affirm the cell is a true period/supercell
-)
-sol = rc.solve()                            # inc=None -> a normal-incidence plane wave
-sol.efficiency("T")                         # transmitted power fraction (all propagating orders)
-sol.efficiency("R")                         # reflected power fraction
-sol.order(+1, 0)                            # efficiency into a specific diffraction order
+rc  = jno.Rcwa([(inf, 1.0), (0.4, 4.0), (inf, 1.0)],   # [(thickness, eps), ...] super -> substrate
+               period=(0.6, 0.6), orders=200, wavelength=1.03, assume_periodic=True)
+sol = rc.solve()
 ```
 
-A patterned layer takes a 2-D `eps` array sampled on the unit-cell grid instead of a scalar; the grid
-must be fine enough to resolve `orders` (a Nyquist guard enforces this).
+## Layer detection
+
+`jno.rcwa.detect_layers(E, z)` groups a z-sampled permittivity `E` of shape `(Nz, Ng, Ng)` into RCWA
+layers, with the two ambients marked semi-infinite. Continuous z-variation (an inclined or curved
+geometry) **raises** unless you opt in with `slices=N` to staircase it.
 
 ## Never fails silently
 
 Every inference is validated and raises `RcwaError` (or `ImportError` for the missing backend) with a
-concrete fix, so a physically wrong result is never returned quietly:
+concrete fix:
 
 | condition | guard |
 |---|---|
 | `fmmax` not installed | `ImportError` pointing at the `[rcwa]` extra |
-| cell not affirmed periodic | must pass `assume_periodic=True` (a finite aperture is not periodic) |
-| non-positive period / empty layers / bad thickness | raises with the offending value |
+| no Floquet ties (finite aperture) | raises — author periodic side walls |
+| periodicity in only one of x / y | raises — add the missing tie |
+| no z-normal ambient faces found | raises — tag the top/bottom faces |
+| `eps` varies continuously in z | raises unless `slices=N` |
+| no source / forcing in the problem | raises — nothing to illuminate with |
+| forcing spread over a z-range, not one face | raises — put the incident wave on one ambient |
 | patterned grid under-resolves `orders` | raises with the required grid size (Nyquist) |
-| wavelength unknown | raises — it is never defaulted |
-| energy `T + R > 1` after a solve | raises — the modal solve has not converged (raise `orders`) |
+| energy `T + R > 1` after a solve | raises — raise `orders` |
 
 Two `fmmax` conventions are baked in so callers never rediscover them: the Poynting flux is summed
 *with sign* (an `abs()` sum over-counts and can report `T+R>1`), and the `JONES_DIRECT_FOURIER`
 factorization is the default (the naive rule converges poorly for high-contrast dielectrics such as
 a-Si). Correctness is checked against the analytic Fresnel/transfer-matrix transmittance in the tests.
 
-## Status and roadmap
+## Roadmap
 
-`jno.rcwa` currently exposes the **forward engine** with an *explicit* layer stack. Two increments are
-planned:
-
-- an `eps`-driven front-end `jno.rcwa(eps, orders=...)` that samples a jNO permittivity expression on a
-  grid (via a new `eps.at(coords)` primitive), **auto-derives the layers**, and threads the design
-  gradient through for inverse design;
-- `Rcwa.as_precond(...)` as a background (`M⁻¹ = A₀⁻¹`) preconditioner for the large 3-D FEM
-  complex-Helmholtz solve, once the FEM↔grid transfer is wired. Until then it raises rather than
-  returning a no-op preconditioner.
+- an `as_precond` path so RCWA can serve as the layered-background preconditioner `M⁻¹ = A₀⁻¹` for the
+  large 3-D FEM complex-Helmholtz solve, once the FEM↔grid transfer is wired;
+- auto-inference of `eps` (a general `eps.at(coords)` primitive) and of `k0`, so both become optional.
 
 ## References
 
@@ -82,6 +106,10 @@ planned:
 
 ## API
 
+::: jno.rcwa.rcwa
+
+::: jno.rcwa.RcwaSpec
+
 ::: jno.rcwa.Rcwa
 
-::: jno.rcwa.rcwa
+::: jno.rcwa.detect_layers

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -1,0 +1,87 @@
+# Rigorous Coupled-Wave Analysis (RCWA)
+
+`jno.rcwa` is an **optional** solver for **periodic, layered** electromagnetic structures — the
+canonical case being an extruded metasurface unit cell (a patterned dielectric slab between two
+semi-infinite ambients). Unlike [`jno.fem`](fem.md), which discretises the whole volume, RCWA is
+*semi-analytic in the propagation direction*: each layer is expanded in a truncated in-plane Fourier
+basis, solved by an eigenmode decomposition, and the layers are stitched together with a scattering
+matrix. For a periodic slab that is far cheaper than a full 3-D complex-Helmholtz solve.
+
+It is built on [`fmmax`](https://github.com/facebookresearch/fmmax), a differentiable JAX Fourier
+Modal Method, which is imported **lazily** — the core `jno` install does not pull it in. Enable the
+backend with the `rcwa` extra:
+
+```bash
+pip install jax-neural-operators[rcwa]      # or:  pixi run -e rcwa ...
+```
+
+Constructing an `Rcwa` without `fmmax` installed raises a clear `ImportError` telling you to install
+the extra — it never silently no-ops.
+
+## Usage
+
+```python
+import numpy as np
+import jno
+
+inf = np.inf
+# a uniform slab (n = 2) between air ambients — the simplest sanity case
+rc = jno.rcwa(
+    [(inf, 1.0), (0.4, 4.0), (inf, 1.0)],   # [(thickness, eps), ...] super -> substrate
+    period=(0.6, 0.6),                      # in-plane unit-cell period
+    orders=200,                             # Fourier truncation (high contrast needs hundreds)
+    wavelength=1.03,
+    assume_periodic=True,                   # you must affirm the cell is a true period/supercell
+)
+sol = rc.solve()                            # inc=None -> a normal-incidence plane wave
+sol.efficiency("T")                         # transmitted power fraction (all propagating orders)
+sol.efficiency("R")                         # reflected power fraction
+sol.order(+1, 0)                            # efficiency into a specific diffraction order
+```
+
+A patterned layer takes a 2-D `eps` array sampled on the unit-cell grid instead of a scalar; the grid
+must be fine enough to resolve `orders` (a Nyquist guard enforces this).
+
+## Never fails silently
+
+Every inference is validated and raises `RcwaError` (or `ImportError` for the missing backend) with a
+concrete fix, so a physically wrong result is never returned quietly:
+
+| condition | guard |
+|---|---|
+| `fmmax` not installed | `ImportError` pointing at the `[rcwa]` extra |
+| cell not affirmed periodic | must pass `assume_periodic=True` (a finite aperture is not periodic) |
+| non-positive period / empty layers / bad thickness | raises with the offending value |
+| patterned grid under-resolves `orders` | raises with the required grid size (Nyquist) |
+| wavelength unknown | raises — it is never defaulted |
+| energy `T + R > 1` after a solve | raises — the modal solve has not converged (raise `orders`) |
+
+Two `fmmax` conventions are baked in so callers never rediscover them: the Poynting flux is summed
+*with sign* (an `abs()` sum over-counts and can report `T+R>1`), and the `JONES_DIRECT_FOURIER`
+factorization is the default (the naive rule converges poorly for high-contrast dielectrics such as
+a-Si). Correctness is checked against the analytic Fresnel/transfer-matrix transmittance in the tests.
+
+## Status and roadmap
+
+`jno.rcwa` currently exposes the **forward engine** with an *explicit* layer stack. Two increments are
+planned:
+
+- an `eps`-driven front-end `jno.rcwa(eps, orders=...)` that samples a jNO permittivity expression on a
+  grid (via a new `eps.at(coords)` primitive), **auto-derives the layers**, and threads the design
+  gradient through for inverse design;
+- `Rcwa.as_precond(...)` as a background (`M⁻¹ = A₀⁻¹`) preconditioner for the large 3-D FEM
+  complex-Helmholtz solve, once the FEM↔grid transfer is wired. Until then it raises rather than
+  returning a no-op preconditioner.
+
+## References
+
+- M. G. Moharam & T. K. Gaylord, *Rigorous coupled-wave analysis of planar-grating diffraction*,
+  J. Opt. Soc. Am. **71**, 811 (1981).
+- M. G. Moharam, D. A. Pommet, E. B. Grann & T. K. Gaylord, *Stable implementation of the enhanced
+  transmittance matrix approach*, J. Opt. Soc. Am. A **12**, 1077 (1995).
+
+## API
+
+::: jno.rcwa.Rcwa
+
+::: jno.rcwa.rcwa

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -19,6 +19,7 @@ from .fdm import fdm
 from .geometry import Path, Shape
 from .integration_operators import IntegrationOperators
 from .noise import noise
+from .rcwa import Rcwa, RcwaError, rcwa
 from .trace import (
     Assembly,
     FemLinearSystem,
@@ -120,6 +121,9 @@ __all__ = [
     "do",
     "fem",
     "fdm",
+    "rcwa",
+    "Rcwa",
+    "RcwaError",
     "AdaptSpec",
     "Coupling",
     "Model",

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1720,6 +1720,48 @@ def _build_periodic_reduction(domain: Any, ties: List[Any], points: Any, cells: 
     return build_periodic_prolongation(points, pairs, faces, vec=vec, facets=facets, phases=phases)
 
 
+def _build_periodic_reduction_n1e(domain: Any, ties: List[Any], offsets: Any) -> dict:
+    """Periodic (Floquet/Bloch) reduction for a **Nédélec N1E** edge field — a DOF-level edge prolongation.
+    Each DOF is one edge's tangential moment, so a tie matches boundary edges across the periodic faces (by
+    midpoint) with an orientation sign and the Bloch phase. Uses the edge topology the non-nodal assembler
+    stashed. Every field is the same N1E element, so one per-field ``P`` is built and block-concatenated."""
+    from .utils.solver.fem_utils import build_periodic_prolongation_n1e
+
+    topo = domain._fem_nonnodal_topology
+    n_edges = int(topo["n_edges"])
+    vpts = np.asarray(topo["vertex_points"])
+    ev = np.asarray(topo["edge_vertices"])
+    emid = np.asarray(topo["edge_midpoints"])
+    edir = np.asarray(topo["edge_dirs"])
+
+    pairs = [(master, slave) for (master, slave, *_rest) in ties]
+    phases = [(t[4] if len(t) > 4 and t[4] is not None else 1.0) for t in ties]  # Bloch phase (e^{iφ}) per tie
+    etags: dict = {}
+    for tag in {t for tie in ties for t in tie[:2]}:
+        f = _face_nodes(domain, vpts, None, tag)
+        if f is None or np.asarray(f).size == 0:
+            raise ValueError(f"jno.fem periodic (N1E): boundary tag {tag!r} has no mesh vertices.")
+        vset = set(int(v) for v in np.asarray(f, dtype=int).reshape(-1))
+        # a global edge is on the boundary tag iff BOTH its canonical vertices are on that tag
+        etags[tag] = np.asarray([e for e in range(n_edges) if int(ev[e, 0]) in vset and int(ev[e, 1]) in vset], dtype=int)
+
+    red = build_periodic_prolongation_n1e(n_edges, emid, edir, etags, pairs, phases)
+    n_fields = len(offsets) - 1
+    blocks, off_full, off_red = [], [0], [0]
+    for _ in range(n_fields):
+        blocks.append({"P": red["P"], "kept": red["kept_nodes"], "vec": 1, "is_selection": red["is_selection"]})
+        off_full.append(off_full[-1] + red["n_full"])
+        off_red.append(off_red[-1] + red["n_red"])
+    return {
+        "blocks": blocks,
+        "off_full": off_full,
+        "off_red": off_red,
+        "n_full": off_full[-1],
+        "n_red": off_red[-1],
+        "is_bloch": red["is_bloch"],
+    }
+
+
 def _build_periodic_reduction_nonnodal(domain: Any, ties: List[Any], offsets: Any) -> dict:
     """Periodic reduction for **non-nodal C¹** fields (Morley) — a DOF-level prolongation the node-based
     builder can't produce. Uses the C¹ topology the non-nodal assembler stashed on the domain: value
@@ -2214,6 +2256,17 @@ def fem(
 
     domain = _discover_domain(constraints)
 
+    # Nédélec (N1E) periodic ties need a CONFORMING periodic mesh — the per-edge DOFs must line up
+    # one-to-one across the tied faces, which gmsh's default unstructured mesh does not guarantee. Infer
+    # this from the constraint list: when periodic ties are present on an N1E field, re-mesh the (Shape-
+    # backed) domain once with gmsh setPeriodic on the tied face pairs. No `periodic=` arg — driven purely
+    # by the periodic conditions the user already authored. (Nodal fields tie by interpolation and need no
+    # re-mesh, so this is gated on N1E.)
+    if "N1E" in _trial_spaces(constraints) and hasattr(domain, "_remesh_periodic"):
+        _pairs = [(s[0], s[1]) for c in constraints if (s := _periodic_tie_spec(c, domain)) is not None]
+        if _pairs:
+            domain._remesh_periodic(_pairs)
+
     # Periodic ties `u(A) - u(B)` are enforced by algebraic reduction (a prolongation P that
     # eliminates the slave-face DOFs), not by assembly. Separate them out *before* the weak/Dirichlet
     # classification (`_region_and_support` would otherwise reject a residual that spans two regions).
@@ -2361,7 +2414,11 @@ def fem(
             # (``None`` for the native 1D route, which falls back to flat-chain facets on points).
             cells = getattr(domain, "_fem_native_assembly_cells", None)
             ele_order = int(getattr(domain, "_fem_native_assembly_order", 1))
-        if getattr(domain, "_fem_nonnodal_topology", None) is not None:
+        _nonnodal_topo = getattr(domain, "_fem_nonnodal_topology", None)
+        if _nonnodal_topo is not None and _nonnodal_topo.get("family") == "N1E":
+            # Nédélec N1E (H(curl) edge): DOF-level edge prolongation (Floquet/Bloch, with orientation sign)
+            periodic = _build_periodic_reduction_n1e(domain, periodic_ties, fem_obj.offsets)
+        elif _nonnodal_topo is not None:
             # non-nodal C¹ (Morley): DOF-level reduction (value + signed edge-derivative ties)
             periodic = _build_periodic_reduction_nonnodal(domain, periodic_ties, fem_obj.offsets)
         elif multifield:

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -515,6 +515,45 @@ def _constant_of(node: Any) -> Optional[float]:
         return None
 
 
+def _scalar_const(node: Any) -> Optional[complex]:
+    """Complex-aware scalar extraction from a constant/Literal node (returns None if not a scalar)."""
+    for attr in ("value", "val", "data", "constant"):
+        if hasattr(node, attr):
+            v = getattr(node, attr)
+            try:
+                if np.ndim(v) != 0:
+                    return None
+                return complex(v)
+            except (TypeError, ValueError):
+                return None
+    try:
+        return complex(node)
+    except (TypeError, ValueError):
+        return None
+
+
+def _tie_phase(bare: Any) -> Optional[complex]:
+    """The Bloch phase of a tie ``u(A) - phase*u(B)``: ``1`` for plain periodic, a complex scalar for a
+    quasi-periodic (Bloch) tie, or ``None`` when the relation is not a valid tie (anti-periodic, etc.).
+
+    The slave side (left) must be a bare trial; the master side (right) is a bare trial (phase 1) or a
+    constant-scalar times a bare trial (the Bloch factor ``e^{i k·L}``)."""
+    if getattr(bare, "op", None) != "-":
+        return None
+    left, right = bare.left, bare.right
+    if getattr(left, "op", None) in {"+", "-", "*", "/"}:  # slave side must be a bare trial
+        return None
+    rop = getattr(right, "op", None)
+    if rop is None:
+        return 1.0 + 0.0j  # plain periodic  u(A) - u(B)
+    if rop == "*":  # Bloch  c*u(B) (either factor order), c a constant scalar
+        for a, b in ((right.left, right.right), (right.right, right.left)):
+            c = _scalar_const(a)
+            if c is not None and getattr(b, "op", None) is None:
+                return c
+    return None
+
+
 def _component_index_of(node: Any) -> Optional[int]:
     """If ``node`` is a single component of the trial (``u[..., i]``), return ``i``.
 
@@ -663,15 +702,30 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic
     from .trace import FemLinearSystem, FunctionCall
     from .utils.solver.fem_utils import prolong_periodic, reduce_matrix_periodic, reduce_vector_periodic
 
-    def _ab(op, args):
+    bloch = bool(periodic is not None and periodic.get("is_bloch", False))
+
+    def _ab(op, args, conj=False):
         A, b = op.evaluate(args) if isinstance(op, FemLinearSystem) else op
         b = jnp.asarray(b).reshape(-1)
         if periodic is not None:
-            A = reduce_matrix_periodic(periodic, A)  # P^T A P  (stays sparse if A is BCOO)
-            b = reduce_vector_periodic(periodic, b)  # P^T b
+            A = reduce_matrix_periodic(periodic, A, conj=conj)  # P^T A P (P^H when Bloch); stays sparse
+            b = reduce_vector_periodic(periodic, b, conj=conj)  # P^T b (P^H when Bloch)
         return A, b  # keep A sparse (BCOO) -- do NOT densify
 
+    def _bloch_solve(args):
+        # Bloch/quasi-periodic: P is complex, so the reduced operator A_c = P^H (A_r + i A_i) P mixes
+        # Re/Im and cannot be split into independent legs. Reduce Hermitian, form the complex reduced
+        # operator, solve it directly (reduced cell is small), and prolong with the complex P.
+        (A_r, b_r), (A_i, b_i) = _ab(ops[0], args, conj=True), _ab(ops[1], args, conj=True)
+        to_d = lambda M: jnp.asarray(M.todense() if hasattr(M, "todense") else M)
+        A_c = to_d(A_r) + 1j * to_d(A_i)
+        b_c = jnp.asarray(b_r) + 1j * jnp.asarray(b_i)
+        u_red = jnp.linalg.solve(A_c, b_c)
+        return prolong_periodic(periodic, u_red)
+
     def _block_solve(args):
+        if bloch:
+            return _bloch_solve(args)
         (A_r, b_r), (A_i, b_i) = _ab(ops[0], args), _ab(ops[1], args)
         n = b_r.shape[0]
         rhs = jnp.concatenate([b_r, b_i])
@@ -1475,16 +1529,15 @@ def _periodic_tie_spec(constraint: Any, domain: Any) -> Optional[Tuple[str, str,
     tie = getattr(constraint, "_periodic_tie", None)
     if tie is None:
         return None
-    # The trace stamps `_periodic_tie` on *any* trial-trial combination with clashing coords; only a
-    # plain `u(A) - u(B)` (bare trial sides, no scaling, not `+`) is a tie. Reject the rest loudly
-    # rather than silently mis-reading e.g. `u(A)+u(B)` (anti-periodic) or `2*u(A)-u(B)` as periodic.
+    # The trace stamps `_periodic_tie` on *any* trial-trial combination with clashing coords. A valid
+    # tie is `u(A) - u(B)` (plain periodic) or `u(A) - c*u(B)` with a constant scalar `c` (Bloch /
+    # quasi-periodic, `c = e^{i k·L}`). Reject the rest loudly (e.g. `u(A)+u(B)` anti-periodic).
     bare = _bare(constraint)
-    if getattr(bare, "op", None) != "-" or any(
-        getattr(side, "op", None) in {"+", "-", "*", "/"} for side in (bare.left, bare.right)
-    ):
+    phase = _tie_phase(bare)
+    if phase is None:
         raise ValueError(
-            "jno.fem: a periodic tie must be `u(A) - u(B)` with bare trial sides (no scaling, no `+`). "
-            "Anti-periodic or scaled relations between two boundaries are not supported."
+            "jno.fem: a periodic tie must be `u(A) - u(B)` (periodic) or `u(A) - c*u(B)` with a constant "
+            "scalar `c` (Bloch/quasi-periodic). Anti-periodic (`+`) or non-scalar relations are not supported."
         )
     slave_tag, master_tag = tie
     breg = getattr(domain, "_boundary_regions", {})
@@ -1495,7 +1548,7 @@ def _periodic_tie_spec(constraint: Any, domain: Any) -> Optional[Tuple[str, str,
             f"jno.fem: a periodic tie `u(A) - u(B)` must connect two distinct boundary regions; "
             f"got {slave_tag!r} and {master_tag!r} (known boundary tags: {sorted(breg)})."
         )
-    return (master_tag, slave_tag, None, _field_key_of(constraint))
+    return (master_tag, slave_tag, None, _field_key_of(constraint), phase)
 
 
 def _ref_interior_facet_dofs(ref_pts: np.ndarray, fv: np.ndarray, dim: int, tol: float = 1e-9) -> List[int]:
@@ -1622,7 +1675,7 @@ def _build_periodic_reduction(domain: Any, ties: List[Any], points: Any, cells: 
     # that case loudly rather than silently under-identify the corners and mis-solve.
     if len(ties) > 1:
         preds = getattr(domain, "_tag_predicates", {})
-        missing = sorted({t for (m, s, _c, _fk) in ties for t in (m, s) if t not in preds})
+        missing = sorted({t for (m, s, *_ignore) in ties for t in (m, s) if t not in preds})
         if missing:
             raise NotImplementedError(
                 "jno.fem: multidirectional periodicity requires each periodic face to be defined via "
@@ -1635,24 +1688,26 @@ def _build_periodic_reduction(domain: Any, ties: List[Any], points: Any, cells: 
     bfacets = _boundary_facets(points, cells, dim, ele_order) if cells is not None else None
     bnodes = np.unique(bfacets) if bfacets is not None and bfacets.size else None
 
-    pairs = [(master, slave) for (master, slave, _comp, _fk) in ties]
+    pairs = [(master, slave) for (master, slave, *_ignore) in ties]
+    # Bloch phase per pair (``e^{i k·L}``); 1.0 = plain periodic (the ties may be 4-tuples pre-Bloch).
+    phases = [complex(t[4]) if len(t) > 4 else 1.0 + 0.0j for t in ties]
     faces: dict = {}
-    for master, slave, _comp, _fk in ties:
+    for master, slave, *_ignore in ties:
         for tag in (master, slave):
             if tag not in faces and (f := _face_nodes(domain, points, bnodes, tag)) is not None:
                 faces[tag] = f
 
     facets: dict = {}
     if bfacets is not None and bfacets.size:
-        for master, _slave, _comp, _fk in ties:
+        for master, _slave, *_ignore in ties:
             fn = set(np.asarray(faces.get(master, np.empty(0, int))).tolist())
             keep = np.array([set(row.tolist()).issubset(fn) for row in bfacets], dtype=bool)
             if keep.any():
                 facets[master] = bfacets[keep]
     else:  # native 1D / no assembly cells -> flat-chain fallback
-        facets = {m: ff for (m, _s, _c, _fk) in ties if (ff := _chain_facets(points, faces.get(m, ()))) is not None}
+        facets = {m: ff for (m, _s, *_ignore) in ties if (ff := _chain_facets(points, faces.get(m, ()))) is not None}
 
-    return build_periodic_prolongation(points, pairs, faces, vec=vec, facets=facets)
+    return build_periodic_prolongation(points, pairs, faces, vec=vec, facets=facets, phases=phases)
 
 
 def _build_periodic_reduction_nonnodal(domain: Any, ties: List[Any], offsets: Any) -> dict:

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -638,24 +638,34 @@ def _value_from_node(node: Any) -> Any:
     return const if const is not None else _coord_value_fn(node)
 
 
+def _node_has_complex_literal(node: Any) -> bool:
+    """True if a single trace node carries a complex-valued constant (a user-written ``1j``)."""
+    for attr in ("value", "val", "data", "constant"):
+        v = getattr(node, attr, None)
+        if v is None:
+            continue
+        try:
+            if jnp.iscomplexobj(jnp.asarray(v)):
+                return True
+        except Exception:  # not array-like; ignore
+            continue
+    return False
+
+
+def _bares_have_complex_coeff(bares: Any) -> bool:
+    """True if any raw weak-form bare contains a complex literal. The complex constant survives
+    lowering unchanged, so walking the raw bares is equivalent to :func:`_is_complex_form` but works
+    *before* the lowered ``ir`` is built (used to route the non-nodal path)."""
+    return any(_node_has_complex_literal(n) for b in bares for n in _walk(b))
+
+
 def _is_complex_form(domain: Any, ir: Any) -> bool:
     """True if any lowered term's expression contains a complex constant — the signal to route a
     (steady, linear) weak form through the real-equivalent complex solver instead of the plain real
     assembly. We walk the tree for a complex-valued literal (a user-written ``1j``) rather than
     evaluating, because the lowered coeff embeds the (non-evaluable) trial/test channel."""
     del domain
-    for term in ir.terms:
-        for node in _walk(term.coeff):
-            for attr in ("value", "val", "data", "constant"):
-                v = getattr(node, attr, None)
-                if v is None:
-                    continue
-                try:
-                    if jnp.iscomplexobj(jnp.asarray(v)):
-                        return True
-                except Exception:  # not array-like; ignore
-                    continue
-    return False
+    return any(_node_has_complex_literal(node) for term in ir.terms for node in _walk(term.coeff))
 
 
 def _complex_block_bcoo(A_r: Any, A_i: Any, n: int) -> Any:
@@ -2508,6 +2518,63 @@ def fem(
     # the shared integrand evaluator (which carries space-guarded branches for the physical basis).
     if _trial_spaces(constraints) - {"Lagrange"}:
         from .utils.solver.fem_nonnodal import assemble_fem_nonnodal
+
+        # ---- complex non-nodal (RT/Nédélec/Argyris): the Re/Im coefficient split, assembled by the
+        # non-nodal push-forward assembler. The basis is real, so ``Re(c·T) = Re(c)·T``: wrapping each
+        # term in ``.real``/``.imag`` gives two ordinary real systems A_r/A_i, and FEM.solve() forms
+        # ``[[A_r,-A_i],[A_i,A_r]]`` (``mode="complex"`` → _solve_complex_block), recombining to a complex
+        # ``u`` — needed for time-harmonic Maxwell (complex ε, the ``i k₀`` impedance BC). Without this the
+        # plain real assembler would SILENTLY cast the imaginary part away, so the unwired compositions
+        # (transient/parametric/nonlinear) raise rather than mislead. ----
+        _nn_bares = volume_terms + [e for exprs in boundary_terms.values() for e in exprs]
+        if _bares_have_complex_coeff(_nn_bares):
+            from .utils.solver.parametric_helpers import _contains_runtime_parameter as _crp_nn
+            from .utils.solver.weak_form import _contains_temporal_derivative as _ctd_nn
+            from .utils.solver.weak_form import _is_obviously_nonlinear_in_unknown as _nlin_nn
+
+            if any(_ctd_nn(b) for b in _nn_bares):
+                raise NotImplementedError(
+                    "jno.fem: a complex non-nodal (RT/Nédélec/Argyris) *transient* form is not wired — only "
+                    "the steady linear complex form is. (The real assembler would silently drop the imaginary "
+                    "part, so this raises instead.)"
+                )
+            if has_neural_coeff or any(_crp_nn(b) for b in _nn_bares):
+                raise NotImplementedError(
+                    "jno.fem: a complex non-nodal *parametric/inverse* form (runtime parameter or neural "
+                    "coefficient) is not wired — the steady linear forward complex form is. (Raises rather than "
+                    "silently dropping the imaginary part.)"
+                )
+            if any(_nlin_nn(domain, b) for b in _nn_bares):
+                raise NotImplementedError(
+                    "jno.fem: a complex non-nodal *nonlinear* form is not wired — complex forms assemble as "
+                    "linear real-equivalent blocks. (Raises rather than silently dropping the imaginary part.)"
+                )
+            real_bd = {tag: [e.real for e in exprs] for tag, exprs in boundary_terms.items()}
+            imag_bd = {tag: [e.imag for e in exprs] for tag, exprs in boundary_terms.items()}
+            domain._fem_problem = None
+            op_r, _mr, offsets = assemble_fem_nonnodal(
+                domain,
+                [b.real for b in volume_terms],
+                real_bd,
+                dirichlet_raw,
+                [],
+                flux_bcs=flux_bcs,
+                rotation_bcs=rotation_bcs,
+                quad_degree=quad_degree,
+            )
+            op_i, _mi, _oi = assemble_fem_nonnodal(
+                domain,
+                [b.imag for b in volume_terms],
+                imag_bd,
+                dirichlet_raw,
+                [],
+                flux_bcs=flux_bcs,
+                rotation_bcs=rotation_bcs,
+                quad_degree=quad_degree,
+            )
+            return _finalize(
+                FEM(domain=domain, op=(op_r, op_i), classification=classification, mode="complex", offsets=offsets)
+            )
 
         op, mode, offsets = assemble_fem_nonnodal(
             domain,

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -1842,6 +1842,34 @@ class domain(MeshIOMixin):
         remesh_with_mmg(self, vertex_size, copy=False, **mmg_options)
         return self
 
+    def _remesh_periodic(self, pairs) -> bool:
+        """Re-mesh IN PLACE from the stored ``jno.Shape`` geometry, making the named opposite-face ``pairs``
+        (``[(master, slave), ...]``) conforming via gmsh ``setPeriodic`` — so a Nédélec (edge) field's
+        per-edge DOFs line up one-to-one across the periodic faces. Inferred from the constraint list (the
+        periodic ties), never requested explicitly. Idempotent: returns ``False`` (a no-op) when the domain
+        is not ``Shape``-backed (a user-supplied conforming mesh is used as-is) or the pairs are already
+        applied; ``True`` after a re-mesh."""
+        from ..geometry.shape import Shape
+
+        shape = getattr(self, "_constructor_source", None)
+        if not isinstance(shape, Shape):
+            return False  # no geometry to re-mesh; rely on the mesh as given (fails loudly if non-conforming)
+        want = frozenset(frozenset(p) for p in pairs)
+        if want <= getattr(self, "_periodic_meshed", frozenset()):
+            return False  # already conforming for these face pairs
+        from ..geometry.emit import build as _emit_build
+
+        mesh, _dim, ds = _emit_build(shape, periodic=list(pairs))
+        self.mesh, self.ds = mesh, ds
+        if hasattr(self, "_reset_custom_tag_state"):
+            self._reset_custom_tag_state()
+        self._apply_mesh(mesh)
+        for name, pred in list(getattr(self, "_tag_predicates", {}).items()):  # re-materialize predicate tags
+            self.tag(name, pred)
+        self._periodic_meshed = getattr(self, "_periodic_meshed", frozenset()) | want
+        self.log.info(f"Re-meshed periodic (conforming) for face pairs {sorted(tuple(sorted(p)) for p in pairs)}")
+        return True
+
     def _build_simplex_pools(self) -> None:
         """Populate ``self._simplex_pools`` from ``_tag_edges`` / ``_tag_triangles``.
 
@@ -2712,6 +2740,7 @@ class domain(MeshIOMixin):
         occlude=True,
         inward=False,
         r_min=None,
+        near_field=True,
     ):
         """Build an :class:`~jno.domain.enclosure.Enclosure` from radiating boundary ``tags``.
 
@@ -2736,10 +2765,20 @@ class domain(MeshIOMixin):
                 use when the radiating ``tags`` are the outer walls of a **meshed cavity** (an oven /
                 furnace filled with a transparent fluid) and radiation crosses the meshed interior, so
                 the facing walls see one another. Default ``False`` (normals out of the mesh, vacuum gap).
-            r_min: Axisymmetric only. Near-field floor for the ring view-factor kernel (``R^2 -> R^2 +
-                r_min^2``), which suppresses the spuriously large (>1) view factors that near-coincident
-                or on-axis (``r -> 0``) ring pairs otherwise produce. Defaults to half the median element
-                length (matched to the mesh resolution); pass a value to override.
+            near_field: Axisymmetric only, default ``True``. Recompute the element pairs that the uniform
+                ``n_phi`` azimuthal rule cannot resolve — near-touching surfaces (two parts meeting in a
+                narrow wedge) and every element's own ring self-view — with a graded azimuthal quadrature
+                sized to each pair's peak. The ring kernel's azimuthal integrand peaks at ``phi = 0`` with
+                width ``d/r`` (``d`` = surface separation, ``r`` = radius); when ``2*pi/n_phi`` exceeds
+                that, the rule samples the peak's crest and multiplies it by a far wider step, overshooting
+                by ``~dphi/(d/r)``. That is what otherwise drives row sums well above the physical bound of
+                1 and forces the ``r_min`` fudge. Costs a one-off build-time pass over the near pairs.
+            r_min: Axisymmetric only. Near-field FLOOR for the ring kernel (``R^2 -> R^2 + r_min^2``) — a
+                fudge that caps the kernel for near-coincident rings rather than integrating them properly.
+                Defaults to ``0`` when ``near_field`` is on (the refinement handles the near field, so any
+                floor is then a pure bias) and to half the median element length otherwise. Note that the
+                legacy default is itself a ~12% systematic error on the analytic concentric-cylinder view
+                factors; pass a value to override either way.
         """
         from .enclosure import build_enclosure
 
@@ -2756,6 +2795,7 @@ class domain(MeshIOMixin):
             occlude=occlude,
             inward=inward,
             r_min=r_min,
+            near_field=near_field,
         )
 
     def compute_enclosure_view_factor(self, tags, opaque_tags=None):

--- a/jno/geometry/emit.py
+++ b/jno/geometry/emit.py
@@ -230,7 +230,35 @@ def _to_meshio(dim: int, labels: Dict[int, Tuple[int, str]]):
     return meshio.Mesh(points=coords, cells=cells, cell_sets=cell_sets)
 
 
-def _build_once(shape, split_full):
+def _apply_periodic(dim, labels, periodic):
+    """gmsh ``setPeriodic`` for each ``(master_name, slave_name)`` boundary-face pair: mesh the slave face
+    as a *translated copy* of the master so opposite boundaries mesh identically (conforming) — required
+    for edge-element (Nédélec) periodic ties, whose per-edge DOFs must line up one-to-one across the cell.
+    The translation is read from the face bounding-box centroids; a pair whose faces aren't both present is
+    skipped (nothing to tie)."""
+    import gmsh
+    import numpy as np
+
+    bdim = dim - 1
+    by_name: dict = {}
+    for etag, lab in labels.items():
+        if lab is not None:
+            by_name.setdefault(lab[1], []).append(int(etag))
+
+    def _centroid(tags):
+        bb = np.array([gmsh.model.getBoundingBox(bdim, t) for t in tags])  # (n, 6): (xlo,ylo,zlo,xhi,yhi,zhi)
+        return 0.5 * (bb[:, :3].min(axis=0) + bb[:, 3:].max(axis=0))
+
+    for master, slave in periodic:
+        m_tags, s_tags = by_name.get(master, []), by_name.get(slave, [])
+        if not m_tags or not s_tags:
+            continue
+        t = _centroid(s_tags) - _centroid(m_tags)  # translation master -> slave
+        affine = [1, 0, 0, t[0], 0, 1, 0, t[1], 0, 0, 1, t[2], 0, 0, 0, 1]  # row-major 4×4
+        gmsh.model.mesh.setPeriodic(bdim, s_tags, m_tags, affine)
+
+
+def _build_once(shape, split_full, periodic=None):
     import gmsh
 
     started = not gmsh.isInitialized()
@@ -246,6 +274,8 @@ def _build_once(shape, split_full):
         leaves = shape.leaves()
         labels = classify_boundary(dim, shape)
         ds = _apply_size_fields(dim, leaves, labels, shape)
+        if periodic:  # make named opposite faces conform (edge-element periodic ties need it)
+            _apply_periodic(dim, labels, periodic)
         gmsh.model.mesh.generate(dim)
         mesh = _to_meshio(dim, labels)
         return mesh, dim, ds
@@ -255,16 +285,19 @@ def _build_once(shape, split_full):
             gmsh.finalize()
 
 
-def build(shape):
+def build(shape, periodic=None):
     """Mesh ``shape`` -> ``(meshio.Mesh, dim, ds)``.
 
-    A single-sweep full (2pi) revolve of a *detached* profile makes a periodic surface gmsh
-    cannot mesh, while an axis-touching profile (a cone) meshes fine that way -- so we try the
-    single sweep first and only fall back to the two-halves construction if meshing fails.
+    ``periodic`` is an optional list of ``(master_name, slave_name)`` boundary-face pairs meshed conforming
+    (via :func:`_apply_periodic`) so opposite faces line up — needed for Nédélec edge periodic ties.
+
+    A single-sweep full (2pi) revolve of a *detached* profile makes a periodic surface gmsh cannot mesh,
+    while an axis-touching profile (a cone) meshes fine that way -- so we try the single sweep first and
+    only fall back to the two-halves construction if meshing fails.
     """
     try:
-        return _build_once(shape, split_full=False)
+        return _build_once(shape, split_full=False, periodic=periodic)
     except Exception as exc:  # noqa: BLE001 - narrow retry on the periodic-surface mesher failure
         if "periodic" in str(exc).lower() and _has_full_revolve(shape._node):
-            return _build_once(shape, split_full=True)
+            return _build_once(shape, split_full=True, periodic=periodic)
         raise

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -8,19 +8,18 @@ canonical case — this is far cheaper than a full 3-D volumetric solve.
 Two entry points, both on `jno.rcwa`:
 
 * **From a jNO problem (the front door).** Hand it the same constraint list you would give
-  :func:`jno.fem` (or the already-built ``FEM``) together with the permittivity expression ``eps``;
-  RCWA reads the rest out of the traced problem::
+  :func:`jno.fem` (or the already-built ``FEM``) — nothing else is required::
 
-      rc  = jno.rcwa(constraints, eps, orders=300, wavelength=1.0)
-      sol = rc.solve()                     # period, layers, ambients, source, incidence all inferred
+      rc  = jno.rcwa(constraints, orders=300)
+      sol = rc.solve()                     # everything inferred from the traced problem
       rc.spec                              # the inferred RcwaSpec (available without fmmax)
 
   Inferred from the problem: **periodicity + period** (from the Floquet ties — absent ⇒ raise, never
-  assumed), the **super/substrate ambients** (the z-normal radiation faces), the **layer stack**
-  (``eps`` sampled along z, then :func:`detect_layers`), and the **incident wave** (illuminated face +
-  transverse angle ``k_in``, read from the assembled forcing). ``eps`` is passed explicitly because
-  isolating one coefficient sub-tree from an assembled weak form is not supported yet; ``wavelength``
-  is passed because a bare-float ``k0`` is not an identifiable node in the trace.
+  assumed), the **super/substrate ambients** (the z-normal radiation faces), the **permittivity**
+  (the ``K0**2*eps`` coefficient recovered from the scalar Helmholtz volume term, sampled along z and
+  grouped by :func:`detect_layers`), the **wavelength** (``k0`` from the vacuum superstrate, or pass
+  ``wavelength=`` to override), and the **incident wave** (illuminated face + transverse angle
+  ``k_in``, read from the assembled forcing).
 
 * **Explicit layers (the backend).** :class:`Rcwa` takes a hand-built ``[(thickness, eps), ...]`` stack;
   this is what the front door constructs internally.
@@ -386,27 +385,98 @@ def _param_zeros(femobj, eps):
     return out
 
 
-def _eval_eps_nodes(eps, domain, params):
-    """Evaluate the eps expression at every mesh node (where nodal parameters align)."""
+def _eval_expr_nodes(node, domain):
+    """Evaluate a coefficient expression at every mesh node (nodal parameters use their current value)."""
     import jax.numpy as jnp
 
     from jno.trace import Variable
     from jno.trace_evaluator import TraceEvaluator
 
     node_coords = jnp.asarray(np.asarray(domain.points))
-    table = {}
-    for mc in _model_calls(eps):
-        m = mc.model
-        mod = m.module
-        name = getattr(m, "_parameter_name", None)
-        if name is not None and name in params:
-            import equinox as eqx
-
-            mod = eqx.tree_at(lambda mm: mm.value, mod, jnp.asarray(params[name]))
-        table[m.layer_id] = mod
-    tags = {v.tag for v in _walk_nodes(eps) if isinstance(v, Variable)}
+    table = {mc.model.layer_id: mc.model.module for mc in _model_calls(node)}
+    tags = {v.tag for v in _walk_nodes(node) if isinstance(v, Variable)}
     ctx = {t: node_coords for t in tags} if tags else {}
-    return np.asarray(TraceEvaluator(table).evaluate(eps, context=ctx)).reshape(-1)
+    return np.asarray(TraceEvaluator(table).evaluate(node, context=ctx)).reshape(-1)
+
+
+# --- recover the permittivity coefficient (K0^2 * eps) from the volume weak form ------------------
+def _add_split(node, sign=1, out=None):
+    """Flatten a tree of +/- into signed additive summands."""
+    from jno.trace import BinaryOp
+
+    if out is None:
+        out = []
+    if isinstance(node, BinaryOp) and node.op in ("+", "-"):
+        _add_split(node.left, sign, out)
+        _add_split(node.right, sign if node.op == "+" else -sign, out)
+    else:
+        out.append((sign, node))
+    return out
+
+
+def _mul_factors(node, out=None):
+    """Flatten a product tree into its multiplicative factors."""
+    from jno.trace import BinaryOp
+
+    if out is None:
+        out = []
+    if isinstance(node, BinaryOp) and node.op == "*":
+        _mul_factors(node.left, out)
+        _mul_factors(node.right, out)
+    else:
+        out.append(node)
+    return out
+
+
+def _volume_constraint(femobj):
+    cls = list(getattr(femobj, "classification", []))
+    cons = list(getattr(femobj, "_constraints", []))
+    vols = [c for c, k in zip(cons, cls) if k == "volume"]
+    if len(vols) != 1:
+        raise RcwaError(
+            f"expected exactly one volume weak-form term, found {len(vols)} (classification={cls}); "
+            "RCWA infers the permittivity from a single scalar Helmholtz volume term."
+        )
+    return vols[0]
+
+
+def _extract_permittivity_coeff(volume_term):
+    """Pull the value-channel (mass) coefficient ``K0**2 * eps`` out of a scalar Helmholtz volume term.
+
+    A Helmholtz volume form is ``grad(u).grad(v) - K0**2 * eps * (u*v)``: the stiffness summands carry
+    trial/test inside ``Jacobian`` nodes, while the mass summand carries them as bare TrialFunction /
+    TestFunction values. We split additively, find the summand with bare trial x test, and drop those
+    two factors — what remains is ``K0**2 * eps``.
+    """
+    import functools
+    import operator
+
+    from jno.trace import TestFunction, TrialFunction
+
+    expr = getattr(volume_term, "expr", volume_term)
+    mass = []
+    for _sign, summand in _add_split(expr):
+        fac = _mul_factors(summand)
+        tv = [f for f in fac if isinstance(f, TrialFunction)]
+        te = [f for f in fac if isinstance(f, TestFunction)]
+        if not (tv and te):
+            continue  # stiffness / other channel
+        for f in tv + te:
+            if getattr(f, "value_shape", ()) != ():
+                raise RcwaError(
+                    "RCWA infers permittivity from a SCALAR Helmholtz term, but this field is "
+                    f"vector/tensor (value_shape={f.value_shape}). Scalar problems only for now."
+                )
+        coeff_factors = [f for f in fac if not isinstance(f, (TrialFunction, TestFunction))]
+        if not coeff_factors:
+            raise RcwaError("mass term has no coefficient factor; cannot recover permittivity.")
+        mass.append(functools.reduce(operator.mul, coeff_factors))
+    if not mass:
+        raise RcwaError(
+            "could not find a K0^2*eps*(u*v) mass term in the volume weak form; RCWA needs a scalar "
+            "Helmholtz term. If the permittivity is authored unusually, isolate it as a named coefficient."
+        )
+    return functools.reduce(operator.add, mass)
 
 
 def _sample_grid(domain, eps_nodes, grid, nz, period, z_range):
@@ -494,24 +564,28 @@ class _RcwaProblem:
         return eng.solve()
 
 
-def rcwa(problem, eps, *, orders, wavelength, grid=64, nz=64, slices=None, formulation="JONES_DIRECT_FOURIER"):
-    """Infer and build an RCWA problem from a jNO constraint list (or built ``FEM``) plus ``eps``.
+def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formulation="JONES_DIRECT_FOURIER"):
+    """Infer and build an RCWA problem from a jNO constraint list (or built ``FEM``).
+
+    Everything is read out of the traced problem: **periodicity + period** (Floquet ties — absent ⇒
+    raise), the **super/substrate ambients**, the **permittivity** (the ``K0**2*eps`` coefficient
+    recovered from the scalar Helmholtz volume term, sampled along z), the **wavelength** (``k0`` from
+    the vacuum superstrate, unless ``wavelength`` is given), and the **incident wave** (illuminated face
+    + transverse angle ``k_in``, from the assembled forcing).
 
     Parameters
     ----------
     problem:
         The same constraint list you would pass to :func:`jno.fem`, or an already-built ``FEM``.
-    eps:
-        The permittivity expression (the traced coefficient, may depend on a trainable parameter).
     orders:
         Fourier truncation for the modal solve.
     wavelength:
-        Free-space wavelength (same length unit as the geometry). Passed explicitly — a bare-float
-        ``k0`` is not an identifiable node in the trace.
+        Free-space wavelength (same length unit as the geometry). Optional — inferred from the
+        superstrate (assumed vacuum) when omitted. Pass it to override or if no ambient is vacuum.
     grid, nz:
         Transverse resolution and number of z-samples used to detect the layer stack.
     slices:
-        Staircase a continuously-varying ``eps`` into this many layers instead of raising.
+        Staircase a continuously-varying permittivity into this many layers instead of raising.
 
     Returns
     -------
@@ -525,24 +599,38 @@ def rcwa(problem, eps, *, orders, wavelength, grid=64, nz=64, slices=None, formu
     pts = np.asarray(domain.points)
     z_range = (float(pts[:, 2].min()), float(pts[:, 2].max()))
 
-    params = _param_zeros(femobj, eps)
-    eps_nodes = _eval_eps_nodes(eps, domain, params)
-    if np.iscomplexobj(eps_nodes) and np.max(np.abs(eps_nodes.imag)) < 1e-9:
-        eps_nodes = eps_nodes.real.astype(complex)
-    E, zs = _sample_grid(domain, eps_nodes, grid, nz, period, z_range)
-    layers = detect_layers(E, zs, slices=slices)
+    # permittivity coefficient K0^2 * eps, recovered from the volume weak form (no assembly, no eps arg)
+    coeff_node = _extract_permittivity_coeff(_volume_constraint(femobj))
+    coeff_nodes = _eval_expr_nodes(coeff_node, domain)
+    if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
+        coeff_nodes = coeff_nodes.real.astype(complex)
+    C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range)
+    coeff_layers = detect_layers(C, zs, slices=slices)
 
     face_z, k_in = _source_kin(femobj, domain)
-    source_face = (
-        bottom
-        if abs(face_z - _region_centroid(domain, bottom)[2]) < abs(face_z - _region_centroid(domain, top)[2])
-        else top
-    )
+    source_at_bottom = abs(face_z - _region_centroid(domain, bottom)[2]) < abs(face_z - _region_centroid(domain, top)[2])
+    source_face = bottom if source_at_bottom else top
+
+    # orient so the incident (source-side) ambient is layers[0] = superstrate
+    if not source_at_bottom:
+        coeff_layers = list(reversed(coeff_layers))
+    # k0 from the superstrate (vacuum ⇒ coeff = k0^2), unless wavelength is given
+    super_coeff = float(np.real(coeff_layers[0][1]).mean())
+    if wavelength is not None:
+        k0 = 2 * np.pi / float(wavelength)
+    elif super_coeff <= 0:
+        raise RcwaError(
+            "cannot infer wavelength: the superstrate permittivity coefficient is non-positive; pass wavelength=."
+        )
+    else:
+        k0 = float(np.sqrt(super_coeff))
+    k0sq = k0 * k0
+    layers = [(t, np.asarray(e) / k0sq) for t, e in coeff_layers]  # relative permittivity
 
     spec = RcwaSpec(
         period=period,
         layers=layers,
-        wavelength=float(wavelength),
+        wavelength=2 * np.pi / k0,
         k_in=k_in,
         source_face=source_face,
         ambient_faces=(bottom, top),

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -292,6 +292,12 @@ class Rcwa:
         self.orders, self.wavelength, self.k_in = orders, wavelength, tuple(k_in)
         self.formulation = fm.Formulation[formulation]
         self.assume_periodic = True
+        # Precompute the (design-INDEPENDENT) Fourier expansion ONCE, eagerly. fmmax's generate_expansion
+        # mixes jnp with np.linalg.norm — fine eagerly, but under jax.jit jnp ops are tracers, so recomputing
+        # it inside the traced solve raised TracerArrayConversionError. Cached here, the design solve is jit-safe.
+        self._lv = fm.LatticeVectors(u=np.array([period[0], 0.0]), v=np.array([0.0, period[1]]))
+        self._ex = fm.generate_expansion(self._lv, approximate_num_terms=orders)
+        self._nt = self._ex.num_terms
 
     def solve(self, inc=None, wavelength=None, k_in=None, layers=None):
         """Solve the stack and return a :class:`_Sol`. Raises if the wavelength is unknown or energy is
@@ -309,9 +315,7 @@ class Rcwa:
             )
         layers_spec = self.layers_spec if layers is None else layers
         kin = jnp.asarray(self.k_in if k_in is None else k_in, float)  # jax -> incidence angle is differentiable
-        lv = fm.LatticeVectors(u=np.array([self.period[0], 0.0]), v=np.array([0.0, self.period[1]]))
-        ex = fm.generate_expansion(lv, approximate_num_terms=self.orders)
-        nt = ex.num_terms
+        lv, ex, nt = self._lv, self._ex, self._nt  # precomputed eagerly in __init__ (jit-safe)
 
         def _grid(g):
             g = jnp.asarray(g) + 0j  # jax-native so a permittivity grid flows -> differentiable in ε
@@ -892,6 +896,8 @@ class _ParametricSol:
     def _node(self, method, *args):
         from jno.trace import FunctionCall
 
+        self._p._engine()  # build the engine + its Fourier expansion EAGERLY here (outside any trace) so the
+        # FunctionCall below reuses the cached engine and stays jit-safe under jax.jit(value_and_grad(...)).
         names = list(self._rpe)
         exprs = [self._rpe[n] for n in names]
 
@@ -928,15 +934,17 @@ class _RcwaProblem:
         return f"_RcwaProblem(orders={self.orders}, params={sorted(self._rpe)}, {self.spec!r})"
 
     def _engine(self):
-        return Rcwa(
-            self.spec.layers,
-            period=self.spec.period,
-            orders=self.orders,
-            wavelength=self.spec.wavelength,
-            k_in=self.spec.k_in,
-            formulation=self.formulation,
-            assume_periodic=True,
-        )
+        if getattr(self, "_eng", None) is None:  # build ONCE (warmed eagerly in _node) so the expansion is trace-free
+            self._eng = Rcwa(
+                self.spec.layers,
+                period=self.spec.period,
+                orders=self.orders,
+                wavelength=self.spec.wavelength,
+                k_in=self.spec.k_in,
+                formulation=self.formulation,
+                assume_periodic=True,
+            )
+        return self._eng
 
     def _solve_at(self, params):
         """Concrete solve at explicit parameter values (JAX) -- re-derives eps, wavelength AND k_in."""

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -1,0 +1,225 @@
+"""Rigorous Coupled-Wave Analysis (RCWA / Fourier Modal Method) for periodic, layered structures.
+
+RCWA is semi-analytic in the propagation direction: each layer is expanded in a truncated Fourier
+basis in-plane and solved by an eigenmode decomposition, then layers are stitched with a scattering
+matrix. For **periodic, piecewise-z-invariant** structures — extruded metasurface pillars are the
+canonical case — this is far cheaper than a full 3-D volumetric solve.
+
+This is an **optional** jNO backend built on `fmmax` (a differentiable JAX Fourier Modal Method);
+`fmmax` is imported lazily so the core install stays lean. Install it with::
+
+    pip install jax-neural-operators[rcwa]      # or: pixi run -e rcwa ...
+
+Usage (forward engine — explicit layers)::
+
+    rc  = jno.rcwa([(inf, 1.0), (0.35, eps_xy), (inf, 2.1)], period=(0.6, 0.6), orders=300, wavelength=1.03)
+    sol = rc.solve(inc=None)     # inc = transverse incident field on the cell grid (None = normal plane wave)
+    sol.efficiency("T")          # transmitted / reflected power (0th order + all propagating orders)
+    sol.order(+1, 0)             # diffraction efficiency into a specific order
+
+Design rules honoured here:
+ * Permittivity is passed, not an equation — the governing (Helmholtz) physics is implicit.
+ * It **never fails silently**: every inference (periodicity, layer thickness, order/grid Nyquist,
+   wavelength, energy balance) is validated and raises :class:`RcwaError` with a concrete fix.
+ * The two `fmmax` gotchas are baked in so callers never rediscover them: the Poynting flux is summed
+   *with sign* (an ``abs()`` sum over-counts and yields ``T+R>1``), and the ``JONES_DIRECT_FOURIER``
+   Fourier factorization is the default (the naive rule converges poorly for high-contrast dielectrics).
+
+Planned increment (needs the ``eps.at(coords)`` primitive): an ``eps``-driven front-end
+``jno.rcwa(eps, orders=...)`` that samples a jNO permittivity expression on a grid, auto-derives the
+layers, and threads the design gradient through — plus ``as_precond`` for ``fem.solve(precond=rc)``.
+
+References:
+ * M. G. Moharam & T. K. Gaylord, "Rigorous coupled-wave analysis of planar-grating diffraction",
+   J. Opt. Soc. Am. 71, 811 (1981).
+ * M. G. Moharam, D. A. Pommet, E. B. Grann & T. K. Gaylord, "Stable implementation of the enhanced
+   transmittance matrix approach", J. Opt. Soc. Am. A 12, 1077 (1995).
+ * fmmax: https://github.com/facebookresearch/fmmax
+"""
+
+import numpy as np
+
+_FMMAX_HINT = (
+    "jno.rcwa needs the optional fmmax backend: pip install jax-neural-operators[rcwa] "
+    "(or `pixi run -e rcwa ...`, or `pip install fmmax`)."
+)
+
+
+def _fmmax():
+    try:
+        import fmmax
+
+        return fmmax
+    except ImportError as e:  # never a silent no-op
+        raise ImportError(_FMMAX_HINT) from e
+
+
+class RcwaError(ValueError):
+    """Raised for any ill-posed RCWA problem — always loud, never a silent wrong answer."""
+
+
+class _Sol:
+    def __init__(self, fm, s, layers, expansion, nt, Pin, wavelength):
+        self._fm, self._s, self._layers, self._ex = fm, s, layers, expansion
+        self._nt, self._Pin, self._wl = nt, Pin, wavelength
+        self._fwd = np.zeros((2 * nt, 1), complex)  # filled by solve()
+
+    def _flux(self, amps, layer, backward=False):
+        f, b = self._fm.directional_poynting_flux(
+            amps if not backward else np.zeros_like(amps),
+            amps if backward else np.zeros_like(amps),
+            layer,
+        )
+        return np.asarray(b if backward else f).reshape(-1)  # SIGNED (not abs) — energy-correct
+
+    def efficiency(self, kind):
+        """Total transmitted (``"T"``) or reflected (``"R"``) power fraction, summed over propagating orders."""
+        if kind == "T":
+            return float(np.sum(self._flux(self._s.s11 @ self._fwd, self._layers[-1]))) / self._Pin
+        if kind == "R":
+            return float(-np.sum(self._flux(self._s.s21 @ self._fwd, self._layers[0], backward=True))) / self._Pin
+        raise RcwaError(f"efficiency(kind): kind must be 'T' or 'R', got {kind!r}")
+
+    def order(self, m, n):
+        """Diffraction efficiency into transmitted order ``(m, n)`` (raises if outside the truncation)."""
+        bc = np.asarray(self._ex.basis_coefficients)
+        hit = np.where((bc[:, 0] == m) & (bc[:, 1] == n))[0]
+        if len(hit) == 0:
+            raise RcwaError(f"order ({m},{n}) is outside the truncation ({self._nt} terms); raise orders= to include it.")
+        i = int(hit[0])
+        tf = np.abs(
+            np.asarray(
+                self._fm.directional_poynting_flux(
+                    self._s.s11 @ self._fwd, np.zeros((2 * self._nt, 1), complex), self._layers[-1]
+                )[0]
+            ).reshape(-1)
+        )
+        return float(tf[i] + tf[i + self._nt]) / self._Pin
+
+
+class Rcwa:
+    """A periodic layered RCWA problem. Construct with the layer stack, period and truncation; call
+    :meth:`solve` with an incident field to obtain a :class:`_Sol`.
+
+    Parameters
+    ----------
+    layers:
+        Ordered ``[(thickness, eps), ...]`` from superstrate to substrate. ``thickness`` is a positive
+        float, or ``inf``/``None`` for the two semi-infinite ambient layers. ``eps`` is a scalar (uniform
+        layer) or a 2-D array sampled on the unit-cell grid (patterned layer).
+    period:
+        In-plane period ``(Px, Py)`` of the unit cell, both > 0.
+    orders:
+        Approximate number of Fourier terms (truncation). High-contrast dielectrics (e.g. a-Si) need
+        several hundred; low-contrast converge in tens.
+    wavelength:
+        Free-space wavelength (same length unit as ``period``/thicknesses). May be deferred to
+        :meth:`solve`. Never defaulted.
+    formulation:
+        `fmmax` Fourier-factorization rule; ``"JONES_DIRECT_FOURIER"`` (the default) is robust for
+        high-contrast structures.
+    assume_periodic:
+        RCWA solves an *infinitely periodic* in-plane problem. You must pass ``True`` to affirm the cell
+        is a genuine period/supercell — a finite aperture is not periodic and would be solved wrongly.
+    """
+
+    def __init__(
+        self, layers, *, period, orders, wavelength=None, formulation="JONES_DIRECT_FOURIER", assume_periodic=False
+    ):
+        fm = _fmmax()
+        # --- guard: periodicity is an ASSUMPTION, not a fact ---
+        if period is None or len(period) != 2 or period[0] <= 0 or period[1] <= 0:
+            raise RcwaError(f"period must be (Px,Py) > 0, got {period!r}.")
+        if not assume_periodic:
+            raise RcwaError(
+                "RCWA is periodic in-plane. If your cell is genuinely a period/supercell, pass "
+                "assume_periodic=True. A finite aperture with absorbing side walls is NOT periodic — "
+                "RCWA would silently solve the wrong (periodic) problem."
+            )
+        # --- guard: layers well-formed ---
+        if not layers:
+            raise RcwaError("layers is empty: need at least [superstrate, ..., substrate].")
+        for k, (t, e) in enumerate(layers):
+            if not (t is None or (np.isreal(t) and t > 0) or t == np.inf):
+                raise RcwaError(f"layer {k} thickness must be > 0 (or inf for ambient), got {t!r}.")
+            eg = np.asarray(e)
+            if eg.ndim == 2 and (eg.shape[0] < 4 or eg.shape[1] < 4):
+                raise RcwaError(f"layer {k} eps grid {eg.shape} is too coarse to rasterize; sample it finer.")
+        # --- guard: patterned grids must resolve the requested orders (Nyquist); uniform layers need none ---
+        grids = [np.asarray(e).shape[0] for _, e in layers if np.asarray(e).ndim == 2]
+        if grids:
+            ng = min(grids)
+            per_axis = int(np.ceil(np.sqrt(orders)))
+            if ng < 2 * per_axis:
+                raise RcwaError(
+                    f"eps grid {ng}x{ng} under-resolves orders={orders} (~{per_axis}/axis); "
+                    f"need >= {2 * per_axis} grid points/axis or fewer orders."
+                )
+        self.fm, self.layers_spec, self.period = fm, layers, period
+        self.orders, self.wavelength = orders, wavelength
+        self.formulation = fm.Formulation[formulation]
+        self.assume_periodic = True
+
+    def solve(self, inc=None, wavelength=None):
+        """Solve the stack for an incident field ``inc`` (``None`` = a normal-incidence plane wave) and
+        return a :class:`_Sol`. Raises if the wavelength is unknown or energy is not conserved."""
+        fm = self.fm
+        wl = wavelength if wavelength is not None else self.wavelength
+        if wl is None:
+            raise RcwaError(
+                "wavelength is unknown: pass wavelength= to solve() (or at construction). "
+                "It sets every layer's eigenmodes and is never defaulted."
+            )
+        lv = fm.LatticeVectors(u=np.array([self.period[0], 0.0]), v=np.array([0.0, self.period[1]]))
+        ex = fm.generate_expansion(lv, approximate_num_terms=self.orders)
+        nt = ex.num_terms
+        k_in = np.zeros(2)
+
+        def solve_layer(e):
+            eg = np.asarray(e) + 0j
+            if eg.ndim == 0:
+                eg = np.full((1, 1), eg)
+            return fm.eigensolve_isotropic_media(np.asarray(wl), k_in, lv, eg, ex, formulation=self.formulation)
+
+        layers = [solve_layer(e) for _, e in self.layers_spec]
+        thick = [np.asarray(1.0 if t is None or t == np.inf else t) for t, _ in self.layers_spec]
+        s = fm.stack_s_matrix(layers, thick)
+        fwd = np.zeros((2 * nt, 1), complex)
+        fwd[0, 0] = 1.0
+        Pin = float(np.sum(np.asarray(fm.directional_poynting_flux(fwd, np.zeros_like(fwd), layers[0])[0])))
+        sol = _Sol(fm, s, layers, ex, nt, Pin, wl)
+        sol._fwd = fwd
+        # --- guard: energy balance (lossless => T+R==1). A violation = non-convergence or a bug. ---
+        T, R = sol.efficiency("T"), sol.efficiency("R")
+        if T + R > 1.0 + 5e-3:
+            raise RcwaError(
+                f"energy not conserved: T+R={T + R:.4f} > 1 at orders={self.orders}. The modal solve is "
+                f"not converged (raise orders) or the structure is unphysical."
+            )
+        return sol
+
+    def as_precond(self, transfer=None):
+        """Return a :mod:`jno.precond` spec applying this (background) RCWA as ``M⁻¹ = A₀⁻¹``.
+
+        The FEM↔grid ``transfer`` (rasterize the residual to the RCWA grid, interpolate the background
+        field back to FEM nodes) is a planned increment; without it this raises rather than silently
+        returning a no-op preconditioner.
+        """
+        rc = self
+
+        class _Spec:
+            def materialize(self, ctx):
+                if transfer is None:
+                    raise RcwaError(
+                        "as_precond needs a FEM<->grid transfer operator (rasterize residual to the RCWA "
+                        "grid, interpolate the background field back to FEM nodes). Not yet wired."
+                    )
+                raise NotImplementedError("transfer wiring is a planned increment (see jno.rcwa module docstring).")
+
+        _ = rc
+        return _Spec()
+
+
+def rcwa(layers, *, period, orders, wavelength=None, **kw):
+    """Build an :class:`Rcwa` problem — the functional entry point (see :class:`Rcwa` for the arguments)."""
+    return Rcwa(layers, period=period, orders=orders, wavelength=wavelength, **kw)

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -245,12 +245,25 @@ class Rcwa:
         layers = [solve_layer(e) for _, e in self.layers_spec]
         thick = [np.asarray(1.0 if t is None or t == np.inf else t) for t, _ in self.layers_spec]
         s = fm.stack_s_matrix(layers, thick)
+        # Incidence: excite the genuinely forward-propagating mode in the superstrate and normalise by
+        # ITS flux. fmmax sorts eigenmodes by eigenvalue, so index 0 need not be the 0th forward order,
+        # and a one-hot forward amplitude can carry zero forward flux -- pick the max-positive-flux mode.
+        flux_sup = np.asarray(fm.eigenmode_poynting_flux(layers[0])).reshape(-1)
+        idx = int(np.argmax(flux_sup.real))
+        Pin = float(flux_sup.real[idx])
+        if Pin <= 0:
+            raise RcwaError("no forward-propagating incident mode in the superstrate; check wavelength/period.")
         fwd = np.zeros((2 * nt, 1), complex)
-        fwd[0, 0] = 1.0
-        Pin = float(np.sum(np.asarray(fm.directional_poynting_flux(fwd, np.zeros_like(fwd), layers[0])[0])))
+        fwd[idx, 0] = 1.0
         sol = _Sol(fm, s, layers, ex, nt, Pin, wl)
         sol._fwd = fwd
         T, R = sol.efficiency("T"), sol.efficiency("R")
+        if not (np.isfinite(T) and np.isfinite(R)):
+            raise RcwaError(
+                "non-finite efficiency (NaN/inf): likely a Rayleigh/Wood anomaly where a diffraction "
+                "order is exactly grazing (the wavelength coincides with a period resonance, e.g. "
+                f"wavelength == period). Nudge the wavelength or period. (period={self.period}, wl={wl})"
+            )
         if T + R > 1.0 + 5e-3:
             raise RcwaError(
                 f"energy not conserved: T+R={T + R:.4f} > 1 at orders={self.orders}. The modal solve is "
@@ -479,6 +492,33 @@ def _extract_permittivity_coeff(volume_term):
     return functools.reduce(operator.add, mass)
 
 
+def _has_nodal_field(node):
+    """True if the coefficient depends on a per-node field parameter (needs mesh interpolation)."""
+    return any(getattr(mc.model, "_fem_field", None) == "node" for mc in _model_calls(node))
+
+
+def _sample_grid_direct(coeff_node, grid, nz, period, z_range):
+    """Evaluate an analytic coefficient expression directly on the RCWA grid (exact, no mesh noise).
+
+    Used when the permittivity is an analytic function of the coordinates (no per-node field); this
+    avoids the staircase/interp noise that makes z-slices look non-invariant on an unstructured mesh."""
+    import jax.numpy as jnp
+
+    from jno.trace import Variable
+    from jno.trace_evaluator import TraceEvaluator
+
+    xs = np.linspace(0, period[0], grid, endpoint=False)
+    ys = np.linspace(0, period[1], grid, endpoint=False)
+    zs = np.linspace(z_range[0], z_range[1], nz)
+    GX, GY, GZ = np.meshgrid(xs, ys, zs, indexing="ij")
+    pts = jnp.asarray(np.stack([GX.ravel(), GY.ravel(), GZ.ravel()], 1))
+    table = {mc.model.layer_id: mc.model.module for mc in _model_calls(coeff_node)}
+    tags = {v.tag for v in _walk_nodes(coeff_node) if isinstance(v, Variable)}
+    ctx = {t: pts for t in tags} if tags else {}
+    vals = np.asarray(TraceEvaluator(table).evaluate(coeff_node, context=ctx)).reshape(grid, grid, nz)
+    return np.moveaxis(vals, 2, 0).astype(complex), zs  # -> (nz, grid, grid)
+
+
 def _sample_grid(domain, eps_nodes, grid, nz, period, z_range):
     """Interpolate nodal eps onto an (nz, grid, grid) unit-cell array over the z-extent."""
     from scipy.interpolate import griddata
@@ -509,9 +549,12 @@ def _source_kin(femobj, domain):
             "(real, imag) operator pair. Author the field with complex=True."
         )
     opr, opi = op
-    pz = _param_zeros(femobj, femobj._constraints[0] if femobj._constraints else 0)
-    _, br = opr.evaluate(pz)
-    _, bi = opi.evaluate(pz)
+    if hasattr(opr, "evaluate"):  # lazy (parametric) operator
+        pz = _param_zeros(femobj, femobj._constraints[0] if femobj._constraints else 0)
+        _, br = opr.evaluate(pz)
+        _, bi = opi.evaluate(pz)
+    else:  # eager (parameter-free) (A, b) legs
+        br, bi = opr[1], opi[1]
     b = np.asarray(br).reshape(-1) + 1j * np.asarray(bi).reshape(-1)
     nz = np.where(np.abs(b) > 1e-9 * (np.abs(b).max() + 1e-30))[0]
     if len(nz) == 0:
@@ -601,10 +644,13 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
 
     # permittivity coefficient K0^2 * eps, recovered from the volume weak form (no assembly, no eps arg)
     coeff_node = _extract_permittivity_coeff(_volume_constraint(femobj))
-    coeff_nodes = _eval_expr_nodes(coeff_node, domain)
-    if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
-        coeff_nodes = coeff_nodes.real.astype(complex)
-    C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range)
+    if _has_nodal_field(coeff_node):  # per-node design field -> interpolate off the mesh
+        coeff_nodes = _eval_expr_nodes(coeff_node, domain)
+        if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
+            coeff_nodes = coeff_nodes.real.astype(complex)
+        C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range)
+    else:  # analytic permittivity -> sample the grid exactly
+        C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range)
     coeff_layers = detect_layers(C, zs, slices=slices)
 
     face_z, k_in = _source_kin(femobj, domain)

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -675,22 +675,26 @@ class _RcwaProblem:
             assume_periodic=True,
         )
 
-    def solve(self, params=None):
+    def solve(self, params=None, wavelength=None):
         """Build the fmmax engine and solve.
 
         Pass ``params={name: value}`` (JAX values for the trainable ``jno.np.parameter`` coefficients) to
         get a **differentiable** solve: the permittivity is re-sampled from those values and the whole
-        modal solve traces, so ``jax.grad`` of a ``sol.efficiency(...)`` objective flows to the design."""
+        modal solve traces, so ``jax.grad`` of a ``sol.efficiency(...)`` objective flows to the design.
+
+        Pass ``wavelength`` to override the inferred one -- sweep it for a **broadband / dispersion**
+        response (the transverse wavevector ``k_in`` is held fixed, i.e. fixed-momentum dispersion). The
+        result is differentiable in the wavelength too."""
         eng = self._engine()
         if params is None:
-            return eng.solve()
+            return eng.solve(wavelength=wavelength)
         if self._resample is None:
             raise RcwaError(
                 "differentiable solve(params=...) needs the analytic re-sampling path, which is only built "
                 "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
                 "permittivity; differentiable nodal re-sampling is not implemented yet."
             )
-        return eng.solve(layers=self._resample(params))
+        return eng.solve(layers=self._resample(params), wavelength=wavelength)
 
 
 def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formulation="JONES_DIRECT_FOURIER"):

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -45,7 +45,16 @@ References:
 
 from dataclasses import dataclass, field
 
+import jax
+import jax.numpy as jnp
 import numpy as np
+
+
+def _concrete(x):
+    """True when ``x`` is a real (non-traced) value, so a never-silent guard may inspect it. Under
+    jit/grad the value is a tracer -- the guard steps aside (validation ran on the eager forward pass)."""
+    return not isinstance(x, jax.core.Tracer)
+
 
 _FMMAX_HINT = (
     "jno.rcwa needs the optional fmmax backend: pip install jax-neural-operators[rcwa] "
@@ -111,7 +120,7 @@ def detect_layers(E, z, tol=1e-3, slices=None):
         idx = np.linspace(0, Nz - 1, slices + 1).round().astype(int)
         slabs = [(idx[i], idx[i + 1]) for i in range(len(idx) - 1)]
 
-    layers, report = [], []
+    layers, report, zmids = [], [], []
     for i, (a, b) in enumerate(slabs):
         mid = (a + b) // 2
         var = float(np.max(np.abs(E[a:b] - E[mid])))
@@ -123,10 +132,12 @@ def detect_layers(E, z, tol=1e-3, slices=None):
         eps_xy = E[mid]
         kind = "uniform" if np.ptp(eps_xy) < tol else "patterned"
         layers.append((thick, eps_xy))
+        zmids.append(float(z[mid]))
         report.append(
             f"  layer {i}: z=[{z[a]:.3f},{z[min(b - 1, Nz - 1)]:.3f}] {kind} eps~[{eps_xy.min():.2f},{eps_xy.max():.2f}]"
         )
     detect_layers.last_report = "detected layers:\n" + "\n".join(report)
+    detect_layers.last_zmid = zmids  # representative z of each layer -- lets a param sweep re-sample eps
     return layers
 
 
@@ -141,36 +152,38 @@ class _Sol:
         self._fwd = np.zeros((2 * nt, 1), complex)
 
     def _flux(self, amps, layer, backward=False):
-        f, b = self._fm.directional_poynting_flux(
-            amps if not backward else np.zeros_like(amps),
-            amps if backward else np.zeros_like(amps),
-            layer,
-        )
-        return np.asarray(b if backward else f).reshape(-1)  # SIGNED — energy-correct
+        zero = jnp.zeros_like(amps)
+        f, b = self._fm.directional_poynting_flux(zero if backward else amps, amps if backward else zero, layer)
+        return jnp.reshape(b if backward else f, (-1,))  # SIGNED — energy-correct; jax-native (differentiable)
 
     def efficiency(self, kind):
-        """Total transmitted (``"T"``) or reflected (``"R"``) power fraction over propagating orders."""
+        """Total transmitted (``"T"``) or reflected (``"R"``) power fraction over propagating orders.
+
+        Returns a JAX scalar -- differentiable in the design (permittivity) so ``jax.grad`` of a
+        transmission/reflection objective flows through the modal solve."""
         if kind == "T":
-            return float(np.sum(self._flux(self._s.s11 @ self._fwd, self._layers[-1]))) / self._Pin
+            return jnp.sum(self._flux(self._s.s11 @ self._fwd, self._layers[-1])) / self._Pin
         if kind == "R":
-            return float(-np.sum(self._flux(self._s.s21 @ self._fwd, self._layers[0], backward=True))) / self._Pin
+            return -jnp.sum(self._flux(self._s.s21 @ self._fwd, self._layers[0], backward=True)) / self._Pin
         raise RcwaError(f"efficiency(kind): kind must be 'T' or 'R', got {kind!r}")
 
     def order(self, m, n):
-        """Diffraction efficiency into transmitted order ``(m, n)`` (raises if outside the truncation)."""
-        bc = np.asarray(self._ex.basis_coefficients)
+        """Diffraction efficiency into transmitted order ``(m, n)`` (raises if outside the truncation).
+        Returns a differentiable JAX scalar."""
+        bc = np.asarray(self._ex.basis_coefficients)  # static (truncation geometry) -> plain numpy index
         hit = np.where((bc[:, 0] == m) & (bc[:, 1] == n))[0]
         if len(hit) == 0:
             raise RcwaError(f"order ({m},{n}) is outside the truncation ({self._nt} terms); raise orders=.")
         i = int(hit[0])
-        tf = np.abs(
-            np.asarray(
+        tf = jnp.abs(
+            jnp.reshape(
                 self._fm.directional_poynting_flux(
-                    self._s.s11 @ self._fwd, np.zeros((2 * self._nt, 1), complex), self._layers[-1]
-                )[0]
-            ).reshape(-1)
+                    self._s.s11 @ self._fwd, jnp.zeros((2 * self._nt, 1), complex), self._layers[-1]
+                )[0],
+                (-1,),
+            )
         )
-        return float(tf[i] + tf[i + self._nt]) / self._Pin
+        return (tf[i] + tf[i + self._nt]) / self._Pin
 
     def field(self, y_frac=0.5, nx=80, density=40.0):
         """Reconstruct the real-space electric field on a vertical (x–z) slice at ``y = y_frac·Py``.
@@ -245,9 +258,13 @@ class Rcwa:
         self.formulation = fm.Formulation[formulation]
         self.assume_periodic = True
 
-    def solve(self, inc=None, wavelength=None, k_in=None):
-        """Solve the stack and return a :class:`_Sol`. Raises if the wavelength is unknown or energy
-        is not conserved."""
+    def solve(self, inc=None, wavelength=None, k_in=None, layers=None):
+        """Solve the stack and return a :class:`_Sol`. Raises if the wavelength is unknown or energy is
+        not conserved.
+
+        ``layers`` optionally overrides the construction layer stack with ``[(thickness, eps), ...]`` at
+        solve time -- pass JAX permittivity grids here to differentiate the solve in the design (the
+        construction-time shape guards run once, eagerly, so the solve itself stays trace-clean)."""
         fm = self.fm
         wl = wavelength if wavelength is not None else self.wavelength
         if wl is None:
@@ -255,44 +272,47 @@ class Rcwa:
                 "wavelength is unknown: pass wavelength= to solve() or at construction; it sets every "
                 "layer's eigenmodes and is never defaulted."
             )
+        layers_spec = self.layers_spec if layers is None else layers
         kin = np.asarray(self.k_in if k_in is None else k_in, float)
         lv = fm.LatticeVectors(u=np.array([self.period[0], 0.0]), v=np.array([0.0, self.period[1]]))
         ex = fm.generate_expansion(lv, approximate_num_terms=self.orders)
         nt = ex.num_terms
 
         def solve_layer(e):
-            eg = np.asarray(e) + 0j
+            eg = jnp.asarray(e) + 0j  # jax-native: a jax permittivity grid flows -> differentiable in eps
             if eg.ndim == 0:
-                eg = np.full((1, 1), eg)
-            return fm.eigensolve_isotropic_media(np.asarray(wl), kin, lv, eg, ex, formulation=self.formulation)
+                eg = jnp.full((1, 1), eg)
+            return fm.eigensolve_isotropic_media(jnp.asarray(wl), kin, lv, eg, ex, formulation=self.formulation)
 
-        layers = [solve_layer(e) for _, e in self.layers_spec]
-        thick = [np.asarray(1.0 if t is None or t == np.inf else t) for t, _ in self.layers_spec]
+        layers = [solve_layer(e) for _, e in layers_spec]
+        thick = [jnp.asarray(1.0 if t is None or t == np.inf else t) for t, _ in layers_spec]
         s = fm.stack_s_matrix(layers, thick)
         # Incidence: excite the genuinely forward-propagating mode in the superstrate and normalise by
         # ITS flux. fmmax sorts eigenmodes by eigenvalue, so index 0 need not be the 0th forward order,
         # and a one-hot forward amplitude can carry zero forward flux -- pick the max-positive-flux mode.
-        flux_sup = np.asarray(fm.eigenmode_poynting_flux(layers[0])).reshape(-1)
-        idx = int(np.argmax(flux_sup.real))
-        Pin = float(flux_sup.real[idx])
-        if Pin <= 0:
+        # (The superstrate is design-independent, so this is effectively constant, but stays jax-native so
+        # the whole solve traces under grad/jit.)
+        flux_sup = jnp.real(jnp.reshape(fm.eigenmode_poynting_flux(layers[0]), (-1,)))
+        idx = jnp.argmax(flux_sup)
+        Pin = flux_sup[idx]
+        if _concrete(Pin) and float(Pin) <= 0:
             raise RcwaError("no forward-propagating incident mode in the superstrate; check wavelength/period.")
-        fwd = np.zeros((2 * nt, 1), complex)
-        fwd[idx, 0] = 1.0
+        fwd = jnp.zeros((2 * nt, 1), complex).at[idx, 0].set(1.0)
         sol = _Sol(fm, s, layers, ex, nt, Pin, wl, thick=thick, period=self.period)
         sol._fwd = fwd
         T, R = sol.efficiency("T"), sol.efficiency("R")
-        if not (np.isfinite(T) and np.isfinite(R)):
-            raise RcwaError(
-                "non-finite efficiency (NaN/inf): likely a Rayleigh/Wood anomaly where a diffraction "
-                "order is exactly grazing (the wavelength coincides with a period resonance, e.g. "
-                f"wavelength == period). Nudge the wavelength or period. (period={self.period}, wl={wl})"
-            )
-        if T + R > 1.0 + 5e-3:
-            raise RcwaError(
-                f"energy not conserved: T+R={T + R:.4f} > 1 at orders={self.orders}. The modal solve is "
-                f"not converged (raise orders) or the structure is unphysical."
-            )
+        if _concrete(T):  # never-silent runtime guards run on the eager forward pass; they step aside under trace
+            if not (np.isfinite(float(T)) and np.isfinite(float(R))):
+                raise RcwaError(
+                    "non-finite efficiency (NaN/inf): likely a Rayleigh/Wood anomaly where a diffraction "
+                    "order is exactly grazing (the wavelength coincides with a period resonance, e.g. "
+                    f"wavelength == period). Nudge the wavelength or period. (period={self.period}, wl={wl})"
+                )
+            if float(T) + float(R) > 1.0 + 5e-3:
+                raise RcwaError(
+                    f"energy not conserved: T+R={float(T) + float(R):.4f} > 1 at orders={self.orders}. The modal "
+                    f"solve is not converged (raise orders) or the structure is unphysical."
+                )
         return sol
 
 
@@ -605,21 +625,47 @@ def _source_kin(femobj, domain):
     return face_z, k_in
 
 
+def _cell_grid_at_z(period, grid, z):
+    xs = np.linspace(0, period[0], grid, endpoint=False)
+    ys = np.linspace(0, period[1], grid, endpoint=False)
+    gx, gy = np.meshgrid(xs, ys, indexing="ij")
+    return np.stack([gx.ravel(), gy.ravel(), np.full(grid * grid, z)], 1)
+
+
+def _eval_coeff_points(coeff_node, pts, params):
+    """Evaluate the permittivity coefficient at ``pts``, substituting trainable parameters from
+    ``params`` (jax values). Returns a JAX array -- differentiable in the design parameters."""
+    import equinox as eqx
+
+    from jno.trace import Variable
+    from jno.trace_evaluator import TraceEvaluator
+
+    table = {}
+    for mc in _model_calls(coeff_node):
+        mod, name = mc.model.module, getattr(mc.model, "_parameter_name", None)
+        if name is not None and name in params:
+            mod = eqx.tree_at(lambda m: m.value, mod, jnp.asarray(params[name]))
+        table[mc.model.layer_id] = mod
+    tags = {v.tag for v in _walk_nodes(coeff_node) if isinstance(v, Variable)}
+    ctx = {t: jnp.asarray(pts) for t in tags} if tags else {}
+    return TraceEvaluator(table).evaluate(coeff_node, context=ctx)
+
+
 class _RcwaProblem:
     """An RCWA problem inferred from a jNO constraint list / FEM problem. Holds the inferred
     :class:`RcwaSpec` and builds the fmmax engine on :meth:`solve`."""
 
-    def __init__(self, spec, orders, formulation="JONES_DIRECT_FOURIER"):
+    def __init__(self, spec, orders, formulation="JONES_DIRECT_FOURIER", resample=None):
         self.spec = spec
         self.orders = orders
         self.formulation = formulation
+        self._resample = resample  # params -> [(thickness, eps_grid), ...]  (jax; for differentiable solves)
 
     def __repr__(self):
         return f"_RcwaProblem(orders={self.orders}, {self.spec!r})"
 
-    def solve(self):
-        """Build the fmmax engine from the inferred spec and solve (needs the fmmax backend)."""
-        eng = Rcwa(
+    def _engine(self):
+        return Rcwa(
             self.spec.layers,
             period=self.spec.period,
             orders=self.orders,
@@ -628,7 +674,23 @@ class _RcwaProblem:
             formulation=self.formulation,
             assume_periodic=True,
         )
-        return eng.solve()
+
+    def solve(self, params=None):
+        """Build the fmmax engine and solve.
+
+        Pass ``params={name: value}`` (JAX values for the trainable ``jno.np.parameter`` coefficients) to
+        get a **differentiable** solve: the permittivity is re-sampled from those values and the whole
+        modal solve traces, so ``jax.grad`` of a ``sol.efficiency(...)`` objective flows to the design."""
+        eng = self._engine()
+        if params is None:
+            return eng.solve()
+        if self._resample is None:
+            raise RcwaError(
+                "differentiable solve(params=...) needs the analytic re-sampling path, which is only built "
+                "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
+                "permittivity; differentiable nodal re-sampling is not implemented yet."
+            )
+        return eng.solve(layers=self._resample(params))
 
 
 def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formulation="JONES_DIRECT_FOURIER"):
@@ -673,9 +735,11 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
         if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
             coeff_nodes = coeff_nodes.real.astype(complex)
         C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range)
+        zmids = None  # nodal-field path: no analytic re-sampling closure (differentiable solve unsupported)
     else:  # analytic permittivity -> sample the grid exactly
         C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range)
     coeff_layers = detect_layers(C, zs, slices=slices)
+    zmids = detect_layers.last_zmid if not _has_nodal_field(coeff_node) else None
 
     face_z, k_in = _source_kin(femobj, domain)
     source_at_bottom = abs(face_z - _region_centroid(domain, bottom)[2]) < abs(face_z - _region_centroid(domain, top)[2])
@@ -684,6 +748,8 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
     # orient so the incident (source-side) ambient is layers[0] = superstrate
     if not source_at_bottom:
         coeff_layers = list(reversed(coeff_layers))
+        if zmids is not None:
+            zmids = list(reversed(zmids))
     # k0 from the superstrate (vacuum ⇒ coeff = k0^2), unless wavelength is given
     super_coeff = float(np.real(coeff_layers[0][1]).mean())
     if wavelength is not None:
@@ -697,6 +763,21 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
     k0sq = k0 * k0
     layers = [(t, np.asarray(e) / k0sq) for t, e in coeff_layers]  # relative permittivity
 
+    # differentiable re-sampling: re-evaluate the analytic permittivity at each layer's representative z
+    # from a parameter dict, so a design (jno.np.parameter) flows through solve(params=...). Only for the
+    # analytic path (nodal-field re-sampling would need mesh interpolation -> deferred, raises in solve).
+    resample = None
+    if zmids is not None:
+        thicks = [t for t, _ in coeff_layers]
+
+        def resample(params):
+            out = []
+            for thick, zmid in zip(thicks, zmids):
+                pts = _cell_grid_at_z(period, grid, zmid)
+                cvals = jnp.reshape(_eval_coeff_points(coeff_node, pts, params), (grid, grid))
+                out.append((thick, jnp.real(cvals) / k0sq))
+            return out
+
     spec = RcwaSpec(
         period=period,
         layers=layers,
@@ -706,4 +787,4 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
         ambient_faces=(bottom, top),
         periodic_axes=axes,
     )
-    return _RcwaProblem(spec, orders=orders, formulation=formulation)
+    return _RcwaProblem(spec, orders=orders, formulation=formulation, resample=resample)

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -278,11 +278,18 @@ class Rcwa:
         ex = fm.generate_expansion(lv, approximate_num_terms=self.orders)
         nt = ex.num_terms
 
+        def _grid(g):
+            g = jnp.asarray(g) + 0j  # jax-native so a permittivity grid flows -> differentiable in ε
+            return jnp.full((1, 1), g) if g.ndim == 0 else g
+
         def solve_layer(e):
-            eg = jnp.asarray(e) + 0j  # jax-native: a jax permittivity grid flows -> differentiable in eps
-            if eg.ndim == 0:
-                eg = jnp.full((1, 1), eg)
-            return fm.eigensolve_isotropic_media(jnp.asarray(wl), kin, lv, eg, ex, formulation=self.formulation)
+            # anisotropic layer: e = (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz) grids -> fmmax's anisotropic eigensolve
+            if isinstance(e, tuple) and len(e) == 5:
+                exx, exy, eyx, eyy, ezz = (_grid(c) for c in e)
+                return fm.eigensolve_anisotropic_media(
+                    jnp.asarray(wl), kin, lv, exx, exy, eyx, eyy, ezz, ex, formulation=self.formulation
+                )
+            return fm.eigensolve_isotropic_media(jnp.asarray(wl), kin, lv, _grid(e), ex, formulation=self.formulation)
 
         layers = [solve_layer(e) for _, e in layers_spec]
         thick = [jnp.asarray(1.0 if t is None or t == np.inf else t) for t, _ in layers_spec]
@@ -519,12 +526,29 @@ def _extract_permittivity_coeff(volume_term):
             isinstance(a0, TestFunction) and isinstance(a1, TrialFunction)
         )
 
+    def _mass_matvec_matrix(f):  # inner(M @ u, v) with bare trial/test -> the tensor node M (anisotropic ε̂)
+        if not (isinstance(f, FunctionCall) and getattr(f, "_name", None) == "inner" and len(f.args) == 2):
+            return None
+
+        def _mv(x):  # matvec(M, u) with a bare trial -> M
+            if isinstance(x, FunctionCall) and getattr(x, "_name", None) == "matvec" and len(x.args) == 2:
+                return x.args[0] if isinstance(x.args[1], TrialFunction) else None
+            return None
+
+        a0, a1 = f.args
+        if (m := _mv(a0)) is not None and isinstance(a1, TestFunction):
+            return m
+        if (m := _mv(a1)) is not None and isinstance(a0, TestFunction):
+            return m
+        return None
+
     expr = getattr(volume_term, "expr", volume_term)
     mass = []
     for _sign, summand in _add_split(expr):
         fac = _mul_factors(summand)
         tv = [f for f in fac if isinstance(f, TrialFunction)]
         te = [f for f in fac if isinstance(f, TestFunction)]
+        matvec_f = next((f for f in fac if _mass_matvec_matrix(f) is not None), None)
         if tv and te:  # scalar Helmholtz mass: bare u * v
             if any(getattr(f, "value_shape", ()) != () for f in tv + te):
                 raise RcwaError(
@@ -532,6 +556,8 @@ def _extract_permittivity_coeff(volume_term):
                     "(a vector curl-curl form) rather than a raw component product."
                 )
             coeff_factors = [f for f in fac if not isinstance(f, (TrialFunction, TestFunction))]
+        elif matvec_f is not None:  # anisotropic Maxwell mass: inner(ε̂ @ u, v) -> coeff = (scalars) · ε̂
+            coeff_factors = [f for f in fac if f is not matvec_f] + [_mass_matvec_matrix(matvec_f)]
         elif any(_bare_mass_inner(f) for f in fac):  # vector Maxwell mass: inner(u, v)
             coeff_factors = [f for f in fac if not _bare_mass_inner(f)]
         else:
@@ -661,8 +687,27 @@ def _sample_grid_direct(coeff_node, grid, nz, period, z_range, params=None):
     zs = np.linspace(z_range[0], z_range[1], nz)
     GX, GY, GZ = np.meshgrid(xs, ys, zs, indexing="ij")
     pts = np.stack([GX.ravel(), GY.ravel(), GZ.ravel()], 1)
-    vals = np.asarray(_eval_coeff_points(coeff_node, pts, params or {})).reshape(grid, grid, nz)
+    vals = np.asarray(_eval_coeff_points(coeff_node, pts, params or {}))
+    if vals.ndim >= 3 and vals.shape[-2:] == (3, 3):  # anisotropic ε̂ -> layer-detect on the xx component
+        vals = vals[..., 0, 0]
+    vals = vals.reshape(grid, grid, nz)
     return np.moveaxis(vals, 2, 0).astype(complex), zs  # -> (nz, grid, grid)
+
+
+def _coeff_is_tensor(coeff_node, period, z_range, params):
+    """True if the permittivity coefficient is a 3×3 tensor (anisotropic ε̂) rather than a scalar — decided
+    by evaluating it once at a representative cell point and checking the value shape."""
+    pt = np.array([[period[0] * 0.5, period[1] * 0.5, 0.5 * (z_range[0] + z_range[1])]])
+    v = np.asarray(_eval_coeff_points(coeff_node, pt, params or {}))
+    return v.ndim >= 3 and v.shape[-2:] == (3, 3)
+
+
+def _tensor_components(coeff_node, period, grid, zmid, params, k0sq):
+    """The 5 relative-permittivity component grids (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz) fmmax needs, sampled on the
+    unit-cell grid at height ``zmid`` from the K0²·ε̂ tensor coefficient (divided by k0²)."""
+    T = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), params), (grid, grid, 3, 3))
+    T = T / k0sq
+    return (T[..., 0, 0], T[..., 0, 1], T[..., 1, 0], T[..., 1, 1], T[..., 2, 2])
 
 
 def _sample_grid(domain, eps_nodes, grid, nz, period, z_range):
@@ -940,6 +985,7 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     # (e.g. a K0 parameter that must be non-zero for the source to exist).
     cparams = _param_values(femobj, coeff_node)
     cparams.update({k: jnp.asarray(v) for k, v in (params or {}).items()})
+    is_aniso = _coeff_is_tensor(coeff_node, period, z_range, cparams)  # 3×3 ε̂ vs scalar ε
     if _has_nodal_field(coeff_node):  # per-node design field -> interpolate off the mesh
         coeff_nodes = _eval_expr_nodes(coeff_node, domain)
         if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
@@ -969,7 +1015,13 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     else:
         k0 = float(np.sqrt(super_coeff))
     k0sq = k0 * k0
-    layers = [(t, np.asarray(e) / k0sq) for t, e in coeff_layers]  # relative permittivity
+    if is_aniso:  # relative-permittivity TENSOR per layer: (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz)
+        layers = [
+            (t, tuple(np.asarray(c) for c in _tensor_components(coeff_node, period, grid, zm, cparams, k0sq)))
+            for (t, _), zm in zip(coeff_layers, zmids)
+        ]
+    else:
+        layers = [(t, np.asarray(e) / k0sq) for t, e in coeff_layers]  # relative permittivity (scalar)
 
     # differentiable re-sampling: re-evaluate the permittivity coefficient at each layer's representative z
     # from a parameter dict, so a design (jno.np.parameter) flows through the solve. Re-deriving the WHOLE
@@ -1006,12 +1058,24 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
 
             return {k: (gather(v) if k in nodal_names else jnp.asarray(v)) for k, v in params.items()}
 
-        sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0))))
-        k0 = jnp.sqrt(sup)
-        out = []
-        for li, (thick, zmid) in enumerate(zip(thicks, zmids)):
-            cvals = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), at(li)), (grid, grid))
-            out.append((thick, jnp.real(cvals) / (k0 * k0)))
+        if is_aniso:  # k0 from the superstrate's xx (isotropic vacuum ⇒ xx = k0²); tensor components per layer
+            sup_xx = jnp.reshape(
+                _eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0)), (grid, grid, 3, 3)
+            )
+            k0 = jnp.sqrt(jnp.mean(jnp.real(sup_xx[..., 0, 0])))
+            out = [
+                (thick, _tensor_components(coeff_node, period, grid, zmid, at(li), k0 * k0))
+                for li, (thick, zmid) in enumerate(zip(thicks, zmids))
+            ]
+        else:
+            sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0))))
+            k0 = jnp.sqrt(sup)
+            out = []
+            for li, (thick, zmid) in enumerate(zip(thicks, zmids)):
+                cvals = jnp.reshape(
+                    _eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), at(li)), (grid, grid)
+                )
+                out.append((thick, jnp.real(cvals) / (k0 * k0)))
         kin = _kin_from_source(src_coeff, period, src_z, params) if src_coeff is not None else jnp.asarray(k_in)
         return out, 2 * jnp.pi / k0, kin
 

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -647,18 +647,52 @@ def _eval_coeff_points(coeff_node, pts, params):
     return TraceEvaluator(table).evaluate(coeff_node, context=ctx)
 
 
+class _ParametricSol:
+    """The solution of a parameterised RCWA problem. Its readouts are **trace nodes** over the graph's
+    ``jno.np.parameter`` values (exactly like a parametric ``jno.fem`` solve), so ``rc.solve().efficiency``
+    composes into a differentiable loss with **no solve arguments** -- the parameters live in the
+    constraint list, and crux threads them. One traced layer, any solver."""
+
+    def __init__(self, problem, rpe):
+        self._p, self._rpe = problem, rpe
+
+    def _node(self, method, *args):
+        from jno.trace import FunctionCall
+
+        names = list(self._rpe)
+        exprs = [self._rpe[n] for n in names]
+
+        def fn(*values):  # crux threads the current parameter values in here
+            return getattr(self._p._solve_at(dict(zip(names, values))), method)(*args)
+
+        return FunctionCall(fn, exprs, name=f"rcwa_{method}")
+
+    def efficiency(self, kind):
+        return self._node("efficiency", kind)
+
+    def order(self, m, n):
+        return self._node("order", m, n)
+
+    def field(self, *a, **k):
+        raise RcwaError(
+            "field() on a parameterised solve is not a scalar readout; reconstruct it at concrete values "
+            "with rc.solve(params={...}).field(...)."
+        )
+
+
 class _RcwaProblem:
     """An RCWA problem inferred from a jNO constraint list / FEM problem. Holds the inferred
     :class:`RcwaSpec` and builds the fmmax engine on :meth:`solve`."""
 
-    def __init__(self, spec, orders, formulation="JONES_DIRECT_FOURIER", resample=None):
+    def __init__(self, spec, orders, formulation="JONES_DIRECT_FOURIER", resample=None, rpe=None):
         self.spec = spec
         self.orders = orders
         self.formulation = formulation
-        self._resample = resample  # params -> [(thickness, eps_grid), ...]  (jax; for differentiable solves)
+        self._resample = resample  # params -> ([(thickness, eps_grid), ...], wavelength)  (jax)
+        self._rpe = rpe or {}  # {name: parameter-expr} for the trainable parameters in the graph
 
     def __repr__(self):
-        return f"_RcwaProblem(orders={self.orders}, {self.spec!r})"
+        return f"_RcwaProblem(orders={self.orders}, params={sorted(self._rpe)}, {self.spec!r})"
 
     def _engine(self):
         return Rcwa(
@@ -671,18 +705,29 @@ class _RcwaProblem:
             assume_periodic=True,
         )
 
+    def _solve_at(self, params):
+        """Concrete solve at explicit parameter values (JAX) -- re-derives eps AND wavelength from them."""
+        eng = self._engine()
+        if not params or self._resample is None:
+            return eng.solve()
+        layers, wl = self._resample(params)
+        return eng.solve(layers=layers, wavelength=wl)
+
     def solve(self, params=None, wavelength=None, k_in=None):
-        """Build the fmmax engine and solve.
+        """Solve.
 
-        Pass ``params={name: value}`` (JAX values for the trainable ``jno.np.parameter`` coefficients) to
-        get a **differentiable** solve: the permittivity AND the wavelength are re-derived from those
-        values and the whole modal solve traces, so ``jax.grad`` of a ``sol.efficiency(...)`` objective
-        flows to the design.
+        The jNO way (**no arguments**): if the constraint list carries ``jno.np.parameter`` coefficients
+        (ε, wavelength, ...), ``rc.solve()`` returns a solution whose ``.efficiency(...)`` / ``.order(...)``
+        are **trace nodes over those parameters** -- differentiable through crux with no solve args, so
+        the exact same parameterised constraint list is differentiable whether you hand it to ``jno.fem``
+        or ``jno.rcwa``. A parameter-free problem solves eagerly and returns concrete readouts.
 
-        Pass ``wavelength`` to override the inferred one -- sweep it for a **broadband / dispersion**
-        response. Pass ``k_in=(kx, ky)`` to set the transverse wavevector -- sweep it for an
-        **angle-resolved** response. Both are differentiable (``jax.grad`` in wavelength / incidence angle
-        flows too)."""
+        Escape hatches for a *forward sweep* (not the traced/optimised path): ``params={name: value}`` for
+        a concrete solve at explicit values, or ``wavelength`` / ``k_in`` to override those directly."""
+        if params is None and wavelength is None and k_in is None:
+            if self._rpe and self._resample is not None:
+                return _ParametricSol(self, self._rpe)  # parametric -> trace node (crux-differentiable)
+            return self._engine().solve()  # parameter-free -> eager concrete
         eng = self._engine()
         if params is None:
             return eng.solve(wavelength=wavelength, k_in=k_in)
@@ -692,7 +737,7 @@ class _RcwaProblem:
                 "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
                 "permittivity; differentiable nodal re-sampling is not implemented yet."
             )
-        layers, wl = self._resample(params)  # eps AND wavelength re-derived from the parameters
+        layers, wl = self._resample(params)
         return eng.solve(layers=layers, wavelength=wavelength if wavelength is not None else wl, k_in=k_in)
 
 
@@ -793,6 +838,15 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
                 out.append((thick, jnp.real(cvals) / (k0 * k0)))
             return out, 2 * jnp.pi / k0
 
+    # the trainable jno.np.parameter(s) the permittivity depends on -> solve() returns trace nodes over
+    # them (crux threads the values), so the parameterised constraint list is differentiable with no solve
+    # args -- the same way jno.fem would differentiate it. (Collected from the bare coefficient tree; the
+    # ScalarView-wrapped raw constraints aren't traversed by the collector.)
+    from jno.utils.solver.parametric_helpers import _collect_runtime_parameter_exprs
+
+    rpe = {}
+    _collect_runtime_parameter_exprs(coeff_node, rpe)
+
     spec = RcwaSpec(
         period=period,
         layers=layers,
@@ -802,4 +856,4 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         ambient_faces=(bottom, top),
         periodic_axes=axes,
     )
-    return _RcwaProblem(spec, orders=orders, formulation=formulation, resample=resample)
+    return _RcwaProblem(spec, orders=orders, formulation=formulation, resample=resample, rpe=rpe)

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -788,11 +788,10 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
             coeff_nodes = coeff_nodes.real.astype(complex)
         C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range)
-        zmids = None  # nodal-field path: no analytic re-sampling closure (differentiable solve unsupported)
     else:  # analytic permittivity -> sample the grid exactly
         C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range, cparams)
     coeff_layers = detect_layers(C, zs, slices=slices)
-    zmids = detect_layers.last_zmid if not _has_nodal_field(coeff_node) else None
+    zmids = list(detect_layers.last_zmid)  # representative z of each layer (both paths) -> re-sampling
 
     face_z, k_in = _source_kin(femobj, domain, cparams)
     source_at_bottom = abs(face_z - _region_centroid(domain, bottom)[2]) < abs(face_z - _region_centroid(domain, top)[2])
@@ -801,8 +800,7 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     # orient so the incident (source-side) ambient is layers[0] = superstrate
     if not source_at_bottom:
         coeff_layers = list(reversed(coeff_layers))
-        if zmids is not None:
-            zmids = list(reversed(zmids))
+        zmids = list(reversed(zmids))
     # k0 from the superstrate (vacuum ⇒ coeff = k0^2), unless wavelength is given
     super_coeff = float(np.real(coeff_layers[0][1]).mean())
     if wavelength is not None:
@@ -816,27 +814,36 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     k0sq = k0 * k0
     layers = [(t, np.asarray(e) / k0sq) for t, e in coeff_layers]  # relative permittivity
 
-    # differentiable re-sampling: re-evaluate the analytic permittivity at each layer's representative z
-    # from a parameter dict, so a design (jno.np.parameter) flows through solve(params=...). Only for the
-    # analytic path (nodal-field re-sampling would need mesh interpolation -> deferred, raises in solve).
-    resample = None
-    if zmids is not None:
-        thicks = [t for t, _ in coeff_layers]
+    # differentiable re-sampling: re-evaluate the permittivity coefficient at each layer's representative z
+    # from a parameter dict, so a design (jno.np.parameter) flows through the solve. Re-deriving the WHOLE
+    # coefficient K0^2*eps handles an EPS/shape parameter (each layer's eps) AND a WAVELENGTH parameter
+    # (k0 = sqrt(coeff in the vacuum superstrate)) in one shot.
+    #
+    # A per-node (free-form / topology-optimisation) density field is interpolated to the RCWA grid by a
+    # precomputed node->grid NEAREST-index gather: the indices are fixed geometry, so ``rho_nodes[idx]`` is
+    # differentiable in the nodal density (the gradient flows to the selected nodes).
+    thicks = [t for t, _ in coeff_layers]
+    nodal_names = {
+        mc.model._parameter_name for mc in _model_calls(coeff_node) if getattr(mc.model, "_fem_field", None) == "node"
+    }
+    nearest = None
+    if nodal_names:
+        from scipy.spatial import cKDTree
 
-        def resample(params):
-            # Re-derive EVERYTHING RCWA reads from the (parameterized) permittivity coefficient K0^2*eps:
-            #   * k0 = sqrt(coeff in the vacuum superstrate)  -> a WAVELENGTH parameter flows here
-            #   * each layer's relative eps = coeff(z)/k0^2    -> an EPS/shape parameter flows here
-            # so a jno.np.parameter anywhere in the volume weak form is a differentiable knob.
-            sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), params)))
-            k0 = jnp.sqrt(sup)
-            out = []
-            for thick, zmid in zip(thicks, zmids):
-                cvals = jnp.reshape(
-                    _eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), params), (grid, grid)
-                )
-                out.append((thick, jnp.real(cvals) / (k0 * k0)))
-            return out, 2 * jnp.pi / k0
+        tree = cKDTree(np.asarray(domain.points))
+        nearest = [np.asarray(tree.query(_cell_grid_at_z(period, grid, zm))[1]) for zm in zmids]
+
+    def resample(params):
+        def at(li):  # parameter values for layer li: nodal fields gathered to the grid, scalars as-is
+            return {k: (jnp.asarray(v)[nearest[li]] if k in nodal_names else jnp.asarray(v)) for k, v in params.items()}
+
+        sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0))))
+        k0 = jnp.sqrt(sup)
+        out = []
+        for li, (thick, zmid) in enumerate(zip(thicks, zmids)):
+            cvals = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), at(li)), (grid, grid))
+            out.append((thick, jnp.real(cvals) / (k0 * k0)))
+        return out, 2 * jnp.pi / k0
 
     # the trainable jno.np.parameter(s) the permittivity depends on -> solve() returns trace nodes over
     # them (crux threads the values), so the parameterised constraint list is differentiable with no solve

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -185,6 +185,41 @@ class _Sol:
         )
         return (tf[i] + tf[i + self._nt]) / self._Pin
 
+    def jones(self, kind="T"):
+        """The 2×2 complex **Jones matrix** at the 0th diffraction order — how the structure maps incident
+        polarization to transmitted (``"T"``) or reflected (``"R"``) polarization.
+
+        ``J[q, p]`` is the 0th-order field amplitude in output polarization ``q`` for a unit-**power**
+        incident wave in input polarization ``p``, normalised so ``|J[q, p]|²`` is the (co- or cross-
+        polarised) power fraction and ``arg(J)`` carries the phase (a waveplate's retardation lives in the
+        phase difference between the two diagonal entries). The columns sum in power to the total efficiency:
+        ``sum_q |J[q, p]|² == efficiency(kind)`` for input ``p``. The two polarizations are fmmax's transverse
+        Jones basis — for the 0th order at normal incidence they are the two in-plane axes (≈ x, y); an
+        isotropic stack gives a diagonal ``J`` (no conversion), an in-plane-anisotropic one an off-diagonal
+        ``J`` (polarization conversion). Differentiable in the design. Returns a JAX ``(2, 2)`` array."""
+        fm, nt = self._fm, self._nt
+        if kind == "T":
+            smat, out_layer = self._s.s11, self._layers[-1]
+        elif kind == "R":
+            smat, out_layer = self._s.s21, self._layers[0]
+        else:
+            raise RcwaError(f"jones(kind): kind must be 'T' or 'R', got {kind!r}")
+        flux_in = jnp.abs(jnp.real(jnp.reshape(fm.eigenmode_poynting_flux(self._layers[0]), (-1,))))
+        flux_out = jnp.abs(jnp.real(jnp.reshape(fm.eigenmode_poynting_flux(out_layer), (-1,))))
+        # fmmax orders eigenmodes by eigenvalue, not by Fourier order — the 0th order's two polarizations are
+        # the two most-forward (largest-flux) ambient modes. The ambient is design-independent, so the two
+        # indices are fixed geometry (read eagerly); the amplitudes/normalisation stay JAX (differentiable).
+        order = np.argsort(-np.asarray(flux_in))
+        pa, pb = int(order[0]), int(order[1])
+        if _concrete(flux_in) and float(flux_in[pb]) <= 1e-9 * float(flux_in[pa] + 1e-30):
+            raise RcwaError("only one forward-propagating polarization at the 0th order; the Jones matrix is degenerate.")
+
+        def col(p):  # transmitted/reflected 0th-order amplitudes for a unit-power input in polarization p
+            amp = jnp.reshape(smat @ jnp.zeros((2 * nt, 1), complex).at[p, 0].set(1.0), (-1,))
+            return jnp.stack([amp[pa] * jnp.sqrt(flux_out[pa] / flux_in[p]), amp[pb] * jnp.sqrt(flux_out[pb] / flux_in[p])])
+
+        return jnp.stack([col(pa), col(pb)], axis=1)  # (out q, in p)
+
     def field(self, y_frac=0.5, nx=80, density=40.0):
         """Reconstruct the real-space electric field on a vertical (x–z) slice at ``y = y_frac·Py``.
 

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -273,7 +273,7 @@ class Rcwa:
                 "layer's eigenmodes and is never defaulted."
             )
         layers_spec = self.layers_spec if layers is None else layers
-        kin = np.asarray(self.k_in if k_in is None else k_in, float)
+        kin = jnp.asarray(self.k_in if k_in is None else k_in, float)  # jax -> incidence angle is differentiable
         lv = fm.LatticeVectors(u=np.array([self.period[0], 0.0]), v=np.array([0.0, self.period[1]]))
         ex = fm.generate_expansion(lv, approximate_num_terms=self.orders)
         nt = ex.num_terms
@@ -671,19 +671,21 @@ class _RcwaProblem:
             assume_periodic=True,
         )
 
-    def solve(self, params=None, wavelength=None):
+    def solve(self, params=None, wavelength=None, k_in=None):
         """Build the fmmax engine and solve.
 
         Pass ``params={name: value}`` (JAX values for the trainable ``jno.np.parameter`` coefficients) to
-        get a **differentiable** solve: the permittivity is re-sampled from those values and the whole
-        modal solve traces, so ``jax.grad`` of a ``sol.efficiency(...)`` objective flows to the design.
+        get a **differentiable** solve: the permittivity AND the wavelength are re-derived from those
+        values and the whole modal solve traces, so ``jax.grad`` of a ``sol.efficiency(...)`` objective
+        flows to the design.
 
         Pass ``wavelength`` to override the inferred one -- sweep it for a **broadband / dispersion**
-        response (the transverse wavevector ``k_in`` is held fixed, i.e. fixed-momentum dispersion). The
-        result is differentiable in the wavelength too."""
+        response. Pass ``k_in=(kx, ky)`` to set the transverse wavevector -- sweep it for an
+        **angle-resolved** response. Both are differentiable (``jax.grad`` in wavelength / incidence angle
+        flows too)."""
         eng = self._engine()
         if params is None:
-            return eng.solve(wavelength=wavelength)
+            return eng.solve(wavelength=wavelength, k_in=k_in)
         if self._resample is None:
             raise RcwaError(
                 "differentiable solve(params=...) needs the analytic re-sampling path, which is only built "
@@ -691,7 +693,7 @@ class _RcwaProblem:
                 "permittivity; differentiable nodal re-sampling is not implemented yet."
             )
         layers, wl = self._resample(params)  # eps AND wavelength re-derived from the parameters
-        return eng.solve(layers=layers, wavelength=wavelength if wavelength is not None else wl)
+        return eng.solve(layers=layers, wavelength=wavelength if wavelength is not None else wl, k_in=k_in)
 
 
 def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, params=None, formulation="JONES_DIRECT_FOURIER"):

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -498,17 +498,26 @@ def _volume_constraint(femobj):
 
 
 def _extract_permittivity_coeff(volume_term):
-    """Pull the value-channel (mass) coefficient ``K0**2 * eps`` out of a scalar Helmholtz volume term.
+    """Pull the value-channel (mass) coefficient ``K0**2 * eps`` out of a Helmholtz / Maxwell volume term.
 
-    A Helmholtz volume form is ``grad(u).grad(v) - K0**2 * eps * (u*v)``: the stiffness summands carry
-    trial/test inside ``Jacobian`` nodes, while the mass summand carries them as bare TrialFunction /
-    TestFunction values. We split additively, find the summand with bare trial x test, and drop those
-    two factors — what remains is ``K0**2 * eps``.
-    """
+    SCALAR Helmholtz ``grad(u).grad(v) - K0**2 * eps * (u*v)``: the stiffness summands carry trial/test
+    inside ``Jacobian`` nodes, the mass summand carries them as bare TrialFunction / TestFunction values.
+    VECTOR Maxwell ``inner(curl u, curl v) - K0**2 * eps * inner(u, v)``: the curl-curl summand carries
+    trial/test inside ``curl`` FunctionCalls, the mass summand as a bare ``inner(u, v)``. Either way we
+    split additively, find the mass summand, and drop the trial/test factor(s) — what remains is
+    ``K0**2 * eps`` (scalar ε only for now; anisotropic ε is a follow-on)."""
     import functools
     import operator
 
-    from jno.trace import TestFunction, TrialFunction
+    from jno.trace import FunctionCall, TestFunction, TrialFunction
+
+    def _bare_mass_inner(f):  # inner(u, v) with the trial & test *bare* (the vector Maxwell mass term)
+        if not (isinstance(f, FunctionCall) and getattr(f, "_name", None) == "inner" and len(f.args) == 2):
+            return False
+        a0, a1 = f.args
+        return (isinstance(a0, TrialFunction) and isinstance(a1, TestFunction)) or (
+            isinstance(a0, TestFunction) and isinstance(a1, TrialFunction)
+        )
 
     expr = getattr(volume_term, "expr", volume_term)
     mass = []
@@ -516,22 +525,24 @@ def _extract_permittivity_coeff(volume_term):
         fac = _mul_factors(summand)
         tv = [f for f in fac if isinstance(f, TrialFunction)]
         te = [f for f in fac if isinstance(f, TestFunction)]
-        if not (tv and te):
-            continue  # stiffness / other channel
-        for f in tv + te:
-            if getattr(f, "value_shape", ()) != ():
+        if tv and te:  # scalar Helmholtz mass: bare u * v
+            if any(getattr(f, "value_shape", ()) != () for f in tv + te):
                 raise RcwaError(
-                    "RCWA infers permittivity from a SCALAR Helmholtz term, but this field is "
-                    f"vector/tensor (value_shape={f.value_shape}). Scalar problems only for now."
+                    "RCWA sees a bare vector trial×test product; author the Maxwell mass as inner(u, v) "
+                    "(a vector curl-curl form) rather than a raw component product."
                 )
-        coeff_factors = [f for f in fac if not isinstance(f, (TrialFunction, TestFunction))]
+            coeff_factors = [f for f in fac if not isinstance(f, (TrialFunction, TestFunction))]
+        elif any(_bare_mass_inner(f) for f in fac):  # vector Maxwell mass: inner(u, v)
+            coeff_factors = [f for f in fac if not _bare_mass_inner(f)]
+        else:
+            continue  # stiffness / curl-curl / other channel
         if not coeff_factors:
             raise RcwaError("mass term has no coefficient factor; cannot recover permittivity.")
         mass.append(functools.reduce(operator.mul, coeff_factors))
     if not mass:
         raise RcwaError(
-            "could not find a K0^2*eps*(u*v) mass term in the volume weak form; RCWA needs a scalar "
-            "Helmholtz term. If the permittivity is authored unusually, isolate it as a named coefficient."
+            "could not find a K0^2*eps mass term in the volume weak form (scalar u*v or vector inner(u,v)); "
+            "RCWA needs a Helmholtz/Maxwell term. If ε is authored unusually, isolate it as a named coefficient."
         )
     return functools.reduce(operator.add, mass)
 
@@ -545,6 +556,12 @@ def _contains_trial(node):
     from jno.trace import TrialFunction
 
     return any(isinstance(n, TrialFunction) for n in _walk_nodes(node))
+
+
+def _contains_test(node):
+    from jno.trace import TestFunction
+
+    return any(isinstance(n, TestFunction) for n in _walk_nodes(node))
 
 
 def _product_terms(factors, sign=1):
@@ -569,12 +586,34 @@ def _extract_source_coeff(term):
     test factor, distribute the coefficient into additive terms, and keep those with no trial. Returns the
     source expression (an evaluable coefficient), or None if the term carries no forcing (e.g. a purely
     absorbing boundary ``-i k0 u v``)."""
-    from jno.trace import TestFunction
+    from jno.trace import FunctionCall, TestFunction
+
+    def _vector_load_source(f):  # a factor `inner(g, n×v)` (trial-free g) -> the source g; else None
+        if not (isinstance(f, FunctionCall) and getattr(f, "_name", None) == "inner" and len(f.args) == 2):
+            return None
+        a0, a1 = f.args
+
+        def _cross_test(x):
+            return isinstance(x, FunctionCall) and getattr(x, "_name", None) == "cross" and _contains_test(x)
+
+        if _cross_test(a0) and not (_contains_trial(a1) or _contains_test(a1)):
+            return a1
+        if _cross_test(a1) and not (_contains_trial(a0) or _contains_test(a0)):
+            return a0
+        return None
 
     expr = getattr(term, "expr", term)
     parts = []
     for tsign, summand in _add_split(expr):
         fac = _mul_factors(summand)
+        # vector Maxwell incident source: a factor inner(g, n×v); source = (other factors) · g
+        vinner = next((f for f in fac if _vector_load_source(f) is not None), None)
+        if vinner is not None:
+            part = _vector_load_source(vinner)
+            for cf in (f for f in fac if f is not vinner):
+                part = cf * part
+            parts.append((tsign, part))
+            continue
         if not any(isinstance(f, TestFunction) for f in fac):
             continue
         rest = [f for f in fac if not isinstance(f, TestFunction)]
@@ -592,14 +631,21 @@ def _extract_source_coeff(term):
 
 def _kin_from_source(src_coeff, period, z0, params):
     """Transverse wavevector k_in = ∇⊥(phase) of the incident wave, read from the source coefficient by a
-    small phase difference across the illuminated face -- differentiable in a source ANGLE parameter."""
+    small phase difference across the illuminated face -- differentiable in a source ANGLE parameter.
+
+    Works for a scalar source (Helmholtz) and a VECTOR source (Maxwell, ``inner(g, n×v)``): a plane wave is
+    ``E_inc·e^{i k⊥·r}``, so every component carries the same transverse phase — read it off the dominant
+    component (avoids the N1E edge-sign corruption that a b-based read suffers)."""
     dx, dy = period[0] * 1e-3, period[1] * 1e-3
     x0, y0 = period[0] * 0.5, period[1] * 0.5
-    base = _eval_coeff_points(src_coeff, np.array([[x0, y0, z0]]), params).reshape(())
-    sx = _eval_coeff_points(src_coeff, np.array([[x0 + dx, y0, z0]]), params).reshape(())
-    sy = _eval_coeff_points(src_coeff, np.array([[x0, y0 + dy, z0]]), params).reshape(())
-    kx = jnp.angle(sx / base) / dx
-    ky = jnp.angle(sy / base) / dy
+
+    def _ev(pt):
+        return jnp.reshape(_eval_coeff_points(src_coeff, np.array([pt]), params), (-1,))
+
+    base, sx, sy = _ev([x0, y0, z0]), _ev([x0 + dx, y0, z0]), _ev([x0, y0 + dy, z0])
+    i = jnp.argmax(jnp.abs(base))  # dominant component (index 0 for a scalar source)
+    kx = jnp.angle(sx[i] / base[i]) / dx
+    ky = jnp.angle(sy[i] / base[i]) / dy
     return jnp.stack([kx, ky])
 
 
@@ -640,6 +686,26 @@ def _sample_grid(domain, eps_nodes, grid, nz, period, z_range):
     return E, zs
 
 
+def _source_dof_coords(domain, n_dof):
+    """Coordinates the flat solution/forcing DOFs live on: mesh vertices for a nodal (Lagrange) field,
+    or edge midpoints for a Nédélec (N1E) edge field, whose DOFs are edges — so the source-face detection
+    reads the right positions for a vector Maxwell problem."""
+    pts = np.asarray(domain.points)
+    if n_dof == len(pts):
+        return pts  # nodal (scalar Helmholtz)
+    from jno.utils.solver.fem_topology import BASIX_TET_EDGES, BASIX_TRIANGLE_EDGES, build_edge_topology
+
+    dim = getattr(domain, "dimension", 3)
+    cells = np.asarray(domain.mesh.cells_dict["tetra" if dim == 3 else "triangle"])
+    topo = build_edge_topology(cells, BASIX_TET_EDGES if dim == 3 else BASIX_TRIANGLE_EDGES)
+    if topo.n_edges == n_dof:  # N1E edge DOFs -> edge midpoints
+        return pts[np.asarray(topo.edge_vertices)].mean(axis=1)
+    raise RcwaError(
+        f"cannot map the {n_dof} forcing DOFs to coordinates (mesh has {len(pts)} vertices, "
+        f"{topo.n_edges} edges); RCWA source-face detection supports nodal (Lagrange) and N1E fields."
+    )
+
+
 def _source_kin(femobj, domain, params=None):
     """Read the illuminated face and transverse wavevector k_in from the assembled forcing b.
     ``params`` overrides trainable-parameter values used when assembling (e.g. a K0/source parameter)."""
@@ -664,7 +730,7 @@ def _source_kin(femobj, domain, params=None):
             "no source/forcing found in the problem: nothing to illuminate the cell with. Author an "
             "incident wave (e.g. an inhomogeneous absorbing boundary carrying the incoming field)."
         )
-    pts = np.asarray(domain.points)
+    pts = _source_dof_coords(domain, len(b))
     zc = pts[nz, 2]
     face_z = np.median(zc)
     if np.ptp(zc) > 1e-6 * (pts[:, 2].max() - pts[:, 2].min() + 1e-30) + 1e-9:
@@ -929,6 +995,8 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         (sc for c in getattr(femobj, "_constraints", []) if (sc := _extract_source_coeff(c)) is not None), None
     )
     src_z = float(_region_centroid(domain, source_face)[2])
+    if src_coeff is not None:  # the source field's phase is the robust k_in (a b-based read is edge-sign-
+        k_in = tuple(float(x) for x in _kin_from_source(src_coeff, period, src_z, cparams))  # corrupted for N1E)
 
     def resample(params):
         def at(li):  # parameter values for layer li: nodal fields barycentrically interpolated, scalars as-is

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -134,9 +134,10 @@ def detect_layers(E, z, tol=1e-3, slices=None):
 # The forward engine (explicit layers) — the fmmax backend the front door constructs.
 # =====================================================================================
 class _Sol:
-    def __init__(self, fm, s, layers, expansion, nt, Pin, wavelength):
+    def __init__(self, fm, s, layers, expansion, nt, Pin, wavelength, thick=None, period=None):
         self._fm, self._s, self._layers, self._ex = fm, s, layers, expansion
         self._nt, self._Pin, self._wl = nt, Pin, wavelength
+        self._thick, self._period = thick, period
         self._fwd = np.zeros((2 * nt, 1), complex)
 
     def _flux(self, amps, layer, backward=False):
@@ -170,6 +171,29 @@ class _Sol:
             ).reshape(-1)
         )
         return float(tf[i] + tf[i + self._nt]) / self._Pin
+
+    def field(self, y_frac=0.5, nx=80, density=40.0):
+        """Reconstruct the real-space electric field on a vertical (x–z) slice at ``y = y_frac·Py``.
+
+        Returns ``(intensity, extent, layer_z)``: ``intensity`` = ``|E|²`` of shape ``(nz, nx)`` (z
+        vertical, x horizontal) for ``imshow``; ``extent`` = ``[0, Px, z_min, z_max]``; ``layer_z`` = the
+        z-interfaces between layers (to annotate the patterned slab). Needs the finite ambient
+        thickness recorded at solve time (semi-infinite ambients are shown as unit-thick slabs)."""
+        fm = self._fm
+        if self._thick is None:
+            raise RcwaError("field() needs the layer thicknesses; call .solve() (which records them).")
+        znum = [max(4, int(round(float(t) * density))) for t in self._thick]
+        smi = fm.stack_s_matrices_interior(self._layers, self._thick)
+        amps = fm.stack_amplitudes_interior(smi, self._fwd, np.zeros_like(self._fwd))
+        efield, _h, (x, y, z) = fm.stack_fields_3d(amps, self._layers, self._thick, znum, grid_shape=(nx, nx))
+        E = np.asarray(efield)  # (3, nx, ny, nz, 1)
+        inten = np.sum(np.abs(E) ** 2, axis=0)[..., 0]  # (nx, ny, nz)
+        yv = np.asarray(y)
+        j = int(np.argmin(np.abs(yv[0, :] - y_frac * self._period[1])))
+        slab = inten[:, j, :].T  # (nz, nx): z vertical, x horizontal
+        zc = np.asarray(z).reshape(-1)
+        layer_z = list(np.cumsum([float(t) for t in self._thick]))[:-1]
+        return slab, [0.0, float(self._period[0]), float(zc.min()), float(zc.max())], layer_z
 
 
 class Rcwa:
@@ -255,7 +279,7 @@ class Rcwa:
             raise RcwaError("no forward-propagating incident mode in the superstrate; check wavelength/period.")
         fwd = np.zeros((2 * nt, 1), complex)
         fwd[idx, 0] = 1.0
-        sol = _Sol(fm, s, layers, ex, nt, Pin, wl)
+        sol = _Sol(fm, s, layers, ex, nt, Pin, wl, thick=thick, period=self.period)
         sol._fwd = fwd
         T, R = sol.efficiency("T"), sol.efficiency("R")
         if not (np.isfinite(T) and np.isfinite(R)):

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -425,8 +425,10 @@ def _z_ambient_faces(domain):
     return bottom, top
 
 
-def _param_zeros(femobj, eps):
-    """{parameter_name: zeros(shape)} for every trainable parameter the operator references."""
+def _param_values(femobj, eps):
+    """{parameter_name: current value} for every trainable parameter the operator references. Uses the
+    parameter's *initialized* value (not zeros) so a parameter that is a physical constant -- e.g. K0 in
+    the source term -- doesn't vanish when the operator is assembled to read the source."""
     out = {}
     nodes = list(_model_calls(eps))
     for c in getattr(femobj, "_constraints", []):
@@ -436,9 +438,7 @@ def _param_zeros(femobj, eps):
         name = getattr(m, "_parameter_name", None)
         if name is None:
             continue
-        import jax.numpy as jnp
-
-        out[name] = jnp.zeros(m.module.value.shape, m.module.value.dtype)
+        out[name] = jnp.asarray(m.module.value)
     return out
 
 
@@ -541,25 +541,19 @@ def _has_nodal_field(node):
     return any(getattr(mc.model, "_fem_field", None) == "node" for mc in _model_calls(node))
 
 
-def _sample_grid_direct(coeff_node, grid, nz, period, z_range):
+def _sample_grid_direct(coeff_node, grid, nz, period, z_range, params=None):
     """Evaluate an analytic coefficient expression directly on the RCWA grid (exact, no mesh noise).
 
     Used when the permittivity is an analytic function of the coordinates (no per-node field); this
-    avoids the staircase/interp noise that makes z-slices look non-invariant on an unstructured mesh."""
-    import jax.numpy as jnp
-
-    from jno.trace import Variable
-    from jno.trace_evaluator import TraceEvaluator
-
+    avoids the staircase/interp noise that makes z-slices look non-invariant on an unstructured mesh.
+    ``params`` substitutes trainable-parameter values (so the eager structure/k0 inference uses valid
+    values, e.g. a K0 parameter)."""
     xs = np.linspace(0, period[0], grid, endpoint=False)
     ys = np.linspace(0, period[1], grid, endpoint=False)
     zs = np.linspace(z_range[0], z_range[1], nz)
     GX, GY, GZ = np.meshgrid(xs, ys, zs, indexing="ij")
-    pts = jnp.asarray(np.stack([GX.ravel(), GY.ravel(), GZ.ravel()], 1))
-    table = {mc.model.layer_id: mc.model.module for mc in _model_calls(coeff_node)}
-    tags = {v.tag for v in _walk_nodes(coeff_node) if isinstance(v, Variable)}
-    ctx = {t: pts for t in tags} if tags else {}
-    vals = np.asarray(TraceEvaluator(table).evaluate(coeff_node, context=ctx)).reshape(grid, grid, nz)
+    pts = np.stack([GX.ravel(), GY.ravel(), GZ.ravel()], 1)
+    vals = np.asarray(_eval_coeff_points(coeff_node, pts, params or {})).reshape(grid, grid, nz)
     return np.moveaxis(vals, 2, 0).astype(complex), zs  # -> (nz, grid, grid)
 
 
@@ -584,8 +578,9 @@ def _sample_grid(domain, eps_nodes, grid, nz, period, z_range):
     return E, zs
 
 
-def _source_kin(femobj, domain):
-    """Read the illuminated face and transverse wavevector k_in from the assembled forcing b."""
+def _source_kin(femobj, domain, params=None):
+    """Read the illuminated face and transverse wavevector k_in from the assembled forcing b.
+    ``params`` overrides trainable-parameter values used when assembling (e.g. a K0/source parameter)."""
     op = femobj.operator
     if not (isinstance(op, tuple) and len(op) == 2):
         raise RcwaError(
@@ -594,7 +589,8 @@ def _source_kin(femobj, domain):
         )
     opr, opi = op
     if hasattr(opr, "evaluate"):  # lazy (parametric) operator
-        pz = _param_zeros(femobj, femobj._constraints[0] if femobj._constraints else 0)
+        pz = _param_values(femobj, femobj._constraints[0] if femobj._constraints else 0)
+        pz.update({k: jnp.asarray(v) for k, v in (params or {}).items()})
         _, br = opr.evaluate(pz)
         _, bi = opi.evaluate(pz)
     else:  # eager (parameter-free) (A, b) legs
@@ -694,10 +690,11 @@ class _RcwaProblem:
                 "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
                 "permittivity; differentiable nodal re-sampling is not implemented yet."
             )
-        return eng.solve(layers=self._resample(params), wavelength=wavelength)
+        layers, wl = self._resample(params)  # eps AND wavelength re-derived from the parameters
+        return eng.solve(layers=layers, wavelength=wavelength if wavelength is not None else wl)
 
 
-def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formulation="JONES_DIRECT_FOURIER"):
+def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, params=None, formulation="JONES_DIRECT_FOURIER"):
     """Infer and build an RCWA problem from a jNO constraint list (or built ``FEM``).
 
     Everything is read out of the traced problem: **periodicity + period** (Floquet ties — absent ⇒
@@ -734,6 +731,11 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
 
     # permittivity coefficient K0^2 * eps, recovered from the volume weak form (no assembly, no eps arg)
     coeff_node = _extract_permittivity_coeff(_volume_constraint(femobj))
+    # construction-time parameter values: the trainable parameters' current values, overridden by any
+    # `params=` the caller supplied -- so the eager inference (structure, source, k0) uses valid values
+    # (e.g. a K0 parameter that must be non-zero for the source to exist).
+    cparams = _param_values(femobj, coeff_node)
+    cparams.update({k: jnp.asarray(v) for k, v in (params or {}).items()})
     if _has_nodal_field(coeff_node):  # per-node design field -> interpolate off the mesh
         coeff_nodes = _eval_expr_nodes(coeff_node, domain)
         if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
@@ -741,11 +743,11 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
         C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range)
         zmids = None  # nodal-field path: no analytic re-sampling closure (differentiable solve unsupported)
     else:  # analytic permittivity -> sample the grid exactly
-        C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range)
+        C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range, cparams)
     coeff_layers = detect_layers(C, zs, slices=slices)
     zmids = detect_layers.last_zmid if not _has_nodal_field(coeff_node) else None
 
-    face_z, k_in = _source_kin(femobj, domain)
+    face_z, k_in = _source_kin(femobj, domain, cparams)
     source_at_bottom = abs(face_z - _region_centroid(domain, bottom)[2]) < abs(face_z - _region_centroid(domain, top)[2])
     source_face = bottom if source_at_bottom else top
 
@@ -775,12 +777,19 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, formu
         thicks = [t for t, _ in coeff_layers]
 
         def resample(params):
+            # Re-derive EVERYTHING RCWA reads from the (parameterized) permittivity coefficient K0^2*eps:
+            #   * k0 = sqrt(coeff in the vacuum superstrate)  -> a WAVELENGTH parameter flows here
+            #   * each layer's relative eps = coeff(z)/k0^2    -> an EPS/shape parameter flows here
+            # so a jno.np.parameter anywhere in the volume weak form is a differentiable knob.
+            sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), params)))
+            k0 = jnp.sqrt(sup)
             out = []
             for thick, zmid in zip(thicks, zmids):
-                pts = _cell_grid_at_z(period, grid, zmid)
-                cvals = jnp.reshape(_eval_coeff_points(coeff_node, pts, params), (grid, grid))
-                out.append((thick, jnp.real(cvals) / k0sq))
-            return out
+                cvals = jnp.reshape(
+                    _eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), params), (grid, grid)
+                )
+                out.append((thick, jnp.real(cvals) / (k0 * k0)))
+            return out, 2 * jnp.pi / k0
 
     spec = RcwaSpec(
         period=period,

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -690,6 +690,31 @@ def _cell_grid_at_z(period, grid, z):
     return np.stack([gx.ravel(), gy.ravel(), np.full(grid * grid, z)], 1)
 
 
+def _bary_weights(node_coords, grid_pts):
+    """Precompute, for each grid point, the 4 containing-tetrahedron node ids and their **barycentric**
+    weights -- so ``rho_grid = sum_i w_i * rho[node_i]`` is a smooth, differentiable interpolation of the
+    nodal design onto the RCWA grid (points outside the mesh hull fall back to the nearest node)."""
+    from scipy.spatial import Delaunay, cKDTree
+
+    tri = Delaunay(node_coords)
+    m = len(grid_pts)
+    simplex = tri.find_simplex(grid_pts)
+    nodes = np.zeros((m, 4), np.int64)
+    w = np.zeros((m, 4), np.float64)
+    inside = simplex >= 0
+    if inside.any():
+        s = simplex[inside]
+        T = tri.transform[s]  # (k, 4, 3): [:3] inverse affine, [3] the last-vertex offset
+        b3 = np.einsum("kij,kj->ki", T[:, :3, :], grid_pts[inside] - T[:, 3, :])
+        nodes[inside] = tri.simplices[s]
+        w[inside] = np.c_[b3, 1.0 - b3.sum(axis=1)]
+    if (~inside).any():  # outside the convex hull -> nearest node (weight 1)
+        _, nn = cKDTree(node_coords).query(grid_pts[~inside])
+        nodes[~inside] = nn[:, None]
+        w[~inside, 0] = 1.0
+    return nodes, w
+
+
 def _eval_coeff_points(coeff_node, pts, params):
     """Evaluate the permittivity coefficient at ``pts``, substituting trainable parameters from
     ``params`` (jax values). Returns a JAX array -- differentiable in the design parameters."""
@@ -886,18 +911,17 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     # (k0 = sqrt(coeff in the vacuum superstrate)) in one shot.
     #
     # A per-node (free-form / topology-optimisation) density field is interpolated to the RCWA grid by a
-    # precomputed node->grid NEAREST-index gather: the indices are fixed geometry, so ``rho_nodes[idx]`` is
-    # differentiable in the nodal density (the gradient flows to the selected nodes).
+    # precomputed node->grid BARYCENTRIC interpolation: the (node ids, weights) are fixed geometry, so
+    # ``sum_i w_i * rho_nodes[id_i]`` is a smooth, differentiable interpolation of the nodal density onto the
+    # RCWA grid (gradient flows to the 4 containing-tet nodes, weighted -- not just the single nearest node).
     thicks = [t for t, _ in coeff_layers]
     nodal_names = {
         mc.model._parameter_name for mc in _model_calls(coeff_node) if getattr(mc.model, "_fem_field", None) == "node"
     }
-    nearest = None
+    bary = None
     if nodal_names:
-        from scipy.spatial import cKDTree
-
-        tree = cKDTree(np.asarray(domain.points))
-        nearest = [np.asarray(tree.query(_cell_grid_at_z(period, grid, zm))[1]) for zm in zmids]
+        nc = np.asarray(domain.points)
+        bary = [_bary_weights(nc, _cell_grid_at_z(period, grid, zm)) for zm in zmids]  # per layer: (ids, weights)
 
     # the illuminated boundary term's forcing -> lets an incidence-ANGLE parameter in the source flow
     # (its transverse phase gradient IS k_in); None when the source has no angle to read.
@@ -907,8 +931,12 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     src_z = float(_region_centroid(domain, source_face)[2])
 
     def resample(params):
-        def at(li):  # parameter values for layer li: nodal fields gathered to the grid, scalars as-is
-            return {k: (jnp.asarray(v)[nearest[li]] if k in nodal_names else jnp.asarray(v)) for k, v in params.items()}
+        def at(li):  # parameter values for layer li: nodal fields barycentrically interpolated, scalars as-is
+            def gather(v):
+                ids, w = bary[li]
+                return jnp.sum(jnp.asarray(w) * jnp.asarray(v).reshape(-1)[jnp.asarray(ids)], axis=1)
+
+            return {k: (gather(v) if k in nodal_names else jnp.asarray(v)) for k, v in params.items()}
 
         sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0))))
         k0 = jnp.sqrt(sup)

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -541,6 +541,68 @@ def _has_nodal_field(node):
     return any(getattr(mc.model, "_fem_field", None) == "node" for mc in _model_calls(node))
 
 
+def _contains_trial(node):
+    from jno.trace import TrialFunction
+
+    return any(isinstance(n, TrialFunction) for n in _walk_nodes(node))
+
+
+def _product_terms(factors, sign=1):
+    """Expand a product of factors (some of which may be additive sums) into signed additive terms."""
+    import functools
+    import operator
+
+    from jno.trace import BinaryOp
+
+    for i, f in enumerate(factors):
+        if isinstance(f, BinaryOp) and f.op in ("+", "-"):
+            rest = factors[:i] + factors[i + 1 :]
+            terms = []
+            for s2, summ in _add_split(f):
+                terms += _product_terms(rest + [summ], sign * s2)
+            return terms
+    return [(sign, functools.reduce(operator.mul, factors) if factors else 1.0)]
+
+
+def _extract_source_coeff(term):
+    """The trial-free (forcing) part of a boundary term ``coeff*v`` -- i.e. the incident wave. Peel the
+    test factor, distribute the coefficient into additive terms, and keep those with no trial. Returns the
+    source expression (an evaluable coefficient), or None if the term carries no forcing (e.g. a purely
+    absorbing boundary ``-i k0 u v``)."""
+    from jno.trace import TestFunction
+
+    expr = getattr(term, "expr", term)
+    parts = []
+    for tsign, summand in _add_split(expr):
+        fac = _mul_factors(summand)
+        if not any(isinstance(f, TestFunction) for f in fac):
+            continue
+        rest = [f for f in fac if not isinstance(f, TestFunction)]
+        for psign, part in _product_terms(rest, tsign):
+            if not _contains_trial(part):
+                parts.append((psign, part))
+    if not parts:
+        return None
+    total = None
+    for psign, part in parts:
+        t = part if psign > 0 else (-1.0) * part
+        total = t if total is None else total + t
+    return total
+
+
+def _kin_from_source(src_coeff, period, z0, params):
+    """Transverse wavevector k_in = ∇⊥(phase) of the incident wave, read from the source coefficient by a
+    small phase difference across the illuminated face -- differentiable in a source ANGLE parameter."""
+    dx, dy = period[0] * 1e-3, period[1] * 1e-3
+    x0, y0 = period[0] * 0.5, period[1] * 0.5
+    base = _eval_coeff_points(src_coeff, np.array([[x0, y0, z0]]), params).reshape(())
+    sx = _eval_coeff_points(src_coeff, np.array([[x0 + dx, y0, z0]]), params).reshape(())
+    sy = _eval_coeff_points(src_coeff, np.array([[x0, y0 + dy, z0]]), params).reshape(())
+    kx = jnp.angle(sx / base) / dx
+    ky = jnp.angle(sy / base) / dy
+    return jnp.stack([kx, ky])
+
+
 def _sample_grid_direct(coeff_node, grid, nz, period, z_range, params=None):
     """Evaluate an analytic coefficient expression directly on the RCWA grid (exact, no mesh noise).
 
@@ -706,12 +768,12 @@ class _RcwaProblem:
         )
 
     def _solve_at(self, params):
-        """Concrete solve at explicit parameter values (JAX) -- re-derives eps AND wavelength from them."""
+        """Concrete solve at explicit parameter values (JAX) -- re-derives eps, wavelength AND k_in."""
         eng = self._engine()
         if not params or self._resample is None:
             return eng.solve()
-        layers, wl = self._resample(params)
-        return eng.solve(layers=layers, wavelength=wl)
+        layers, wl, kin = self._resample(params)
+        return eng.solve(layers=layers, wavelength=wl, k_in=kin)
 
     def solve(self, params=None, wavelength=None, k_in=None):
         """Solve.
@@ -737,8 +799,12 @@ class _RcwaProblem:
                 "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
                 "permittivity; differentiable nodal re-sampling is not implemented yet."
             )
-        layers, wl = self._resample(params)
-        return eng.solve(layers=layers, wavelength=wavelength if wavelength is not None else wl, k_in=k_in)
+        layers, wl, kin = self._resample(params)
+        return eng.solve(
+            layers=layers,
+            wavelength=wavelength if wavelength is not None else wl,
+            k_in=k_in if k_in is not None else kin,
+        )
 
 
 def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, params=None, formulation="JONES_DIRECT_FOURIER"):
@@ -833,6 +899,13 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         tree = cKDTree(np.asarray(domain.points))
         nearest = [np.asarray(tree.query(_cell_grid_at_z(period, grid, zm))[1]) for zm in zmids]
 
+    # the illuminated boundary term's forcing -> lets an incidence-ANGLE parameter in the source flow
+    # (its transverse phase gradient IS k_in); None when the source has no angle to read.
+    src_coeff = next(
+        (sc for c in getattr(femobj, "_constraints", []) if (sc := _extract_source_coeff(c)) is not None), None
+    )
+    src_z = float(_region_centroid(domain, source_face)[2])
+
     def resample(params):
         def at(li):  # parameter values for layer li: nodal fields gathered to the grid, scalars as-is
             return {k: (jnp.asarray(v)[nearest[li]] if k in nodal_names else jnp.asarray(v)) for k, v in params.items()}
@@ -843,7 +916,8 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         for li, (thick, zmid) in enumerate(zip(thicks, zmids)):
             cvals = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), at(li)), (grid, grid))
             out.append((thick, jnp.real(cvals) / (k0 * k0)))
-        return out, 2 * jnp.pi / k0
+        kin = _kin_from_source(src_coeff, period, src_z, params) if src_coeff is not None else jnp.asarray(k_in)
+        return out, 2 * jnp.pi / k0, kin
 
     # the trainable jno.np.parameter(s) the permittivity depends on -> solve() returns trace nodes over
     # them (crux threads the values), so the parameterised constraint list is differentiable with no solve
@@ -852,7 +926,9 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     from jno.utils.solver.parametric_helpers import _collect_runtime_parameter_exprs
 
     rpe = {}
-    _collect_runtime_parameter_exprs(coeff_node, rpe)
+    _collect_runtime_parameter_exprs(coeff_node, rpe)  # eps / wavelength parameters
+    if src_coeff is not None:
+        _collect_runtime_parameter_exprs(src_coeff, rpe)  # an incidence-angle parameter in the source
 
     spec = RcwaSpec(
         period=period,

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -5,29 +5,36 @@ basis in-plane and solved by an eigenmode decomposition, then layers are stitche
 matrix. For **periodic, piecewise-z-invariant** structures — extruded metasurface pillars are the
 canonical case — this is far cheaper than a full 3-D volumetric solve.
 
-This is an **optional** jNO backend built on `fmmax` (a differentiable JAX Fourier Modal Method);
-`fmmax` is imported lazily so the core install stays lean. Install it with::
+Two entry points, both on `jno.rcwa`:
+
+* **From a jNO problem (the front door).** Hand it the same constraint list you would give
+  :func:`jno.fem` (or the already-built ``FEM``) together with the permittivity expression ``eps``;
+  RCWA reads the rest out of the traced problem::
+
+      rc  = jno.rcwa(constraints, eps, orders=300, wavelength=1.0)
+      sol = rc.solve()                     # period, layers, ambients, source, incidence all inferred
+      rc.spec                              # the inferred RcwaSpec (available without fmmax)
+
+  Inferred from the problem: **periodicity + period** (from the Floquet ties — absent ⇒ raise, never
+  assumed), the **super/substrate ambients** (the z-normal radiation faces), the **layer stack**
+  (``eps`` sampled along z, then :func:`detect_layers`), and the **incident wave** (illuminated face +
+  transverse angle ``k_in``, read from the assembled forcing). ``eps`` is passed explicitly because
+  isolating one coefficient sub-tree from an assembled weak form is not supported yet; ``wavelength``
+  is passed because a bare-float ``k0`` is not an identifiable node in the trace.
+
+* **Explicit layers (the backend).** :class:`Rcwa` takes a hand-built ``[(thickness, eps), ...]`` stack;
+  this is what the front door constructs internally.
+
+Built on `fmmax` (a differentiable JAX Fourier Modal Method), imported lazily so the core install stays
+lean. Enable with the ``rcwa`` extra::
 
     pip install jax-neural-operators[rcwa]      # or: pixi run -e rcwa ...
 
-Usage (forward engine — explicit layers)::
-
-    rc  = jno.rcwa([(inf, 1.0), (0.35, eps_xy), (inf, 2.1)], period=(0.6, 0.6), orders=300, wavelength=1.03)
-    sol = rc.solve(inc=None)     # inc = transverse incident field on the cell grid (None = normal plane wave)
-    sol.efficiency("T")          # transmitted / reflected power (0th order + all propagating orders)
-    sol.order(+1, 0)             # diffraction efficiency into a specific order
-
-Design rules honoured here:
- * Permittivity is passed, not an equation — the governing (Helmholtz) physics is implicit.
- * It **never fails silently**: every inference (periodicity, layer thickness, order/grid Nyquist,
-   wavelength, energy balance) is validated and raises :class:`RcwaError` with a concrete fix.
- * The two `fmmax` gotchas are baked in so callers never rediscover them: the Poynting flux is summed
-   *with sign* (an ``abs()`` sum over-counts and yields ``T+R>1``), and the ``JONES_DIRECT_FOURIER``
-   Fourier factorization is the default (the naive rule converges poorly for high-contrast dielectrics).
-
-Planned increment (needs the ``eps.at(coords)`` primitive): an ``eps``-driven front-end
-``jno.rcwa(eps, orders=...)`` that samples a jNO permittivity expression on a grid, auto-derives the
-layers, and threads the design gradient through — plus ``as_precond`` for ``fem.solve(precond=rc)``.
+It **never fails silently**: every inference (periodicity, layer invariance, order/grid Nyquist,
+wavelength, energy balance, a recognisable source) is validated and raises :class:`RcwaError` with a
+concrete fix. Two `fmmax` conventions are baked in: the Poynting flux is summed *with sign* (an
+``abs()`` sum over-counts and yields ``T+R>1``), and ``JONES_DIRECT_FOURIER`` is the default
+factorization (the naive rule converges poorly for high-contrast dielectrics such as a-Si).
 
 References:
  * M. G. Moharam & T. K. Gaylord, "Rigorous coupled-wave analysis of planar-grating diffraction",
@@ -36,6 +43,8 @@ References:
    transmittance matrix approach", J. Opt. Soc. Am. A 12, 1077 (1995).
  * fmmax: https://github.com/facebookresearch/fmmax
 """
+
+from dataclasses import dataclass, field
 
 import numpy as np
 
@@ -58,11 +67,78 @@ class RcwaError(ValueError):
     """Raised for any ill-posed RCWA problem — always loud, never a silent wrong answer."""
 
 
+# =====================================================================================
+# Layer auto-detection: group z-invariant slabs of a sampled permittivity into RCWA layers.
+# =====================================================================================
+def detect_layers(E, z, tol=1e-3, slices=None):
+    """Group a z-sampled permittivity into RCWA layers.
+
+    Parameters
+    ----------
+    E:
+        ``(Nz, Ng, Ng)`` permittivity sampled on the unit-cell grid at each height ``z``.
+    z:
+        ``(Nz,)`` ascending heights.
+    tol:
+        In-plane change below which two adjacent z-slices are the same material.
+    slices:
+        If given, staircase a continuously-varying ``eps`` into this many layers instead of raising.
+
+    Returns
+    -------
+    list[tuple[float, np.ndarray]]
+        ``[(thickness, eps_xy), ...]`` super→substrate; the two ambients have thickness ``inf``.
+
+    Raises
+    ------
+    RcwaError
+        If ``eps`` varies continuously in z and ``slices`` is None (RCWA needs invariant slabs).
+    """
+    Nz = len(z)
+    if E.shape[0] != Nz:
+        raise RcwaError(f"detect_layers: E has {E.shape[0]} z-slices but z has {Nz}.")
+    step = np.array([np.max(np.abs(E[k] - E[k - 1])) for k in range(1, Nz)])
+    boundary = step > tol
+    edges = [0] + [k for k in range(1, Nz) if boundary[k - 1]] + [Nz]
+    slabs = [(edges[i], edges[i + 1]) for i in range(len(edges) - 1)]
+
+    thin = sum((b - a) <= 2 for a, b in slabs)
+    if slices is None and len(slabs) > 4 and thin > 0.3 * len(slabs):
+        raise RcwaError(
+            f"eps varies continuously in z ({thin}/{len(slabs)} slabs are 1-cell thin) -> not "
+            f"layer-invariant. Pass slices=N to staircase it, or the geometry isn't RCWA-appropriate."
+        )
+    if slices is not None:
+        idx = np.linspace(0, Nz - 1, slices + 1).round().astype(int)
+        slabs = [(idx[i], idx[i + 1]) for i in range(len(idx) - 1)]
+
+    layers, report = [], []
+    for i, (a, b) in enumerate(slabs):
+        mid = (a + b) // 2
+        var = float(np.max(np.abs(E[a:b] - E[mid])))
+        if var > tol and slices is None:
+            raise RcwaError(
+                f"slab z=[{z[a]:.3f},{z[min(b, Nz - 1)]:.3f}] is not z-invariant (var={var:.2g}); pass slices=."
+            )
+        thick = np.inf if (i == 0 or i == len(slabs) - 1) else float(z[b - 1] - z[a])
+        eps_xy = E[mid]
+        kind = "uniform" if np.ptp(eps_xy) < tol else "patterned"
+        layers.append((thick, eps_xy))
+        report.append(
+            f"  layer {i}: z=[{z[a]:.3f},{z[min(b - 1, Nz - 1)]:.3f}] {kind} eps~[{eps_xy.min():.2f},{eps_xy.max():.2f}]"
+        )
+    detect_layers.last_report = "detected layers:\n" + "\n".join(report)
+    return layers
+
+
+# =====================================================================================
+# The forward engine (explicit layers) — the fmmax backend the front door constructs.
+# =====================================================================================
 class _Sol:
     def __init__(self, fm, s, layers, expansion, nt, Pin, wavelength):
         self._fm, self._s, self._layers, self._ex = fm, s, layers, expansion
         self._nt, self._Pin, self._wl = nt, Pin, wavelength
-        self._fwd = np.zeros((2 * nt, 1), complex)  # filled by solve()
+        self._fwd = np.zeros((2 * nt, 1), complex)
 
     def _flux(self, amps, layer, backward=False):
         f, b = self._fm.directional_poynting_flux(
@@ -70,10 +146,10 @@ class _Sol:
             amps if backward else np.zeros_like(amps),
             layer,
         )
-        return np.asarray(b if backward else f).reshape(-1)  # SIGNED (not abs) — energy-correct
+        return np.asarray(b if backward else f).reshape(-1)  # SIGNED — energy-correct
 
     def efficiency(self, kind):
-        """Total transmitted (``"T"``) or reflected (``"R"``) power fraction, summed over propagating orders."""
+        """Total transmitted (``"T"``) or reflected (``"R"``) power fraction over propagating orders."""
         if kind == "T":
             return float(np.sum(self._flux(self._s.s11 @ self._fwd, self._layers[-1]))) / self._Pin
         if kind == "R":
@@ -85,7 +161,7 @@ class _Sol:
         bc = np.asarray(self._ex.basis_coefficients)
         hit = np.where((bc[:, 0] == m) & (bc[:, 1] == n))[0]
         if len(hit) == 0:
-            raise RcwaError(f"order ({m},{n}) is outside the truncation ({self._nt} terms); raise orders= to include it.")
+            raise RcwaError(f"order ({m},{n}) is outside the truncation ({self._nt} terms); raise orders=.")
         i = int(hit[0])
         tf = np.abs(
             np.asarray(
@@ -98,45 +174,32 @@ class _Sol:
 
 
 class Rcwa:
-    """A periodic layered RCWA problem. Construct with the layer stack, period and truncation; call
-    :meth:`solve` with an incident field to obtain a :class:`_Sol`.
+    """A periodic layered RCWA problem with an **explicit** layer stack (the backend engine).
 
-    Parameters
-    ----------
-    layers:
-        Ordered ``[(thickness, eps), ...]`` from superstrate to substrate. ``thickness`` is a positive
-        float, or ``inf``/``None`` for the two semi-infinite ambient layers. ``eps`` is a scalar (uniform
-        layer) or a 2-D array sampled on the unit-cell grid (patterned layer).
-    period:
-        In-plane period ``(Px, Py)`` of the unit cell, both > 0.
-    orders:
-        Approximate number of Fourier terms (truncation). High-contrast dielectrics (e.g. a-Si) need
-        several hundred; low-contrast converge in tens.
-    wavelength:
-        Free-space wavelength (same length unit as ``period``/thicknesses). May be deferred to
-        :meth:`solve`. Never defaulted.
-    formulation:
-        `fmmax` Fourier-factorization rule; ``"JONES_DIRECT_FOURIER"`` (the default) is robust for
-        high-contrast structures.
-    assume_periodic:
-        RCWA solves an *infinitely periodic* in-plane problem. You must pass ``True`` to affirm the cell
-        is a genuine period/supercell — a finite aperture is not periodic and would be solved wrongly.
+    Most users reach this through :func:`jno.rcwa` with a problem list; construct it directly only when
+    you already have the ``[(thickness, eps), ...]`` stack, period and truncation in hand.
     """
 
     def __init__(
-        self, layers, *, period, orders, wavelength=None, formulation="JONES_DIRECT_FOURIER", assume_periodic=False
+        self,
+        layers,
+        *,
+        period,
+        orders,
+        wavelength=None,
+        k_in=(0.0, 0.0),
+        formulation="JONES_DIRECT_FOURIER",
+        assume_periodic=False,
     ):
         fm = _fmmax()
-        # --- guard: periodicity is an ASSUMPTION, not a fact ---
         if period is None or len(period) != 2 or period[0] <= 0 or period[1] <= 0:
             raise RcwaError(f"period must be (Px,Py) > 0, got {period!r}.")
         if not assume_periodic:
             raise RcwaError(
                 "RCWA is periodic in-plane. If your cell is genuinely a period/supercell, pass "
-                "assume_periodic=True. A finite aperture with absorbing side walls is NOT periodic — "
-                "RCWA would silently solve the wrong (periodic) problem."
+                "assume_periodic=True. (The jno.rcwa front door sets this only after confirming the "
+                "problem has Floquet ties.)"
             )
-        # --- guard: layers well-formed ---
         if not layers:
             raise RcwaError("layers is empty: need at least [superstrate, ..., substrate].")
         for k, (t, e) in enumerate(layers):
@@ -145,7 +208,6 @@ class Rcwa:
             eg = np.asarray(e)
             if eg.ndim == 2 and (eg.shape[0] < 4 or eg.shape[1] < 4):
                 raise RcwaError(f"layer {k} eps grid {eg.shape} is too coarse to rasterize; sample it finer.")
-        # --- guard: patterned grids must resolve the requested orders (Nyquist); uniform layers need none ---
         grids = [np.asarray(e).shape[0] for _, e in layers if np.asarray(e).ndim == 2]
         if grids:
             ng = min(grids)
@@ -156,30 +218,30 @@ class Rcwa:
                     f"need >= {2 * per_axis} grid points/axis or fewer orders."
                 )
         self.fm, self.layers_spec, self.period = fm, layers, period
-        self.orders, self.wavelength = orders, wavelength
+        self.orders, self.wavelength, self.k_in = orders, wavelength, tuple(k_in)
         self.formulation = fm.Formulation[formulation]
         self.assume_periodic = True
 
-    def solve(self, inc=None, wavelength=None):
-        """Solve the stack for an incident field ``inc`` (``None`` = a normal-incidence plane wave) and
-        return a :class:`_Sol`. Raises if the wavelength is unknown or energy is not conserved."""
+    def solve(self, inc=None, wavelength=None, k_in=None):
+        """Solve the stack and return a :class:`_Sol`. Raises if the wavelength is unknown or energy
+        is not conserved."""
         fm = self.fm
         wl = wavelength if wavelength is not None else self.wavelength
         if wl is None:
             raise RcwaError(
-                "wavelength is unknown: pass wavelength= to solve() (or at construction). "
-                "It sets every layer's eigenmodes and is never defaulted."
+                "wavelength is unknown: pass wavelength= to solve() or at construction; it sets every "
+                "layer's eigenmodes and is never defaulted."
             )
+        kin = np.asarray(self.k_in if k_in is None else k_in, float)
         lv = fm.LatticeVectors(u=np.array([self.period[0], 0.0]), v=np.array([0.0, self.period[1]]))
         ex = fm.generate_expansion(lv, approximate_num_terms=self.orders)
         nt = ex.num_terms
-        k_in = np.zeros(2)
 
         def solve_layer(e):
             eg = np.asarray(e) + 0j
             if eg.ndim == 0:
                 eg = np.full((1, 1), eg)
-            return fm.eigensolve_isotropic_media(np.asarray(wl), k_in, lv, eg, ex, formulation=self.formulation)
+            return fm.eigensolve_isotropic_media(np.asarray(wl), kin, lv, eg, ex, formulation=self.formulation)
 
         layers = [solve_layer(e) for _, e in self.layers_spec]
         thick = [np.asarray(1.0 if t is None or t == np.inf else t) for t, _ in self.layers_spec]
@@ -189,7 +251,6 @@ class Rcwa:
         Pin = float(np.sum(np.asarray(fm.directional_poynting_flux(fwd, np.zeros_like(fwd), layers[0])[0])))
         sol = _Sol(fm, s, layers, ex, nt, Pin, wl)
         sol._fwd = fwd
-        # --- guard: energy balance (lossless => T+R==1). A violation = non-convergence or a bug. ---
         T, R = sol.efficiency("T"), sol.efficiency("R")
         if T + R > 1.0 + 5e-3:
             raise RcwaError(
@@ -198,28 +259,293 @@ class Rcwa:
             )
         return sol
 
-    def as_precond(self, transfer=None):
-        """Return a :mod:`jno.precond` spec applying this (background) RCWA as ``M⁻¹ = A₀⁻¹``.
 
-        The FEM↔grid ``transfer`` (rasterize the residual to the RCWA grid, interpolate the background
-        field back to FEM nodes) is a planned increment; without it this raises rather than silently
-        returning a no-op preconditioner.
-        """
-        rc = self
+# =====================================================================================
+# Front door: infer an RCWA problem from a jNO constraint list / FEM problem + eps.
+# =====================================================================================
+@dataclass
+class RcwaSpec:
+    """Everything the RCWA engine needs, inferred from a jNO problem. Inspectable without fmmax."""
 
-        class _Spec:
-            def materialize(self, ctx):
-                if transfer is None:
-                    raise RcwaError(
-                        "as_precond needs a FEM<->grid transfer operator (rasterize residual to the RCWA "
-                        "grid, interpolate the background field back to FEM nodes). Not yet wired."
-                    )
-                raise NotImplementedError("transfer wiring is a planned increment (see jno.rcwa module docstring).")
+    period: tuple
+    layers: list  # [(thickness, eps_xy), ...]
+    wavelength: float
+    k_in: tuple = (0.0, 0.0)
+    source_face: str = ""
+    ambient_faces: tuple = ()
+    periodic_axes: dict = field(default_factory=dict)
 
-        _ = rc
-        return _Spec()
+    def __repr__(self):
+        return (
+            f"RcwaSpec(period={tuple(round(p, 4) for p in self.period)}, layers={len(self.layers)}, "
+            f"wavelength={self.wavelength}, k_in={tuple(round(k, 4) for k in self.k_in)}, "
+            f"source_face={self.source_face!r})"
+        )
 
 
-def rcwa(layers, *, period, orders, wavelength=None, **kw):
-    """Build an :class:`Rcwa` problem — the functional entry point (see :class:`Rcwa` for the arguments)."""
-    return Rcwa(layers, period=period, orders=orders, wavelength=wavelength, **kw)
+def _walk_nodes(node):
+    from jno._fem import _walk
+
+    return _walk(node)
+
+
+def _model_calls(node):
+    return [nd for nd in _walk_nodes(node) if type(nd).__name__ == "ModelCall"]
+
+
+def _as_fem(problem):
+    """Accept a constraint list or a built FEM; return the FEM object."""
+    from jno._fem import FEM
+    from jno._fem import fem as _fem
+
+    if isinstance(problem, FEM):
+        return problem
+    if isinstance(problem, (list, tuple)):
+        return _fem(list(problem))
+    raise RcwaError(
+        "jno.rcwa(problem, ...): problem must be the constraint list you'd pass to jno.fem, or a built "
+        f"FEM object; got {type(problem).__name__}."
+    )
+
+
+def _region_centroid(domain, tag):
+    br = getattr(domain, "_boundary_regions", {}).get(tag)
+    if br is None or len(getattr(br, "points", [])) == 0:
+        raise RcwaError(f"boundary region {tag!r} has no points; cannot locate it.")
+    return np.asarray(br.points).mean(0)
+
+
+def _periodic_period(femobj, domain):
+    """Recover {axis: (tagA, tagB)} and (Px, Py) from the Floquet ties. Raise if not periodic in x and y."""
+    from jno._fem import _periodic_tie_spec
+
+    ties = []
+    for c in getattr(femobj, "_constraints", []):
+        spec = _periodic_tie_spec(c, domain)
+        if spec is not None:
+            ties.append((spec[0], spec[1]))  # (master, slave) tags
+    if not ties:
+        raise RcwaError(
+            "no Floquet/periodic ties found: RCWA solves an infinitely periodic cell. Author the "
+            "in-plane boundaries as periodic ties (u(left)-u(right), u(front)-u(back)); a finite "
+            "aperture with absorbing side walls is NOT periodic and cannot be solved by RCWA."
+        )
+    axes, period = {}, {}
+    for a, b in ties:
+        ca, cb = _region_centroid(domain, a), _region_centroid(domain, b)
+        d = cb - ca
+        ax = int(np.argmax(np.abs(d)))  # dominant separation axis: 0=x, 1=y
+        axes["xyz"[ax]] = (a, b)
+        period["xyz"[ax]] = float(abs(d[ax]))
+    if "x" not in period or "y" not in period:
+        raise RcwaError(
+            f"RCWA needs periodicity in BOTH x and y; found ties only along {sorted(period)}. Add the missing periodic tie."
+        )
+    return axes, (period["x"], period["y"])
+
+
+def _z_ambient_faces(domain):
+    """The two z-normal radiation faces (bottom, top), by z-extent of the boundary-region centroids."""
+    pts = np.asarray(domain.points)
+    zmin, zmax = float(pts[:, 2].min()), float(pts[:, 2].max())
+    normals = getattr(domain, "normals_by_tag", {})
+    bottom = top = None
+    for tag, br in getattr(domain, "_boundary_regions", {}).items():
+        if tag == "boundary" or br is None or len(getattr(br, "points", [])) == 0:
+            continue
+        nrm = np.asarray(normals.get(tag, np.zeros((1, 3)))).mean(0)
+        if abs(nrm[2]) < 0.8 * (np.linalg.norm(nrm) + 1e-30):
+            continue  # not a z-normal face
+        cz = np.asarray(br.points)[:, 2].mean()
+        if abs(cz - zmin) < abs(cz - zmax):
+            bottom = tag
+        else:
+            top = tag
+    if bottom is None or top is None:
+        raise RcwaError(
+            "could not identify the two z-normal ambient faces (superstrate/substrate). Tag the top and "
+            "bottom faces of the cell so RCWA can place the ambients."
+        )
+    return bottom, top
+
+
+def _param_zeros(femobj, eps):
+    """{parameter_name: zeros(shape)} for every trainable parameter the operator references."""
+    out = {}
+    nodes = list(_model_calls(eps))
+    for c in getattr(femobj, "_constraints", []):
+        nodes += _model_calls(c)
+    for mc in nodes:
+        m = getattr(mc, "model", None)
+        name = getattr(m, "_parameter_name", None)
+        if name is None:
+            continue
+        import jax.numpy as jnp
+
+        out[name] = jnp.zeros(m.module.value.shape, m.module.value.dtype)
+    return out
+
+
+def _eval_eps_nodes(eps, domain, params):
+    """Evaluate the eps expression at every mesh node (where nodal parameters align)."""
+    import jax.numpy as jnp
+
+    from jno.trace import Variable
+    from jno.trace_evaluator import TraceEvaluator
+
+    node_coords = jnp.asarray(np.asarray(domain.points))
+    table = {}
+    for mc in _model_calls(eps):
+        m = mc.model
+        mod = m.module
+        name = getattr(m, "_parameter_name", None)
+        if name is not None and name in params:
+            import equinox as eqx
+
+            mod = eqx.tree_at(lambda mm: mm.value, mod, jnp.asarray(params[name]))
+        table[m.layer_id] = mod
+    tags = {v.tag for v in _walk_nodes(eps) if isinstance(v, Variable)}
+    ctx = {t: node_coords for t in tags} if tags else {}
+    return np.asarray(TraceEvaluator(table).evaluate(eps, context=ctx)).reshape(-1)
+
+
+def _sample_grid(domain, eps_nodes, grid, nz, period, z_range):
+    """Interpolate nodal eps onto an (nz, grid, grid) unit-cell array over the z-extent."""
+    from scipy.interpolate import griddata
+
+    pts = np.asarray(domain.points)
+    xs = np.linspace(0, period[0], grid, endpoint=False)
+    ys = np.linspace(0, period[1], grid, endpoint=False)
+    zs = np.linspace(z_range[0], z_range[1], nz)
+    GX, GY = np.meshgrid(xs, ys, indexing="ij")
+    E = np.empty((nz, grid, grid), complex)
+    for k, zz in enumerate(zs):
+        sel = np.abs(pts[:, 2] - zz) < (z_range[1] - z_range[0]) / (nz - 1) * 0.75 + 1e-9
+        if sel.sum() < 3:
+            j = np.argsort(np.abs(pts[:, 2] - zz))[: max(3, grid)]
+            sel = np.zeros(len(pts), bool)
+            sel[j] = True
+        vals = griddata(pts[sel][:, :2], eps_nodes[sel], (GX, GY), method="nearest")
+        E[k] = vals
+    return E, zs
+
+
+def _source_kin(femobj, domain):
+    """Read the illuminated face and transverse wavevector k_in from the assembled forcing b."""
+    op = femobj.operator
+    if not (isinstance(op, tuple) and len(op) == 2):
+        raise RcwaError(
+            "jno.rcwa expects a complex (time-harmonic) Helmholtz problem: fem.operator did not return a "
+            "(real, imag) operator pair. Author the field with complex=True."
+        )
+    opr, opi = op
+    pz = _param_zeros(femobj, femobj._constraints[0] if femobj._constraints else 0)
+    _, br = opr.evaluate(pz)
+    _, bi = opi.evaluate(pz)
+    b = np.asarray(br).reshape(-1) + 1j * np.asarray(bi).reshape(-1)
+    nz = np.where(np.abs(b) > 1e-9 * (np.abs(b).max() + 1e-30))[0]
+    if len(nz) == 0:
+        raise RcwaError(
+            "no source/forcing found in the problem: nothing to illuminate the cell with. Author an "
+            "incident wave (e.g. an inhomogeneous absorbing boundary carrying the incoming field)."
+        )
+    pts = np.asarray(domain.points)
+    zc = pts[nz, 2]
+    face_z = np.median(zc)
+    if np.ptp(zc) > 1e-6 * (pts[:, 2].max() - pts[:, 2].min() + 1e-30) + 1e-9:
+        raise RcwaError(
+            f"the forcing is spread over a z-range [{zc.min():.3g},{zc.max():.3g}], not a single "
+            f"illuminated face; RCWA needs the incident wave on one ambient face."
+        )
+    # transverse angle from the phase gradient of b across the lit face
+    xy = pts[nz, :2]
+    phase = np.unwrap(np.angle(b[nz]))
+    A = np.c_[xy, np.ones(len(xy))]
+    (kx, ky, _), *_ = np.linalg.lstsq(A, phase, rcond=None)
+    k_in = (float(kx), float(ky))
+    if abs(kx) < 1e-6 and abs(ky) < 1e-6:
+        k_in = (0.0, 0.0)
+    return face_z, k_in
+
+
+class _RcwaProblem:
+    """An RCWA problem inferred from a jNO constraint list / FEM problem. Holds the inferred
+    :class:`RcwaSpec` and builds the fmmax engine on :meth:`solve`."""
+
+    def __init__(self, spec, orders, formulation="JONES_DIRECT_FOURIER"):
+        self.spec = spec
+        self.orders = orders
+        self.formulation = formulation
+
+    def __repr__(self):
+        return f"_RcwaProblem(orders={self.orders}, {self.spec!r})"
+
+    def solve(self):
+        """Build the fmmax engine from the inferred spec and solve (needs the fmmax backend)."""
+        eng = Rcwa(
+            self.spec.layers,
+            period=self.spec.period,
+            orders=self.orders,
+            wavelength=self.spec.wavelength,
+            k_in=self.spec.k_in,
+            formulation=self.formulation,
+            assume_periodic=True,
+        )
+        return eng.solve()
+
+
+def rcwa(problem, eps, *, orders, wavelength, grid=64, nz=64, slices=None, formulation="JONES_DIRECT_FOURIER"):
+    """Infer and build an RCWA problem from a jNO constraint list (or built ``FEM``) plus ``eps``.
+
+    Parameters
+    ----------
+    problem:
+        The same constraint list you would pass to :func:`jno.fem`, or an already-built ``FEM``.
+    eps:
+        The permittivity expression (the traced coefficient, may depend on a trainable parameter).
+    orders:
+        Fourier truncation for the modal solve.
+    wavelength:
+        Free-space wavelength (same length unit as the geometry). Passed explicitly — a bare-float
+        ``k0`` is not an identifiable node in the trace.
+    grid, nz:
+        Transverse resolution and number of z-samples used to detect the layer stack.
+    slices:
+        Staircase a continuously-varying ``eps`` into this many layers instead of raising.
+
+    Returns
+    -------
+    _RcwaProblem
+        Holds the inferred :class:`RcwaSpec` (``.spec``) and a :meth:`~_RcwaProblem.solve`.
+    """
+    femobj = _as_fem(problem)
+    domain = femobj.domain
+    axes, period = _periodic_period(femobj, domain)
+    bottom, top = _z_ambient_faces(domain)
+    pts = np.asarray(domain.points)
+    z_range = (float(pts[:, 2].min()), float(pts[:, 2].max()))
+
+    params = _param_zeros(femobj, eps)
+    eps_nodes = _eval_eps_nodes(eps, domain, params)
+    if np.iscomplexobj(eps_nodes) and np.max(np.abs(eps_nodes.imag)) < 1e-9:
+        eps_nodes = eps_nodes.real.astype(complex)
+    E, zs = _sample_grid(domain, eps_nodes, grid, nz, period, z_range)
+    layers = detect_layers(E, zs, slices=slices)
+
+    face_z, k_in = _source_kin(femobj, domain)
+    source_face = (
+        bottom
+        if abs(face_z - _region_centroid(domain, bottom)[2]) < abs(face_z - _region_centroid(domain, top)[2])
+        else top
+    )
+
+    spec = RcwaSpec(
+        period=period,
+        layers=layers,
+        wavelength=float(wavelength),
+        k_in=k_in,
+        source_face=source_face,
+        ambient_faces=(bottom, top),
+        periodic_axes=axes,
+    )
+    return _RcwaProblem(spec, orders=orders, formulation=formulation)

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -517,13 +517,41 @@ def assemble_fem_nonnodal(
 
     # --- BCs computed once, separate from per-mode application: the natural BC (p_D·(v·n)) is a constant
     #     RHS load; the essential edge-trace BC is a set of (dof, value) pins (mirrors 1D Dirichlet). ---
+    # A weak boundary term is either a LOAD (trial-free → into b) or a BILINEAR surface term (trial+test →
+    # into A). The only bilinear surface term wired is the N1E tangential-trace mass `c·inner(n×u, n×v)`
+    # (the impedance / first-order absorbing Maxwell BC): split it off and assemble it into the stiffness.
+    from ..._fem import _bare as _bare_nn
+
+    load_terms, surface_terms = {}, {}
+    for region, terms in (boundary_terms or {}).items():
+        for t in terms:
+            spec = _n1e_surface_mass_spec(_bare_nn(t))
+            if spec is not None:
+                surface_terms.setdefault(region, []).append(spec[0])
+            else:
+                load_terms.setdefault(region, []).append(t)
     nat_load = (
         _apply_natural_boundary_terms(
-            jnp.zeros(total), boundary_terms, domain, field_index, spaces, top, np.asarray(pts), offs, n_cells, quad_degree
+            jnp.zeros(total), load_terms, domain, field_index, spaces, top, np.asarray(pts), offs, n_cells, quad_degree
         )
-        if boundary_terms
+        if load_terms
         else jnp.zeros(total)
     )
+    # the tangential-trace surface mass added to A (steady linear only; unwired compositions raise below)
+    surf_mass = (
+        _assemble_n1e_surface_mass(total, surface_terms, domain, spaces, top, np.asarray(pts), offs, quad_degree, dim)
+        if surface_terms
+        else None
+    )
+    if surf_mass is not None:
+        _nonlinear = any(_is_obviously_nonlinear_in_unknown(domain, t) for t in volume_terms)
+        _transient = bool(ic_residuals) or any(_contains_temporal_derivative(t) for t in volume_terms)
+        if _transient or _nonlinear or runtime_parameter_tags or neural_param_names:
+            raise NotImplementedError(
+                "jno.fem (non-nodal): the N1E tangential-trace surface term (impedance / absorbing BC) is wired "
+                "for the steady linear forward problem only — not with a transient, nonlinear, or parametric/inverse "
+                "form. (Raises rather than silently dropping the surface contribution.)"
+            )
     pins = (
         _flux_bc_pins(flux_bcs, domain, field_index, spaces, top, np.asarray(pts), offs, n_cells, quad_degree, dim=dim)
         if flux_bcs
@@ -842,10 +870,131 @@ def assemble_fem_nonnodal(
 
     # --- steady linear (non-parametric): A u = b (byte-identical to before the refactor) ---
     A = jax.jacfwd(full_residual)(zeros)
+    if surf_mass is not None:  # add the tangential-trace surface mass (impedance / absorbing BC) to the stiffness
+        A = A + surf_mass
     b = -full_residual(zeros)
     if pins:
         A, b = _apply_dirichlet_symmetric(jnp.asarray(A), jnp.asarray(b), pins)
     return (A, b), "linear", offs
+
+
+def _n1e_surface_mass_spec(bare):
+    """Recognise a tangential-trace surface-mass boundary term ``[c *] inner(n×u, n×v)`` (the natural
+    N1E impedance / first-order absorbing BC for Maxwell) → a 1-tuple ``(coeff_node,)`` (``coeff_node``
+    is ``None`` when the coefficient is 1); ``None`` if the term is not of this form.
+
+    The tangential trace ``n×u`` is authored as ``u.vector.cross(nvec)`` (a ``cross`` FunctionCall over
+    the trial and the region normal), paired with the test's ``n×v`` inside an ``inner`` FunctionCall,
+    optionally scaled by a trial/test-free scalar coefficient (e.g. ``i·k₀``). Distinct from the
+    essential PEC ``n×u = 0`` (no test function → pinned, not assembled)."""
+    from ..._fem import _contains
+    from ...trace import BinaryOp, FunctionCall, Literal, TestFunction, TrialFunction
+
+    node, coeff = bare, None
+    wrap = None  # a `.real`/`.imag` wrapper from the complex leg split (Re/Im of `c·inner(n×u,n×v)`)
+    if isinstance(node, FunctionCall) and node._name in ("real", "imag") and len(node.args) == 1:
+        wrap, node = node._name, node.args[0]
+    if isinstance(node, BinaryOp) and node.op == "*":  # peel a leading/trailing scalar coefficient
+        left, right = node.left, node.right
+        l_uv = _contains(left, TrialFunction) or _contains(left, TestFunction)
+        r_uv = _contains(right, TrialFunction) or _contains(right, TestFunction)
+        if isinstance(right, FunctionCall) and right._name == "inner" and not l_uv:
+            coeff, node = left, right
+        elif isinstance(left, FunctionCall) and left._name == "inner" and not r_uv:
+            coeff, node = right, left
+    if not (isinstance(node, FunctionCall) and node._name == "inner" and len(node.args) == 2):
+        return None
+
+    def _is_cross(x, which):
+        return isinstance(x, FunctionCall) and x._name == "cross" and len(x.args) == 2 and _contains(x, which)
+
+    a0, a1 = node.args
+    ok = (_is_cross(a0, TrialFunction) and _is_cross(a1, TestFunction)) or (
+        _is_cross(a0, TestFunction) and _is_cross(a1, TrialFunction)
+    )
+    if not ok:
+        return None
+    if wrap is not None:  # fold the leg's Re/Im into the coefficient: Re(i·k₀)=0, Im(i·k₀)=k₀
+        base = coeff if coeff is not None else Literal(1.0)
+        coeff = base.real if wrap == "real" else base.imag
+    return (coeff,)
+
+
+def _assemble_n1e_surface_mass(total, surface_terms, domain, spaces, top, pts_np, offs, quad_degree, dim):
+    """Assemble the tangential-trace surface mass ``∑ ∫_Γ c (n×φ_a)·(n×φ_b) dS`` (N1E impedance /
+    absorbing BC) into a dense ``(total, total)`` matrix to ADD to the stiffness ``A``.
+
+    Integrates over the region's boundary faces (tet faces used by one cell): the N1E basis is tabulated
+    at reference face-quadrature points (per local face), covariant-Piola-pushed to each physical cell,
+    and the tangential projection ``(n×φ_a)·(n×φ_b) = φ_a·φ_b − (φ_a·n)(φ_b·n)`` is integrated with the
+    physical face measure. 3-D tets only (the 2-D H(curl) tangential trace is a scalar, not yet wired)."""
+    import basix
+    from basix import CellType, ElementFamily
+
+    from ..._fem import _eval_value_node_at
+    from .fem_1d import _region_node_ids
+    from .fem_elements import piola_covariant
+    from .fem_facets import _LOCAL_FACES_TET, build_facet_connectivity
+
+    if dim != 3:
+        raise NotImplementedError(
+            "jno.fem (non-nodal): the tangential-trace surface term `inner(n×u, n×v)` (impedance / absorbing "
+            "BC) is wired for 3-D N1E (Maxwell) only — the 2-D H(curl) tangential trace is a scalar u·t, not yet wired."
+        )
+    fidx = next((i for i, s in enumerate(spaces) if s == "N1E"), None)
+    if fidx is None:
+        raise NotImplementedError(
+            "jno.fem (non-nodal): the tangential-trace surface term is only supported on an N1E field."
+        )
+
+    cells = np.asarray(domain.mesh.cells_dict["tetra"], dtype=np.int64)
+    fc = build_facet_connectivity(cells, "tetrahedron")
+    elem = basix.create_element(ElementFamily.N1E, CellType.tetrahedron, 1)
+    fqp, fqw = (np.asarray(a) for a in basix.make_quadrature(CellType.triangle, quad_degree))  # (nqf,2),(nqf,)
+    ref_tet = np.array([[0.0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    b0, b1 = fqp[:, 0:1], fqp[:, 1:2]  # face barycentric weights (ξ, η); the third is 1−ξ−η
+    face_rv = []  # per local face f: N1E basis (nqf, 6, 3) at the face-mapped reference points
+    for f in range(4):
+        lv = list(_LOCAL_FACES_TET[f][:3])
+        V = ref_tet[lv]
+        ref_pts = (1.0 - b0 - b1) * V[0] + b0 * V[1] + b1 * V[2]
+        face_rv.append(np.asarray(elem.tabulate(0, ref_pts)[0]))  # (nqf, 6, 3)
+
+    signs = np.asarray(top.cell_edge_signs.astype(np.float64))  # (nc, 6)
+    cell_edges = np.asarray(top.cell_edges)  # (nc, 6) global edge ids
+    S = np.zeros((total, total))
+    for region, coeff_nodes in surface_terms.items():
+        region_nodes = {int(n) for n in _region_node_ids(domain, region)}
+        for bf in range(fc.n_bfaces):
+            fnodes = [int(x) for x in fc.face_nodes[bf]]
+            if not all(v in region_nodes for v in fnodes):
+                continue  # face not on this region
+            c, f = int(fc.parent_cell[bf]), int(fc.local_face[bf])
+            cverts = pts_np[cells[c]]  # (4, 3)
+            J = np.stack([cverts[k] - cverts[0] for k in (1, 2, 3)], axis=1)  # (3, 3)
+            detJ = float(np.linalg.det(J))
+            phi = np.asarray(piola_covariant(jnp.asarray(face_rv[f]), None, jnp.asarray(J), detJ, jnp.asarray(signs[c]))[0])
+            lv = list(_LOCAL_FACES_TET[f][:3])
+            P = cverts[lv]  # (3, 3) physical face vertices (same local order as the reference map)
+            nrm = np.cross(P[1] - P[0], P[2] - P[0])
+            measure = float(np.linalg.norm(nrm))  # = 2·area = |det of the face map|
+            nhat = nrm / measure
+            opp = cverts[next(i for i in range(4) if i not in lv)]  # 4th vertex → orient the normal outward
+            if np.dot(nhat, P[0] - opp) < 0:
+                nhat = -nhat
+            pn = phi @ nhat  # (nqf, 6) normal component
+            tang = np.einsum("qai,qbi->qab", phi, phi) - np.einsum("qa,qb->qab", pn, pn)  # tangential φ·φ
+            xq = (1.0 - b0 - b1) * P[0] + b0 * P[1] + b1 * P[2]  # physical quad points (for a spatial coeff)
+            gdofs = offs[fidx] + cell_edges[c]
+            for coeff in coeff_nodes:  # each surface term in this region adds coeff·(surface mass)
+                cval = (
+                    np.ones(len(fqw))
+                    if coeff is None
+                    else np.asarray(_eval_value_node_at(coeff, jnp.asarray(xq))).reshape(-1)
+                )
+                Sloc = np.einsum("q,qab->ab", fqw * measure * cval, tang)  # (6, 6)
+                S[np.ix_(gdofs, gdofs)] += Sloc
+    return jnp.asarray(S)
 
 
 def _apply_natural_boundary_terms(b, boundary_terms, domain, field_index, spaces, top, pts_np, offs, n_cells, quad_degree):

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -521,20 +521,33 @@ def assemble_fem_nonnodal(
     # into A). The only bilinear surface term wired is the N1E tangential-trace mass `c·inner(n×u, n×v)`
     # (the impedance / first-order absorbing Maxwell BC): split it off and assemble it into the stiffness.
     from ..._fem import _bare as _bare_nn
+    from ...trace import FunctionCall as _FC
+    from ...trace import Literal as _Lit
 
     # A weak boundary term is one of: an N1E tangential-trace surface MASS `c·inner(n×u, n×v)` (bilinear →
     # into A, the impedance/absorbing BC); an N1E incident LOAD `inner(g, n×v)` (trial-free → into b, the
-    # source); or an RT pressure load `p·(v·n)` (→ into b). Classify each so the right assembler handles it.
+    # source); or an RT pressure load `p·(v·n)` (→ into b). Split each term additively and classify each
+    # summand, so a combined `i k₀·inner(n×u,n×v) + 2 i k₀·inner(g,n×v)` (absorbing + incident on one face)
+    # is routed correctly. The complex leg wraps the whole term as `real(…)`/`imag(…)` and `.real` does NOT
+    # distribute over `+`, so peel that wrapper first, split inside, then re-wrap each summand.
+    def _signed(x, sign):  # fold a −1 summand sign into the extracted coefficient/source
+        return (_Lit(-1.0) if x is None else (-1.0) * x) if sign < 0 else x
+
     pressure_terms, surface_terms, incident_terms = {}, {}, {}
     for region, terms in (boundary_terms or {}).items():
         for t in terms:
             bt = _bare_nn(t)
-            if (mass := _n1e_surface_mass_spec(bt)) is not None:
-                surface_terms.setdefault(region, []).append(mass[0])
-            elif (load := _n1e_surface_load_spec(bt)) is not None:
-                incident_terms.setdefault(region, []).append(load[0])
-            else:
-                pressure_terms.setdefault(region, []).append(t)
+            wrap, inner_expr = None, bt
+            if isinstance(bt, _FC) and getattr(bt, "_name", None) in ("real", "imag") and len(bt.args) == 1:
+                wrap, inner_expr = bt._name, bt.args[0]
+            for sign, sub in _split_additive_terms(domain, inner_expr):
+                sub_w = sub if wrap is None else (sub.real if wrap == "real" else sub.imag)
+                if (mass := _n1e_surface_mass_spec(sub_w)) is not None:
+                    surface_terms.setdefault(region, []).append(_signed(mass[0], sign))
+                elif (load := _n1e_surface_load_spec(sub_w)) is not None:
+                    incident_terms.setdefault(region, []).append(_signed(load[0], sign))
+                else:
+                    pressure_terms.setdefault(region, []).append(_apply_sign(domain, sign, sub_w))
     nat_load = (
         _apply_natural_boundary_terms(
             jnp.zeros(total), pressure_terms, domain, field_index, spaces, top, np.asarray(pts), offs, n_cells, quad_degree

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -338,6 +338,22 @@ def assemble_fem_nonnodal(
             "family": "Morley" if has_morley else ("Argyris" if has_argyris else "Hermite"),
         }
 
+    # N1E (H(curl) edge) topology for periodic (Floquet/Bloch) ties: each DOF is one edge's tangential
+    # moment, so a periodic tie matches boundary edges across faces (by midpoint) with an orientation sign
+    # (the lo→hi edge direction). Read back in ``_fem._build_periodic_reduction_n1e`` when ties are present.
+    if "N1E" in spaces and top is not None:
+        _evn = np.asarray(top.edge_vertices)
+        _ptsn = np.asarray(pts)
+        domain._fem_nonnodal_topology = {
+            "n_verts": int(_ptsn.shape[0]),
+            "n_edges": int(n_edges),
+            "vertex_points": _ptsn,
+            "edge_vertices": _evn,
+            "edge_midpoints": 0.5 * (_ptsn[_evn[:, 0]] + _ptsn[_evn[:, 1]]),
+            "edge_dirs": _ptsn[_evn[:, 1]] - _ptsn[_evn[:, 0]],  # lo→hi direction (sets the tangential sign)
+            "family": "N1E",
+        }
+
     # Hermite per-cell global DOF map: 3 DOFs per vertex (value, ∂x, ∂y, in basix order) + 1 interior
     # (centroid) DOF per cell. Continuity is automatic from shared global vertex ids (point functionals --
     # no edge dedup, no orientation sign; the M(cell) transform takes that role).

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -522,35 +522,45 @@ def assemble_fem_nonnodal(
     # (the impedance / first-order absorbing Maxwell BC): split it off and assemble it into the stiffness.
     from ..._fem import _bare as _bare_nn
 
-    load_terms, surface_terms = {}, {}
+    # A weak boundary term is one of: an N1E tangential-trace surface MASS `c·inner(n×u, n×v)` (bilinear →
+    # into A, the impedance/absorbing BC); an N1E incident LOAD `inner(g, n×v)` (trial-free → into b, the
+    # source); or an RT pressure load `p·(v·n)` (→ into b). Classify each so the right assembler handles it.
+    pressure_terms, surface_terms, incident_terms = {}, {}, {}
     for region, terms in (boundary_terms or {}).items():
         for t in terms:
-            spec = _n1e_surface_mass_spec(_bare_nn(t))
-            if spec is not None:
-                surface_terms.setdefault(region, []).append(spec[0])
+            bt = _bare_nn(t)
+            if (mass := _n1e_surface_mass_spec(bt)) is not None:
+                surface_terms.setdefault(region, []).append(mass[0])
+            elif (load := _n1e_surface_load_spec(bt)) is not None:
+                incident_terms.setdefault(region, []).append(load[0])
             else:
-                load_terms.setdefault(region, []).append(t)
+                pressure_terms.setdefault(region, []).append(t)
     nat_load = (
         _apply_natural_boundary_terms(
-            jnp.zeros(total), load_terms, domain, field_index, spaces, top, np.asarray(pts), offs, n_cells, quad_degree
+            jnp.zeros(total), pressure_terms, domain, field_index, spaces, top, np.asarray(pts), offs, n_cells, quad_degree
         )
-        if load_terms
+        if pressure_terms
         else jnp.zeros(total)
     )
+    # the N1E incident forcing added to the RHS load b (∫ g·(n×v))
+    if incident_terms:
+        nat_load = nat_load + _assemble_n1e_surface_load(
+            total, incident_terms, domain, spaces, top, np.asarray(pts), offs, quad_degree, dim
+        )
     # the tangential-trace surface mass added to A (steady linear only; unwired compositions raise below)
     surf_mass = (
         _assemble_n1e_surface_mass(total, surface_terms, domain, spaces, top, np.asarray(pts), offs, quad_degree, dim)
         if surface_terms
         else None
     )
-    if surf_mass is not None:
+    if surf_mass is not None or incident_terms:
         _nonlinear = any(_is_obviously_nonlinear_in_unknown(domain, t) for t in volume_terms)
         _transient = bool(ic_residuals) or any(_contains_temporal_derivative(t) for t in volume_terms)
         if _transient or _nonlinear or runtime_parameter_tags or neural_param_names:
             raise NotImplementedError(
-                "jno.fem (non-nodal): the N1E tangential-trace surface term (impedance / absorbing BC) is wired "
-                "for the steady linear forward problem only — not with a transient, nonlinear, or parametric/inverse "
-                "form. (Raises rather than silently dropping the surface contribution.)"
+                "jno.fem (non-nodal): the N1E tangential-trace surface terms (impedance / absorbing / incident BC) "
+                "are wired for the steady linear forward problem only — not with a transient, nonlinear, or "
+                "parametric/inverse form. (Raises rather than silently dropping the surface contribution.)"
             )
     pins = (
         _flux_bc_pins(flux_bcs, domain, field_index, spaces, top, np.asarray(pts), offs, n_cells, quad_degree, dim=dim)
@@ -920,32 +930,62 @@ def _n1e_surface_mass_spec(bare):
     return (coeff,)
 
 
-def _assemble_n1e_surface_mass(total, surface_terms, domain, spaces, top, pts_np, offs, quad_degree, dim):
-    """Assemble the tangential-trace surface mass ``∑ ∫_Γ c (n×φ_a)·(n×φ_b) dS`` (N1E impedance /
-    absorbing BC) into a dense ``(total, total)`` matrix to ADD to the stiffness ``A``.
+def _n1e_surface_load_spec(bare):
+    """Recognise an N1E incident/forcing surface term ``inner(g, n×v)`` (trial-FREE, into ``b``) → a
+    1-tuple ``(g_node,)`` (the prescribed tangential source, e.g. the incident wave ``2 i k₀ E_inc``);
+    ``None`` otherwise. Distinct from the bilinear impedance mass (which carries the trial as well)."""
+    from ..._fem import _contains
+    from ...trace import BinaryOp, FunctionCall, TestFunction, TrialFunction
 
-    Integrates over the region's boundary faces (tet faces used by one cell): the N1E basis is tabulated
-    at reference face-quadrature points (per local face), covariant-Piola-pushed to each physical cell,
-    and the tangential projection ``(n×φ_a)·(n×φ_b) = φ_a·φ_b − (φ_a·n)(φ_b·n)`` is integrated with the
-    physical face measure. 3-D tets only (the 2-D H(curl) tangential trace is a scalar, not yet wired)."""
+    def _source(x):  # trial/test-free factor (the source g or a scalar coefficient)
+        return not _contains(x, TrialFunction) and not _contains(x, TestFunction)
+
+    node, wrap, coeff = bare, None, None
+    if isinstance(node, FunctionCall) and node._name in ("real", "imag") and len(node.args) == 1:
+        wrap, node = node._name, node.args[0]
+    if isinstance(node, BinaryOp) and node.op == "*":  # peel a scalar coefficient (e.g. 2 i k₀) into the source
+        left, right = node.left, node.right
+        if isinstance(right, FunctionCall) and right._name == "inner" and _source(left):
+            coeff, node = left, right
+        elif isinstance(left, FunctionCall) and left._name == "inner" and _source(right):
+            coeff, node = right, left
+    if not (isinstance(node, FunctionCall) and node._name == "inner" and len(node.args) == 2):
+        return None
+
+    def _cross_test(x):
+        return isinstance(x, FunctionCall) and x._name == "cross" and len(x.args) == 2 and _contains(x, TestFunction)
+
+    a0, a1 = node.args
+    if _cross_test(a0) and _source(a1):
+        g = a1
+    elif _cross_test(a1) and _source(a0):
+        g = a0
+    else:
+        return None
+    if coeff is not None:  # fold the scalar coefficient into the source: c·inner(g, n×v) = inner(c·g, n×v)
+        g = coeff * g
+    if wrap is not None:  # complex leg split: Re/Im of the (complex) source
+        g = g.real if wrap == "real" else g.imag
+    return (g,)
+
+
+def _n1e_surface_precompute(domain, top, quad_degree, spaces, dim):
+    """Shared precompute for N1E boundary-face surface integrals (impedance mass + incident load): validate
+    3-D/N1E, build facet connectivity, tabulate the N1E basis at reference face-quadrature points (per local
+    face), and return the topology arrays. Returns ``(fidx, cells, fc, fqp, fqw, face_rv, signs, cell_edges)``."""
     import basix
     from basix import CellType, ElementFamily
 
-    from ..._fem import _eval_value_node_at
-    from .fem_1d import _region_node_ids
-    from .fem_elements import piola_covariant
     from .fem_facets import _LOCAL_FACES_TET, build_facet_connectivity
 
     if dim != 3:
         raise NotImplementedError(
-            "jno.fem (non-nodal): the tangential-trace surface term `inner(n×u, n×v)` (impedance / absorbing "
-            "BC) is wired for 3-D N1E (Maxwell) only — the 2-D H(curl) tangential trace is a scalar u·t, not yet wired."
+            "jno.fem (non-nodal): N1E tangential-trace surface terms (impedance / absorbing / incident BC) are "
+            "wired for 3-D N1E (Maxwell) only — the 2-D H(curl) tangential trace is a scalar u·t, not yet wired."
         )
     fidx = next((i for i, s in enumerate(spaces) if s == "N1E"), None)
     if fidx is None:
-        raise NotImplementedError(
-            "jno.fem (non-nodal): the tangential-trace surface term is only supported on an N1E field."
-        )
+        raise NotImplementedError("jno.fem (non-nodal): N1E surface terms are only supported on an N1E field.")
 
     cells = np.asarray(domain.mesh.cells_dict["tetra"], dtype=np.int64)
     fc = build_facet_connectivity(cells, "tetrahedron")
@@ -955,36 +995,62 @@ def _assemble_n1e_surface_mass(total, surface_terms, domain, spaces, top, pts_np
     b0, b1 = fqp[:, 0:1], fqp[:, 1:2]  # face barycentric weights (ξ, η); the third is 1−ξ−η
     face_rv = []  # per local face f: N1E basis (nqf, 6, 3) at the face-mapped reference points
     for f in range(4):
-        lv = list(_LOCAL_FACES_TET[f][:3])
-        V = ref_tet[lv]
-        ref_pts = (1.0 - b0 - b1) * V[0] + b0 * V[1] + b1 * V[2]
-        face_rv.append(np.asarray(elem.tabulate(0, ref_pts)[0]))  # (nqf, 6, 3)
-
+        V = ref_tet[list(_LOCAL_FACES_TET[f][:3])]
+        face_rv.append(np.asarray(elem.tabulate(0, (1.0 - b0 - b1) * V[0] + b0 * V[1] + b1 * V[2])[0]))
     signs = np.asarray(top.cell_edge_signs.astype(np.float64))  # (nc, 6)
     cell_edges = np.asarray(top.cell_edges)  # (nc, 6) global edge ids
+    return fidx, cells, fc, fqp, fqw, face_rv, signs, cell_edges
+
+
+def _n1e_face_geometry(bf, cells, fc, pts_np, top, face_rv, fqp, signs):
+    """Per boundary face ``bf``: the physical N1E basis (nqf, 6, 3), the OUTWARD unit normal, the face
+    measure |detJ_face| (= 2·area), and the physical quad points (nqf, 3). Covariant-Piola push with the
+    same cell Jacobian/edge signs the volume assembly uses."""
+    from .fem_elements import piola_covariant
+    from .fem_facets import _LOCAL_FACES_TET
+
+    c, f = int(fc.parent_cell[bf]), int(fc.local_face[bf])
+    cverts = pts_np[cells[c]]  # (4, 3)
+    J = np.stack([cverts[k] - cverts[0] for k in (1, 2, 3)], axis=1)
+    detJ = float(np.linalg.det(J))
+    phi = np.asarray(piola_covariant(jnp.asarray(face_rv[f]), None, jnp.asarray(J), detJ, jnp.asarray(signs[c]))[0])
+    lv = list(_LOCAL_FACES_TET[f][:3])
+    P = cverts[lv]  # physical face vertices (same local order as the reference map)
+    nrm = np.cross(P[1] - P[0], P[2] - P[0])
+    measure = float(np.linalg.norm(nrm))  # = 2·area = |det of the face map|
+    nhat = nrm / measure
+    opp = cverts[next(i for i in range(4) if i not in lv)]  # 4th vertex → orient outward
+    if np.dot(nhat, P[0] - opp) < 0:
+        nhat = -nhat
+    b0, b1 = fqp[:, 0:1], fqp[:, 1:2]
+    xq = (1.0 - b0 - b1) * P[0] + b0 * P[1] + b1 * P[2]  # physical quad points (for a spatial coeff/source)
+    return c, phi, nhat, measure, xq
+
+
+def _n1e_region_faces(fc, region_nodes):
+    """Yield the boundary-face indices whose vertices all lie in the region."""
+    for bf in range(fc.n_bfaces):
+        if all(int(v) in region_nodes for v in fc.face_nodes[bf]):
+            yield bf
+
+
+def _assemble_n1e_surface_mass(total, surface_terms, domain, spaces, top, pts_np, offs, quad_degree, dim):
+    """Assemble the tangential-trace surface mass ``∑ ∫_Γ c (n×φ_a)·(n×φ_b) dS`` (N1E impedance /
+    absorbing BC) into a dense ``(total, total)`` matrix to ADD to the stiffness ``A``.
+
+    The tangential projection ``(n×φ_a)·(n×φ_b) = φ_a·φ_b − (φ_a·n)(φ_b·n)`` is integrated over the
+    region's boundary faces with the physical face measure. 3-D N1E only."""
+    from ..._fem import _eval_value_node_at
+    from .fem_1d import _region_node_ids
+
+    fidx, cells, fc, fqp, fqw, face_rv, signs, cell_edges = _n1e_surface_precompute(domain, top, quad_degree, spaces, dim)
     S = np.zeros((total, total))
     for region, coeff_nodes in surface_terms.items():
         region_nodes = {int(n) for n in _region_node_ids(domain, region)}
-        for bf in range(fc.n_bfaces):
-            fnodes = [int(x) for x in fc.face_nodes[bf]]
-            if not all(v in region_nodes for v in fnodes):
-                continue  # face not on this region
-            c, f = int(fc.parent_cell[bf]), int(fc.local_face[bf])
-            cverts = pts_np[cells[c]]  # (4, 3)
-            J = np.stack([cverts[k] - cverts[0] for k in (1, 2, 3)], axis=1)  # (3, 3)
-            detJ = float(np.linalg.det(J))
-            phi = np.asarray(piola_covariant(jnp.asarray(face_rv[f]), None, jnp.asarray(J), detJ, jnp.asarray(signs[c]))[0])
-            lv = list(_LOCAL_FACES_TET[f][:3])
-            P = cverts[lv]  # (3, 3) physical face vertices (same local order as the reference map)
-            nrm = np.cross(P[1] - P[0], P[2] - P[0])
-            measure = float(np.linalg.norm(nrm))  # = 2·area = |det of the face map|
-            nhat = nrm / measure
-            opp = cverts[next(i for i in range(4) if i not in lv)]  # 4th vertex → orient the normal outward
-            if np.dot(nhat, P[0] - opp) < 0:
-                nhat = -nhat
+        for bf in _n1e_region_faces(fc, region_nodes):
+            c, phi, nhat, measure, xq = _n1e_face_geometry(bf, cells, fc, pts_np, top, face_rv, fqp, signs)
             pn = phi @ nhat  # (nqf, 6) normal component
             tang = np.einsum("qai,qbi->qab", phi, phi) - np.einsum("qa,qb->qab", pn, pn)  # tangential φ·φ
-            xq = (1.0 - b0 - b1) * P[0] + b0 * P[1] + b1 * P[2]  # physical quad points (for a spatial coeff)
             gdofs = offs[fidx] + cell_edges[c]
             for coeff in coeff_nodes:  # each surface term in this region adds coeff·(surface mass)
                 cval = (
@@ -992,9 +1058,32 @@ def _assemble_n1e_surface_mass(total, surface_terms, domain, spaces, top, pts_np
                     if coeff is None
                     else np.asarray(_eval_value_node_at(coeff, jnp.asarray(xq))).reshape(-1)
                 )
-                Sloc = np.einsum("q,qab->ab", fqw * measure * cval, tang)  # (6, 6)
-                S[np.ix_(gdofs, gdofs)] += Sloc
+                S[np.ix_(gdofs, gdofs)] += np.einsum("q,qab->ab", fqw * measure * cval, tang)
     return jnp.asarray(S)
+
+
+def _assemble_n1e_surface_load(total, load_terms, domain, spaces, top, pts_np, offs, quad_degree, dim):
+    """Assemble the tangential incident/forcing surface term ``∑ ∫_Γ g·(φ_a×n) dS`` (the ``inner(g, n×v)``
+    RHS of the Silver–Müller ABC) into a dense ``(total,)`` load vector to ADD to ``b``. 3-D N1E only.
+
+    ``g`` is a prescribed (possibly complex, possibly spatial) tangential source; the test factor ``φ_a×n``
+    matches the authored ``v.vector.cross(nvec)`` and uses the same OUTWARD normal as the impedance mass."""
+    from ..._fem import _eval_value_node_at
+    from .fem_1d import _region_node_ids
+
+    fidx, cells, fc, fqp, fqw, face_rv, signs, cell_edges = _n1e_surface_precompute(domain, top, quad_degree, spaces, dim)
+    b = np.zeros(total)
+    for region, g_nodes in load_terms.items():
+        region_nodes = {int(n) for n in _region_node_ids(domain, region)}
+        for bf in _n1e_region_faces(fc, region_nodes):
+            c, phi, nhat, measure, xq = _n1e_face_geometry(bf, cells, fc, pts_np, top, face_rv, fqp, signs)
+            phi_x_n = np.cross(phi, nhat)  # (nqf, 6, 3) = φ_a × n  (the authored `v.vector.cross(nvec)`)
+            gdofs = offs[fidx] + cell_edges[c]
+            for g in g_nodes:
+                gval = np.asarray(_eval_value_node_at(g, jnp.asarray(xq))).reshape(len(fqw), 3)  # (nqf, 3)
+                integrand = np.einsum("qi,qai->qa", gval, phi_x_n)  # g·(φ_a×n)
+                b[gdofs] += np.einsum("q,qa->a", fqw * measure, integrand)
+    return jnp.asarray(b)
 
 
 def _apply_natural_boundary_terms(b, boundary_terms, domain, field_index, spaces, top, pts_np, offs, n_cells, quad_degree):

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -2570,6 +2570,69 @@ def _periodic_blocks(periodic):
     return block, np.array([0, nf]), np.array([0, nr])
 
 
+def build_periodic_prolongation_n1e(n_edges, edge_midpoints, edge_dirs, etags, pairs, phases=None, tol=None):
+    """DOF-level periodic (Floquet/Bloch) prolongation for a lowest-order Nédélec (N1E) edge field.
+
+    Each edge carries one tangential-moment DOF. A slave-face edge ties to the master-face edge at the same
+    transverse position; the tie weight is the Bloch phase times an orientation **sign** (+1 if the two
+    edges point the same way along their lo→hi canonical direction, −1 if opposed — the tangential moment
+    flips with the edge orientation). Corner edges shared by two periodic faces are tied twice; the chain is
+    resolved to a single retained master DOF. Returns a legacy single-field prolongation dict."""
+    mid = np.asarray(edge_midpoints, dtype=np.float64)
+    dirs = np.asarray(edge_dirs, dtype=np.float64)
+    if phases is None:
+        phases = [1.0] * len(pairs)
+    is_bloch = any(abs(complex(p) - 1.0) > 1e-12 for p in phases)
+    if tol is None:
+        span = float(np.linalg.norm(mid.max(axis=0) - mid.min(axis=0)))
+        tol = max(span, 1.0) * 1.0e-6
+
+    s2m: Dict[int, int] = {}  # slave edge -> master edge
+    weight: Dict[int, complex] = {}  # slave edge -> tie weight (orientation sign × Bloch phase)
+    for (mtag, stag), ph in zip(pairs, phases):
+        me, se = np.asarray(etags[mtag], dtype=int), np.asarray(etags[stag], dtype=int)
+        if me.size == 0 or se.size == 0:
+            raise ValueError(f"periodic N1E: boundary tag {mtag!r}/{stag!r} has no edges to tie.")
+        mm, sm = mid[me], mid[se]
+        axis = int(np.argmax(np.abs(mm.mean(axis=0) - sm.mean(axis=0))))  # periodic axis = largest mean gap
+        tr = [d for d in range(mid.shape[1]) if d != axis]
+        mt, st = mm[:, tr], sm[:, tr]
+        d2 = np.sum((st[:, None, :] - mt[None, :, :]) ** 2, axis=-1)
+        nn = np.argmin(d2, axis=1)
+        dist = np.sqrt(d2[np.arange(len(se)), nn])
+        for k, s in enumerate(se):
+            if dist[k] > tol:
+                raise ValueError(
+                    f"periodic N1E: slave edge {int(s)} has no transverse master match "
+                    f"(nearest {dist[k]:.2e} > tol {tol:.2e}); a conforming periodic mesh is required."
+                )
+            m = int(me[nn[k]])
+            sign = 1.0 if float(dirs[int(s)] @ dirs[m]) >= 0.0 else -1.0
+            s2m[int(s)], weight[int(s)] = m, sign * complex(ph)
+
+    slaves = set(s2m)
+    kept = np.array([e for e in range(n_edges) if e not in slaves], dtype=int)
+    col = {int(e): j for j, e in enumerate(kept)}
+    P = np.zeros((n_edges, len(kept)), dtype=(np.complex128 if is_bloch else np.float64))
+    for j, e in enumerate(kept):
+        P[e, j] = 1.0
+    for s in slaves:  # resolve a possibly-chained tie (corner edge tied via two faces) to a kept master
+        m, w = s2m[s], weight[s]
+        while m in s2m:
+            w *= weight[m]
+            m = s2m[m]
+        P[s, col[m]] = w if is_bloch else w.real  # non-Bloch weight is a real ±1 sign
+    return {
+        "P": jnp.asarray(P),
+        "kept_nodes": kept,
+        "vec": 1,
+        "is_selection": False,  # ±1 signs (and complex phases) → not a pure 0/1 selection
+        "is_bloch": is_bloch,
+        "n_full": int(n_edges),
+        "n_red": int(len(kept)),
+    }
+
+
 def reduce_matrix_periodic(periodic, mat, conj=False):
     """``P^T mat P`` (or Hermitian ``P^H mat P`` when ``conj``) for a single- or multi-field reduction.
 

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -2049,6 +2049,7 @@ def build_periodic_prolongation(
     vec: int = 1,
     tol: float | None = None,
     facets: Dict[str, np.ndarray] | None = None,
+    phases: Sequence[complex] | None = None,
 ) -> Dict[str, object]:
     """Build the node-level periodic prolongation matrix ``P``.
 
@@ -2093,16 +2094,22 @@ def build_periodic_prolongation(
     pts = np.asarray(points, dtype=np.float64)
     n_nodes = pts.shape[0]
     facets = facets or {}
+    if phases is None:
+        phases = [1.0] * len(pairs)
+    # Bloch/quasi-periodic: a non-unit phase makes P complex; a plain periodic cell keeps P real 0/1
+    # so the fast (selection) reduction path is untouched.
+    is_bloch = any(abs(complex(p) - 1.0) > 1e-12 for p in phases)
 
     if tol is None:
         span = float(np.linalg.norm(pts.max(axis=0) - pts.min(axis=0)))
         tol = max(span, 1.0) * 1.0e-6
 
-    # slave -> master node (exact 0/1 tie); slave -> [(master node, weight)] (interpolated tie).
+    # slave -> master node (exact tie, weight = Bloch phase); slave -> [(master node, weight)] (interp).
     slave_to_master: Dict[int, int] = {}
+    slave_phase: Dict[int, complex] = {}
     slave_interp: Dict[int, List[Tuple[int, float]]] = {}
 
-    for master_tag, slave_tag in pairs:
+    for (master_tag, slave_tag), ph in zip(pairs, phases):
         if master_tag not in tag_indices or slave_tag not in tag_indices:
             raise KeyError(
                 f"Periodic pair ({master_tag!r}, {slave_tag!r}) refers to a tag "
@@ -2129,8 +2136,9 @@ def build_periodic_prolongation(
         for k, sid in enumerate(s_ids):
             if m_ids.size and dist[k] <= tol:  # conforming: exact node-to-node (corners land here too)
                 slave_to_master[int(sid)] = int(m_ids[nn[k]])
+                slave_phase[int(sid)] = complex(ph)
                 continue
-            # non-matching: tie to the master facet by interpolation
+            # non-matching: tie to the master facet by interpolation (weights scaled by the Bloch phase)
             w = _periodic_facet_weights(s_trans[k], facets.get(master_tag), pts, transverse) if facets else None
             if w is None:
                 raise ValueError(
@@ -2139,7 +2147,7 @@ def build_periodic_prolongation(
                     "connectivity was supplied for interpolation. Pass `facets=` (unstructured) or use a "
                     "conforming mesh."
                 )
-            slave_interp[int(sid)] = w
+            slave_interp[int(sid)] = [(int(m), complex(ph) * wt) for (m, wt) in w]
 
     slave_set = set(slave_to_master) | set(slave_interp)
 
@@ -2148,7 +2156,9 @@ def build_periodic_prolongation(
     # several directions, and an interpolation can land on a master edge whose endpoint is itself a
     # slave — so resolve every slave **transitively** to kept (master) nodes. This handles any number
     # of periodic directions (e.g. a doubly-periodic cell) with a single general mechanism.
-    raw: Dict[int, List[Tuple[int, float]]] = {sid: [(m, 1.0)] for sid, m in slave_to_master.items()}
+    raw: Dict[int, List[Tuple[int, complex]]] = {
+        sid: [(m, slave_phase.get(sid, 1.0))] for sid, m in slave_to_master.items()
+    }
     raw.update({sid: list(ws) for sid, ws in slave_interp.items()})
     resolved: Dict[int, Dict[int, float]] = {}
 
@@ -2179,13 +2189,13 @@ def build_periodic_prolongation(
 
     rows: List[int] = []
     cols: List[int] = []
-    data: List[float] = []
+    data: List[complex] = []
     for i in range(n_nodes):
         if i in slave_set:
             for kept_node, weight in _expand(i, frozenset()).items():
                 rows.append(i)
                 cols.append(reduced_index[kept_node])
-                data.append(float(weight))
+                data.append(weight if is_bloch else float(np.real(weight)))
         else:
             rows.append(i)
             cols.append(reduced_index[i])
@@ -2196,7 +2206,7 @@ def build_periodic_prolongation(
 
     rows_a = np.asarray(rows, dtype=np.int64)
     cols_a = np.asarray(cols, dtype=np.int64)
-    data_a = np.asarray(data, dtype=np.float64)
+    data_a = np.asarray(data, dtype=np.complex128 if is_bloch else np.float64)
     if vec > 1:  # kron(P_node, I_vec): each node entry -> vec component entries
         comp = np.arange(vec, dtype=np.int64)
         rows_a = (rows_a[:, None] * vec + comp[None, :]).reshape(-1)
@@ -2216,6 +2226,9 @@ def build_periodic_prolongation(
         # whether P is a one-master-per-slave selection (conforming) -> the sparse remap reduction is
         # exact; computed once here (eager, concrete P) so the reduce path never inspects P under trace.
         "is_selection": _is_selection(P),
+        # Bloch/quasi-periodic: P is complex, so the reduction is Hermitian (P^H A P) and the reduced
+        # complex system can't be split into independent real/imag legs.
+        "is_bloch": bool(is_bloch),
     }
 
 
@@ -2415,8 +2428,9 @@ def _remap_bcoo(mat, m_row, p_row, m_col, p_col, shape):
     return jsparse.BCOO((rdata, ridx), shape=shape)
 
 
-def _remap_bcoo_weighted(mat, P):
-    """Sparse Galerkin reduction ``P^T mat P`` for an *interpolation* (nonconforming) periodic ``P``
+def _remap_bcoo_weighted(mat, P, conj=False):
+    """Sparse Galerkin reduction ``P^T mat P`` (or ``P^H mat P`` when ``conj``) for an *interpolation*
+    (nonconforming) periodic ``P``
     -- a few masters per slave, weighted. Generalises :func:`_remap_bcoo` (one master, weight 1) by
     spreading each ``mat`` triplet ``(r, c, v)`` across the ``D x D`` master pairs of its row and
     column with the interpolation weights: ``v -> v · w_r[a] · w_c[b]`` at ``(master_r[a], master_c[b])``.
@@ -2439,11 +2453,13 @@ def _remap_bcoo_weighted(mat, P):
     D = int(slot.max()) + 1
     master = np.zeros((n_full, D), np.int64)
     master[rows, slot] = cols
-    weight = np.zeros((n_full, D), np.float64)
+    weight = np.zeros((n_full, D), np.complex128 if np.iscomplexobj(pdat) else np.float64)
     weight[rows, slot] = wts
     master, weight = jnp.asarray(master), jnp.asarray(weight)
     r, c, v = mat.indices[:, 0], mat.indices[:, 1], mat.data
     mr, wr, mc, wc = master[r], weight[r], master[c], weight[c]  # (nnz, D)
+    if conj:  # P^H mat P conjugates the row (left) weights
+        wr = jnp.conj(wr)
     nnz = r.shape[0]
     a = jnp.broadcast_to(mr[:, :, None], (nnz, D, D)).reshape(-1)
     b = jnp.broadcast_to(mc[:, None, :], (nnz, D, D)).reshape(-1)
@@ -2452,8 +2468,9 @@ def _remap_bcoo_weighted(mat, P):
     return jsparse.BCOO((data, idx), shape=(n_red, n_red)).sum_duplicates()
 
 
-def reduce_matrix(P, mat, is_selection=None):
-    """Galerkin reduction ``P^T mat P``.
+def reduce_matrix(P, mat, is_selection=None, conj=False):
+    """Galerkin reduction ``P^T mat P`` (or the Hermitian ``P^H mat P`` when ``conj`` — for a complex
+    Bloch/quasi-periodic ``P``, where the left factor must be conjugated).
 
     When ``mat`` is BCOO and ``P`` is a BCOO *selection* (conforming/structured tie, one master per
     slave — e.g. the doubly-periodic PEB) the reduction remaps ``mat``'s triplets to their master
@@ -2467,24 +2484,32 @@ def reduce_matrix(P, mat, is_selection=None):
     ``None`` (a direct/eager call) it is computed once here."""
     if is_selection is None:
         is_selection = _is_selection(P)
+    _dt = lambda x: x.data.dtype if hasattr(x, "data") else np.asarray(x).dtype  # noqa: E731
+    pdtype = np.result_type(_dt(P), _dt(mat))
     if hasattr(mat, "indices") and is_selection:
-        master, pval = _selection_maps(P, mat.data.dtype)
-        return _remap_bcoo(mat, master, pval, master, pval, (int(P.shape[1]), int(P.shape[1])))
+        master, pval = _selection_maps(P, pdtype)
+        prow = jnp.conj(pval) if conj else pval  # P^H remap conjugates the row (left) factor
+        return _remap_bcoo(mat, master, prow, master, pval, (int(P.shape[1]), int(P.shape[1])))
     if hasattr(mat, "indices") and hasattr(P, "indices"):
         # nonconforming (interpolation) tie: weighted triplet-remap, stays sparse (falls back to the
         # dense product below only if P was built under trace, which the nonconforming path never is)
-        remapped = _remap_bcoo_weighted(mat, P)
+        remapped = _remap_bcoo_weighted(mat, P, conj=conj)
         if remapped is not None:
             return remapped
     mat = mat.todense() if hasattr(mat, "todense") else mat
-    P = P if hasattr(P, "todense") else jnp.asarray(P)  # keep a BCOO P sparse
-    return P.T @ jnp.asarray(mat, P.dtype) @ P
+    Pd = jnp.asarray(P.todense() if hasattr(P, "todense") else P, pdtype)
+    left = jnp.conj(Pd).T if conj else Pd.T
+    return left @ jnp.asarray(mat, pdtype) @ Pd
 
 
-def reduce_vector(P, vec):
-    """Reduce a full-space load/bias vector via ``P^T vec`` (dense or BCOO ``P``)."""
-    P = P if hasattr(P, "todense") else jnp.asarray(P)
-    return P.T @ jnp.asarray(vec, P.dtype).reshape(-1)
+def reduce_vector(P, vec, conj=False):
+    """Reduce a full-space load/bias vector via ``P^T vec`` (or ``P^H vec`` when ``conj``)."""
+    Pd = P if hasattr(P, "todense") else jnp.asarray(P)
+    left = (jnp.conj(Pd).T if conj else Pd.T) if not hasattr(Pd, "indices") else None
+    if left is not None:
+        return left @ jnp.asarray(vec, Pd.dtype).reshape(-1)
+    Pc = jsparse.BCOO((jnp.conj(Pd.data), Pd.indices), shape=Pd.shape) if conj else Pd
+    return Pc.T @ jnp.asarray(vec, Pc.dtype).reshape(-1)
 
 
 def restrict_state(P, state_full, kept_nodes, vec: int = 1):
@@ -2545,8 +2570,8 @@ def _periodic_blocks(periodic):
     return block, np.array([0, nf]), np.array([0, nr])
 
 
-def reduce_matrix_periodic(periodic, mat):
-    """``P^T mat P`` for a single- or multi-field periodic reduction.
+def reduce_matrix_periodic(periodic, mat, conj=False):
+    """``P^T mat P`` (or Hermitian ``P^H mat P`` when ``conj``) for a single- or multi-field reduction.
 
     When ``mat`` and every field's ``P_i`` are BCOO, the whole blocked reduction
     ``reduced[i,j] = P_i^T mat[i,j] P_j`` is one global triplet-remap (the per-field offsets are
@@ -2559,39 +2584,50 @@ def reduce_matrix_periodic(periodic, mat):
         return b["is_selection"] if b.get("is_selection") is not None else _is_selection(b["P"])
 
     if len(blocks) == 1:
-        return reduce_matrix(blocks[0]["P"], mat, is_selection=_sel(blocks[0]))  # fast path == single-field
+        return reduce_matrix(blocks[0]["P"], mat, is_selection=_sel(blocks[0]), conj=conj)  # single-field
     if hasattr(mat, "indices") and all(_sel(b) for b in blocks):
         n_full, n_red = int(off_f[-1]), int(off_r[-1])
+        pdtype = np.result_type(*[b["P"].data.dtype for b in blocks], mat.data.dtype)
         gmaster = jnp.zeros(n_full, mat.indices.dtype)
-        gpval = jnp.zeros(n_full, mat.data.dtype)
+        gpval = jnp.zeros(n_full, pdtype)
         for i, b in enumerate(blocks):
             Pi = b["P"]
             full_local = Pi.indices[:, 0]  # field-i local full DOF
             gmaster = gmaster.at[int(off_f[i]) + full_local].set(
                 (int(off_r[i]) + Pi.indices[:, 1]).astype(mat.indices.dtype)
             )
-            gpval = gpval.at[int(off_f[i]) + full_local].set(jnp.asarray(Pi.data, mat.data.dtype))
-        return _remap_bcoo(mat, gmaster, gpval, gmaster, gpval, (n_red, n_red))
+            gpval = gpval.at[int(off_f[i]) + full_local].set(jnp.asarray(Pi.data, pdtype))
+        prow = jnp.conj(gpval) if conj else gpval
+        return _remap_bcoo(mat, gmaster, prow, gmaster, gpval, (n_red, n_red))
     mat = jnp.asarray(mat.todense()) if hasattr(mat, "todense") else jnp.asarray(mat)
-    out = jnp.zeros((int(off_r[-1]), int(off_r[-1])), mat.dtype)
-    _sp = lambda P: P if hasattr(P, "todense") else jnp.asarray(P, mat.dtype)  # keep BCOO sparse  # noqa: E731
+    pdtype = np.result_type(
+        *[np.asarray(b["P"].todense() if hasattr(b["P"], "todense") else b["P"]).dtype for b in blocks], mat.dtype
+    )
+    out = jnp.zeros((int(off_r[-1]), int(off_r[-1])), pdtype)
+    _sp = lambda P: P if hasattr(P, "todense") else jnp.asarray(P, pdtype)  # keep BCOO sparse  # noqa: E731
     for i, bi in enumerate(blocks):
         Pi = _sp(bi["P"])
+        left = (jnp.conj(Pi).T if conj else Pi.T) if not hasattr(Pi, "indices") else Pi.T
         for j, bj in enumerate(blocks):
             Pj = _sp(bj["P"])
-            blk = mat[off_f[i] : off_f[i + 1], off_f[j] : off_f[j + 1]]
-            out = out.at[off_r[i] : off_r[i + 1], off_r[j] : off_r[j + 1]].set(Pi.T @ blk @ Pj)
+            blk = jnp.asarray(mat[off_f[i] : off_f[i + 1], off_f[j] : off_f[j + 1]], pdtype)
+            out = out.at[off_r[i] : off_r[i + 1], off_r[j] : off_r[j + 1]].set(left @ blk @ Pj)
     return out
 
 
-def reduce_vector_periodic(periodic, vec):
-    """``P^T vec`` for a single- or multi-field periodic reduction (per-field block)."""
+def reduce_vector_periodic(periodic, vec, conj=False):
+    """``P^T vec`` (or ``P^H vec`` when ``conj``) for a single- or multi-field reduction (per-field block)."""
     blocks, off_f, _ = _periodic_blocks(periodic)
     if len(blocks) == 1:
-        return reduce_vector(blocks[0]["P"], vec)
+        return reduce_vector(blocks[0]["P"], vec, conj=conj)
     vec = jnp.asarray(vec).reshape(-1)
     _sp = lambda P: P if hasattr(P, "todense") else jnp.asarray(P, vec.dtype)  # keep BCOO sparse  # noqa: E731
-    return jnp.concatenate([_sp(b["P"]).T @ vec[off_f[i] : off_f[i + 1]] for i, b in enumerate(blocks)])
+    out = []
+    for i, b in enumerate(blocks):
+        Pi = _sp(b["P"])
+        Pc = jsparse.BCOO((jnp.conj(Pi.data), Pi.indices), shape=Pi.shape) if (conj and hasattr(Pi, "indices")) else Pi
+        out.append(Pc.T @ vec[off_f[i] : off_f[i + 1]])
+    return jnp.concatenate(out)
 
 
 def restrict_state_periodic(periodic, state):

--- a/jno/utils/solver/weak_form.py
+++ b/jno/utils/solver/weak_form.py
@@ -640,6 +640,8 @@ def _is_obviously_nonlinear_in_unknown(domain, expr):
             "inner",
             "dot",
             "cross",  # n×u is linear in u (the normal is a constant); the genuine bilinear case is caught below
+            "matvec",  # M @ u (anisotropic ε·E) and A @ B are linear in the unknown when the matrix is a coefficient
+            "matmul",
             "reshape",
             "transpose",
             "getitem",

--- a/jno/utils/solver/weak_form.py
+++ b/jno/utils/solver/weak_form.py
@@ -639,6 +639,7 @@ def _is_obviously_nonlinear_in_unknown(domain, expr):
         linearish = {
             "inner",
             "dot",
+            "cross",  # n×u is linear in u (the normal is a constant); the genuine bilinear case is caught below
             "reshape",
             "transpose",
             "getitem",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
   - Traditional Solvers:
     - Finite Element Method: fem.md
     - Finite Difference Method: fdm.md
+    - Rigorous Coupled-Wave Analysis: rcwa.md
   - Tutorials:
     - PINN:
       - Laplace 1D: tutorials/01-basics/laplace-1d.md

--- a/pixi.lock
+++ b/pixi.lock
@@ -840,6 +840,174 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/18/0c4060f99abfbdf4caa72ee6492d726801d5b1daf31d48e899ecdb306035/fenics_basix-0.10.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
+  rcwa:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py313h18e8e13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py313hf159716_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py313hf46b229_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.14.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py313h3dea7bd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.34.1-py313hf481762_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.26.1-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py313hd5f5364_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backrefs-7.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-1.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.7.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocstrings-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocstrings-python-2.0.2-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/paginate-0.5.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-2.61.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-3.10.0.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/0e/a7/83b321492fe7e5d0af07f484ec0100bb6ca561aa64cad1d34fc58a015d0f/blackjax-1.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/fd/0f518e6880b401ad8a415701ffab0205240233dc5ab9522e93430e0bc1cf/foundax-0.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/38/2e/21a3ede87f0bf82d6c7bcb90480d50a6490eb974c6ab20881188e440957c/simplejson-4.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/6e/5087e0347188f6970aba1ffbd0018754d23c3f3461e9f21785f2f27a02c2/jax-0.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/c6/82669e70cef67c803852285ba6f59d7e3d102983c0ab4be8269c14756677/tensorstore-0.1.84-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6e/67/9d4ac4b0d683aaa4170da59a1980740b281fd38fc253e1830fde4dac3d4f/pygmsh-7.1.17-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/4d/3ff82b88c7195ee9fccc27a506e9d365490e95ae996a54f377ae91bed69f/jax_cuda12_plugin-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/86/58/1b7d6077edbd13fd5447279c5fc41b1920bd602a52a3c5cd0f4e0a8a058b/fmmax-1.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/60/829ed84939aaa8c7d4693e255b9b9d9a61d14c3426d45ab05218b1f49d3b/orbax_checkpoint-0.11.40-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/89/5f/39cbadc320cd78f4834b0a9f7a2fa3c980dca942bf193f315837eacb8870/meshio-5.3.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/69/6a93d8600c339d7687a05857c7907bd4dd8cf88691a5ea106d7a50af90a1/optax-0.2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/da/36fa8307cc40889307fed415d70b67d35ec330ffce889a9c03cf8f616cfa/nvidia_nvshmem_cu12-3.6.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/8f/2ede6b758b7524608472010f632bdd3370ea271d715d1d66044614b84cdc/nvidia_cudnn_cu12-9.22.0.52-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/d4/336becb1488ac4fbab205043987128839c8c62d54e2036b7e887bd009040/gmsh-4.15.2-py2.py3-none-manylinux_2_24_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/d6/69a76c8ccdef14af687c497040292a46e59fc7a0ab24724b60e50ca61030/equinox-0.13.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/18/0c4060f99abfbdf4caa72ee6492d726801d5b1daf31d48e899ecdb306035/fenics_basix-0.10.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -4030,6 +4198,7 @@ packages:
   - pyfiglet ; extra == 'dev'
   - iree-base-compiler ; extra == 'iree'
   - iree-base-runtime ; extra == 'iree'
+  - fmmax ; extra == 'rcwa'
   requires_python: '>=3.11,<3.14'
 - pypi: https://files.pythonhosted.org/packages/0e/a7/83b321492fe7e5d0af07f484ec0100bb6ca561aa64cad1d34fc58a015d0f/blackjax-1.5-py3-none-any.whl
   name: blackjax
@@ -4381,6 +4550,33 @@ packages:
   - nvidia-cuda-nvrtc-cu12>=12.1.55 ; sys_platform == 'linux' and extra == 'with-cuda'
   - nvidia-nvshmem-cu12>=3.2.5 ; sys_platform == 'linux' and extra == 'with-cuda'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/86/58/1b7d6077edbd13fd5447279c5fc41b1920bd602a52a3c5cd0f4e0a8a058b/fmmax-1.7.1-py3-none-any.whl
+  name: fmmax
+  version: 1.7.1
+  sha256: 537ccd7ceeb517107fe0404a2dc7d2d27562690505a5b698c9e3b118e90fda3a
+  requires_dist:
+  - jax>=0.4.36
+  - jaxlib
+  - numpy
+  - matplotlib ; extra == 'docs'
+  - jupyter-book==1.0.4.post1 ; extra == 'docs'
+  - sphinx-autodoc-typehints ; extra == 'docs'
+  - sphinx-click ; extra == 'docs'
+  - matplotlib ; extra == 'examples'
+  - scikit-image ; extra == 'examples'
+  - scipy ; extra == 'examples'
+  - jeig ; extra == 'jeig'
+  - grcwa ; extra == 'tests'
+  - parameterized ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-subtests ; extra == 'tests'
+  - bump-my-version ; extra == 'dev'
+  - darglint ; extra == 'dev'
+  - fmmax[docs,examples,tests] ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
   name: cloudpickle
   version: 3.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,12 @@ iree = [
     "iree-base-compiler",
     "iree-base-runtime"
 ]
+# RCWA (Fourier Modal Method) backend for jno.rcwa. fmmax is imported lazily
+# inside jno/rcwa.py, so the core install stays lean and only needs this extra
+# when the periodic-layered RCWA solver is actually used.
+rcwa = [
+    "fmmax",
+]
 
 
 [tool.setuptools]
@@ -142,6 +148,7 @@ default = { solve-group = "default" }
 dev = { features = ["dev"], solve-group = "default" }
 fem = { features = ["fem"], solve-group = "default" }
 iree = { features = ["iree"], solve-group = "default" }
+rcwa = { features = ["rcwa"], solve-group = "default" }
 
 [tool.pixi.tasks]
 fmt = "ruff format ."

--- a/tests/test_fem_nedelec_anisotropic.py
+++ b/tests/test_fem_nedelec_anisotropic.py
@@ -1,0 +1,86 @@
+"""Anisotropic permittivity on a Nédélec (N1E) Maxwell field — a 3×3 tensor ε̂ instead of a scalar.
+
+The mass term is authored ``inner(ε̂ @ u, v)`` (a ``MatrixView`` applied to the vector trial), giving the
+weak form ``∫ (ε̂·E)·v``. Because ``M @ u`` is linear in the unknown (the matrix is a coefficient), the
+form assembles as a steady linear system — enabling birefringence / waveplates / liquid-crystal / gyrotropic
+media in ``jno.fem``. Any tensor works: diagonal (uniaxial/biaxial), full symmetric, or complex non-symmetric.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygmsh", reason="pygmsh required for 3D cube meshing")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+from jno.trace.views import MatrixView  # noqa: E402
+
+inner, vec = jno.np.inner, jno.np.vector
+_dense = lambda A: np.asarray(jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A))  # noqa: E731
+_arr = lambda x: np.asarray(jnp.asarray(x)).reshape(-1)  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _cube(mesh_size=0.5):
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    cu, cv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    return d, (xi, yi, zi), (ui, vi), (cu, cv)
+
+
+def test_uniaxial_quadratic_form_picks_the_axis_component():
+    """Decisive physics check. For a uniaxial ε̂ = diag(εₒ, εₒ, εₑ), the mass ∫(ε̂·E)·E on the unit cube with
+    a CONSTANT field (exact in N1E0) equals εₑ for E=(0,0,1) and εₒ for E=(1,0,0) — the tensor applies the
+    right principal value per direction. Uses uᵀ·M_aniso·u on the projected constant field."""
+    eo, ee = 2.0, 5.0
+    d, (xi, yi, zi), (ui, vi), _ = _cube(0.4)
+    eps = MatrixView(vec(eo + 0 * xi, eo + 0 * yi, ee + 0 * zi).expr).from_diag()
+    M_iso = _dense(jno.fem([inner(ui, vi)]).A)  # standard mass, to project constants
+    M_an = _dense(jno.fem([inner(eps @ ui, vi)]).A)  # anisotropic mass ∫(ε̂ φ_a)·φ_b
+
+    for field, expect in [(vec(0.0 * xi, 0.0 * yi, 1.0 + 0.0 * zi), ee), (vec(1.0 + 0.0 * xi, 0.0 * yi, 0.0 * zi), eo)]:
+        u_dof = np.linalg.solve(M_iso, _arr(jno.fem([inner(ui, vi) - inner(field, vi)]).b))  # exact projection
+        np.testing.assert_allclose(float(u_dof @ M_an @ u_dof), expect, atol=1e-9)
+
+
+def test_full_symmetric_tensor_assembles_symmetric_and_is_genuinely_anisotropic():
+    """A full symmetric, spatially-varying ε̂ (off-diagonal, x/y/z-dependent) assembles to a symmetric matrix
+    that differs from BOTH isotropic limits — genuine anisotropy, not a disguised scalar."""
+    d, (xi, yi, zi), (ui, vi), (cu, cv) = _cube(0.5)
+    e00, e11, e22 = 3.0 + xi, 4.0 + yi, 5.0 - zi
+    e01, e02, e12 = 0.5 * yi, 0.3 + 0.0 * xi, 0.2 * zi
+    eps = MatrixView(vec(e00, e01, e02, e01, e11, e12, e02, e12, e22).expr).from_flat(3, 3)
+
+    A = _dense(jno.fem([inner(cu, cv) - inner(eps @ ui, vi)]).A)
+    np.testing.assert_allclose(A, A.T, atol=1e-7)  # symmetric ε̂ → symmetric operator
+    A_lo = _dense(jno.fem([inner(cu, cv) - 3.0 * inner(ui, vi)]).A)
+    A_hi = _dense(jno.fem([inner(cu, cv) - 5.0 * inner(ui, vi)]).A)
+    assert not np.allclose(A, A_lo, atol=1e-6) and not np.allclose(A, A_hi, atol=1e-6)
+
+
+def test_gyrotropic_tensor_is_complex_and_not_misclassified_nonlinear():
+    """A gyrotropic ε̂ (Hermitian, imaginary off-diagonal ε_xy = -ε_yx = ig) assembles as a COMPLEX steady
+    LINEAR system — ε̂ @ u is linear in u, so it must not be misread as a nonlinear form."""
+    g = 0.8
+    d, (xi, yi, zi), (ui, vi), (cu, cv) = _cube(0.6)
+    o, z = 1.0 + 0.0 * xi, 0.0 * xi
+    eps = MatrixView(vec(3 * o, 1j * g * o, z, -1j * g * o, 3 * o, z, z, z, 3 * o).expr).from_flat(3, 3)
+
+    fem = jno.fem([inner(cu, cv) - inner(eps @ ui, vi)])
+    assert fem.is_complex  # complex tensor → complex system (steady linear, not nonlinear)
+    op_r, op_i = fem._op
+    assert np.max(np.abs(_dense(op_i[0]))) > 1e-6  # the imaginary (gyrotropic) part survives assembly

--- a/tests/test_fem_nedelec_complex.py
+++ b/tests/test_fem_nedelec_complex.py
@@ -1,0 +1,85 @@
+"""Complex assembly on the non-nodal (Nédélec / N1E) path — the Re/Im coefficient split.
+
+The N1E basis is real, so a complex weak form ``∫curl u·curl v + i·∫u·v`` assembles as two real
+systems (the ``.real``/``.imag`` legs) that ``FEM.solve()`` recombines as ``[[K,-M],[M,K]]`` into a
+complex solution. This is the foundation for time-harmonic Maxwell in ``jno.fem`` (complex ε and the
+``i k₀`` impedance BC). Before this, the plain real assembler SILENTLY cast the imaginary part away —
+so the unwired compositions must now raise, never mislead.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygmsh", reason="pygmsh required for 3D cube meshing")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+
+inner = jno.np.inner
+_dense = lambda A: np.asarray(jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A))  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _n1e_cube(mesh_size=0.5):
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    cu, cv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    return d, (xi, yi, zi), (ui, vi), (cu, cv)
+
+
+def test_complex_coefficient_is_not_silently_dropped():
+    """A complex mass coefficient on N1E must survive assembly. The real-equivalent block routes it, so
+    the recovered solution is genuinely complex (a nonzero imaginary part) — not the real cast the plain
+    assembler used to produce."""
+    vec = jno.np.vector
+    d, (xi, yi, zi), (ui, vi), (cu, cv) = _n1e_cube(0.5)
+    fvec = vec(1.0 + 0.0 * xi, 0.0 * yi, 0.0 * zi)  # a real forcing on E_x
+
+    # (K + iM) u = L  — curl-curl stiffness K, mass M, load L from the real forcing
+    K = _dense(jno.fem([inner(cu, cv)]).A)
+    M = _dense(jno.fem([inner(ui, vi)]).A)
+    L = np.asarray(jnp.asarray(jno.fem([inner(cu, cv) - inner(fvec, vi)]).b)).reshape(-1)
+    u_ref = np.linalg.solve(K + 1j * M, L)  # the complex reference
+
+    fem = jno.fem([inner(cu, cv) + 1j * inner(ui, vi) - inner(fvec, vi)])
+    assert fem.is_complex  # routed through the real-equivalent complex path
+    u = np.asarray(jnp.asarray(fem.solve())).reshape(-1)
+
+    assert np.iscomplexobj(u) and np.max(np.abs(u.imag)) > 1e-6, "imaginary part was dropped"
+    np.testing.assert_allclose(u, u_ref, rtol=1e-8, atol=1e-9)
+
+
+def test_imaginary_leg_is_the_mass_matrix():
+    """The Im-coefficient leg of ``curl-curl + i·mass`` is exactly the N1E mass matrix, and the Re leg is
+    exactly the curl-curl matrix — the split is faithful, not approximate."""
+    d, _, (ui, vi), (cu, cv) = _n1e_cube(0.6)
+    K = _dense(jno.fem([inner(cu, cv)]).A)
+    M = _dense(jno.fem([inner(ui, vi)]).A)
+
+    fem = jno.fem([inner(cu, cv) + 1j * inner(ui, vi)])
+    op_r, op_i = fem._op  # (A_r, b_r), (A_i, b_i)
+    np.testing.assert_allclose(_dense(op_r[0]), K, atol=1e-10)
+    np.testing.assert_allclose(_dense(op_i[0]), M, atol=1e-10)
+
+
+def test_complex_parametric_nonnodal_raises_not_silent():
+    """A complex N1E *parametric/inverse* form is not wired — it must RAISE (the earlier behaviour silently
+    cast the imaginary part to zero, a silently-wrong solve)."""
+    d, (xi, yi, zi), (ui, vi), (cu, cv) = _n1e_cube(0.6)
+    a = jno.np.parameter((), name="a").initialize(jax.nn.initializers.constant(2.0))  # a runtime parameter in ε
+    with pytest.raises(NotImplementedError, match="complex non-nodal.*parametric"):
+        jno.fem([inner(cu, cv) + 1j * a * inner(ui, vi)]).A

--- a/tests/test_fem_nedelec_impedance.py
+++ b/tests/test_fem_nedelec_impedance.py
@@ -1,0 +1,103 @@
+"""N1E tangential-trace surface term — the natural impedance / first-order absorbing Maxwell BC.
+
+The weak boundary term ``c·∫_Γ (n×u)·(n×v)`` assembles into the stiffness ``A`` (a *surface mass* over
+the boundary faces), distinct from the essential PEC ``n×u=0`` (which pins DOFs). This is the boundary
+half of the Silver–Müller absorbing BC ``∫curl u·curl v − k₀²∫εu·v + i k₀∫(n×u)(n×v)`` used by RCWA.
+
+Field discovery keys off the volume term, so the surface mass is isolated as ``A[vol+surf] − A[vol]``
+(the volume block is identical in both, so the difference is exactly the surface contribution).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygmsh", reason="pygmsh required for 3D cube meshing")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+
+inner = jno.np.inner
+_dense = lambda A: np.asarray(jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A))  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _cube(mesh_size=0.5):
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    ccu, ccv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    nvec = d.variable("boundary", normals=True)
+    tu, tv = u.vector.cross(nvec), v.vector.cross(nvec)  # n×u, n×v (tangential trace)
+    return d, (xi, yi, zi), (ui, vi), (ccu, ccv), (tu, tv)
+
+
+def _surface_mass(vol, surf):
+    """Isolate the surface-mass matrix S = A[vol + surf] − A[vol] (a real volume term registers the field)."""
+    return _dense(jno.fem([vol, surf]).A) - _dense(jno.fem([vol]).A)
+
+
+def test_surface_mass_is_symmetric_psd():
+    """The tangential-trace surface term assembles to a symmetric, positive-SEMI-definite matrix (a mass on
+    the boundary edges only — interior/normal DOFs give zero, hence semi-definite, not definite)."""
+    d, _, (ui, vi), (ccu, ccv), (tu, tv) = _cube(0.5)
+    S = _surface_mass(inner(ccu, ccv) + inner(ui, vi), inner(tu, tv))
+    np.testing.assert_allclose(S, S.T, atol=1e-10)
+    evals = np.linalg.eigvalsh(S)
+    assert evals.min() > -1e-9, f"surface mass must be PSD; min eig = {evals.min():.2e}"
+    assert evals.max() > 1e-6, "surface mass is entirely zero — the boundary faces were not integrated"
+
+
+def test_surface_mass_matches_analytic_tangential_integral():
+    """Decisive geometry check: the constant field E=(0,0,1) is exact in N1E0 (Whitney), and its
+    tangential-trace surface integral over the unit cube is ∮|n×E|² = 4 (the four side faces contribute
+    1 each; the top/bottom faces have n∥E so contribute 0). Projecting E to its edge DOFs and evaluating
+    uᵀSu must reproduce 4."""
+    vec = jno.np.vector
+    d, (xi, yi, zi), (ui, vi), (ccu, ccv), (tu, tv) = _cube(0.4)
+    E0 = vec(0.0 * xi, 0.0 * yi, 1.0 + 0.0 * zi)  # constant (0,0,1)
+
+    M = _dense(jno.fem([inner(ui, vi)]).A)  # N1E mass
+    load = np.asarray(jnp.asarray(jno.fem([inner(ui, vi) - inner(E0, vi)]).b)).reshape(-1)  # ∫ E0·φ
+    u_dof = np.linalg.solve(M, load)  # exact L² projection of the constant field
+    S = _surface_mass(inner(ui, vi), inner(tu, tv))
+
+    np.testing.assert_allclose(float(u_dof @ S @ u_dof), 4.0, atol=1e-9)
+
+
+def test_coefficient_scales_the_surface_mass():
+    """A scalar coefficient multiplies the surface mass linearly: 2.5·inner(n×u,n×v) gives 2.5·S."""
+    d, _, (ui, vi), (ccu, ccv), (tu, tv) = _cube(0.6)
+    vol = inner(ccu, ccv) + inner(ui, vi)
+    S = _surface_mass(vol, inner(tu, tv))
+    S25 = _surface_mass(vol, 2.5 * inner(tu, tv))
+    np.testing.assert_allclose(S25, 2.5 * S, atol=1e-9)
+
+
+def test_imaginary_impedance_lands_in_the_imag_leg():
+    """The physical use: an ``i·k₀`` impedance coefficient is purely imaginary, so the surface mass lands in
+    the Im leg of the complex system (A_i) and the Re leg (A_r) keeps only the curl-curl − k₀² mass volume."""
+    d, (xi, yi, zi), (ui, vi), (ccu, ccv), (tu, tv) = _cube(0.6)
+    k0 = 2.0
+
+    fem = jno.fem([inner(ccu, ccv) - k0**2 * inner(ui, vi), 1j * k0 * inner(tu, tv)])
+    assert fem.is_complex
+    op_r, op_i = fem._op
+
+    S = _surface_mass(inner(ui, vi), inner(tu, tv))
+    K = _dense(jno.fem([inner(ccu, ccv)]).A)
+    Mm = _dense(jno.fem([inner(ui, vi)]).A)
+    np.testing.assert_allclose(_dense(op_r[0]), K - k0**2 * Mm, atol=1e-8)  # Re leg: curl-curl − k0² mass
+    np.testing.assert_allclose(_dense(op_i[0]), k0 * S, atol=1e-8)  # Im leg: k0 · surface mass

--- a/tests/test_fem_nedelec_incident.py
+++ b/tests/test_fem_nedelec_incident.py
@@ -84,6 +84,30 @@ def test_complex_incident_lands_in_the_imag_leg():
     np.testing.assert_allclose(_arr(b_i), 2.0 * k0 * b_ref, atol=1e-8)  # Im leg: 2 k0 · load
 
 
+def test_combined_absorbing_plus_incident_on_one_face():
+    """A single boundary entry may combine the absorbing mass and the incident load —
+    ``i k₀·inner(n×u,n×v) + 2 i k₀·inner(g,n×v)`` — and the additive split routes the bilinear part into A
+    and the trial-free part into b (equal to authoring them as two separate entries)."""
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=0.5))
+    d.tag("top", lambda x, y, z: z > 1.0 - 1e-6)
+    k0 = 2.0
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    nt = d.variable("top", normals=True)
+    ct = d.variable("top", split=True)
+    tu, tv = u.vector.cross(nt), v.vector.cross(nt)
+    g = vec(1.0 + 0.0 * ct[0], 0.0 * ct[1], 0.0 * ct[2])
+
+    combined = jno.fem([inner(ui, vi), 1j * k0 * inner(tu, tv) + 2j * k0 * inner(g, tv)])
+    separate = jno.fem([inner(ui, vi), 1j * k0 * inner(tu, tv), 2j * k0 * inner(g, tv)])
+    (Ar_c, br_c), (Ai_c, bi_c) = combined._op
+    (Ar_s, br_s), (Ai_s, bi_s) = separate._op
+    np.testing.assert_allclose(_dense(Ai_c), _dense(Ai_s), atol=1e-9)  # same surface mass into A_i
+    np.testing.assert_allclose(_arr(bi_c), _arr(bi_s), atol=1e-9)  # same incident load into b_i
+
+
 def test_driven_maxwell_end_to_end_solves():
     """Integration of commits 1–3: a FULL driven time-harmonic Maxwell problem — curl-curl − k₀²·mass
     volume, the i·k₀ impedance absorbing BC on the whole boundary, and a plane-wave incident source on the

--- a/tests/test_fem_nedelec_incident.py
+++ b/tests/test_fem_nedelec_incident.py
@@ -1,0 +1,119 @@
+"""N1E incident/forcing surface term — the RHS of the Silver–Müller absorbing BC.
+
+The trial-free weak boundary term ``inner(g, n×v)`` assembles into the load ``b`` (a surface integral
+``∫_Γ g·(φ×n) dS`` over the boundary faces): ``g`` is the prescribed tangential source — e.g. a
+plane-wave incident field ``2 i k₀ E_inc``. This completes the driven Maxwell problem
+``∫curl E·curl v − k₀²∫εE·v + i k₀∫(n×E)(n×v) = ∫ g·(n×v)`` in ``jno.fem``.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygmsh", reason="pygmsh required for 3D cube meshing")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+
+inner = jno.np.inner
+vec = jno.np.vector
+_dense = lambda A: np.asarray(jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A))  # noqa: E731
+_arr = lambda x: np.asarray(jnp.asarray(x)).reshape(-1)  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _cube_with_top(mesh_size=0.4):
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    d.tag("top", lambda x, y, z: z > 1.0 - 1e-6)  # a single boundary face (z = 1)
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    ntop = d.variable("top", normals=True)
+    ct = d.variable("top", split=True)  # top-face coords, so a source g lives on the `top` region
+    tv_top = v.vector.cross(ntop)  # v×n on the top face
+    return d, (xi, yi, zi), (ct[0], ct[1], ct[2]), (ui, vi), tv_top
+
+
+def test_incident_load_matches_analytic_single_face():
+    """Decisive geometry/sign check on one face. On the top face (n=(0,0,1)) with source g=(0,1,0) and the
+    constant field u*=(1,0,0) (exact in N1E0): ∫_top g·(u*×n) = (0,1,0)·((1,0,0)×(0,0,1)) = (0,1,0)·(0,−1,0)
+    = −1 over the unit-area face. Projecting u* to its DOFs, u*·b must reproduce −1."""
+    d, (xi, yi, zi), (xt, yt, zt), (ui, vi), tv_top = _cube_with_top(0.4)
+    g = vec(0.0 * xt, 1.0 + 0.0 * yt, 0.0 * zt)  # constant (0,1,0) on the top face
+    u_star = vec(1.0 + 0.0 * xi, 0.0 * yi, 0.0 * zi)  # constant (1,0,0), exact in N1E0
+
+    M = _dense(jno.fem([inner(ui, vi)]).A)
+    u_dof = np.linalg.solve(M, _arr(jno.fem([inner(ui, vi) - inner(u_star, vi)]).b))  # exact projection
+    b = _arr(jno.fem([inner(ui, vi), inner(g, tv_top)]).b)  # volume mass registers the field; load into b
+
+    np.testing.assert_allclose(float(u_dof @ b), -1.0, atol=1e-9)
+
+
+def test_incident_load_is_linear_in_the_source():
+    """The load is linear in g: doubling the source doubles the load vector."""
+    d, (xi, yi, zi), (xt, yt, zt), (ui, vi), tv_top = _cube_with_top(0.5)
+    g = vec(0.3 + 0.0 * xt, 1.0 + 0.0 * yt, -0.5 + 0.0 * zt)
+    b1 = _arr(jno.fem([inner(ui, vi), inner(g, tv_top)]).b)
+    b2 = _arr(jno.fem([inner(ui, vi), inner(2.0 * g, tv_top)]).b)
+    np.testing.assert_allclose(b2, 2.0 * b1, atol=1e-10)
+
+
+def test_complex_incident_lands_in_the_imag_leg():
+    """A physical ``i·k₀`` incident source is purely imaginary, so the forcing lands in the Im leg's load
+    (b_i) and the Re leg's load (b_r) stays zero — composing with the complex N1E path."""
+    d, (xi, yi, zi), (xt, yt, zt), (ui, vi), tv_top = _cube_with_top(0.5)
+    k0 = 2.0
+    g = vec(0.0 * xt, 1.0 + 0.0 * yt, 0.0 * zt)
+
+    fem = jno.fem([inner(ui, vi) + 0j * inner(ui, vi), 2j * k0 * inner(g, tv_top)])
+    assert fem.is_complex
+    (_Ar, b_r), (_Ai, b_i) = fem._op
+    b_ref = _arr(jno.fem([inner(ui, vi), inner(g, tv_top)]).b)  # real reference load
+    np.testing.assert_allclose(_arr(b_r), 0.0, atol=1e-10)  # Re leg: no source
+    np.testing.assert_allclose(_arr(b_i), 2.0 * k0 * b_ref, atol=1e-8)  # Im leg: 2 k0 · load
+
+
+def test_driven_maxwell_end_to_end_solves():
+    """Integration of commits 1–3: a FULL driven time-harmonic Maxwell problem — curl-curl − k₀²·mass
+    volume, the i·k₀ impedance absorbing BC on the whole boundary, and a plane-wave incident source on the
+    top face — assembles as a complex system and SOLVES to a finite, non-trivial complex field. (The
+    impedance term provides radiation damping, so the otherwise-indefinite Helmholtz operator is well posed.)"""
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=0.4))
+    d.tag("top", lambda x, y, z: z > 1.0 - 1e-6)
+    k0 = 3.0
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    ccu, ccv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    nb = d.variable("boundary", normals=True)
+    nt = d.variable("top", normals=True)
+    ct = d.variable("top", split=True)
+    tu, tv = u.vector.cross(nb), v.vector.cross(nb)  # impedance on the whole boundary
+    tv_top = v.vector.cross(nt)
+    g = vec(1.0 + 0.0 * ct[0], 0.0 * ct[1], 0.0 * ct[2])  # x-polarised incident source on top
+
+    fem = jno.fem(
+        [
+            inner(ccu, ccv) - k0**2 * inner(ui, vi),  # curl-curl − k0² mass
+            1j * k0 * inner(tu, tv),  # impedance absorbing BC
+            2j * k0 * inner(g, tv_top),  # incident plane wave
+        ]
+    )
+    assert fem.is_complex
+    E = _arr(fem.solve())
+    assert np.iscomplexobj(E)
+    assert np.all(np.isfinite(E))
+    assert np.max(np.abs(E)) > 1e-6  # a genuine, non-trivial scattered field
+    assert np.max(np.abs(E.imag)) > 1e-9  # genuinely complex (radiation phase), not a real solve

--- a/tests/test_fem_nedelec_periodic.py
+++ b/tests/test_fem_nedelec_periodic.py
@@ -1,0 +1,96 @@
+"""Floquet/Bloch periodic ties on a Nédélec (N1E) edge field — DOF-level edge prolongation.
+
+An N1E DOF is one edge's tangential moment, so a periodic tie matches boundary edges across the tied
+faces (by transverse midpoint) with an orientation sign and a Bloch phase. Because edge DOFs must line
+up one-to-one, jno RE-MESHES the box conforming (gmsh setPeriodic) automatically when it sees periodic
+ties on an N1E field — inferred from the constraint list, no explicit request.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+
+inner = jno.np.inner
+_dense = lambda A: np.asarray(jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A))  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _periodic_box(size=0.3):
+    d = jno.domain(jno.Shape.box(0, 0, 0, 0.6, 0.6, 1.0, size=size))
+    e = 1e-6
+    d.tag("left", lambda x, y, z: x < e)
+    d.tag("right", lambda x, y, z: x > 0.6 - e)
+    d.tag("front", lambda x, y, z: y < e)
+    d.tag("back", lambda x, y, z: y > 0.6 - e)
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    cu, cv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+
+    def face(nm):
+        cc = d.variable(nm, split=True)
+        return u.bind(x=cc[0], y=cc[1], z=cc[2])
+
+    ties = [face("left") - face("right"), face("front") - face("back")]
+    return d, (inner(cu, cv) + inner(ui, vi)), ties
+
+
+def test_periodic_n1e_reduces_and_is_symmetric_pd():
+    """Periodic ties on an N1E field eliminate the slave-face edge DOFs (``n_red < n_full``) and the reduced
+    curl-curl + mass operator PᵀAP stays symmetric positive-definite. The box is auto-re-meshed conforming."""
+    from jno.utils.solver.fem_utils import reduce_matrix_periodic
+
+    d, vol, ties = _periodic_box(0.3)
+    fem = jno.fem([vol, *ties])  # triggers the conforming re-mesh + edge reduction
+    per = fem._periodic
+    assert per is not None and per["n_red"] < per["n_full"], "periodic reduction eliminated no slave-face edges"
+
+    A_red = _dense(reduce_matrix_periodic(per, fem.A))
+    assert A_red.shape == (per["n_red"], per["n_red"])
+    np.testing.assert_allclose(A_red, A_red.T, atol=1e-9)
+    assert float(np.linalg.eigvalsh(A_red).min()) > 0.0  # +mass makes the reduced operator PD
+
+
+def test_periodic_n1e_infers_remesh_from_constraints_only():
+    """The conforming re-mesh is inferred purely from the periodic constraints — no explicit ``periodic=``
+    argument. After a periodic solve the domain is marked, and a non-periodic assembly on it is a no-op."""
+    d, vol, ties = _periodic_box(0.25)
+    assert not getattr(d, "_periodic_meshed", frozenset())  # nothing yet
+    jno.fem([vol, *ties])  # authoring periodic ties on an N1E field re-meshes the box
+    marked = getattr(d, "_periodic_meshed", frozenset())
+    assert frozenset({"left", "right"}) in marked and frozenset({"front", "back"}) in marked
+
+
+def test_periodic_n1e_bloch_phase_is_complex():
+    """A Bloch (quasi-periodic) phase makes the prolongation — and the reduced operator — complex, while a
+    plain periodic tie stays real. Validates the phase threads through the edge prolongation."""
+    d, vol, _ = _periodic_box(0.25)
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    cu, cv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+
+    def face(nm):
+        cc = d.variable(nm, split=True)
+        return u.bind(x=cc[0], y=cc[1], z=cc[2])
+
+    phase = np.exp(1j * 0.7)  # Bloch phase e^{iφ}
+    fem = jno.fem([inner(cu, cv) + inner(ui, vi), face("left") - phase * face("right"), face("front") - face("back")])
+    assert fem._periodic is not None and fem._periodic.get("is_bloch")  # quasi-periodic reduction

--- a/tests/test_fem_periodic_bloch.py
+++ b/tests/test_fem_periodic_bloch.py
@@ -1,0 +1,104 @@
+"""Bloch / quasi-periodic ties: ``u(A) = e^{i k·L} u(B)``. The phase makes the prolongation ``P``
+complex, so the reduction is Hermitian (``P^H A P``) and the complex system is solved directly.
+
+Plain periodic (phase == 1) must stay a real 0/1 selection (regression guard)."""
+
+import numpy as np
+import pytest
+
+import jno
+
+
+def test_bloch_prolongation_is_complex_plain_is_real():
+    from jno.utils.solver.fem_utils import build_periodic_prolongation
+
+    pts = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
+    tags = {"left": np.array([0, 1]), "right": np.array([2, 3])}
+    plain = build_periodic_prolongation(pts, [("left", "right")], tags)
+    bloch = build_periodic_prolongation(pts, [("left", "right")], tags, phases=[np.exp(1j * 0.7)])
+    assert plain["is_bloch"] is False and not np.iscomplexobj(np.asarray(plain["P"].data))
+    assert bloch["is_bloch"] is True and np.iscomplexobj(np.asarray(bloch["P"].data))
+    # slave rows carry the Bloch factor e^{i 0.7}
+    assert np.allclose(np.abs(np.asarray(bloch["P"].data)), 1.0)
+
+
+def test_bloch_scaled_by_nonconstant_rejected():
+    """A tie may be scaled only by a constant scalar; a coordinate-dependent factor is not a Bloch phase."""
+    d = jno.domain(jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5))
+    e = 1e-6
+    d.tag("left", lambda x, y, z: x < e)
+    d.tag("right", lambda x, y, z: x > 1 - e)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    lc = d.variable("left", split=True)
+    rc = d.variable("right", split=True)
+    ul = u.bind(x=lc[0], y=lc[1], z=lc[2])
+    ur = u.bind(x=rc[0], y=rc[1], z=rc[2])
+    vi = phi.bind(x=xi, y=yi, z=zi)
+    ui = u.bind(x=xi, y=yi, z=zi)
+    with pytest.raises(ValueError, match="periodic tie"):
+        jno.fem([ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - (u * vi), ul - rc[0] * ur])  # x*u(B): not constant
+
+
+@pytest.mark.slow
+def test_bloch_empty_cell_transmits_at_oblique():
+    """The end-to-end physical check: an empty (eps=1) periodic cell must transmit fully (T=1, R=0) at
+    oblique incidence for *every* Bloch phase -- validates the complex prolongation + Hermitian reduce +
+    complex solve, independent of any scattering structure."""
+    import jax
+
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        import jax.numpy as jnp
+
+        K0 = 2 * np.pi
+        P0, Lz = 0.6, 1.6
+        for deg in (0.0, 20.0, 35.0):
+            kx = float(K0 * np.sin(np.deg2rad(deg)))
+            kz = float(np.sqrt(K0**2 - kx**2))
+            d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.12))
+            e = 1e-6
+            for nm, f in [
+                ("left", lambda x, y, z: x < e),
+                ("right", lambda x, y, z: x > P0 - e),
+                ("front", lambda x, y, z: y < e),
+                ("back", lambda x, y, z: y > P0 - e),
+                ("bottom", lambda x, y, z: z < e),
+                ("top", lambda x, y, z: z > Lz - e),
+            ]:
+                d.tag(nm, f)
+            u, phi = d.fem_symbols()
+            xi, yi, zi, _ = d.variable("interior", split=True)
+            ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+            def fc(nm):
+                c = d.variable(nm, split=True)
+                return c, u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+            cb, ubt, vbt = fc("bottom")
+            _ct, utp, vtp = fc("top")
+            _cl, ul, _ = fc("left")
+            _cr, ur, _ = fc("right")
+            _cf, uf, _ = fc("front")
+            _ck, ubk, _ = fc("back")
+            cphase = np.exp(-1j * kx * P0)
+            src = jno.fn(lambda x, y: jnp.exp(1j * kx * x), [cb[0], cb[1]])
+            cons = [
+                ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * (u * vi),
+                -(1j * kz * utp) * vtp,
+                -(1j * kz * ubt - 2j * kz * src) * vbt,
+                ul - cphase * ur,
+                uf - ubk,
+            ]
+            uu = np.asarray(jno.fem(cons).solve())
+            P = np.asarray(d.points)
+            top = P[:, 2] > Lz - 1e-4
+            bot = P[:, 2] < 1e-4
+            t0 = (uu[top] * np.exp(-1j * kx * P[top, 0])).mean()
+            r0 = (uu[bot] * np.exp(-1j * kx * P[bot, 0])).mean() - 1.0
+            T, R = abs(t0) ** 2, abs(r0) ** 2
+            assert abs(T - 1.0) < 0.03, f"theta={deg}: empty cell T={T:.3f} (expected 1)"
+            assert R < 0.02, f"theta={deg}: empty cell R={R:.3f} (expected 0)"
+    finally:
+        jax.config.update("jax_enable_x64", prev)

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -106,8 +106,9 @@ def _build_periodic_problem(dx=0.4):
 # Inference (no fmmax needed)
 # ------------------------------------------------------------------------------------
 def test_infer_spec_from_periodic_problem():
-    constraints, eps = _build_periodic_problem()
-    rc = jno.rcwa(constraints, eps, orders=100, wavelength=WL, grid=16, nz=33)
+    """Everything — period, layers, permittivity AND wavelength — inferred from the constraint list."""
+    constraints, _ = _build_periodic_problem()
+    rc = jno.rcwa(constraints, orders=100, grid=16, nz=33)  # no eps, no wavelength
     s = rc.spec
     # periodicity + period from the Floquet ties
     assert abs(s.period[0] - 2.4) < 1e-6 and abs(s.period[1] - 2.4) < 1e-6
@@ -116,26 +117,33 @@ def test_infer_spec_from_periodic_problem():
     assert len(s.layers) == 3, [ly[0] for ly in s.layers]
     assert s.layers[0][0] == INF and s.layers[-1][0] == INF
     assert abs(s.layers[1][0] - 0.35) < 0.12, s.layers[1][0]
-    # patterned layer eps at rho=0 -> 1 + 0.5*(EMAX-1) = 3.5; ambients are air
+    # relative permittivity recovered: patterned layer -> 3.5 at rho=0; ambients are vacuum (1.0)
     assert abs(float(np.real(s.layers[1][1]).max()) - 3.5) < 0.05
-    assert abs(float(np.real(s.layers[0][1]).max()) - 1.0) < 0.05
+    assert abs(float(np.real(s.layers[0][1]).max()) - 1.0) < 0.02
+    # wavelength inferred from the vacuum superstrate (k0 = 2*pi -> lambda = 1)
+    assert abs(s.wavelength - 1.0) < 1e-3
     # normally-incident source read off the bottom face
     assert s.k_in == (0.0, 0.0)
-    assert s.wavelength == WL
     assert s.source_face in ("bottom", "top")
+
+
+def test_explicit_wavelength_override():
+    constraints, _ = _build_periodic_problem()
+    rc = jno.rcwa(constraints, orders=100, wavelength=WL, grid=16, nz=33)
+    assert abs(rc.spec.wavelength - WL) < 1e-9
 
 
 def test_non_periodic_problem_raises():
     """A finite aperture (absorbing side walls, no ties) must be rejected, never silently periodicised."""
-    constraints, eps = _build_periodic_problem()
+    constraints, _ = _build_periodic_problem()
     non_periodic = constraints[:3]  # drop the two periodic ties
     with pytest.raises(jno.RcwaError, match="periodic"):
-        jno.rcwa(non_periodic, eps, orders=100, wavelength=WL, grid=16, nz=33)
+        jno.rcwa(non_periodic, orders=100, grid=16, nz=33)
 
 
 def test_bad_problem_type_raises():
     with pytest.raises(jno.RcwaError, match="constraint list"):
-        jno.rcwa(42, None, orders=10, wavelength=WL)
+        jno.rcwa(42, orders=10)
 
 
 # ------------------------------------------------------------------------------------
@@ -207,8 +215,8 @@ def test_engine_requires_assume_periodic():
 @needs_fmmax
 def test_infer_and_solve_end_to_end():
     """The full path: infer from the periodic problem, then solve — energy must be conserved."""
-    constraints, eps = _build_periodic_problem()
-    rc = jno.rcwa(constraints, eps, orders=100, wavelength=WL, grid=32, nz=33)
+    constraints, _ = _build_periodic_problem()
+    rc = jno.rcwa(constraints, orders=100, grid=32, nz=33)
     sol = rc.solve()
     T, R = sol.efficiency("T"), sol.efficiency("R")
     assert T + R <= 1.0 + 5e-3 and T >= 0 and R >= 0

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -301,6 +301,38 @@ def test_parameter_anywhere_wavelength_and_eps_flow():
 
 
 @needs_fmmax
+def test_free_form_nodal_density_is_differentiable():
+    """A per-node (topology-optimisation) density — jno.np.parameter(<symbol>) — flows: solve() is a trace
+    node over the whole nodal field, and jax.grad w.r.t. it matches a directional finite-difference."""
+    import equinox as eqx
+    import jax
+    import jax.numpy as jnp
+
+    from jno.trace_evaluator import TraceEvaluator
+
+    constraints, _ = _build_periodic_problem(dx=0.4)  # eps = 1 + lay * proj(rho) * (EMAX-1), rho per node
+    rc = jno.rcwa(constraints, orders=40, grid=16, nz=33)
+    assert sorted(rc._rpe) == ["rho"]
+    node = rc.solve().efficiency("T")  # NO solve args -> trace node over the nodal density
+    mc = rc._rpe["rho"]
+    mod0 = mc.model.module
+    n = int(np.asarray(mod0.value).shape[0])
+
+    def T(rv):
+        mod = eqx.tree_at(lambda mm: mm.value, mod0, jnp.asarray(rv))
+        return TraceEvaluator({mc.model.layer_id: mod}).evaluate(node)
+
+    rng = np.random.default_rng(0)
+    rv0 = rng.standard_normal(n) * 0.5
+    g = np.asarray(jax.grad(T)(rv0))
+    assert np.all(np.isfinite(g)) and np.linalg.norm(g) > 1e-3  # a real, non-zero design gradient
+    d = rng.standard_normal(n)
+    h = 1e-3
+    fd = (float(T(rv0 + h * d)) - float(T(rv0 - h * d))) / (2 * h)
+    assert abs(float(g @ d) - fd) < 2e-2, f"directional grad {float(g @ d)} vs finite-diff {fd}"
+
+
+@needs_fmmax
 def test_parameter_is_traced_no_solve_args():
     """The jNO way: a jno.np.parameter in the constraint list makes rc.solve().efficiency() a TRACE NODE
     over that parameter -- differentiable through crux with NO solve arguments, exactly like jno.fem."""

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -301,6 +301,72 @@ def test_parameter_anywhere_wavelength_and_eps_flow():
 
 
 @needs_fmmax
+def test_parameter_is_traced_no_solve_args():
+    """The jNO way: a jno.np.parameter in the constraint list makes rc.solve().efficiency() a TRACE NODE
+    over that parameter -- differentiable through crux with NO solve arguments, exactly like jno.fem."""
+    import equinox as eqx
+    import jax
+    import jax.numpy as jnp
+
+    from jno.trace import FunctionCall
+    from jno.trace_evaluator import TraceEvaluator
+
+    P0, Lz = 0.6, 3.2
+    d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
+    e = 1e-6
+    for nm, f in [
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > P0 - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > P0 - e),
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > Lz - e),
+    ]:
+        d.tag(nm, f)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def fc(nm):
+        c = d.variable(nm, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = fc("bottom")
+    utp, vtp = fc("top")
+    ul, _ = fc("left")
+    ur, _ = fc("right")
+    uf, _ = fc("front")
+    ubk, _ = fc("back")
+    K0 = 2 * jnp.pi
+    ep = jno.np.parameter((), name="ep").initialize(jax.nn.initializers.constant(6.0))  # a parameter in eps
+    ind = jno.fn(
+        lambda x, y, z: jnp.where(((x - 0.3) ** 2 + (y - 0.3) ** 2 < 0.18**2) & (z >= 0.8) & (z < 1.15), 1.0, 0.0),
+        [xi, yi, zi],
+    )
+    eps = 1.0 + ind * (ep - 1.0)
+    cons = [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ubk,
+    ]
+    rc = jno.rcwa(cons, orders=40, grid=32, nz=40, params={"ep": 6.0})
+
+    node = rc.solve().efficiency("T")  # NO solve arguments
+    assert isinstance(node, FunctionCall), type(node)
+
+    def T(v):  # thread the parameter value through the trace node -- what jno.core/crux does
+        mod = eqx.tree_at(lambda m: m.value, ep.model.module, jnp.asarray(v))
+        return TraceEvaluator({ep.model.layer_id: mod}).evaluate(node)
+
+    g = float(jax.grad(T)(6.0))
+    h = 1e-2
+    fd = (float(T(6.0 + h)) - float(T(6.0 - h))) / (2 * h)
+    assert abs(g - fd) < 5e-3, f"autodiff {g} vs finite-diff {fd}"
+
+
+@needs_fmmax
 def test_broadband_spectrum_and_wavelength_gradient():
     """Sweeping wavelength gives a dispersion curve; T is differentiable in wavelength (matches FD)."""
     import jax

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -242,6 +242,65 @@ def test_efficiency_is_differentiable_in_the_design():
 
 
 @needs_fmmax
+def test_parameter_anywhere_wavelength_and_eps_flow():
+    """A jno.np.parameter used as the wavelength (K0) — anywhere in the graph — is a differentiable knob:
+    jno.rcwa re-derives eps AND k0 from the parameterized coefficient, and jax.grad flows (matches FD)."""
+    import jax
+    import jax.numpy as jnp
+
+    P0, Lz = 0.6, 3.2
+    d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
+    e = 1e-6
+    for nm, f in [
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > P0 - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > P0 - e),
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > Lz - e),
+    ]:
+        d.tag(nm, f)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def fc(nm):
+        c = d.variable(nm, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = fc("bottom")
+    utp, vtp = fc("top")
+    ul, _ = fc("left")
+    ur, _ = fc("right")
+    uf, _ = fc("front")
+    ubk, _ = fc("back")
+    K0 = jno.np.parameter((), name="k0").initialize(jax.nn.initializers.constant(2 * np.pi))  # WAVELENGTH param
+    ind = jno.fn(
+        lambda x, y, z: jnp.where(((x - 0.3) ** 2 + (y - 0.3) ** 2 < 0.18**2) & (z >= 0.8) & (z < 1.15), 1.0, 0.0),
+        [xi, yi, zi],
+    )
+    eps = 1.0 + ind * (6.0 - 1.0)
+    cons = [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ubk,
+    ]
+    rc = jno.rcwa(cons, orders=40, grid=32, nz=40, params={"k0": 2 * np.pi})
+    assert abs(rc.spec.wavelength - 1.0) < 1e-3
+
+    def T(k0v):
+        return rc.solve(params={"k0": k0v}).efficiency("T")
+
+    k = 2 * np.pi
+    g = float(jax.grad(T)(k))
+    h = 1e-2
+    fd = (float(T(k + h)) - float(T(k - h))) / (2 * h)
+    assert g == g and abs(g - fd) < 5e-2, f"dT/dK0 autodiff {g} vs finite-diff {fd}"
+
+
+@needs_fmmax
 def test_broadband_spectrum_and_wavelength_gradient():
     """Sweeping wavelength gives a dispersion curve; T is differentiable in wavelength (matches FD)."""
     import jax

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -1,0 +1,86 @@
+"""Tests for jno.rcwa: physical correctness (vs analytic Fresnel/TMM) + the never-silent guards.
+
+Skipped in full when the optional `fmmax` backend is not installed (mirrors tests/test_iree.py)."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("fmmax", reason="fmmax (jno.rcwa backend) not installed")
+
+import jno  # noqa: E402
+from jno.rcwa import Rcwa, RcwaError  # noqa: E402
+
+WL = 1.03
+INF = np.inf
+
+
+def tmm_slab(nn, h, lam):
+    """Analytic air|slab|air transmittance via a 2x2 transfer matrix."""
+
+    def iface(a, b):
+        r = (a - b) / (a + b)
+        t = 2 * a / (a + b)
+        return np.array([[1, r], [r, 1]]) / t
+
+    beta = 2 * np.pi * nn * h / lam
+    M = iface(1, nn) @ np.array([[np.exp(-1j * beta), 0], [0, np.exp(1j * beta)]]) @ iface(nn, 1)
+    return abs(1 / M[0, 0]) ** 2
+
+
+@pytest.mark.parametrize("nn,h", [(1.45, 0.5), (2.0, 0.4), (3.317, 0.3)])
+def test_fresnel_matches_analytic(nn, h):
+    """A uniform slab reproduces the analytic Fresnel transmittance and conserves energy."""
+    rc = Rcwa([(INF, 1.0), (h, nn**2), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
+    sol = rc.solve(inc=None)
+    T, R = sol.efficiency("T"), sol.efficiency("R")
+    assert abs(T - tmm_slab(nn, h, WL)) < 2e-3
+    assert abs(T + R - 1) < 1e-3
+
+
+def test_functional_entry_point_matches_class():
+    """jno.rcwa(...) builds the same problem as the Rcwa class."""
+    rc = jno.rcwa([(INF, 1.0), (0.4, 4.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
+    assert isinstance(rc, Rcwa)
+    T = rc.solve().efficiency("T")
+    assert abs(T - tmm_slab(2.0, 0.4, WL)) < 2e-3
+
+
+def test_guard_non_periodic_raises():
+    with pytest.raises(RcwaError, match="assume_periodic"):
+        Rcwa([(INF, 1.0), (0.3, 11.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL)
+
+
+def test_guard_bad_period_raises():
+    with pytest.raises(RcwaError, match="period"):
+        Rcwa([(INF, 1.0)], period=(-1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
+
+
+def test_guard_empty_layers_raises():
+    with pytest.raises(RcwaError, match="layers"):
+        Rcwa([], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
+
+
+def test_guard_missing_wavelength_raises():
+    rc = Rcwa([(INF, 1.0), (0.3, 11.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, assume_periodic=True)
+    with pytest.raises(RcwaError, match="wavelength"):
+        rc.solve(None)
+
+
+def test_guard_coarse_grid_vs_orders_raises():
+    big = np.ones((6, 6)) * 11.0
+    with pytest.raises(RcwaError, match="under-resolve"):
+        Rcwa([(INF, 1.0), (0.3, big), (INF, 1.0)], period=(1.0, 1.0), orders=400, wavelength=WL, assume_periodic=True)
+
+
+def test_bad_efficiency_kind_raises():
+    rc = Rcwa([(INF, 1.0), (0.4, 4.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
+    with pytest.raises(RcwaError, match="'T' or 'R'"):
+        rc.solve().efficiency("Q")
+
+
+def test_as_precond_without_transfer_raises():
+    """as_precond must never hand back a silent no-op preconditioner."""
+    rc = Rcwa([(INF, 1.0), (0.4, 4.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
+    spec = rc.as_precond()
+    with pytest.raises(RcwaError, match="transfer"):
+        spec.materialize(ctx=None)

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -324,6 +324,14 @@ def test_broadband_spectrum_and_wavelength_gradient():
     fd = (float(T(1.0 + h)) - float(T(1.0 - h))) / (2 * h)
     assert abs(g - fd) < 5e-2, f"dT/dlambda autodiff {g} vs finite-diff {fd}"
 
+    # angle-resolved: k_in is a differentiable knob too (oblique incidence)
+    def T_angle(kx):
+        return rc.solve(k_in=jnp.array([kx, 0.0])).efficiency("T")
+
+    ga = float(jax.grad(T_angle)(1.0))
+    fda = (float(T_angle(1.0 + h)) - float(T_angle(1.0 - h))) / (2 * h)
+    assert abs(ga - fda) < 5e-2, f"dT/dk_in autodiff {ga} vs finite-diff {fda}"
+
 
 @needs_fmmax
 def test_infer_and_solve_end_to_end():

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -242,6 +242,31 @@ def test_efficiency_is_differentiable_in_the_design():
 
 
 @needs_fmmax
+def test_broadband_spectrum_and_wavelength_gradient():
+    """Sweeping wavelength gives a dispersion curve; T is differentiable in wavelength (matches FD)."""
+    import jax
+    import jax.numpy as jnp
+
+    from jno.rcwa import Rcwa
+
+    P, r, th, ng = 0.6, 0.18, 0.5, 32
+    xs = (np.arange(ng) + 0.5) / ng * P
+    X, Y = np.meshgrid(xs, xs, indexing="ij")
+    E = jnp.asarray(np.where((X - P / 2) ** 2 + (Y - P / 2) ** 2 < r**2, 6.0, 1.0))
+    rc = Rcwa([(INF, 1.0), (th, E), (INF, 1.0)], period=(P, P), orders=40, wavelength=1.0, assume_periodic=True)
+
+    def T(wl):
+        return rc.solve(wavelength=wl).efficiency("T")
+
+    spec = [float(T(wl)) for wl in (0.9, 1.0, 1.2)]
+    assert max(spec) - min(spec) > 0.1, f"expected a dispersive response, got {spec}"  # not flat
+    g = float(jax.grad(T)(1.0))
+    h = 1e-2
+    fd = (float(T(1.0 + h)) - float(T(1.0 - h))) / (2 * h)
+    assert abs(g - fd) < 5e-2, f"dT/dlambda autodiff {g} vs finite-diff {fd}"
+
+
+@needs_fmmax
 def test_infer_and_solve_end_to_end():
     """The full path: infer from the periodic problem, then solve — energy must be conserved."""
     constraints, _ = _build_periodic_problem()

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -301,6 +301,74 @@ def test_parameter_anywhere_wavelength_and_eps_flow():
 
 
 @needs_fmmax
+def test_incidence_angle_source_parameter_is_differentiable():
+    """An incidence ANGLE written as a jno.np.parameter in the source (its transverse phase) flows:
+    rc.solve() is a trace node over it, and jax.grad matches finite-difference -- read from the graph, no
+    solve args."""
+    import equinox as eqx
+    import jax
+    import jax.numpy as jnp
+
+    from jno.trace_evaluator import TraceEvaluator
+
+    P0, Lz = 0.6, 3.2
+    d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
+    e = 1e-6
+    for nm, f in [
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > P0 - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > P0 - e),
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > Lz - e),
+    ]:
+        d.tag(nm, f)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def fc(nm):
+        c = d.variable(nm, split=True)
+        return c, u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    cb, ubt, vbt = fc("bottom")
+    _ct, utp, vtp = fc("top")
+    _cl, ul, _ = fc("left")
+    _cr, ur, _ = fc("right")
+    _cf, uf, _ = fc("front")
+    _ck, ubk, _ = fc("back")
+    K0 = 2 * jnp.pi
+    kx = jno.np.parameter((), name="kx").initialize(jax.nn.initializers.constant(1.0))  # incidence angle in source
+    ind = jno.fn(
+        lambda x, y, z: jnp.where(((x - 0.3) ** 2 + (y - 0.3) ** 2 < 0.18**2) & (z >= 0.8) & (z < 1.15), 6.0, 1.0),
+        [xi, yi, zi],
+    )
+    src = jno.np.exp(1j * kx * cb[0])  # the incident transverse phase -- a TRACE expression, not a jno.fn
+    cons = [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * ind * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0 * src) * vbt,
+        ul - ur,
+        uf - ubk,
+    ]
+    rc = jno.rcwa(cons, orders=40, grid=32, nz=40, params={"kx": 1.0})
+    assert "kx" in rc._rpe
+
+    node = rc.solve().efficiency("T")  # trace node over the angle parameter
+    mc = rc._rpe["kx"]
+    mod0 = mc.model.module
+
+    def T(v):
+        mod = eqx.tree_at(lambda m: m.value, mod0, jnp.asarray(v))
+        return TraceEvaluator({mc.model.layer_id: mod}).evaluate(node)
+
+    g = float(jax.grad(T)(1.0))
+    h = 1e-2
+    fd = (float(T(1.0 + h)) - float(T(1.0 - h))) / (2 * h)
+    assert abs(g - fd) < 5e-3, f"dT/dkx autodiff {g} vs finite-diff {fd}"
+
+
+@needs_fmmax
 def test_free_form_nodal_density_is_differentiable():
     """A per-node (topology-optimisation) density — jno.np.parameter(<symbol>) — flows: solve() is a trace
     node over the whole nodal field, and jax.grad w.r.t. it matches a directional finite-difference."""

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -507,3 +507,33 @@ def test_infer_and_solve_end_to_end():
     sol = rc.solve()
     T, R = sol.efficiency("T"), sol.efficiency("R")
     assert T + R <= 1.0 + 5e-3 and T >= 0 and R >= 0
+
+
+@needs_fmmax
+def test_parametric_solve_is_jit_differentiable():
+    """The parametric RCWA solve is ``jax.jit``-able: the design-INDEPENDENT Fourier expansion is cached
+    eagerly (in the engine, warmed when the trace node is built), not recomputed inside the traced solve —
+    fmmax's ``generate_expansion`` mixes jnp with ``np.linalg.norm`` and breaks under jit otherwise.
+    ``jit(grad)`` must match the un-jitted gradient."""
+    import equinox as eqx
+    import jax
+    import jax.numpy as jnp
+
+    from jno.trace_evaluator import TraceEvaluator
+
+    constraints, _ = _build_periodic_problem(dx=0.4)
+    rc = jno.rcwa(constraints, orders=40, grid=24)
+    node = rc.solve().efficiency("T")
+    mc = rc._rpe["rho"]
+    mod0 = mc.model.module
+    n = int(np.asarray(mod0.value).shape[0])
+
+    def T(rv):
+        mod = eqx.tree_at(lambda m: m.value, mod0, jnp.asarray(rv))
+        return TraceEvaluator({mc.model.layer_id: mod}).evaluate(node)
+
+    rv0 = np.random.default_rng(0).standard_normal(n) * 0.3
+    g = np.asarray(jax.grad(T)(rv0))
+    g_jit = np.asarray(jax.jit(jax.grad(T))(rv0))  # must not raise (the fix); must match
+    assert np.all(np.isfinite(g_jit))
+    np.testing.assert_allclose(g_jit, g, rtol=1e-6, atol=1e-8)

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -215,6 +215,33 @@ def test_engine_requires_assume_periodic():
 
 
 @needs_fmmax
+def test_efficiency_is_differentiable_in_the_design():
+    """jax.grad of transmission w.r.t. the permittivity flows through the modal solve (matches FD)."""
+    import jax
+    import jax.numpy as jnp
+
+    from jno.rcwa import Rcwa
+
+    P, r, th, ng = 0.6, 0.18, 0.35, 32
+    xs = (np.arange(ng) + 0.5) / ng * P
+    X, Y = np.meshgrid(xs, xs, indexing="ij")
+    mask = jnp.asarray((((X - P / 2) ** 2 + (Y - P / 2) ** 2) < r**2).astype(float))
+    rc = Rcwa(
+        [(INF, 1.0), (th, jnp.ones((ng, ng))), (INF, 1.0)], period=(P, P), orders=40, wavelength=WL, assume_periodic=True
+    )
+
+    def T(epsval):  # transmission as a function of the pillar permittivity
+        g = 1.0 + mask * (epsval - 1.0)
+        return rc.solve(layers=[(INF, 1.0), (th, g), (INF, 1.0)]).efficiency("T")
+
+    grad = float(jax.grad(T)(6.0))
+    h = 1e-2
+    fd = (float(T(6.0 + h)) - float(T(6.0 - h))) / (2 * h)
+    assert grad == grad and abs(grad) > 1e-3, "gradient must be finite and non-zero"
+    assert abs(grad - fd) < 5e-3, f"autodiff {grad} vs finite-diff {fd}"  # FD is the approximation here
+
+
+@needs_fmmax
 def test_infer_and_solve_end_to_end():
     """The full path: infer from the periodic problem, then solve — energy must be conserved."""
     constraints, _ = _build_periodic_problem()

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -197,7 +197,9 @@ def tmm_slab(nn, h, lam):
 def test_engine_fresnel_matches_analytic(nn, h):
     from jno.rcwa import Rcwa
 
-    rc = Rcwa([(INF, 1.0), (h, nn**2), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
+    # period 0.85 < wavelength 1.0 keeps all higher orders evanescent AND avoids the Rayleigh anomaly
+    # at wavelength == period (grazing order, NaN); a uniform slab is period-independent otherwise.
+    rc = Rcwa([(INF, 1.0), (h, nn**2), (INF, 1.0)], period=(0.85, 0.85), orders=5, wavelength=WL, assume_periodic=True)
     sol = rc.solve()
     T, R = sol.efficiency("T"), sol.efficiency("R")
     assert abs(T - tmm_slab(nn, h, WL)) < 2e-3

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -1,22 +1,179 @@
-"""Tests for jno.rcwa: physical correctness (vs analytic Fresnel/TMM) + the never-silent guards.
+"""Tests for jno.rcwa.
 
-Skipped in full when the optional `fmmax` backend is not installed (mirrors tests/test_iree.py)."""
+Two layers:
+* the FROM-FEM inference (jno.rcwa(constraints, eps, ...)) is pure trace-walking + geometry and runs
+  WITHOUT the optional fmmax backend — these assert the inferred RcwaSpec;
+* the forward engine (Rcwa, and .solve()) needs fmmax and is guarded per-test."""
+
+import importlib.util
 
 import numpy as np
 import pytest
 
-pytest.importorskip("fmmax", reason="fmmax (jno.rcwa backend) not installed")
+import jno
 
-import jno  # noqa: E402
-from jno.rcwa import Rcwa, RcwaError  # noqa: E402
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
 
-WL = 1.03
+WL = 1.0
 INF = np.inf
 
 
-def tmm_slab(nn, h, lam):
-    """Analytic air|slab|air transmittance via a 2x2 transfer matrix."""
+# ------------------------------------------------------------------------------------
+# A small PERIODIC-supercell Helmholtz problem: an a-Si pillar slab, periodic side walls,
+# absorbing top, absorbing bottom carrying a normally-incident wave. (Periodic variant of
+# code/opt3d.py from the metasurface project.)
+# ------------------------------------------------------------------------------------
+def _build_periodic_problem(dx=0.4):
+    import jax
 
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    from jno.utils.solver.fem_adapt import _domain_from_arrays
+
+    K0 = 2 * np.pi
+    EMAX = 6.0
+    Lx = Ly = 2.4  # keep opt3d's default extent (avoids the _domain_from_arrays "no trial fields" footgun)
+    Lz = 3.2
+    ZL0, ZL1 = 0.8, 1.15
+    Eb = 1e-6
+    xs = np.linspace(0, Lx, int(round(Lx / dx)) + 1)
+    ys = np.linspace(0, Ly, int(round(Ly / dx)) + 1)
+    zs = np.linspace(0, Lz, int(round(Lz / dx)) + 1)
+    nx, ny, nz = len(xs), len(ys), len(zs)
+    X, Y, Z = np.meshgrid(xs, ys, zs, indexing="ij")
+    P = np.stack([X.ravel(), Y.ravel(), Z.ravel()], 1)
+
+    def vid(i, j, k):
+        return (i * ny + j) * nz + k
+
+    CUBE = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0), (0, 0, 1), (1, 0, 1), (0, 1, 1), (1, 1, 1)]
+    TETS6 = [(0, 1, 3, 7), (0, 1, 5, 7), (0, 2, 3, 7), (0, 2, 6, 7), (0, 4, 5, 7), (0, 4, 6, 7)]
+    tets = []
+    for i in range(nx - 1):
+        for j in range(ny - 1):
+            for k in range(nz - 1):
+                c = [vid(i + a, j + b, k + cc) for (a, b, cc) in CUBE]
+                for t in TETS6:
+                    tets.append([c[t[0]], c[t[1]], c[t[2]], c[t[3]]])
+    tets = np.asarray(tets)
+    F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
+    Fs = np.sort(F, axis=1)
+    uq, cnt = np.unique(Fs, axis=0, return_counts=True)
+    BF = uq[cnt == 1]
+
+    d = _domain_from_arrays(
+        jno.domain.cube(x_range=(0, Lx), y_range=(0, Ly), z_range=(0, Lz), mesh_size=1.0), P, tets, BF, copy=True
+    )
+    d.tag("bottom", lambda x, y, z: z < Eb)
+    d.tag("top", lambda x, y, z: z > Lz - Eb)
+    d.tag("left", lambda x, y, z: x < Eb)
+    d.tag("right", lambda x, y, z: x > Lx - Eb)
+    d.tag("front", lambda x, y, z: y < Eb)
+    d.tag("back", lambda x, y, z: y > Ly - Eb)
+
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    bt = d.variable("bottom", split=True)
+    tp = d.variable("top", split=True)
+    lf = d.variable("left", split=True)
+    rt = d.variable("right", split=True)
+    fr = d.variable("front", split=True)
+    bk = d.variable("back", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+    ubt, vbt = u.bind(x=bt[0], y=bt[1], z=bt[2]), phi.bind(x=bt[0], y=bt[1], z=bt[2])
+    utp, vtp = u.bind(x=tp[0], y=tp[1], z=tp[2]), phi.bind(x=tp[0], y=tp[1], z=tp[2])
+    ulf = u.bind(x=lf[0], y=lf[1], z=lf[2])
+    urt = u.bind(x=rt[0], y=rt[1], z=rt[2])
+    ufr = u.bind(x=fr[0], y=fr[1], z=fr[2])
+    ubk = u.bind(x=bk[0], y=bk[1], z=bk[2])
+
+    lay = jno.fn(lambda x, y, z: jnp.where((z >= ZL0) & (z < ZL1), 1.0, 0.0), [xi, yi, zi])
+    rho = jno.np.parameter(phi, name="rho")
+    eps = 1.0 + lay * (0.5 * (1 + jno.np.tanh(rho / 2))) * (EMAX - 1.0)
+    constraints = [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ulf - urt,
+        ufr - ubk,
+    ]
+    return constraints, eps
+
+
+# ------------------------------------------------------------------------------------
+# Inference (no fmmax needed)
+# ------------------------------------------------------------------------------------
+def test_infer_spec_from_periodic_problem():
+    constraints, eps = _build_periodic_problem()
+    rc = jno.rcwa(constraints, eps, orders=100, wavelength=WL, grid=16, nz=33)
+    s = rc.spec
+    # periodicity + period from the Floquet ties
+    assert abs(s.period[0] - 2.4) < 1e-6 and abs(s.period[1] - 2.4) < 1e-6
+    assert set(s.periodic_axes) == {"x", "y"}
+    # air | pillar-slab | air  -> three layers, middle ~0.35 thick, ambients semi-infinite
+    assert len(s.layers) == 3, [ly[0] for ly in s.layers]
+    assert s.layers[0][0] == INF and s.layers[-1][0] == INF
+    assert abs(s.layers[1][0] - 0.35) < 0.12, s.layers[1][0]
+    # patterned layer eps at rho=0 -> 1 + 0.5*(EMAX-1) = 3.5; ambients are air
+    assert abs(float(np.real(s.layers[1][1]).max()) - 3.5) < 0.05
+    assert abs(float(np.real(s.layers[0][1]).max()) - 1.0) < 0.05
+    # normally-incident source read off the bottom face
+    assert s.k_in == (0.0, 0.0)
+    assert s.wavelength == WL
+    assert s.source_face in ("bottom", "top")
+
+
+def test_non_periodic_problem_raises():
+    """A finite aperture (absorbing side walls, no ties) must be rejected, never silently periodicised."""
+    constraints, eps = _build_periodic_problem()
+    non_periodic = constraints[:3]  # drop the two periodic ties
+    with pytest.raises(jno.RcwaError, match="periodic"):
+        jno.rcwa(non_periodic, eps, orders=100, wavelength=WL, grid=16, nz=33)
+
+
+def test_bad_problem_type_raises():
+    with pytest.raises(jno.RcwaError, match="constraint list"):
+        jno.rcwa(42, None, orders=10, wavelength=WL)
+
+
+# ------------------------------------------------------------------------------------
+# detect_layers (pure numpy, no fmmax)
+# ------------------------------------------------------------------------------------
+def test_detect_layers_extruded():
+    Ng, Nz = 12, 60
+    z = np.linspace(0, 3.2, Nz)
+    E = np.ones((Nz, Ng, Ng))
+    for k, zz in enumerate(z):
+        if 0.8 <= zz < 1.15:
+            E[k] = 1.0
+            E[k, 4:8, 4:8] = 11.0
+    layers = detect_layers_ref(E, z)
+    assert len(layers) == 3
+    assert layers[0][0] == INF and layers[-1][0] == INF
+
+
+def detect_layers_ref(E, z):
+    from jno.rcwa import detect_layers
+
+    return detect_layers(E, z)
+
+
+def test_detect_layers_continuous_raises():
+    from jno.rcwa import detect_layers
+
+    Ng, Nz = 8, 40
+    z = np.linspace(0, 1, Nz)
+    E = np.stack([np.full((Ng, Ng), 1.0 + zz) for zz in z])  # continuous in z
+    with pytest.raises(jno.RcwaError, match="continuous"):
+        detect_layers(E, z)
+
+
+# ------------------------------------------------------------------------------------
+# Forward engine + analytic Fresnel (needs fmmax)
+# ------------------------------------------------------------------------------------
+def tmm_slab(nn, h, lam):
     def iface(a, b):
         r = (a - b) / (a + b)
         t = 2 * a / (a + b)
@@ -27,60 +184,31 @@ def tmm_slab(nn, h, lam):
     return abs(1 / M[0, 0]) ** 2
 
 
+@needs_fmmax
 @pytest.mark.parametrize("nn,h", [(1.45, 0.5), (2.0, 0.4), (3.317, 0.3)])
-def test_fresnel_matches_analytic(nn, h):
-    """A uniform slab reproduces the analytic Fresnel transmittance and conserves energy."""
+def test_engine_fresnel_matches_analytic(nn, h):
+    from jno.rcwa import Rcwa
+
     rc = Rcwa([(INF, 1.0), (h, nn**2), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
-    sol = rc.solve(inc=None)
+    sol = rc.solve()
     T, R = sol.efficiency("T"), sol.efficiency("R")
     assert abs(T - tmm_slab(nn, h, WL)) < 2e-3
     assert abs(T + R - 1) < 1e-3
 
 
-def test_functional_entry_point_matches_class():
-    """jno.rcwa(...) builds the same problem as the Rcwa class."""
-    rc = jno.rcwa([(INF, 1.0), (0.4, 4.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
-    assert isinstance(rc, Rcwa)
-    T = rc.solve().efficiency("T")
-    assert abs(T - tmm_slab(2.0, 0.4, WL)) < 2e-3
+@needs_fmmax
+def test_engine_requires_assume_periodic():
+    from jno.rcwa import Rcwa
 
-
-def test_guard_non_periodic_raises():
-    with pytest.raises(RcwaError, match="assume_periodic"):
+    with pytest.raises(jno.RcwaError, match="assume_periodic"):
         Rcwa([(INF, 1.0), (0.3, 11.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL)
 
 
-def test_guard_bad_period_raises():
-    with pytest.raises(RcwaError, match="period"):
-        Rcwa([(INF, 1.0)], period=(-1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
-
-
-def test_guard_empty_layers_raises():
-    with pytest.raises(RcwaError, match="layers"):
-        Rcwa([], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
-
-
-def test_guard_missing_wavelength_raises():
-    rc = Rcwa([(INF, 1.0), (0.3, 11.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, assume_periodic=True)
-    with pytest.raises(RcwaError, match="wavelength"):
-        rc.solve(None)
-
-
-def test_guard_coarse_grid_vs_orders_raises():
-    big = np.ones((6, 6)) * 11.0
-    with pytest.raises(RcwaError, match="under-resolve"):
-        Rcwa([(INF, 1.0), (0.3, big), (INF, 1.0)], period=(1.0, 1.0), orders=400, wavelength=WL, assume_periodic=True)
-
-
-def test_bad_efficiency_kind_raises():
-    rc = Rcwa([(INF, 1.0), (0.4, 4.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
-    with pytest.raises(RcwaError, match="'T' or 'R'"):
-        rc.solve().efficiency("Q")
-
-
-def test_as_precond_without_transfer_raises():
-    """as_precond must never hand back a silent no-op preconditioner."""
-    rc = Rcwa([(INF, 1.0), (0.4, 4.0), (INF, 1.0)], period=(1.0, 1.0), orders=5, wavelength=WL, assume_periodic=True)
-    spec = rc.as_precond()
-    with pytest.raises(RcwaError, match="transfer"):
-        spec.materialize(ctx=None)
+@needs_fmmax
+def test_infer_and_solve_end_to_end():
+    """The full path: infer from the periodic problem, then solve — energy must be conserved."""
+    constraints, eps = _build_periodic_problem()
+    rc = jno.rcwa(constraints, eps, orders=100, wavelength=WL, grid=32, nz=33)
+    sol = rc.solve()
+    T, R = sol.efficiency("T"), sol.efficiency("R")
+    assert T + R <= 1.0 + 5e-3 and T >= 0 and R >= 0

--- a/tests/test_rcwa_anisotropic.py
+++ b/tests/test_rcwa_anisotropic.py
@@ -1,0 +1,107 @@
+"""jno.rcwa with an ANISOTROPIC permittivity tensor ε̂ — inferred from inner(ε̂ @ u, v) and solved via
+fmmax's ``eigensolve_anisotropic_media`` (5 component grids ε_xx, ε_xy, ε_yx, ε_yy, ε_zz).
+
+The same curl-curl list, but the mass term carries a 3×3 ``MatrixView`` instead of a scalar. The front
+door detects the tensor, samples its 5 components per layer, and routes to the anisotropic eigensolve —
+reducing exactly to the isotropic path when ε̂ = ε·I.
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+from jno.trace.views import MatrixView  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+inner, vec = jno.np.inner, jno.np.vector
+K0 = 2 * jnp.pi
+P, LZ = 0.6, 3.2
+Z0, Z1 = 0.8, 1.15  # the anisotropic slab occupies this z-range
+
+
+def _common(d):
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    cu, cv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    nt, nb = d.variable("top", normals=True), d.variable("bottom", normals=True)
+    cb = d.variable("bottom", split=True)
+    tut, tvt = u.vector.cross(nt), v.vector.cross(nt)
+    tub, tvb = u.vector.cross(nb), v.vector.cross(nb)
+    einc = vec(1.0 + 0.0 * cb[0], 0.0 * cb[1], 0.0 * cb[2])  # x-polarised normal-incidence plane wave
+
+    def face(n):
+        cc = d.variable(n, split=True)
+        return u.bind(x=cc[0], y=cc[1], z=cc[2])
+
+    bcs = [
+        1j * K0 * inner(tut, tvt),
+        1j * K0 * inner(tub, tvb) + 2j * K0 * inner(einc, tvb),
+        face("left") - face("right"),
+        face("front") - face("back"),
+    ]
+    return (xi, yi, zi), (ui, vi), (cu, cv), bcs
+
+
+def _slab(x, y, z, val):
+    return jnp.where((z >= Z0) & (z < Z1), val, 1.0)
+
+
+def _aniso_constraints(exx, eyy, ezz):
+    """A uniform diagonal-anisotropic slab diag(exx, eyy, ezz) embedded in vacuum."""
+    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    (xi, yi, zi), (ui, vi), (cu, cv), bcs = _common(d)
+    ex = jno.fn(lambda x, y, z: _slab(x, y, z, exx), [xi, yi, zi])
+    ey = jno.fn(lambda x, y, z: _slab(x, y, z, eyy), [xi, yi, zi])
+    ez = jno.fn(lambda x, y, z: _slab(x, y, z, ezz), [xi, yi, zi])
+    eps = MatrixView(vec(ex, ey, ez).expr).from_diag()
+    return [inner(cu, cv) - K0**2 * inner(eps @ ui, vi), *bcs]
+
+
+def _scalar_constraints(e):
+    """The isotropic reference: the same slab with scalar ε."""
+    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    (xi, yi, zi), (ui, vi), (cu, cv), bcs = _common(d)
+    eps = jno.fn(lambda x, y, z: _slab(x, y, z, e), [xi, yi, zi])
+    return [inner(cu, cv) - K0**2 * eps * inner(ui, vi), *bcs]
+
+
+def _T(cons, R=False):
+    sol = jno.rcwa(cons, orders=60, grid=24).solve()
+    return float(sol.efficiency("R" if R else "T"))
+
+
+@needs_fmmax
+def test_isotropic_tensor_reduces_to_scalar():
+    """ε̂ = ε·I must give exactly the scalar-ε result — the anisotropic path reduces correctly (same eps fed
+    to fmmax, isotropic vs anisotropic eigensolve agree for a scalar-diagonal tensor)."""
+    assert _T(_aniso_constraints(6.0, 6.0, 6.0)) == pytest.approx(_T(_scalar_constraints(6.0)), abs=1e-6)
+
+
+@needs_fmmax
+def test_in_plane_anisotropy_x_pol_sees_exx():
+    """Decisive anisotropy check: for a biaxial slab diag(εxx, εyy, εzz), an x-polarised normal-incidence
+    wave sees εxx — so T matches the scalar-εxx result and differs from scalar-εyy/εzz. (ε_zz does NOT act
+    at normal incidence: the field is purely transverse, no E_z to couple to.)"""
+    Tbi = _T(_aniso_constraints(8.0, 4.0, 6.0))  # x-pol sees εxx = 8
+    assert Tbi == pytest.approx(_T(_scalar_constraints(8.0)), abs=1e-4)
+    assert abs(Tbi - _T(_scalar_constraints(6.0))) > 1e-3  # genuinely anisotropic, not the scalar answer
+
+
+@needs_fmmax
+def test_anisotropic_conserves_energy():
+    """A lossless anisotropic slab conserves energy: T + R ≈ 1."""
+    cons = _aniso_constraints(8.0, 4.0, 6.0)
+    assert _T(cons) + _T(cons, R=True) == pytest.approx(1.0, abs=5e-3)

--- a/tests/test_rcwa_anisotropic.py
+++ b/tests/test_rcwa_anisotropic.py
@@ -13,6 +13,7 @@ os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small
 
 import jax  # noqa: E402
 import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
 jax.config.update("jax_enable_x64", True)
@@ -70,6 +71,22 @@ def _aniso_constraints(exx, eyy, ezz):
     return [inner(cu, cv) - K0**2 * inner(eps @ ui, vi), *bcs]
 
 
+def _tensor_constraints(flat9):
+    """A uniform slab with a full 3×3 tensor (row-major ``flat9``): diagonal defaults to 1 outside the slab,
+    off-diagonal to 0 (isotropic vacuum ambient). Lets an off-diagonal ε̂ rotate polarization."""
+    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    (xi, yi, zi), (ui, vi), (cu, cv), bcs = _common(d)
+    comps = [
+        jno.fn(
+            lambda x, y, z, vv=val, dd=(1.0 if i in (0, 4, 8) else 0.0): jnp.where((z >= Z0) & (z < Z1), vv, dd),
+            [xi, yi, zi],
+        )
+        for i, val in enumerate(flat9)
+    ]
+    eps = MatrixView(vec(*comps).expr).from_flat(3, 3)
+    return [inner(cu, cv) - K0**2 * inner(eps @ ui, vi), *bcs]
+
+
 def _scalar_constraints(e):
     """The isotropic reference: the same slab with scalar ε."""
     d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
@@ -105,3 +122,40 @@ def test_anisotropic_conserves_energy():
     """A lossless anisotropic slab conserves energy: T + R ≈ 1."""
     cons = _aniso_constraints(8.0, 4.0, 6.0)
     assert _T(cons) + _T(cons, R=True) == pytest.approx(1.0, abs=5e-3)
+
+
+def _jones(cons):
+    sol = jno.rcwa(cons, orders=60, grid=24).solve()
+    return np.asarray(jnp.asarray(sol.jones("T"))), float(sol.efficiency("T"))
+
+
+@needs_fmmax
+def test_jones_isotropic_is_diagonal_and_energy_consistent():
+    """An isotropic stack does not convert polarization: the Jones matrix is diagonal (zero cross-pol) with
+    equal diagonal entries, and each input column's power sums to the total transmission efficiency."""
+    J, T = _jones(_scalar_constraints(6.0))
+    p = np.abs(J) ** 2
+    assert p[0, 1] < 1e-6 and p[1, 0] < 1e-6  # no cross-polarization
+    assert p[0, 0] == pytest.approx(p[1, 1], abs=1e-4)  # both polarizations transmit alike
+    assert p[:, 0].sum() == pytest.approx(T, abs=1e-4)  # |J[:,in]|² sums to efficiency("T")
+
+
+@needs_fmmax
+def test_jones_diagonal_biaxial_is_birefringent_no_conversion():
+    """A biaxial slab diag(8,4,6) whose principal axes are x,y is birefringent but does NOT convert: the
+    Jones matrix stays diagonal, with unequal diagonal entries (x-pol sees εxx=8, y-pol sees εyy=4)."""
+    J, _ = _jones(_tensor_constraints([8, 0, 0, 0, 4, 0, 0, 0, 6]))
+    p = np.abs(J) ** 2
+    assert p[0, 1] < 1e-6 and p[1, 0] < 1e-6  # diagonal ε̂ (axes = x,y) → no conversion
+    assert abs(p[0, 0] - p[1, 1]) > 1e-2  # but the two polarizations transmit differently (birefringence)
+
+
+@needs_fmmax
+def test_jones_rotated_tensor_converts_polarization():
+    """A rotated in-plane tensor [[6,2],[2,6]] (off-diagonal εxy≠0) CONVERTS polarization: the Jones matrix
+    has nonzero off-diagonal (cross-pol) entries, and stays symmetric (reciprocity for a lossless
+    reciprocal medium). This is what a scalar or diagonal ε can never do."""
+    J, _ = _jones(_tensor_constraints([6, 2, 0, 2, 6, 0, 0, 0, 6]))
+    p = np.abs(J) ** 2
+    assert p[1, 0] > 1e-2 and p[0, 1] > 1e-2  # genuine polarization conversion (cross-pol)
+    np.testing.assert_allclose(J, J.T, atol=1e-6)  # reciprocity: J is symmetric

--- a/tests/test_rcwa_vector.py
+++ b/tests/test_rcwa_vector.py
@@ -1,0 +1,125 @@
+"""jno.rcwa on a VECTOR (curl-curl / Nédélec) Maxwell constraint list — the vector front door.
+
+The same ``jno.fem``-style list that authors a time-harmonic Maxwell problem (``inner(curl u, curl v)
+− K0²·eps·inner(u, v)`` + impedance/absorbing faces + incident wave + Floquet ties) is inferred by
+``jno.rcwa``: the permittivity is pulled from the vector mass term, the incident polarization/angle from
+the vector source, and the solve runs on fmmax (which always solves vector Maxwell). Because it feeds the
+same ε to the same solver, a scalar-Helmholtz and a vector-Maxwell list of the SAME structure agree.
+"""
+
+import importlib.util
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+inner, vec = jno.np.inner, jno.np.vector
+K0 = 2 * jnp.pi
+P, LZ = 0.6, 3.2
+
+
+def _tag_faces(d):
+    e = 1e-6
+    for nm, f in [
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > P - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > P - e),
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > LZ - e),
+    ]:
+        d.tag(nm, f)
+
+
+def _pillar(xi, yi, zi, eps_pillar=11.0):
+    return jno.fn(
+        lambda x, y, z: jnp.where(((x - 0.3) ** 2 + (y - 0.3) ** 2 < 0.18**2) & (z >= 0.8) & (z < 1.15), eps_pillar, 1.0),
+        [xi, yi, zi],
+    )
+
+
+def _scalar_constraints():
+    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    _tag_faces(d)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def fc(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = fc("bottom")
+    utp, vtp = fc("top")
+    ul, _ = fc("left")
+    ur, _ = fc("right")
+    uf, _ = fc("front")
+    ubk, _ = fc("back")
+    eps = _pillar(xi, yi, zi)
+    return [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ubk,
+    ]
+
+
+def _vector_constraints():
+    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    _tag_faces(d)
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    cu, cv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    nt, nb = d.variable("top", normals=True), d.variable("bottom", normals=True)
+    cb = d.variable("bottom", split=True)
+    tut, tvt = u.vector.cross(nt), v.vector.cross(nt)
+    tub, tvb = u.vector.cross(nb), v.vector.cross(nb)
+    eps = _pillar(xi, yi, zi)
+    einc = vec(1.0 + 0.0 * cb[0], 0.0 * cb[1], 0.0 * cb[2])  # x-polarised normal-incidence plane wave
+
+    def face(n):
+        cc = d.variable(n, split=True)
+        return u.bind(x=cc[0], y=cc[1], z=cc[2])
+
+    return [
+        inner(cu, cv) - K0**2 * eps * inner(ui, vi),  # vector Maxwell volume
+        1j * K0 * inner(tut, tvt),  # absorbing top
+        1j * K0 * inner(tub, tvb) + 2j * K0 * inner(einc, tvb),  # absorbing bottom + incident
+        face("left") - face("right"),  # Floquet ties
+        face("front") - face("back"),
+    ]
+
+
+@needs_fmmax
+def test_vector_front_door_infers_and_solves():
+    """A vector curl-curl Maxwell list is inferred + solved by jno.rcwa: correct period/wavelength, normal
+    incidence read from the vector source (k_in≈0, not corrupted by the N1E edge signs), and T+R≈1."""
+    rc = jno.rcwa(_vector_constraints(), orders=60, grid=24)
+    assert rc.spec.period[0] == pytest.approx(P, abs=1e-3)
+    assert rc.spec.wavelength == pytest.approx(1.0, abs=1e-3)
+    assert abs(rc.spec.k_in[0]) < 1e-3 and abs(rc.spec.k_in[1]) < 1e-3  # normal incidence
+    sol = rc.solve()
+    T, R = float(sol.efficiency("T")), float(sol.efficiency("R"))
+    assert np.isfinite(T) and np.isfinite(R)
+    assert T + R == pytest.approx(1.0, abs=5e-3)  # energy conserved
+
+
+@needs_fmmax
+def test_vector_matches_scalar_front_door():
+    """The decisive check: a vector-Maxwell list and a scalar-Helmholtz list of the SAME structure (period,
+    pillar ε, wavelength) feed the same ε to the same fmmax solve, so their transmission must agree."""
+    Ts = float(jno.rcwa(_scalar_constraints(), orders=100, grid=32).solve().efficiency("T"))
+    Tv = float(jno.rcwa(_vector_constraints(), orders=100, grid=32).solve().efficiency("T"))
+    assert Tv == pytest.approx(Ts, abs=1e-6), f"vector T {Tv} != scalar T {Ts}"


### PR DESCRIPTION
## Summary

Adds `jno.rcwa` — an **optional, in-tree RCWA (Fourier Modal Method) backend** on top of a lazily-imported `fmmax`. The same `jno.fem`-style constraint list you'd hand `jno.fem` is inferred and solved by `jno.rcwa`: periodicity + period, ambient faces, permittivity, wavelength, and the incident wave are all recovered from the traced problem — nothing is hand-specified except the Fourier truncation. It never fails silently (every ill-posed inference raises `RcwaError` with a concrete fix).

The guiding invariant throughout: **one traced constraint list, any solver.** A problem authored once solves via `jno.fem` (full 3-D) *and* infers + solves via `jno.rcwa` (fast layered), for scalar, vector, and tensor permittivity — differentiable end to end.

## What's new

**RCWA front door + engine**
- Infer the RCWA problem from a constraint list; explicit-layer `jno.Rcwa([...])` backend underneath.
- Differentiable solve — `jax.grad`/`jax.jit` flow to the design (permittivity, wavelength, incidence angle, free-form nodal density).
- Broadband/dispersion sweeps, angle-resolved incidence, real-space field reconstruction.
- Free-form nodal-density topology optimization (barycentric node→grid interpolation for smooth gradients).

**Vector Maxwell (Nédélec / N1E), enabling the vector RCWA front door**
- Complex assembly on the non-nodal path (previously real-only — silently dropped the imaginary part).
- N1E impedance / first-order absorbing (Silver–Müller) boundary term, and the incident-wave forcing → a full driven Maxwell scattering problem now assembles *and solves* in `jno.fem`.
- Floquet/Bloch periodic ties on edge DOFs, with the conforming periodic mesh **inferred from the constraints** (gmsh `setPeriodic`, no explicit flag).
- Vector-Maxwell RCWA inference: a curl-curl N1E list yields the same transmission as the equivalent scalar Helmholtz list (they feed the same ε to the same fmmax solve).

**Anisotropic permittivity**
- Author `inner(ε̂ @ u, v)` with a 3×3 `MatrixView` (uniaxial/biaxial/gyrotropic) — assembles generally in `jno.fem`.
- `jno.rcwa` routes a tensor ε̂ to fmmax's `eigensolve_anisotropic_media`.
- `sol.jones("T"|"R")` returns the 2×2 Jones matrix — read polarization conversion (off-diagonal) directly.

## Testing

New suites cover: RCWA inference + Fresnel/energy-conservation, differentiability (incl. `jax.jit`), the N1E complex/impedance/incident/periodic paths, anisotropic assembly + the uniaxial quadratic form, vector-vs-scalar RCWA agreement, and the Jones matrix (diagonal for isotropic, off-diagonal + reciprocal for a rotated tensor). `ruff format`/`check` clean.

## Notes

- `fmmax` is optional: `pip install jax-neural-operators[rcwa]`. `rc.spec` is inspectable without it.
- RCWA is periodic + layered (extruded structures); the FEM path handles the general 3-D case.
- Follow-ups (not blocking): sparse N1E assembly for large 3-D, differentiable `.jones` under a parametric solve, min-feature-size/binarization filters for fabricable inverse design.
