### PR TITLE
RCWA imaging + differentiable resist models (computational lithography)

### DIFF
--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -227,10 +227,28 @@ loss = lambda: ((jno.rcwa(mask(rho)).solve().printed(NA=0.33, source=src, resist
 
 `Threshold` is the standard linear-diffusion + constant-threshold resist (Poonawala & Milanfar, *IEEE Trans.
 Image Process.* **16**, 774, 2007; PEB diffusion after Mack, *Fundamental Principles of Optical Lithography*,
-2007). A rigorous **reaction-diffusion PEB** resist plugs into the same `develop(...)` seam — it reads the
-exposure's angular spectrum (`exp.spectrum()`) to propagate a standing-wave bulk image into the resist film,
-then runs the 3-species kinetics. That model, its 3-D development-rate profile, and bulk-absorption effects
-live in the standalone photoresist model.
+2007).
+
+For a **physical** resist, `jno.litho.CAResist` plugs into the same `develop(...)` seam — the rigorous
+3-species reaction-diffusion **post-exposure bake** (dos Santos), authored as one transient `jno.fem` system:
+
+```python
+peb = jno.litho.CAResist(n=64, t_peb=45.0, steps=30, dill_c=1.0, dose=1.0, diffusion_length=(12.0, 8.0))
+dev = sol.expose(NA=0.33, source=0.5).develop(peb)   # -> developed (n, n) pattern in [0, 1]
+```
+
+It maps the exposure's aerial intensity to a **latent acid** via Dill kinetics (`A(0) = 1 − exp(−dill_c·dose·I)`),
+then bakes inhibitor `M`, acid `A`, and quencher `B`:
+
+```
+M_t = −k1 M A − k2 M                A_t = D_A ΔA − k3 A − k4 A B                B_t = D_B ΔB − k4 A B − k5 B
+```
+
+on a doubly-periodic film mesh, and returns `1 − M` (the developed/soluble fraction, positive tone). It is
+heavier than `Threshold` (a nonlinear multifield transient solve) — for **verification**, not the fast design
+loop. First cut: the latent acid is driven by the 2-D aerial image; propagating the exposure's angular
+spectrum (`exp.spectrum()`) into the resist film for the depth-resolved **standing-wave bulk image** is the
+next refinement.
 
 ## The backend — explicit layers
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -198,6 +198,31 @@ high NA, and by `jax.grad` vs finite difference. The vector pupil follows Flagel
 *J. Opt. Soc. Am. A* **13**, 53 (1996). The full angular-rigorous Abbe (re-solving the mask per source point)
 remains future work.
 
+### Resist — `sol.printed(...)` (the developed pattern)
+
+`sol.printed(...)` takes the aerial image one step further to the **developed resist image** (the printed
+pattern), closing the computational-lithography chain `mask → aerial image → resist`:
+
+```python
+img = sol.printed(NA=0.33, source=0.5, threshold=0.3, diffusion=0.02, steepness=50)  # -> (grid, grid) in [0, 1]
+```
+
+The aerial image (all the `aerial(...)` arguments pass straight through) is optionally blurred by a linear
+**post-exposure-bake diffusion** (a periodic Gaussian of length `diffusion`) and then developed by a soft
+**constant threshold**, `sigmoid(steepness · (I − threshold))` — `1` = clears. `threshold` sets the printed
+CD; `steepness` is the development contrast. Because the whole chain stays JAX, `jax.grad` of a
+printed-vs-target loss now drives **OPC / ILT / SMO with the resist in the loop** — back through development,
+imaging, *and* the rigorous RCWA mask solve:
+
+```python
+loss = lambda: ((jno.rcwa(mask(rho)).solve().printed(NA=0.33, source=src, threshold=0.3) - target) ** 2).mean()
+```
+
+This is the standard linear-diffusion + constant-threshold resist (Poonawala & Milanfar, *IEEE Trans. Image
+Process.* **16**, 774, 2007; PEB diffusion after Mack, *Fundamental Principles of Optical Lithography*, 2007).
+The full reaction-diffusion PEB kinetics, the 3-D development-rate profile, and standing-wave/bulk-absorption
+effects are out of scope here (a separate rigorous photoresist model handles those).
+
 ## The backend — explicit layers
 
 `jno.Rcwa` takes a hand-built stack directly; this is what the front door constructs internally:

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -130,6 +130,32 @@ rigorous **tensor** scheme (Farjadpour et al., *Opt. Lett.* **31**, 2972 (2006):
 harmonic normal averaging at the interface, which additionally accelerates Fourier convergence) is future
 work. Recommended `k = 2`–`4` for topology optimization; leave it off for a fixed-geometry forward solve.
 
+## Profiling and convergence sweeps — `solve(orders=…, profile=…)`
+
+Two escape hatches on `.solve()` for a *forward* solve (they don't affect the differentiable no-arg path):
+
+```python
+rc = jno.rcwa(constraints, orders=200)
+
+# re-solve at a different Fourier truncation (a fresh engine; the construction `orders` is untouched)
+T20  = rc.solve(orders=120).efficiency("T")
+T30  = rc.solve(orders=180).efficiency("T")     # converged if T20 ~= T30 (a Richardson check)
+
+# JAX performance profile, exactly like jno.core.solve(profile=True)
+sol = rc.solve(profile=True)
+# -> [rcwa profile] 3 layers · n_t=193 · 386×386 eigenproblem/layer | solve 1.2 s | Perfetto trace -> ./rcwa_traces
+```
+
+`orders=N` is the enabler for a **convergence sweep**: RCWA is only exact as the truncation → ∞, and how
+fast it converges is structure-dependent (a sharp, high-contrast pillar can need several ×N more orders than
+a smooth slab), so comparing `efficiency` at `N` vs `~1.5N` tells you whether `orders` is enough — solve at
+both and check they agree.
+
+`profile=True` runs the solve **eagerly** (at the current parameter values) inside a `jax.profiler.trace`
+with per-stage `TraceAnnotation`s (`rcwa:eigensolve`, `rcwa:s_matrix`), prints the problem size and wall
+time, and writes a Perfetto trace to `./rcwa_traces`. RCWA's cost is dominated by the `O((2·n_t)³)` per-layer
+eigensolves — the trace makes that explicit (open it at `chrome://tracing` or Perfetto UI).
+
 ## The backend — explicit layers
 
 `jno.Rcwa` takes a hand-built stack directly; this is what the front door constructs internally:

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -38,6 +38,8 @@ What is inferred from the problem, and from where:
 | **permittivity** | the `K0²·ε` coefficient recovered from the scalar Helmholtz volume term, sampled along z, then grouped by [`detect_layers`](#layer-detection) |
 | **wavelength / `k0`** | the coefficient's value in the vacuum superstrate (`k0 = √coeff`); pass `wavelength=` to override |
 | **incident wave** (lit face + angle `k_in`) | the assembled forcing `b` — a constant-phase source ⇒ normal incidence |
+| **tensor permittivity `ε̂`** | an `inner(ε̂ @ u, v)` mass term (a 3×3 `MatrixView`) — birefringence, polarization conversion |
+| **in-plane PML** | a complex coordinate stretch `S = 1 + iσ/k` in the stiffness coefficients — see below |
 
 The permittivity is recovered by splitting the volume weak form `∇u·∇v − K0²·ε·u·v`: the stiffness
 summands carry trial/test inside `Jacobian` nodes, the mass summand carries them as bare values, so
@@ -46,9 +48,35 @@ a trainable `jno.np.parameter` carries through, so inverse design flows unchange
 numerical truncation choice) is genuinely the user's; `wavelength` is an optional override for the case
 where no ambient is vacuum.
 
-Because RCWA solves the *infinitely periodic* problem, a finite aperture (absorbing side walls, no
-ties) is **rejected** rather than silently periodicised — exactly the difference between a supercell
-and a finite metasurface.
+Because RCWA solves the *infinitely periodic* problem, a finite aperture with plain absorbing side
+walls and **no ties** is **rejected** rather than silently periodicised. To model an *isolated*
+scatterer, keep the ties and add an in-plane PML frame (below) — the standard periodic-supercell trick.
+
+## In-plane PML — an isolated scatterer from a periodic supercell
+
+A [Perfectly Matched Layer](https://en.wikipedia.org/wiki/Perfectly_matched_layer) is a complex
+coordinate stretch `S = 1 + iσ/k` (σ ramps up in an absorbing frame, `0` in the physical core). Written
+into the **scalar Helmholtz** volume term it appears as anisotropic **stiffness** coefficients (and a
+matching mass coefficient):
+
+```python
+Sx, Sy = 1 + 1j*sx/K0, 1 + 1j*sy/K0                       # sx, sy ramp near the x / y walls
+vol = (  (Sy/Sx)*(ui.x*vi.x) + (Sx/Sy)*(ui.y*vi.y) + (Sx*Sy)*(ui.z*vi.z)   # uniaxial stretch, Sz = 1
+       - K0**2 * (Sx*Sy) * eps * (u*vi) )
+constraints = [vol, absorbing_top, absorbing_incident_bottom, u_left-u_right, u_front-u_back]
+sol = jno.rcwa(constraints, orders=200).solve()
+```
+
+The front door reads the stretch `Λ = diag(Sy/Sx, Sx/Sy, Sx·Sy)` straight off the stiffness
+coefficients and forms the Maxwell uniaxial PML — a **diagonal `ε̂` *and* `μ̂`** (`ε̂ = ε·Λ`, `μ̂ = Λ`) —
+solved with `fmmax`'s general anisotropic eigensolve. The **Floquet ties stay** (`fmmax` is inherently
+periodic); the absorbing frame just makes the supercell walls non-coupling, so light diffracted toward a
+neighbour is absorbed instead of recirculated, and the cell behaves like a single isolated scatterer.
+The traced stretch is honoured **exactly** — any σ profile, not a fixed built-in one.
+
+Scope: a **uniaxial** (diagonal) **in-plane** stretch on the **scalar** Helmholtz term, forward solve.
+An off-diagonal stretch, a z-stretch (meaningless for RCWA — the S-matrix already gives outgoing-wave
+z-boundaries), or a design `jno.np.parameter` routed *through* a PML each **raise**.
 
 ## The backend — explicit layers
 
@@ -94,9 +122,8 @@ a-Si). Correctness is checked against the analytic Fresnel/transfer-matrix trans
 
 - an `as_precond` path so RCWA can serve as the layered-background preconditioner `M⁻¹ = A₀⁻¹` for the
   large 3-D FEM complex-Helmholtz solve, once the FEM↔grid transfer is wired;
-- a differentiable sampling path (currently the permittivity is evaluated on the grid with the
-  parameter's current value; threading the gradient through would let RCWA drive inverse design directly);
-- support beyond the scalar isotropic Helmholtz volume term (vector/anisotropic media).
+- a differentiable PML path (a design `jno.np.parameter` routed through a PML supercell — the forward
+  solve works today, the re-sample does not yet).
 
 ## References
 
@@ -104,6 +131,10 @@ a-Si). Correctness is checked against the analytic Fresnel/transfer-matrix trans
   J. Opt. Soc. Am. **71**, 811 (1981).
 - M. G. Moharam, D. A. Pommet, E. B. Grann & T. K. Gaylord, *Stable implementation of the enhanced
   transmittance matrix approach*, J. Opt. Soc. Am. A **12**, 1077 (1995).
+- W. C. Chew & W. H. Weedon, *A 3D perfectly matched medium from modified Maxwell's equations with
+  stretched coordinates*, Microw. Opt. Technol. Lett. **7**, 599 (1994) — the complex coordinate stretch.
+- Z. S. Sacks, D. M. Kingsland, R. Lee & J.-F. Lee, *A perfectly matched anisotropic absorber for use as
+  an absorbing boundary condition*, IEEE Trans. Antennas Propag. **43**, 1460 (1995) — the uniaxial `ε̂`/`μ̂` PML.
 
 ## API
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -246,9 +246,24 @@ M_t = −k1 M A − k2 M                A_t = D_A ΔA − k3 A − k4 A B       
 
 on a doubly-periodic film mesh, and returns `1 − M` (the developed/soluble fraction, positive tone). It is
 heavier than `Threshold` (a nonlinear multifield transient solve) — for **verification**, not the fast design
-loop. First cut: the latent acid is driven by the 2-D aerial image; propagating the exposure's angular
-spectrum (`exp.spectrum()`) into the resist film for the depth-resolved **standing-wave bulk image** is the
-next refinement.
+loop. The whole chain stays differentiable: `jax.grad` of a developed-pattern loss w.r.t. the mask matches
+finite difference through the RCWA solve → aerial image → Dill acid → transient PEB (so you can design the
+mask against the *physically-baked* pattern, not just the aerial image).
+
+**Standing-wave bulk image.** The exposure also exposes the depth-resolved field inside the resist film via
+`exp.bulk(film)` — each diffraction order is refracted into the film and interferes with its substrate
+reflection (the vertical standing wave), with absorption from a complex resist index:
+
+```python
+vol = sol.expose(NA=0.33, source=0.5).bulk(jno.litho.Film(n_resist=1.7 + 0.02j, thickness=0.1, n_substrate=4.0, nz=16))
+# -> (grid, grid, nz) intensity |E(x, y, z)|²
+```
+
+`jno.litho.Film` carries the resist stack (`n_resist`, `thickness`, `n_substrate`, `n_top`, `nz`). At `z = 0`
+with no substrate reflection `bulk` equals the aerial image; a reflective substrate produces a vertical
+standing wave of period `λ/(2·n_resist)`. `CAResist` currently drives its acid from the 2-D aerial image;
+consuming `bulk` in a full 3-D `(x, y, z)` PEB solve is the next refinement. `bulk` is scalar (`E_x`) with a
+single-substrate-reflection model (full multilayer Airy and a vector bulk image are future work).
 
 ## The backend — explicit layers
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -198,30 +198,39 @@ high NA, and by `jax.grad` vs finite difference. The vector pupil follows Flagel
 *J. Opt. Soc. Am. A* **13**, 53 (1996). The full angular-rigorous Abbe (re-solving the mask per source point)
 remains future work.
 
-### Resist — `sol.printed(...)` (the developed pattern)
+### Resist — `sol.expose(...).develop(resist)` (the developed pattern)
 
-`sol.printed(...)` takes the aerial image one step further to the **developed resist image** (the printed
-pattern), closing the computational-lithography chain `mask → aerial image → resist`:
-
-```python
-img = sol.printed(NA=0.33, source=0.5, threshold=0.3, diffusion=0.02, steepness=50)  # -> (grid, grid) in [0, 1]
-```
-
-The aerial image (all the `aerial(...)` arguments pass straight through) is optionally blurred by a linear
-**post-exposure-bake diffusion** (a periodic Gaussian of length `diffusion`) and then developed by a soft
-**constant threshold**, `sigmoid(steepness · (I − threshold))` — `1` = clears. `threshold` sets the printed
-CD; `steepness` is the development contrast. Because the whole chain stays JAX, `jax.grad` of a
-printed-vs-target loss now drives **OPC / ILT / SMO with the resist in the loop** — back through development,
-imaging, *and* the rigorous RCWA mask solve:
+The last step of the computational-lithography chain `mask → aerial image → resist` is development.
+`sol.expose(...)` returns the **optical exposure** at the wafer (optics only), and a **resist model** turns
+it into the developed pattern:
 
 ```python
-loss = lambda: ((jno.rcwa(mask(rho)).solve().printed(NA=0.33, source=src, threshold=0.3) - target) ** 2).mean()
+exp = sol.expose(NA=0.33, source=0.5)                       # the exposure (all aerial(...) args apply)
+img = exp.develop(jno.litho.Threshold(threshold=0.3, diffusion=0.02, steepness=50))  # -> (grid, grid) in [0, 1]
 ```
 
-This is the standard linear-diffusion + constant-threshold resist (Poonawala & Milanfar, *IEEE Trans. Image
-Process.* **16**, 774, 2007; PEB diffusion after Mack, *Fundamental Principles of Optical Lithography*, 2007).
-The full reaction-diffusion PEB kinetics, the 3-D development-rate profile, and standing-wave/bulk-absorption
-effects are out of scope here (a separate rigorous photoresist model handles those).
+A resist is any callable `exposure -> developed field`, so new physics plugs into the same seam without
+touching the imaging code. The shipped `jno.litho.Threshold` is the fast, differentiable design-loop model:
+it reads the exposure's aerial image (`exp.intensity()`), optionally blurs it by a linear **post-exposure-bake
+diffusion** (a periodic Gaussian of length `diffusion`), then develops by a soft **constant threshold**,
+`sigmoid(steepness · (I − threshold))` — `1` = clears. `threshold` sets the printed CD, `steepness` the
+development contrast. `sol.printed(NA, source, …, resist=…)` is a one-call shortcut for
+`expose(…).develop(resist)`, defaulting `resist` to `Threshold()`.
+
+Because the whole chain stays JAX, `jax.grad` of a printed-vs-target loss drives **OPC / ILT / SMO with the
+resist in the loop** — back through development, imaging, *and* the rigorous RCWA mask solve:
+
+```python
+r = jno.litho.Threshold(threshold=0.3)
+loss = lambda: ((jno.rcwa(mask(rho)).solve().printed(NA=0.33, source=src, resist=r) - target) ** 2).mean()
+```
+
+`Threshold` is the standard linear-diffusion + constant-threshold resist (Poonawala & Milanfar, *IEEE Trans.
+Image Process.* **16**, 774, 2007; PEB diffusion after Mack, *Fundamental Principles of Optical Lithography*,
+2007). A rigorous **reaction-diffusion PEB** resist plugs into the same `develop(...)` seam — it reads the
+exposure's angular spectrum (`exp.spectrum()`) to propagate a standing-wave bulk image into the resist film,
+then runs the 3-species kinetics. That model, its 3-D development-rate profile, and bulk-absorption effects
+live in the standalone photoresist model.
 
 ## The backend — explicit layers
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -261,9 +261,21 @@ vol = sol.expose(NA=0.33, source=0.5).bulk(jno.litho.Film(n_resist=1.7 + 0.02j, 
 
 `jno.litho.Film` carries the resist stack (`n_resist`, `thickness`, `n_substrate`, `n_top`, `nz`). At `z = 0`
 with no substrate reflection `bulk` equals the aerial image; a reflective substrate produces a vertical
-standing wave of period `λ/(2·n_resist)`. `CAResist` currently drives its acid from the 2-D aerial image;
-consuming `bulk` in a full 3-D `(x, y, z)` PEB solve is the next refinement. `bulk` is scalar (`E_x`) with a
-single-substrate-reflection model (full multilayer Airy and a vector bulk image are future work).
+standing wave of period `λ/(2·n_resist)`. `bulk` is scalar (`E_x`) with a single-substrate-reflection model
+(full multilayer Airy and a vector bulk image are future work).
+
+**3-D PEB.** Pass a `Film` to `CAResist` and it switches from the 2-D aerial-driven bake to a full **3-D
+`(x, y, z)`** reaction-diffusion PEB: the acid is seeded from the standing-wave `bulk` image, the species
+diffuse in x, y *and* z on a `jno.Shape` box (periodic in x, y via a conforming remesh; free in z), and a
+developed `(n, n, film.nz)` volume is returned:
+
+```python
+film = jno.litho.Film(n_resist=1.6, thickness=0.1, n_substrate=4.0, nz=16)
+vol  = sol.expose(NA=0.33, source=0.5).develop(jno.litho.CAResist(film=film, n=64, t_peb=45, steps=30))
+```
+
+The film mesh is isotropic tets (size = smallest box dimension / 4), so very thin films are expensive
+(anisotropic meshing is future work). Without `film`, `CAResist` stays the 2-D model.
 
 ## The backend — explicit layers
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -40,6 +40,7 @@ What is inferred from the problem, and from where:
 | **incident wave** (lit face + angle `k_in`) | the assembled forcing `b` — a constant-phase source ⇒ normal incidence |
 | **tensor permittivity `ε̂`** | an `inner(ε̂ @ u, v)` mass term (a 3×3 `MatrixView`) — birefringence, polarization conversion |
 | **in-plane PML** | a complex coordinate stretch `S = 1 + iσ/k` in the stiffness coefficients — see below |
+| **internal source** | a `- f·v` / `- inner(J, v)` volume forcing — a dipole / Gaussian emitter — see below |
 
 The permittivity is recovered by splitting the volume weak form `∇u·∇v − K0²·ε·u·v`: the stiffness
 summands carry trial/test inside `Jacobian` nodes, the mass summand carries them as bare values, so
@@ -77,6 +78,33 @@ The traced stretch is honoured **exactly** — any σ profile, not a fixed built
 Scope: a **uniaxial** (diagonal) **in-plane** stretch on the **scalar** Helmholtz term, forward solve.
 An off-diagonal stretch, a z-stretch (meaningless for RCWA — the S-matrix already gives outgoing-wave
 z-boundaries), or a design `jno.np.parameter` routed *through* a PML each **raise**.
+
+## Internal sources — dipole / Gaussian emitters
+
+An emitter is authored the **same way you drive `jno.fem` or a PINN** — as a forcing term in the residual,
+not a special object. A scalar monopole is `- f·v`; a vector dipole is `- inner(J, v)` (with `J` a
+current-density vector giving the orientation):
+
+```python
+profile = jno.np.exp(-(((xi-x0)**2 + (yi-y0)**2 + (zi-z0)**2) / (2*w**2)))   # localized emitter
+vol = ui.x*vi.x + ui.y*vi.y + ui.z*vi.z - K0**2*eps*(u*vi) - A*profile*vi     # `- A·profile·v` forcing
+sol = jno.rcwa([vol, absorbing_top, absorbing_bottom, u_left-u_right, u_front-u_back]).solve()
+sol.power("up"), sol.power("down")     # power radiated into each ambient
+sol.extraction("up")                   # directionality = up / (up + down)
+```
+
+The front door detects the trial-free / test-present volume summand, **localizes** it (centroid → point
+`dirac_delta_source` vs Gaussian `gaussian_source(fwhm)`; which z-layer it sits in), splits the stack at the
+source plane, and drives `fmmax`'s `amplitudes_for_source`. A higher-index substrate correctly biases
+emission downward (substrate-emission enhancement — the LED/OLED extraction physics). The **amplitude /
+orientation and the design ε are differentiable** (`jax.grad` of extraction or emitted power flows through),
+so you can inverse-design the environment around a fixed emitter, or recover an unknown source strength.
+
+Scope: scalar Helmholtz, the source must lie in a **finite (contrast-defined) layer**, `k_in` is nudged off
+the singular Γ-point (a single Bloch point — full Brillouin-zone averaging is future work), the source
+*location* is static (amplitude/orientation are the differentiable knobs), and a boundary plane-wave
+incidence together with an internal source **raises** (author one excitation). Purcell / LDOS (total emitted
+power ÷ a homogeneous-medium reference) is not wired yet.
 
 ## The backend — explicit layers
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -109,6 +109,27 @@ the singular Γ-point (a single Bloch point — full Brillouin-zone averaging is
 plane-wave incidence together with an internal source **raises** (author one excitation). Purcell / LDOS
 (total emitted power ÷ a homogeneous-medium reference) is not wired yet.
 
+## Subpixel smoothing (for inverse design)
+
+`smoothing=k` (default `1` = off) supersamples each RCWA pixel `k×k` and **area-averages** the
+permittivity, anti-aliasing material boundaries:
+
+```python
+jno.rcwa(constraints, orders=200, smoothing=3)     # 3×3 supersample per pixel, averaged
+```
+
+Why it matters for inverse design: a point-sampled ε **staircases** as a design boundary sweeps — the
+rasterized structure is piecewise-constant and only jumps when an edge crosses a grid line, so the gradient
+w.r.t. a boundary-moving parameter is jumpy (flat, then a spike). Area-averaging makes the rasterized fill —
+and hence the gradient — vary **smoothly**. It costs `k²`× more (cheap) coefficient evaluations; the fmmax
+eigensolve size is unchanged. Fully differentiable (a plain mean), threaded through every ε path (scalar,
+tensor, PML, nodal density) in both the eager and the re-sampled (parametric) solve.
+
+This is the **arithmetic** (isotropic) form of subpixel averaging — a solid, general anti-aliasing. The
+rigorous **tensor** scheme (Farjadpour et al., *Opt. Lett.* **31**, 2972 (2006): arithmetic tangential +
+harmonic normal averaging at the interface, which additionally accelerates Fourier convergence) is future
+work. Recommended `k = 2`–`4` for topology optimization; leave it off for a fixed-geometry forward solve.
+
 ## The backend — explicit layers
 
 `jno.Rcwa` takes a hand-built stack directly; this is what the front door constructs internally:
@@ -166,6 +187,9 @@ a-Si). Correctness is checked against the analytic Fresnel/transfer-matrix trans
   stretched coordinates*, Microw. Opt. Technol. Lett. **7**, 599 (1994) — the complex coordinate stretch.
 - Z. S. Sacks, D. M. Kingsland, R. Lee & J.-F. Lee, *A perfectly matched anisotropic absorber for use as
   an absorbing boundary condition*, IEEE Trans. Antennas Propag. **43**, 1460 (1995) — the uniaxial `ε̂`/`μ̂` PML.
+- A. Farjadpour et al., *Improving accuracy by subpixel smoothing in the finite-difference time domain*,
+  Opt. Lett. **31**, 2972 (2006) — the rigorous tensor subpixel-smoothing scheme (jno.rcwa currently does
+  the arithmetic form).
 
 ## API
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -181,10 +181,22 @@ mask solve:
 loss = lambda: ((jno.rcwa(mask(rho)).solve().aerial(NA=0.33, source=src) - target) ** 2).mean()
 ```
 
-Validated against the imaging limits (open frame → uniform; partial coherence reduces contrast) and by
-`jax.grad` vs finite difference. Scalar (uses `E_x`); the vector high-NA form (both `E_x, E_y` with
-polarization in the pupil) and the full angular-rigorous Abbe (re-solving the mask per source point) are
-future work.
+By default the image is **scalar** (uses `E_x`) — correct at low NA. Pass `polarization=` to switch on the
+**vector high-NA** model, which rotates each order's transverse `(E_x, E_y)` to the 3-D wafer field through
+the Richards-Wolf/Flagello vector pupil (with the aplanatic `1/√(cosθ)` apodization), so the TM component
+loses contrast at large ray angles — the defining high-NA effect:
+
+```python
+img = sol.aerial(NA=0.9, source=0.5, polarization="x")            # linearly polarized (TM for an x-grating)
+img = sol.aerial(NA=0.9, source=0.5, polarization="unpolarized")  # mean of the two linear images
+```
+
+`"x"`/`"y"` are linear illumination; `"unpolarized"` averages the two. At NA→0 the vector pupil is the
+identity and the image reduces to the scalar one. Validated against the imaging limits (open frame → uniform;
+partial coherence reduces contrast), the vector→scalar reduction as NA drops, the TE-over-TM contrast split at
+high NA, and by `jax.grad` vs finite difference. The vector pupil follows Flagello, Milster & Rosenbluth,
+*J. Opt. Soc. Am. A* **13**, 53 (1996). The full angular-rigorous Abbe (re-solving the mask per source point)
+remains future work.
 
 ## The backend — explicit layers
 

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -156,6 +156,36 @@ with per-stage `TraceAnnotation`s (`rcwa:eigensolve`, `rcwa:s_matrix`), prints t
 time, and writes a Perfetto trace to `./rcwa_traces`. RCWA's cost is dominated by the `O((2·n_t)³)` per-layer
 eigensolves — the trace makes that explicit (open it at `chrome://tracing` or Perfetto UI).
 
+## Aerial imaging — `sol.aerial(...)` (computational lithography)
+
+RCWA gives the rigorous **mask diffraction**; `sol.aerial(NA, source, …)` is the **litho imaging step** on
+top of it — the partially-coherent **aerial image** (wafer-plane intensity) by **Abbe** source integration:
+
+```python
+sol = jno.rcwa(mask_constraints, orders=200).solve()   # rigorous mask (mask-3D, polarization)
+img = sol.aerial(NA=0.33, source=0.5)                  # -> (grid, grid) intensity over one period
+```
+
+The mask's diffraction orders (this solution's spectrum) are projected through a lens of numerical aperture
+`NA` and summed over the illumination `source`. Everything else — wavelength, period, the complex mask
+spectrum — is read from the solve; only the optics are yours. `source` is polymorphic: a **float** `σ`
+(conventional, partial-coherence radius), a **(σ_in, σ_out) tuple** (annular), or a raw **array** of pupil
+weights (differentiable, for source-mask optimization). `defocus=` applies the quadratic pupil phase;
+`kind="R"` handles a reflective EUV mask.
+
+Because the whole chain is JAX, the image is **differentiable in the mask design and the source** — so
+`jax.grad` of a printed-vs-target loss drives **OPC / ILT / SMO**, back through the imaging *and* the RCWA
+mask solve:
+
+```python
+loss = lambda: ((jno.rcwa(mask(rho)).solve().aerial(NA=0.33, source=src) - target) ** 2).mean()
+```
+
+Validated against the imaging limits (open frame → uniform; partial coherence reduces contrast) and by
+`jax.grad` vs finite difference. Scalar (uses `E_x`); the vector high-NA form (both `E_x, E_y` with
+polarization in the pupil) and the full angular-rigorous Abbe (re-solving the mask per source point) are
+future work.
+
 ## The backend — explicit layers
 
 `jno.Rcwa` takes a hand-built stack directly; this is what the front door constructs internally:

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -75,9 +75,11 @@ periodic); the absorbing frame just makes the supercell walls non-coupling, so l
 neighbour is absorbed instead of recirculated, and the cell behaves like a single isolated scatterer.
 The traced stretch is honoured **exactly** — any σ profile, not a fixed built-in one.
 
-Scope: a **uniaxial** (diagonal) **in-plane** stretch on the **scalar** Helmholtz term, forward solve.
-An off-diagonal stretch, a z-stretch (meaningless for RCWA — the S-matrix already gives outgoing-wave
-z-boundaries), or a design `jno.np.parameter` routed *through* a PML each **raise**.
+A design `jno.np.parameter` on the **scatterer** inside the PML supercell **is differentiable** — the PML
+layers are re-derived from it (`ε̂ = ε·Λ`, `μ̂ = Λ`), so `jax.grad` flows and you can inverse-design an
+*isolated* structure. Scope: a **uniaxial** (diagonal) **in-plane** stretch on the **scalar** Helmholtz
+term. An off-diagonal stretch or a z-stretch (meaningless for RCWA — the S-matrix already gives
+outgoing-wave z-boundaries) each **raise**.
 
 ## Internal sources — dipole / Gaussian emitters
 
@@ -96,15 +98,16 @@ sol.extraction("up")                   # directionality = up / (up + down)
 The front door detects the trial-free / test-present volume summand, **localizes** it (centroid → point
 `dirac_delta_source` vs Gaussian `gaussian_source(fwhm)`; which z-layer it sits in), splits the stack at the
 source plane, and drives `fmmax`'s `amplitudes_for_source`. A higher-index substrate correctly biases
-emission downward (substrate-emission enhancement — the LED/OLED extraction physics). The **amplitude /
-orientation and the design ε are differentiable** (`jax.grad` of extraction or emitted power flows through),
-so you can inverse-design the environment around a fixed emitter, or recover an unknown source strength.
+emission downward (substrate-emission enhancement — the LED/OLED extraction physics). The **amplitude,
+orientation, lateral location, z-position and Gaussian width — plus the design ε — are all differentiable**
+(`jax.grad` of extraction or emitted power flows through), so you can inverse-design the environment around
+an emitter, optimize *where* it sits, or recover an unknown source strength. Only the discrete choices
+(which layer, point-vs-Gaussian) are frozen at construction.
 
 Scope: scalar Helmholtz, the source must lie in a **finite (contrast-defined) layer**, `k_in` is nudged off
-the singular Γ-point (a single Bloch point — full Brillouin-zone averaging is future work), the source
-*location* is static (amplitude/orientation are the differentiable knobs), and a boundary plane-wave
-incidence together with an internal source **raises** (author one excitation). Purcell / LDOS (total emitted
-power ÷ a homogeneous-medium reference) is not wired yet.
+the singular Γ-point (a single Bloch point — full Brillouin-zone averaging is future work), and a boundary
+plane-wave incidence together with an internal source **raises** (author one excitation). Purcell / LDOS
+(total emitted power ÷ a homogeneous-medium reference) is not wired yet.
 
 ## The backend — explicit layers
 

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -8,7 +8,7 @@ jNO: Physics-Informed Neural Operators.
 
 import sys
 
-from . import bayesian, fn, lora, optimizers, precond, solve, trackers
+from . import bayesian, fn, litho, lora, optimizers, precond, solve, trackers
 from . import jnp_ops as np
 from ._fem import Coupling, fem, lag
 from .architectures.models import nn, parameter
@@ -124,6 +124,7 @@ __all__ = [
     "rcwa",
     "Rcwa",
     "RcwaError",
+    "litho",
     "AdaptSpec",
     "Coupling",
     "Model",

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1087,7 +1087,9 @@ class FEM:
             raise KeyError(f"FEM.block_index: trial field {getattr(field, 'name', fk)!r} is not part of this system.")
         return keys.index(fk)
 
-    def solve(self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, **kwargs) -> Any:
+    def solve(
+        self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, profile=False, **kwargs
+    ) -> Any:
         """Differentiable forward solve as a trace node — the inverse-problem entry.
 
         Pass ``adapt=AdaptSpec(...)`` to run the **adaptive** loop
@@ -1161,15 +1163,28 @@ class FEM:
         (``x0`` is rejected — the ICs own the initial state). Not yet supported: slots on
         complex/complex-transient problems, and slots combined with ``adapt=`` (remeshing
         invalidates warm starts and cached preconditioner setups — pass ``solve_fn=`` there).
+
+        ``profile=True`` runs the (eager, non-parametric) solve inside a JAX Perfetto trace, prints the DOF
+        count + wall time, and writes the trace to ``./jno_traces`` — like ``jno.core.solve(profile=True)``.
+        Profile a *concrete* forward solve; a parametric solve returns a deferred trace node with no numeric
+        work to time.
         """
-        result = self._solve_dispatch(
-            solve_fn, adapt=adapt, x0=x0, nonlinear=nonlinear, linear=linear, precond=precond, **kwargs
-        )
-        if isinstance(result, Placeholder):
-            # Tag the solve node with its domain so jno.core can infer the domain straight from the graph
-            # (a data-misfit inverse `jno.core([(fem.solve() - u_obs).mse])` needs no explicit `domain=`).
-            result._domain = self.domain
-        return result
+
+        def _run():
+            result = self._solve_dispatch(
+                solve_fn, adapt=adapt, x0=x0, nonlinear=nonlinear, linear=linear, precond=precond, **kwargs
+            )
+            if isinstance(result, Placeholder):
+                # Tag the solve node with its domain so jno.core can infer the domain straight from the graph
+                # (a data-misfit inverse `jno.core([(fem.solve() - u_obs).mse])` needs no explicit `domain=`).
+                result._domain = self.domain
+            return result
+
+        if not profile:  # profile=True: run the (eager) solve inside a JAX Perfetto trace + print a summary
+            return _run()
+        from .utils.profiling import profile_solve
+
+        return profile_solve(_run, label=f"fem profile · {self.dofs} DOFs · {self._mode}", warm=(adapt is None))
 
     def _solve_dispatch(self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, **kwargs):
         """Mode dispatch for :meth:`solve` — returns the solution array or a differentiable trace node."""

--- a/jno/core.py
+++ b/jno/core.py
@@ -165,12 +165,29 @@ def _find_temporal_variable(expr: Placeholder):
     return visit(expr)
 
 
+_TRIVIAL_DOMAIN = None
+
+
+def _trivial_domain():
+    """A tiny placeholder domain for a **parameter-only fit** — a loss that references no domain Variable, e.g.
+    a pure data fit ``(pred(params) - obs).mse`` (an inverse problem, or an ILT loss over a solver wrapped as a
+    ``jno.fn``). There are no collocation coordinates to sample, so any domain works; this just satisfies the
+    collocation machinery. Built once and reused (read-only)."""
+    global _TRIVIAL_DOMAIN
+    if _TRIVIAL_DOMAIN is None:
+        from .geometry.shape import Shape
+
+        _TRIVIAL_DOMAIN = Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    return _TRIVIAL_DOMAIN
+
+
 def _infer_domain_from_constraints(constraints: List[Placeholder]):
     """Walk the constraint trees and return the unique domain referenced by
-    every Variable / TensorTag inside.
+    every Variable / TensorTag inside, or ``None`` when there is no domain
+    Variable at all (a parameter-only fit — the caller supplies a trivial domain).
 
-    Raises ``ValueError`` if zero (no Variables at all) or more than one
-    distinct domain is found — the caller must then pass ``domain=`` explicitly.
+    Raises ``ValueError`` if more than one distinct domain is found — the caller
+    must then pass ``domain=`` explicitly.
     """
     domains: list = []  # preserve insertion order for nicer error messages
     seen_domains: set = set()
@@ -215,11 +232,7 @@ def _infer_domain_from_constraints(constraints: List[Placeholder]):
     if not constraints:
         raise ValueError("jno.core requires at least one constraint.")
     if not domains:
-        raise ValueError(
-            "Cannot infer domain: no Variables or TensorTags were found in the "
-            "constraints. Every loss must reference at least one Variable so the "
-            "core can resolve its domain."
-        )
+        return None  # no domain Variable -> a parameter-only fit; the caller supplies a trivial domain
     raise ValueError(
         f"Cannot infer domain: constraints reference {len(domains)} distinct "
         f"domains ({domains!r}). All constraints must share a single domain."
@@ -492,6 +505,13 @@ class core:
             self.domain = domain
         elif constraints:
             self.domain = _infer_domain_from_constraints(constraints)
+            if self.domain is None:  # no domain Variable -> a parameter-only fit (e.g. an ILT/data-fit loss)
+                self.log.warning(
+                    "No domain Variable found in the constraints — treating this as a parameter-only fit and "
+                    "using a trivial domain. If the loss was meant to sample a domain, ensure it references a "
+                    "Variable or pass domain= explicitly."
+                )
+                self.domain = _trivial_domain()
         else:
             self.domain = None
         self.models: Dict[int, Any] = {}

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -2742,7 +2742,6 @@ class domain(MeshIOMixin):
         occlude=True,
         inward=False,
         r_min=None,
-        near_field=True,
     ):
         """Build an :class:`~jno.domain.enclosure.Enclosure` from radiating boundary ``tags``.
 
@@ -2767,20 +2766,10 @@ class domain(MeshIOMixin):
                 use when the radiating ``tags`` are the outer walls of a **meshed cavity** (an oven /
                 furnace filled with a transparent fluid) and radiation crosses the meshed interior, so
                 the facing walls see one another. Default ``False`` (normals out of the mesh, vacuum gap).
-            near_field: Axisymmetric only, default ``True``. Recompute the element pairs that the uniform
-                ``n_phi`` azimuthal rule cannot resolve — near-touching surfaces (two parts meeting in a
-                narrow wedge) and every element's own ring self-view — with a graded azimuthal quadrature
-                sized to each pair's peak. The ring kernel's azimuthal integrand peaks at ``phi = 0`` with
-                width ``d/r`` (``d`` = surface separation, ``r`` = radius); when ``2*pi/n_phi`` exceeds
-                that, the rule samples the peak's crest and multiplies it by a far wider step, overshooting
-                by ``~dphi/(d/r)``. That is what otherwise drives row sums well above the physical bound of
-                1 and forces the ``r_min`` fudge. Costs a one-off build-time pass over the near pairs.
             r_min: Axisymmetric only. Near-field FLOOR for the ring kernel (``R^2 -> R^2 + r_min^2``) — a
                 fudge that caps the kernel for near-coincident rings rather than integrating them properly.
-                Defaults to ``0`` when ``near_field`` is on (the refinement handles the near field, so any
-                floor is then a pure bias) and to half the median element length otherwise. Note that the
-                legacy default is itself a ~12% systematic error on the analytic concentric-cylinder view
-                factors; pass a value to override either way.
+                Defaults to half the median element length. Note that this default is itself a ~12%
+                systematic error on the analytic concentric-cylinder view factors; pass a value to override.
         """
         from .enclosure import build_enclosure
 
@@ -2797,7 +2786,6 @@ class domain(MeshIOMixin):
             occlude=occlude,
             inward=inward,
             r_min=r_min,
-            near_field=near_field,
         )
 
     def compute_enclosure_view_factor(self, tags, opaque_tags=None):

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -1866,6 +1866,8 @@ class domain(MeshIOMixin):
         self._apply_mesh(mesh)
         for name, pred in list(getattr(self, "_tag_predicates", {}).items()):  # re-materialize predicate tags
             self.tag(name, pred)
+        if getattr(self, "_is_time_dependent", False) and self.time is not None:
+            self._add_time_dimension(*self.time)  # re-broadcast the fresh (N, D) tags across time (idempotent)
         self._periodic_meshed = getattr(self, "_periodic_meshed", frozenset()) | want
         self.log.info(f"Re-meshed periodic (conforming) for face pairs {sorted(tuple(sorted(p)) for p in pairs)}")
         return True

--- a/jno/fdm.py
+++ b/jno/fdm.py
@@ -660,22 +660,32 @@ class _TraceFDM:
             u0 = u0.at[jnp.asarray(idx if len(idx) else allnodes)].set(vals)
         return u0
 
-    def solve(self, nonlinear=None, x0=None):
+    def solve(self, nonlinear=None, x0=None, profile=False):
         """Solve the strong-form system. **Steady** problems fold the Dirichlet rows into the residual
         (``u - g`` on the region) and hand it to the same ``jno.solve`` Newton–Krylov + ``custom_root``
         machinery ``jno.fem`` uses (linear/nonlinear uniform, differentiable for inverse problems).
         **Transient** problems (an ``u(initial) - u0`` condition is present) march by method-of-lines —
         ``t_span`` and the step count come from ``domain.time`` and the initial state from the IC — and
-        return the trajectory (``(n_save, N)``); ``x0`` is rejected (the IC owns the initial state)."""
-        if self._transient:
-            if x0 is not None:
-                raise ValueError("jno.fdm([...]): x0= is rejected for a transient problem — the IC owns the state.")
-            return self._march(nonlinear=nonlinear)
+        return the trajectory (``(n_save, N)``); ``x0`` is rejected (the IC owns the initial state).
 
-        trainable = self._trainable_params()
-        if trainable:
-            return self._parametric_node(trainable, nonlinear=nonlinear, x0=x0)
-        return self._steady_solve(nonlinear=nonlinear, x0=x0)
+        ``profile=True`` runs the (eager, non-parametric) solve inside a JAX Perfetto trace, prints the node
+        count + wall time, and writes the trace to ``./jno_traces`` — like ``jno.core.solve(profile=True)``."""
+
+        def _run():
+            if self._transient:
+                if x0 is not None:
+                    raise ValueError("jno.fdm([...]): x0= is rejected for a transient problem — the IC owns the state.")
+                return self._march(nonlinear=nonlinear)
+            trainable = self._trainable_params()
+            if trainable:
+                return self._parametric_node(trainable, nonlinear=nonlinear, x0=x0)
+            return self._steady_solve(nonlinear=nonlinear, x0=x0)
+
+        if not profile:
+            return _run()
+        from .utils.profiling import profile_solve
+
+        return profile_solve(_run, label=f"fdm profile · {self._N} nodes · {'transient' if self._transient else 'steady'}")
 
     def _steady_solve(self, *, nonlinear=None, x0=None, extra_params=None, extra_pins=None):
         """The eager steady solve: fold the flux and Dirichlet rows into the residual and hand it to the

--- a/jno/litho.py
+++ b/jno/litho.py
@@ -105,10 +105,11 @@ class CAResist:
         Uniform initial base-quencher loading ``B(t=0)``.
     tone:
         ``"positive"`` (default) returns the developed/soluble fraction ``1 − M``; ``"negative"`` returns ``M``.
-
-    First cut: the latent acid is driven by the 2-D aerial image (matching the dos Santos 2-D model). The
-    depth-resolved standing-wave bulk image is available from :meth:`_Exposure.bulk`; consuming it in a 3-D
-    (x, y, z) PEB solve is the next refinement.
+    film:
+        ``None`` (default) → **2-D** PEB driven by the aerial image (matching the dos Santos 2-D model),
+        returning a ``(n, n)`` pattern. A :class:`Film` → **3-D** ``(x, y, z)`` PEB on a ``jno.Shape`` box:
+        the acid is seeded from the depth-resolved standing-wave bulk image (:meth:`_Exposure.bulk`), the
+        species diffuse in x, y *and* z, and a developed ``(n, n, film.nz)`` volume is returned.
     """
 
     def __init__(
@@ -123,6 +124,7 @@ class CAResist:
         dose=1.0,
         quencher=0.4,
         tone="positive",
+        film=None,
     ):
         if tone not in ("positive", "negative"):
             raise ValueError(f"tone must be 'positive' or 'negative', got {tone!r}")
@@ -132,11 +134,15 @@ class CAResist:
         self.k = tuple(float(v) for v in k)
         self.rho_a, self.rho_b = (float(v) for v in diffusion_length)
         self.dill_c, self.dose, self.quencher, self.tone = float(dill_c), float(dose), float(quencher), tone
+        self.film = film
 
     def __call__(self, exposure):
-        """Develop an exposure through the reaction-diffusion PEB. Reads ``exposure.intensity()`` (the aerial
-        image) and ``exposure.period``; returns a developed ``(n, n)`` pattern in ``[0, 1]``."""
-        return _peb_develop(exposure.intensity(), exposure.period, self)
+        """Develop an exposure through the reaction-diffusion PEB. With no ``film`` this reads the 2-D aerial
+        image (``exposure.intensity()``) → ``(n, n)``; with a :class:`Film` it reads the depth-resolved bulk
+        image (``exposure.bulk(film)``) and solves the 3-D PEB → ``(n, n, film.nz)``. Both in ``[0, 1]``."""
+        if self.film is None:
+            return _peb_develop(exposure.intensity(), exposure.period, self)
+        return _peb_develop_3d(exposure.bulk(self.film), exposure.period, self.film, self)
 
 
 def _sample_periodic(img, x, y, period):
@@ -220,4 +226,106 @@ def _peb_develop(img, period, r):
     ix = np.round(coords[:, 0] / hx).astype(int) % n
     iy = np.round(coords[:, 1] / hy).astype(int) % n
     grid = jnp.zeros((n, n)).at[ix, iy].set(m_final)  # regrid M onto one period (differentiable in M)
+    return 1.0 - grid if r.tone == "positive" else grid
+
+
+def _sample_bulk(vol, x, y, z, period, thickness):
+    """Differentiable trilinear sample of a ``(G, G, nz)`` bulk image -- periodic in x, y (over ``period``),
+    clamped in z (over ``thickness``) -- at node coordinates ``(x, y, z)``."""
+    G, nz = vol.shape[0], vol.shape[2]
+    gx, gy = (x / period[0] % 1.0) * G, (y / period[1] % 1.0) * G
+    gz = jnp.clip(z / thickness, 0.0, 1.0) * (nz - 1)
+    x0, y0 = jnp.floor(gx).astype(int) % G, jnp.floor(gy).astype(int) % G
+    x1, y1 = (x0 + 1) % G, (y0 + 1) % G
+    z0 = jnp.clip(jnp.floor(gz).astype(int), 0, nz - 1)
+    z1 = jnp.clip(z0 + 1, 0, nz - 1)
+    fx, fy, fz = gx - jnp.floor(gx), gy - jnp.floor(gy), gz - jnp.floor(gz)
+
+    def face(zi):
+        return (
+            vol[x0, y0, zi] * (1 - fx) * (1 - fy)
+            + vol[x1, y0, zi] * fx * (1 - fy)
+            + vol[x0, y1, zi] * (1 - fx) * fy
+            + vol[x1, y1, zi] * fx * fy
+        )
+
+    return face(z0) * (1 - fz) + face(z1) * fz
+
+
+def _regrid3d(vals, coords, n, nz, period, thickness):
+    """Regrid unstructured node values onto a regular ``(n, n, nz)`` grid by nearest-cell scatter-mean
+    (differentiable in ``vals``); empty cells take the global mean."""
+    ix = np.clip((coords[:, 0] / period[0] * n).astype(int), 0, n - 1)
+    iy = np.clip((coords[:, 1] / period[1] * n).astype(int), 0, n - 1)
+    iz = np.clip((coords[:, 2] / thickness * nz).astype(int), 0, nz - 1)
+    flat = (ix * n + iy) * nz + iz
+    tot = jnp.zeros(n * n * nz).at[flat].add(vals)
+    cnt = jnp.zeros(n * n * nz).at[flat].add(1.0)
+    grid = jnp.where(cnt > 0, tot / jnp.where(cnt > 0, cnt, 1.0), jnp.mean(vals))
+    return grid.reshape(n, n, nz)
+
+
+def _peb_develop_3d(vol, period, film, r):
+    """3-D reaction-diffusion PEB on a ``jno.Shape`` box (periodic in x, y; free in z), seeded by the Dill
+    latent acid from the standing-wave bulk image ``vol`` (``(G, G, nz)``). The species diffuse in x, y and z;
+    returns the developed ``(n, n, film.nz)`` volume. ``jno`` is imported lazily (no package import cycle)."""
+    import jno
+    from jno.trace_evaluator import TraceEvaluator
+
+    Px, Py = period
+    d, n = float(film.thickness), r.n
+    k1, k2, k3, k4, k5 = r.k
+    d_a, d_b = r.rho_a**2 / (2.0 * r.t_peb), r.rho_b**2 / (2.0 * r.t_peb)
+    size = min(Px, Py, d) / 4.0  # isotropic tets; ≥ ~4 elements through the thinnest dimension
+
+    dom = jno.Shape.box(0.0, 0.0, 0.0, Px, Py, d, size=size).domain(
+        time=(0.0, r.t_peb, r.steps), compute_mesh_connectivity=False
+    )
+    ex, ey = 1e-6 * Px, 1e-6 * Py
+    for nm, pred in {
+        "left": lambda x, y, z: x < ex,
+        "right": lambda x, y, z: x > Px - ex,
+        "front": lambda x, y, z: y < ey,
+        "back": lambda x, y, z: y > Py - ey,
+    }.items():
+        dom.tag(nm, pred)
+    dom._remesh_periodic([("left", "right"), ("front", "back")])  # conforming x,y faces for the nodal ties
+    M, pM = dom.fem_symbols(names=("M", "pM"))
+    A, pA = dom.fem_symbols(names=("A", "pA"))
+    B, pB = dom.fem_symbols(names=("B", "pB"))
+    xi, yi, zi, ti = dom.variable("interior", split=True)
+    ci = dom.variable("initial", split=True)
+    xl, yl, zl, _ = dom.variable("left", split=True)
+    xr, yr, zr, _ = dom.variable("right", split=True)
+    xf, yf, zf, _ = dom.variable("front", split=True)
+    xk, yk, zk, _ = dom.variable("back", split=True)
+    Mi, qM = M.bind(x=xi, y=yi, z=zi, t=ti), pM.bind(x=xi, y=yi, z=zi, t=ti)
+    Ai, qA = A.bind(x=xi, y=yi, z=zi, t=ti), pA.bind(x=xi, y=yi, z=zi, t=ti)
+    Bi, qB = B.bind(x=xi, y=yi, z=zi, t=ti), pB.bind(x=xi, y=yi, z=zi, t=ti)
+
+    def acid0(x, y, z):  # Dill latent acid from the bulk image at the film nodes
+        return 1.0 - jnp.exp(-r.dill_c * r.dose * _sample_bulk(vol, x, y, z, period, d))
+
+    A0 = jno.fn(acid0, [ci[0], ci[1], ci[2]])
+    fem = jno.fem(
+        [
+            Mi.t * qM + k1 * Mi * Ai * qM + k2 * Mi * qM,  # inhibitor: immobile, reaction only
+            Ai.t * qA + d_a * (Ai.x * qA.x + Ai.y * qA.y + Ai.z * qA.z) + k3 * Ai * qA + k4 * Ai * Bi * qA,  # acid
+            Bi.t * qB + d_b * (Bi.x * qB.x + Bi.y * qB.y + Bi.z * qB.z) + k4 * Ai * Bi * qB + k5 * Bi * qB,  # quencher
+            M(xl, yl, zl) - M(xr, yr, zr),
+            M(xf, yf, zf) - M(xk, yk, zk),
+            A(xl, yl, zl) - A(xr, yr, zr),
+            A(xf, yf, zf) - A(xk, yk, zk),
+            B(xl, yl, zl) - B(xr, yr, zr),
+            B(xf, yf, zf) - B(xk, yk, zk),
+            M(ci[0], ci[1], ci[2]) - 1.0,
+            A(ci[0], ci[1], ci[2]) - A0,
+            B(ci[0], ci[1], ci[2]) - r.quencher,
+        ]
+    )
+    node = fem.solve()
+    traj = TraceEvaluator({}).evaluate(node.expr if hasattr(node, "expr") else node, context={})
+    m_final = traj[-1][fem.offsets[0] : fem.offsets[1]]
+    coords = np.asarray(fem.field_points[0])[:, :3]
+    grid = _regrid3d(m_final, coords, n, int(film.nz), period, d)
     return 1.0 - grid if r.tone == "positive" else grid

--- a/jno/litho.py
+++ b/jno/litho.py
@@ -3,12 +3,14 @@
 A **resist** turns the optical exposure at the wafer (``sol.expose(...)``) into a developed pattern. It is
 any callable ``exposure -> developed field`` -- so it is applied with ``exposure.develop(resist)`` and new
 models plug in without touching the imaging code. This module ships the fast, differentiable design-loop
-model :class:`Threshold`; a rigorous reaction-diffusion PEB model (``CAResist``) plugs into the same seam by
-reading the exposure's angular spectrum instead of just its intensity.
+model :class:`Threshold` and the rigorous 3-species reaction-diffusion PEB model :class:`CAResist`, which
+plug into the same ``develop`` seam. ``CAResist`` currently drives its latent acid from the aerial image;
+propagating the exposure's angular spectrum into the resist film (standing-wave bulk image) is the next step.
 """
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 
 class Threshold:
@@ -54,3 +56,152 @@ def _develop(img, threshold, diffusion, steepness, period):
         ker = jnp.exp(-2.0 * (jnp.pi * diffusion) ** 2 * (FX**2 + FY**2))
         img = jnp.real(jnp.fft.ifft2(jnp.fft.fft2(img) * ker))
     return jax.nn.sigmoid(steepness * (img - threshold))
+
+
+class CAResist:
+    """Rigorous **chemically-amplified-resist** post-exposure bake -- the 3-species reaction-diffusion PEB
+    (dos Santos, *Simulation of post-exposure bake reactions using PINNs for chemically amplified resists*),
+    coupled to an RCWA exposure. The exposure's aerial image sets the **latent acid** (Dill exposure kinetics),
+    then inhibitor ``M``, acid ``A`` and quencher ``B`` react-and-diffuse over the bake, and the developed
+    ``1 − M`` (deprotection) is the printed pattern::
+
+        M_t = −k1 M A − k2 M                 (inhibitor    — immobile)
+        A_t =  D_A ΔA − k3 A − k4 A B        (acid         — diffuses)
+        B_t =  D_B ΔB − k4 A B − k5 B        (base quencher — diffuses)
+
+    Authored as one transient :func:`jno.fem` system (the sole FEM entry) on a doubly-periodic film mesh, so
+    it is a **drop-in resist** for ``exposure.develop(...)`` -- the rigorous counterpart of :class:`Threshold`.
+    It is heavier (a nonlinear multifield transient solve), for verification rather than the fast design loop.
+
+    Parameters
+    ----------
+    n, t_peb, steps:
+        Film-mesh resolution per side, bake time, and number of (backward-Euler) time steps.
+    k:
+        Rate constants ``(k1, k2, k3, k4, k5)``. ``k4`` is the bilinear acid-base neutralization (the stiff,
+        genuinely-nonlinear coupling).
+    diffusion_length:
+        Acid/base diffusion lengths ``(ρ_A, ρ_B)`` (same length unit as the mask period); ``D = ρ²/(2 t_peb)``.
+    dill_c, dose:
+        Dill exposure-rate constant and exposure dose -- the latent acid is
+        ``A(t=0) = 1 − exp(−dill_c · dose · I)`` from the aerial intensity ``I``.
+    quencher:
+        Uniform initial base-quencher loading ``B(t=0)``.
+    tone:
+        ``"positive"`` (default) returns the developed/soluble fraction ``1 − M``; ``"negative"`` returns ``M``.
+
+    First cut: the latent acid is driven by the 2-D aerial image (matching the dos Santos 2-D model). The
+    depth-resolved standing-wave bulk image (``exposure.spectrum()`` propagated into the resist film) is the
+    next refinement -- see :meth:`_Exposure.spectrum`.
+    """
+
+    def __init__(
+        self,
+        *,
+        n=48,
+        t_peb=45.0,
+        steps=30,
+        k=(0.5, 0.005, 0.005, 5.0, 0.005),
+        diffusion_length=(12.0, 8.0),
+        dill_c=1.0,
+        dose=1.0,
+        quencher=0.4,
+        tone="positive",
+    ):
+        if tone not in ("positive", "negative"):
+            raise ValueError(f"tone must be 'positive' or 'negative', got {tone!r}")
+        if len(k) != 5:
+            raise ValueError(f"k must be (k1, k2, k3, k4, k5), got {len(k)} values")
+        self.n, self.t_peb, self.steps = int(n), float(t_peb), int(steps)
+        self.k = tuple(float(v) for v in k)
+        self.rho_a, self.rho_b = (float(v) for v in diffusion_length)
+        self.dill_c, self.dose, self.quencher, self.tone = float(dill_c), float(dose), float(quencher), tone
+
+    def __call__(self, exposure):
+        """Develop an exposure through the reaction-diffusion PEB. Reads ``exposure.intensity()`` (the aerial
+        image) and ``exposure.period``; returns a developed ``(n, n)`` pattern in ``[0, 1]``."""
+        return _peb_develop(exposure.intensity(), exposure.period, self)
+
+
+def _sample_periodic(img, x, y, period):
+    """Differentiable periodic bilinear sample of a ``(G, G)`` image (axis 0 = x, axis 1 = y, over one
+    ``period``) at node coordinates ``(x, y)``."""
+    gx, gy = (x / period[0] % 1.0) * img.shape[0], (y / period[1] % 1.0) * img.shape[1]
+    x0, y0 = jnp.floor(gx).astype(int) % img.shape[0], jnp.floor(gy).astype(int) % img.shape[1]
+    x1, y1 = (x0 + 1) % img.shape[0], (y0 + 1) % img.shape[1]
+    fx, fy = gx - jnp.floor(gx), gy - jnp.floor(gy)
+    return (
+        img[x0, y0] * (1 - fx) * (1 - fy)
+        + img[x1, y0] * fx * (1 - fy)
+        + img[x0, y1] * (1 - fx) * fy
+        + img[x1, y1] * fx * fy
+    )
+
+
+def _peb_develop(img, period, r):
+    """Build and solve the 3-species reaction-diffusion PEB (weak form after dos Santos) on a doubly-periodic
+    film mesh, seeded by the Dill latent acid from ``img``, and return the developed ``(n, n)`` pattern.
+    ``jno`` is imported lazily so this resist module has no import cycle with the package."""
+    import jno
+    from jno.trace_evaluator import TraceEvaluator
+
+    Px, Py = period
+    n, (k1, k2, k3, k4, k5) = r.n, r.k
+    d_a, d_b = r.rho_a**2 / (2.0 * r.t_peb), r.rho_b**2 / (2.0 * r.t_peb)
+
+    dom = jno.domain(
+        constructor=jno.domain.equi_distant_rect(x_range=(0.0, Px), y_range=(0.0, Py), nx=n, ny=n),
+        time=(0.0, r.t_peb, r.steps),
+        compute_mesh_connectivity=False,
+    )
+    ex, ey = 1e-6 * Px, 1e-6 * Py
+    for nm, pred in {
+        "left": lambda x, y: x < ex,
+        "right": lambda x, y: x > Px - ex,
+        "bottom": lambda x, y: y < ey,
+        "top": lambda x, y: y > Py - ey,
+    }.items():
+        dom.tag(nm, pred)
+    M, pM = dom.fem_symbols(names=("M", "pM"))
+    A, pA = dom.fem_symbols(names=("A", "pA"))
+    B, pB = dom.fem_symbols(names=("B", "pB"))
+    xi, yi, ti = dom.variable("interior", split=True)
+    ci = dom.variable("initial", split=True)
+    xl, yl, _ = dom.variable("left", split=True)
+    xr, yr, _ = dom.variable("right", split=True)
+    xb, yb, _ = dom.variable("bottom", split=True)
+    xt, yt, _ = dom.variable("top", split=True)
+    Mi, qM = M.bind(x=xi, y=yi, t=ti), pM.bind(x=xi, y=yi, t=ti)
+    Ai, qA = A.bind(x=xi, y=yi, t=ti), pA.bind(x=xi, y=yi, t=ti)
+    Bi, qB = B.bind(x=xi, y=yi, t=ti), pB.bind(x=xi, y=yi, t=ti)
+
+    def acid0(x, y):  # Dill latent acid from the aerial intensity, sampled at the film nodes
+        return 1.0 - jnp.exp(-r.dill_c * r.dose * _sample_periodic(img, x, y, period))
+
+    A0 = jno.fn(acid0, [ci[0], ci[1]])
+    fem = jno.fem(
+        [
+            Mi.t * qM + k1 * Mi * Ai * qM + k2 * Mi * qM,  # inhibitor: immobile, reaction only
+            Ai.t * qA + d_a * (Ai.x * qA.x + Ai.y * qA.y) + k3 * Ai * qA + k4 * Ai * Bi * qA,  # acid: diffuse + react
+            Bi.t * qB + d_b * (Bi.x * qB.x + Bi.y * qB.y) + k4 * Ai * Bi * qB + k5 * Bi * qB,  # quencher: diffuse + react
+            M(xl, yl) - M(xr, yr),
+            M(xb, yb) - M(xt, yt),
+            A(xl, yl) - A(xr, yr),
+            A(xb, yb) - A(xt, yt),
+            B(xl, yl) - B(xr, yr),
+            B(xb, yb) - B(xt, yt),
+            M(ci[0], ci[1]) - 1.0,
+            A(ci[0], ci[1]) - A0,
+            B(ci[0], ci[1]) - r.quencher,
+        ]
+    )
+    node = fem.solve()
+    traj = TraceEvaluator({}).evaluate(node.expr if hasattr(node, "expr") else node, context={})
+    off = fem.offsets
+    m_final = traj[-1][off[0] : off[1]]  # inhibitor M on the (periodic-reduced) film nodes
+    coords = np.asarray(fem.field_points[0])[:, :2]
+    hx, hy = Px / n, Py / n
+    ix = np.round(coords[:, 0] / hx).astype(int) % n
+    iy = np.round(coords[:, 1] / hy).astype(int) % n
+    grid = jnp.zeros((n, n)).at[ix, iy].set(m_final)  # regrid M onto one period (differentiable in M)
+    return 1.0 - grid if r.tone == "positive" else grid

--- a/jno/litho.py
+++ b/jno/litho.py
@@ -5,12 +5,28 @@ any callable ``exposure -> developed field`` -- so it is applied with ``exposure
 models plug in without touching the imaging code. This module ships the fast, differentiable design-loop
 model :class:`Threshold` and the rigorous 3-species reaction-diffusion PEB model :class:`CAResist`, which
 plug into the same ``develop`` seam. ``CAResist`` currently drives its latent acid from the aerial image;
-propagating the exposure's angular spectrum into the resist film (standing-wave bulk image) is the next step.
+the exposure's :meth:`_Exposure.bulk` gives the depth-resolved standing-wave field (a :class:`Film` stack),
+so consuming it in a 3-D PEB solve is the next step.
 """
+
+from dataclasses import dataclass
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+
+
+@dataclass
+class Film:
+    """Resist-film stack for the standing-wave **bulk image** (:meth:`_Exposure.bulk`): a resist of index
+    ``n_resist`` (complex ⇒ absorption) and ``thickness`` on a substrate ``n_substrate``, under a top medium
+    ``n_top``, sampled at ``nz`` depths. Same length unit as the mask period."""
+
+    n_resist: complex
+    thickness: float
+    n_substrate: complex = 1.0
+    n_top: float = 1.0
+    nz: int = 16
 
 
 class Threshold:
@@ -91,8 +107,8 @@ class CAResist:
         ``"positive"`` (default) returns the developed/soluble fraction ``1 − M``; ``"negative"`` returns ``M``.
 
     First cut: the latent acid is driven by the 2-D aerial image (matching the dos Santos 2-D model). The
-    depth-resolved standing-wave bulk image (``exposure.spectrum()`` propagated into the resist film) is the
-    next refinement -- see :meth:`_Exposure.spectrum`.
+    depth-resolved standing-wave bulk image is available from :meth:`_Exposure.bulk`; consuming it in a 3-D
+    (x, y, z) PEB solve is the next refinement.
     """
 
     def __init__(

--- a/jno/litho.py
+++ b/jno/litho.py
@@ -1,0 +1,56 @@
+"""Resist models for ``jno.rcwa`` computational lithography.
+
+A **resist** turns the optical exposure at the wafer (``sol.expose(...)``) into a developed pattern. It is
+any callable ``exposure -> developed field`` -- so it is applied with ``exposure.develop(resist)`` and new
+models plug in without touching the imaging code. This module ships the fast, differentiable design-loop
+model :class:`Threshold`; a rigorous reaction-diffusion PEB model (``CAResist``) plugs into the same seam by
+reading the exposure's angular spectrum instead of just its intensity.
+"""
+
+import jax
+import jax.numpy as jnp
+
+
+class Threshold:
+    """Constant-threshold resist with a linear (Gaussian) post-exposure-bake (PEB) diffusion -- the fast,
+    differentiable resist that drives OPC / ILT / SMO.
+
+    Development blurs the aerial image by the PEB acid-diffusion length (a periodic Gaussian, the bake heat
+    kernel), then applies a soft constant threshold ``sigmoid(steepness · (I_bake − threshold))`` ∈ ``[0, 1]``
+    (1 = clears, positive tone) -- a differentiable stand-in for the printed contour. Linear-diffusion +
+    constant-threshold model: Poonawala & Milanfar, *IEEE Trans. Image Process.* **16**, 774 (2007); PEB
+    diffusion after Mack, *Fundamental Principles of Optical Lithography* (2007).
+
+    Parameters
+    ----------
+    threshold:
+        Dose-to-clear fraction on the aerial-intensity scale (an open frame images to ≈ 1). Raising it
+        shrinks a bright feature -- the knob that sets printed CD.
+    diffusion:
+        PEB acid-diffusion length (same length unit as the geometry; ``0`` = no bake).
+    steepness:
+        Development contrast -- the sigmoid sharpness (larger → a harder threshold / steeper resist).
+    """
+
+    def __init__(self, threshold=0.3, diffusion=0.0, steepness=50.0):
+        self.threshold = float(threshold)
+        self.diffusion = float(diffusion)
+        self.steepness = float(steepness)
+
+    def __call__(self, exposure):
+        """Develop an exposure into a ``[0, 1]`` resist image. Needs ``exposure.intensity()`` (the aerial
+        image) and ``exposure.period`` (for the diffusion length scale)."""
+        return _develop(exposure.intensity(), self.threshold, self.diffusion, self.steepness, exposure.period)
+
+
+def _develop(img, threshold, diffusion, steepness, period):
+    """Constant-threshold resist with a linear (Gaussian) PEB diffusion: blur the aerial image by the acid-
+    diffusion length (periodic, in Fourier space -- the image is one period), then soft-threshold. Axis 0 is
+    x (period ``period[0]``), axis 1 is y. Differentiable; ``diffusion == 0`` skips the blur exactly."""
+    if diffusion > 0:  # linear PEB diffusion == a periodic Gaussian blur (heat kernel over the bake)
+        fx = jnp.fft.fftfreq(img.shape[0], d=period[0] / img.shape[0])
+        fy = jnp.fft.fftfreq(img.shape[1], d=period[1] / img.shape[1])
+        FX, FY = jnp.meshgrid(fx, fy, indexing="ij")
+        ker = jnp.exp(-2.0 * (jnp.pi * diffusion) ** 2 * (FX**2 + FY**2))
+        img = jnp.real(jnp.fft.ifft2(jnp.fft.fft2(img) * ker))
+    return jax.nn.sigmoid(steepness * (img - threshold))

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -322,6 +322,27 @@ class Rcwa:
             return jnp.full((1, 1), g) if g.ndim == 0 else g
 
         def solve_layer(e):
+            # general anisotropic layer: e = (ε_xx..ε_zz, μ_xx..μ_zz) -> ε AND μ tensors. Used for a uniaxial
+            # PML (an in-plane coordinate stretch is a diagonal ε̂ and μ̂), and for magnetic / magneto-optic media.
+            if isinstance(e, tuple) and len(e) == 10:
+                exx, exy, eyx, eyy, ezz, uxx, uxy, uyx, uyy, uzz = (_grid(c) for c in e)
+                return fm.eigensolve_general_anisotropic_media(
+                    jnp.asarray(wl),
+                    kin,
+                    lv,
+                    exx,
+                    exy,
+                    eyx,
+                    eyy,
+                    ezz,
+                    uxx,
+                    uxy,
+                    uyx,
+                    uyy,
+                    uzz,
+                    ex,
+                    formulation=self.formulation,
+                )
             # anisotropic layer: e = (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz) grids -> fmmax's anisotropic eigensolve
             if isinstance(e, tuple) and len(e) == 5:
                 exx, exy, eyx, eyy, ezz = (_grid(c) for c in e)

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -365,8 +365,13 @@ class _Sol:
             ax, ay = AX + s[0], AY + s[1]
             r2 = ax**2 + ay**2
             passes = r2 <= NA**2
-            rho = jnp.sqrt(jnp.clip(r2, 0.0, 1.0))  # sinθ (transverse direction-cosine magnitude)
-            cth = jnp.sqrt(jnp.clip(1.0 - r2, 0.0, 1.0))  # cosθ
+            # sinθ / cosθ via a double-`where` safe sqrt: √ is only ever evaluated at a strictly-positive
+            # argument, so its reverse-mode `1/(2√·)` never hits the 0th-order (r2=0) or grazing (r2=1)
+            # singularity. rho/cth are constant in the design, but an unguarded √0 grad still poisons the sum.
+            s2 = jnp.clip(r2, 0.0, 1.0)
+            rho = jnp.where(s2 > 0.0, jnp.sqrt(jnp.where(s2 > 0.0, s2, 1.0)), 0.0)  # sinθ
+            c2 = jnp.clip(1.0 - r2, 0.0, 1.0)
+            cth = jnp.where(c2 > 0.0, jnp.sqrt(jnp.where(c2 > 0.0, c2, 1.0)), 0.0)  # cosθ
             safe = rho > 1e-9
             cf = jnp.where(safe, ax / jnp.where(safe, rho, 1.0), 1.0)  # cosφ (azimuth)
             sf = jnp.where(safe, ay / jnp.where(safe, rho, 1.0), 0.0)  # sinφ

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -69,21 +69,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from jno.utils.profiling import annotate as _annot  # stage annotator for rc.solve(profile=True)
+
 
 def _concrete(x):
     """True when ``x`` is a real (non-traced) value, so a never-silent guard may inspect it. Under
     jit/grad the value is a tracer -- the guard steps aside (validation ran on the eager forward pass)."""
     return not isinstance(x, jax.core.Tracer)
-
-
-def _annot(name):
-    """A ``jax.profiler.TraceAnnotation`` labelling a solve stage in a Perfetto trace when profiling is
-    active (``rc.solve(profile=True)``); a no-op context otherwise, so it never costs anything normally."""
-    from contextlib import nullcontext
-
-    from jax._src import profiler as _jp
-
-    return jax.profiler.TraceAnnotation(name) if _jp._profile_state.profile_session is not None else nullcontext()
 
 
 _FMMAX_HINT = (
@@ -1223,29 +1215,14 @@ class _ParametricSol:
 
 
 def _profile_solve(run, eng):
-    """Run an eager RCWA solve inside a JAX Perfetto trace (per-stage annotated) and print a size/time
-    summary -- the profiling path of ``rc.solve(profile=True)``, mirroring ``jno.core.solve(profile=True)``."""
-    import os
-    import time
+    """The profiling path of ``rc.solve(profile=True)`` -- an eager, per-stage-annotated RCWA solve inside a
+    JAX Perfetto trace (shared with ``jno.fem``/``jno.fdm``). The eager solve self-blocks (its energy guard
+    reads ``efficiency`` concretely), so the shared timer sees the real O((2·n_t)³) eigensolve work."""
+    from jno.utils.profiling import profile_solve
 
-    trace_dir = os.path.join(os.getcwd(), "rcwa_traces")
-    os.makedirs(trace_dir, exist_ok=True)
-
-    def _block(sol):  # force the DAG to execute so the trace/timer sees the real work
-        jax.block_until_ready(sol.power("total") if isinstance(sol, _EmitterSol) else sol.efficiency("T"))
-        return sol
-
-    _block(run())  # warm: trigger XLA compilation so the trace times the hot solve
-    t0 = time.perf_counter()
-    with jax.profiler.trace(trace_dir, create_perfetto_trace=True):
-        sol = _block(run())
-    dt = time.perf_counter() - t0
     nt = eng._nt
-    print(
-        f"[rcwa profile] {len(eng.layers_spec)} layers · n_t={nt} Fourier orders · "
-        f"{2 * nt}×{2 * nt} eigenproblem/layer  |  solve {dt * 1e3:.1f} ms  |  Perfetto trace → {trace_dir}"
-    )
-    return sol
+    label = f"rcwa profile · {len(eng.layers_spec)} layers · n_t={nt} · {2 * nt}×{2 * nt} eigenproblem/layer"
+    return profile_solve(run, label=label)
 
 
 class _RcwaProblem:

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -784,24 +784,27 @@ def _extract_pml_stretch(volume_term):
     }
 
 
-def _pml_layer_components(mass_node, stretch, period, grid, zmid, params, k0sq):
+def _pml_layer_components(mass_node, stretch, period, grid, zmid, params, k0sq, sub=1):
     """The 10 relative-permittivity/permeability grids ``(ε_xx,ε_xy,ε_yx,ε_yy,ε_zz, μ_xx,μ_xy,μ_yx,μ_yy,μ_zz)``
     of an in-plane uniaxial PML layer at height ``zmid``.
 
     ``Λ = diag(c_xx, c_yy, c_zz)`` is read off the stiffness coefficients (``stretch``); the Maxwell PML is
     ``ε̂ = ε·Λ``, ``μ̂ = Λ`` with ``ε = (K0²·ε·SₓSᵧS_z)/k0² / (c_xx·c_yy·c_zz)`` since
-    ``SₓSᵧS_z = c_xx·c_yy·c_zz``. Off-diagonal components are zero (uniaxial)."""
-    pts = _cell_grid_at_z(period, grid, zmid)
+    ``SₓSᵧS_z = c_xx·c_yy·c_zz``. Off-diagonal components are zero (uniaxial). ``sub`` = subpixel smoothing
+    (each ε̂/μ̂ component is built at ``grid·sub`` and averaged per pixel)."""
+    g = grid * sub
+    pts = _cell_grid_at_z(period, g, zmid)
 
     def samp(node):
-        v = jnp.full((grid * grid,), node) if np.isscalar(node) else _eval_coeff_points(node, pts, params)
-        return jnp.reshape(v, (grid, grid)) + 0j
+        v = jnp.full((g * g,), node) if np.isscalar(node) else _eval_coeff_points(node, pts, params)
+        return jnp.reshape(v, (g, g)) + 0j
 
     lam = [samp(stretch[ax]) for ax in (0, 1, 2)]
-    m = jnp.reshape(_eval_coeff_points(mass_node, pts, params), (grid, grid)) + 0j
+    m = jnp.reshape(_eval_coeff_points(mass_node, pts, params), (g, g)) + 0j
     eps_rel = (m / k0sq) / (lam[0] * lam[1] * lam[2])
-    z = jnp.zeros((grid, grid), complex)
-    return (eps_rel * lam[0], z, z, eps_rel * lam[1], eps_rel * lam[2], lam[0], z, z, lam[1], lam[2])
+    z = jnp.zeros((g, g), complex)
+    comps = (eps_rel * lam[0], z, z, eps_rel * lam[1], eps_rel * lam[2], lam[0], z, z, lam[1], lam[2])
+    return tuple(_pixel_average(c, grid, sub) for c in comps)
 
 
 def _extract_volume_source(volume_term):
@@ -976,22 +979,37 @@ def _kin_from_source(src_coeff, period, z0, params):
     return jnp.stack([kx, ky])
 
 
-def _sample_grid_direct(coeff_node, grid, nz, period, z_range, params=None):
+def _pixel_average(vals, grid, sub):
+    """**Subpixel smoothing**: area-average a ``(grid·sub, grid·sub[, …])`` supersampled field down to
+    ``(grid, grid[, …])`` by averaging each pixel's ``sub×sub`` block. Anti-aliases material boundaries so
+    the Fourier expansion converges faster (less Gibbs ringing) and the gradient w.r.t. a boundary-moving
+    design parameter is smooth, not staircased. A plain mean -- differentiable, works on NumPy or JAX."""
+    if sub == 1:
+        return vals
+    tail = tuple(vals.shape[2:])
+    return vals.reshape(grid, sub, grid, sub, *tail).mean(axis=(1, 3))
+
+
+def _sample_grid_direct(coeff_node, grid, nz, period, z_range, params=None, sub=1):
     """Evaluate an analytic coefficient expression directly on the RCWA grid (exact, no mesh noise).
 
     Used when the permittivity is an analytic function of the coordinates (no per-node field); this
     avoids the staircase/interp noise that makes z-slices look non-invariant on an unstructured mesh.
     ``params`` substitutes trainable-parameter values (so the eager structure/k0 inference uses valid
-    values, e.g. a K0 parameter)."""
-    xs = np.linspace(0, period[0], grid, endpoint=False)
-    ys = np.linspace(0, period[1], grid, endpoint=False)
+    values, e.g. a K0 parameter). ``sub`` supersamples each pixel ``sub×sub`` and averages (subpixel
+    smoothing)."""
+    g = grid * sub
+    xs = np.linspace(0, period[0], g, endpoint=False)
+    ys = np.linspace(0, period[1], g, endpoint=False)
     zs = np.linspace(z_range[0], z_range[1], nz)
     GX, GY, GZ = np.meshgrid(xs, ys, zs, indexing="ij")
     pts = np.stack([GX.ravel(), GY.ravel(), GZ.ravel()], 1)
     vals = np.asarray(_eval_coeff_points(coeff_node, pts, params or {}))
     if vals.ndim >= 3 and vals.shape[-2:] == (3, 3):  # anisotropic ε̂ -> layer-detect on the xx component
         vals = vals[..., 0, 0]
-    vals = vals.reshape(grid, grid, nz)
+    vals = vals.reshape(g, g, nz)
+    if sub > 1:  # anti-alias: average each pixel's sub×sub supersamples (z untouched)
+        vals = vals.reshape(grid, sub, grid, sub, nz).mean(axis=(1, 3))
     return np.moveaxis(vals, 2, 0).astype(complex), zs  # -> (nz, grid, grid)
 
 
@@ -1003,32 +1021,36 @@ def _coeff_is_tensor(coeff_node, period, z_range, params):
     return v.ndim >= 3 and v.shape[-2:] == (3, 3)
 
 
-def _tensor_components(coeff_node, period, grid, zmid, params, k0sq):
+def _tensor_components(coeff_node, period, grid, zmid, params, k0sq, sub=1):
     """The 5 relative-permittivity component grids (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz) fmmax needs, sampled on the
-    unit-cell grid at height ``zmid`` from the K0²·ε̂ tensor coefficient (divided by k0²)."""
-    T = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), params), (grid, grid, 3, 3))
-    T = T / k0sq
+    unit-cell grid at height ``zmid`` from the K0²·ε̂ tensor coefficient (divided by k0²). ``sub`` = subpixel
+    smoothing factor."""
+    g = grid * sub
+    T = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, g, zmid), params), (g, g, 3, 3))
+    T = _pixel_average(T, grid, sub) / k0sq
     return (T[..., 0, 0], T[..., 0, 1], T[..., 1, 0], T[..., 1, 1], T[..., 2, 2])
 
 
-def _sample_grid(domain, eps_nodes, grid, nz, period, z_range):
-    """Interpolate nodal eps onto an (nz, grid, grid) unit-cell array over the z-extent."""
+def _sample_grid(domain, eps_nodes, grid, nz, period, z_range, sub=1):
+    """Interpolate nodal eps onto an (nz, grid, grid) unit-cell array over the z-extent (``sub`` = subpixel
+    supersampling, averaged per pixel)."""
     from scipy.interpolate import griddata
 
+    g = grid * sub
     pts = np.asarray(domain.points)
-    xs = np.linspace(0, period[0], grid, endpoint=False)
-    ys = np.linspace(0, period[1], grid, endpoint=False)
+    xs = np.linspace(0, period[0], g, endpoint=False)
+    ys = np.linspace(0, period[1], g, endpoint=False)
     zs = np.linspace(z_range[0], z_range[1], nz)
     GX, GY = np.meshgrid(xs, ys, indexing="ij")
     E = np.empty((nz, grid, grid), complex)
     for k, zz in enumerate(zs):
         sel = np.abs(pts[:, 2] - zz) < (z_range[1] - z_range[0]) / (nz - 1) * 0.75 + 1e-9
         if sel.sum() < 3:
-            j = np.argsort(np.abs(pts[:, 2] - zz))[: max(3, grid)]
+            j = np.argsort(np.abs(pts[:, 2] - zz))[: max(3, g)]
             sel = np.zeros(len(pts), bool)
             sel[j] = True
         vals = griddata(pts[sel][:, :2], eps_nodes[sel], (GX, GY), method="nearest")
-        E[k] = vals
+        E[k] = vals.reshape(grid, sub, grid, sub).mean(axis=(1, 3)) if sub > 1 else vals
     return E, zs
 
 
@@ -1276,6 +1298,7 @@ def _build_emitter_problem(
     vsrc,
     is_aniso,
     is_pml,
+    sub=1,
 ):
     """Build an internal-source (dipole / Gaussian) emission problem: localize the traced ``- f·v`` /
     ``- inner(J, v)`` forcing, split its layer, and route it to fmmax's ``amplitudes_for_source``.
@@ -1362,11 +1385,12 @@ def _build_emitter_problem(
     kin = (1e-3, 1e-3)  # nudge off the singular Γ-point (exactly-normal k_in is degenerate for an internal source)
 
     def resample(params):
-        k0p = jnp.sqrt(jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zm[0]), params))))
+        g = grid * sub  # supersampled lattice for subpixel smoothing
+        k0p = jnp.sqrt(jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, g, zm[0]), params))))
         out = []
         for (thick, _), zmid in zip(layers, zm):
-            cvals = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), params), (grid, grid))
-            out.append((thick, jnp.real(cvals) / (k0p * k0p)))
+            cfine = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, g, zmid), params), (g, g))
+            out.append((thick, _pixel_average(jnp.real(cfine), grid, sub) / (k0p * k0p)))
         return out, 2 * jnp.pi / k0p, kin, make_source(params)
 
     from jno.utils.solver.parametric_helpers import _collect_runtime_parameter_exprs
@@ -1387,7 +1411,18 @@ def _build_emitter_problem(
     return _RcwaProblem(spec, orders=orders, formulation=formulation, resample=resample, rpe=rpe)
 
 
-def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, params=None, formulation="JONES_DIRECT_FOURIER"):
+def rcwa(
+    problem,
+    *,
+    orders,
+    wavelength=None,
+    grid=64,
+    nz=64,
+    slices=None,
+    params=None,
+    formulation="JONES_DIRECT_FOURIER",
+    smoothing=1,
+):
     """Infer and build an RCWA problem from a jNO constraint list (or built ``FEM``).
 
     Everything is read out of the traced problem: **periodicity + period** (Floquet ties — absent ⇒
@@ -1421,12 +1456,21 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         Transverse resolution and number of z-samples used to detect the layer stack.
     slices:
         Staircase a continuously-varying permittivity into this many layers instead of raising.
+    smoothing:
+        Subpixel-smoothing factor (default ``1`` = off). ``smoothing=k`` supersamples each RCWA pixel
+        ``k×k`` and area-averages the permittivity, anti-aliasing material boundaries. Recommended (``2``–``4``)
+        for **inverse design**: it cuts Fourier (Gibbs) ringing so fewer ``orders`` converge, and makes the
+        gradient w.r.t. a boundary-moving design parameter smooth rather than staircased. Costs ``k²``× more
+        coefficient evaluations (cheap) — the fmmax eigensolve size is unchanged.
 
     Returns
     -------
     _RcwaProblem
         Holds the inferred :class:`RcwaSpec` (``.spec``) and a :meth:`~_RcwaProblem.solve`.
     """
+    sub = int(smoothing)
+    if sub < 1:
+        raise RcwaError(f"smoothing must be a positive integer (1 = off), got {smoothing!r}.")
     femobj = _as_fem(problem)
     domain = femobj.domain
     axes, period = _periodic_period(femobj, domain)
@@ -1450,9 +1494,9 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         coeff_nodes = _eval_expr_nodes(coeff_node, domain)
         if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
             coeff_nodes = coeff_nodes.real.astype(complex)
-        C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range)
+        C, zs = _sample_grid(domain, coeff_nodes, grid, nz, period, z_range, sub=sub)
     else:  # analytic permittivity -> sample the grid exactly
-        C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range, cparams)
+        C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range, cparams, sub=sub)
     coeff_layers = detect_layers(C, zs, slices=slices)
     zmids = list(detect_layers.last_zmid)  # representative z of each layer (both paths) -> re-sampling
     zspans = list(detect_layers.last_zspan)  # (z_lo, z_hi) per layer -> place an internal source in its layer
@@ -1480,6 +1524,7 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
             vsrc,
             is_aniso,
             is_pml,
+            sub,
         )
 
     face_z, k_in = _source_kin(femobj, domain, cparams)
@@ -1509,12 +1554,17 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     k0sq = k0 * k0
     if is_pml:  # in-plane uniaxial PML: general-anisotropic layer (ε̂ AND μ̂), 10 grids per layer
         layers = [
-            (t, tuple(np.asarray(c) for c in _pml_layer_components(coeff_node, stretch, period, grid, zm, cparams, k0sq)))
+            (
+                t,
+                tuple(
+                    np.asarray(c) for c in _pml_layer_components(coeff_node, stretch, period, grid, zm, cparams, k0sq, sub)
+                ),
+            )
             for (t, _), zm in zip(coeff_layers, zmids)
         ]
     elif is_aniso:  # relative-permittivity TENSOR per layer: (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz)
         layers = [
-            (t, tuple(np.asarray(c) for c in _tensor_components(coeff_node, period, grid, zm, cparams, k0sq)))
+            (t, tuple(np.asarray(c) for c in _tensor_components(coeff_node, period, grid, zm, cparams, k0sq, sub)))
             for (t, _), zm in zip(coeff_layers, zmids)
         ]
     else:
@@ -1534,9 +1584,9 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         mc.model._parameter_name for mc in _model_calls(coeff_node) if getattr(mc.model, "_fem_field", None) == "node"
     }
     bary = None
-    if nodal_names:
+    if nodal_names:  # bary at grid·sub -> the nodal density is interpolated on the supersampled lattice, then averaged
         nc = np.asarray(domain.points)
-        bary = [_bary_weights(nc, _cell_grid_at_z(period, grid, zm)) for zm in zmids]  # per layer: (ids, weights)
+        bary = [_bary_weights(nc, _cell_grid_at_z(period, grid * sub, zm)) for zm in zmids]  # per layer: (ids, weights)
 
     # the illuminated boundary term's forcing -> lets an incidence-ANGLE parameter in the source flow
     # (its transverse phase gradient IS k_in); None when the source has no angle to read.
@@ -1548,6 +1598,8 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         k_in = tuple(float(x) for x in _kin_from_source(src_coeff, period, src_z, cparams))  # corrupted for N1E)
 
     def resample(params):
+        g = grid * sub  # supersampled lattice for subpixel smoothing
+
         def at(li):  # parameter values for layer li: nodal fields barycentrically interpolated, scalars as-is
             def gather(v):
                 ids, w = bary[li]
@@ -1559,27 +1611,23 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
             center_pt = np.array([[period[0] * 0.5, period[1] * 0.5, zmids[0]]])
             k0 = jnp.sqrt(jnp.real(jnp.reshape(_eval_coeff_points(coeff_node, center_pt, at(0)), (-1,))[0]))
             out = [
-                (thick, _pml_layer_components(coeff_node, stretch, period, grid, zmid, at(li), k0 * k0))
+                (thick, _pml_layer_components(coeff_node, stretch, period, grid, zmid, at(li), k0 * k0, sub))
                 for li, (thick, zmid) in enumerate(zip(thicks, zmids))
             ]
         elif is_aniso:  # k0 from the superstrate's xx (isotropic vacuum ⇒ xx = k0²); tensor components per layer
-            sup_xx = jnp.reshape(
-                _eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0)), (grid, grid, 3, 3)
-            )
+            sup_xx = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, g, zmids[0]), at(0)), (g, g, 3, 3))
             k0 = jnp.sqrt(jnp.mean(jnp.real(sup_xx[..., 0, 0])))
             out = [
-                (thick, _tensor_components(coeff_node, period, grid, zmid, at(li), k0 * k0))
+                (thick, _tensor_components(coeff_node, period, grid, zmid, at(li), k0 * k0, sub))
                 for li, (thick, zmid) in enumerate(zip(thicks, zmids))
             ]
         else:
-            sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0))))
+            sup = jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, g, zmids[0]), at(0))))
             k0 = jnp.sqrt(sup)
             out = []
             for li, (thick, zmid) in enumerate(zip(thicks, zmids)):
-                cvals = jnp.reshape(
-                    _eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), at(li)), (grid, grid)
-                )
-                out.append((thick, jnp.real(cvals) / (k0 * k0)))
+                cfine = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, g, zmid), at(li)), (g, g))
+                out.append((thick, _pixel_average(jnp.real(cfine), grid, sub) / (k0 * k0)))
         kin = _kin_from_source(src_coeff, period, src_z, params) if src_coeff is not None else jnp.asarray(k_in)
         return out, 2 * jnp.pi / k0, kin, None  # source=None: plane-wave incidence, not an internal source
 

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -76,6 +76,16 @@ def _concrete(x):
     return not isinstance(x, jax.core.Tracer)
 
 
+def _annot(name):
+    """A ``jax.profiler.TraceAnnotation`` labelling a solve stage in a Perfetto trace when profiling is
+    active (``rc.solve(profile=True)``); a no-op context otherwise, so it never costs anything normally."""
+    from contextlib import nullcontext
+
+    from jax._src import profiler as _jp
+
+    return jax.profiler.TraceAnnotation(name) if _jp._profile_state.profile_session is not None else nullcontext()
+
+
 _FMMAX_HINT = (
     "jno.rcwa needs the optional fmmax backend: pip install jax-neural-operators[rcwa] "
     "(or `pixi run -e rcwa ...`, or `pip install fmmax`)."
@@ -416,8 +426,10 @@ class Rcwa:
         nt = self._nt  # precomputed eagerly in __init__ (jit-safe)
         if source is not None:
             return self._solve_source(source, layers_spec, wl, kin)
-        layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
-        s = fm.stack_s_matrix(layers, thick)
+        with _annot("rcwa:eigensolve"):
+            layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
+        with _annot("rcwa:s_matrix"):
+            s = fm.stack_s_matrix(layers, thick)
         # Incidence: excite the genuinely forward-propagating mode in the superstrate and normalise by
         # ITS flux. fmmax sorts eigenmodes by eigenvalue, so index 0 need not be the 0th forward order,
         # and a one-hot forward amplitude can carry zero forward flux -- pick the max-positive-flux mode.
@@ -456,7 +468,8 @@ class Rcwa:
         ``amplitudes_for_source`` propagates it to the ambients. Returns an :class:`_EmitterSol` with the
         power radiated up / down (differentiable in ``amp``, ``orient`` and the design ε)."""
         fm, lv, ex = self.fm, self._lv, self._ex
-        layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
+        with _annot("rcwa:eigensolve"):
+            layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
         si = source["layer"]
         tu, tl = jnp.asarray(source["t_upper"]), jnp.asarray(source["t_lower"])  # z-split thicknesses (differentiable)
         before = layers[: si + 1]
@@ -1209,6 +1222,32 @@ class _ParametricSol:
         )
 
 
+def _profile_solve(run, eng):
+    """Run an eager RCWA solve inside a JAX Perfetto trace (per-stage annotated) and print a size/time
+    summary -- the profiling path of ``rc.solve(profile=True)``, mirroring ``jno.core.solve(profile=True)``."""
+    import os
+    import time
+
+    trace_dir = os.path.join(os.getcwd(), "rcwa_traces")
+    os.makedirs(trace_dir, exist_ok=True)
+
+    def _block(sol):  # force the DAG to execute so the trace/timer sees the real work
+        jax.block_until_ready(sol.power("total") if isinstance(sol, _EmitterSol) else sol.efficiency("T"))
+        return sol
+
+    _block(run())  # warm: trigger XLA compilation so the trace times the hot solve
+    t0 = time.perf_counter()
+    with jax.profiler.trace(trace_dir, create_perfetto_trace=True):
+        sol = _block(run())
+    dt = time.perf_counter() - t0
+    nt = eng._nt
+    print(
+        f"[rcwa profile] {len(eng.layers_spec)} layers · n_t={nt} Fourier orders · "
+        f"{2 * nt}×{2 * nt} eigenproblem/layer  |  solve {dt * 1e3:.1f} ms  |  Perfetto trace → {trace_dir}"
+    )
+    return sol
+
+
 class _RcwaProblem:
     """An RCWA problem inferred from a jNO constraint list / FEM problem. Holds the inferred
     :class:`RcwaSpec` and builds the fmmax engine on :meth:`solve`."""
@@ -1223,17 +1262,20 @@ class _RcwaProblem:
     def __repr__(self):
         return f"_RcwaProblem(orders={self.orders}, params={sorted(self._rpe)}, {self.spec!r})"
 
+    def _build_engine(self, orders):
+        return Rcwa(
+            self.spec.layers,
+            period=self.spec.period,
+            orders=orders,
+            wavelength=self.spec.wavelength,
+            k_in=self.spec.k_in,
+            formulation=self.formulation,
+            assume_periodic=True,
+        )
+
     def _engine(self):
         if getattr(self, "_eng", None) is None:  # build ONCE (warmed eagerly in _node) so the expansion is trace-free
-            self._eng = Rcwa(
-                self.spec.layers,
-                period=self.spec.period,
-                orders=self.orders,
-                wavelength=self.spec.wavelength,
-                k_in=self.spec.k_in,
-                formulation=self.formulation,
-                assume_periodic=True,
-            )
+            self._eng = self._build_engine(self.orders)
         return self._eng
 
     def _solve_at(self, params):
@@ -1245,7 +1287,7 @@ class _RcwaProblem:
         layers, wl, kin, source = self._resample(params)
         return eng.solve(layers=layers, wavelength=wl, k_in=kin, source=source)
 
-    def solve(self, params=None, wavelength=None, k_in=None):
+    def solve(self, params=None, wavelength=None, k_in=None, orders=None, profile=False):
         """Solve.
 
         The jNO way (**no arguments**): if the constraint list carries ``jno.np.parameter`` coefficients
@@ -1255,27 +1297,39 @@ class _RcwaProblem:
         or ``jno.rcwa``. A parameter-free problem solves eagerly and returns concrete readouts.
 
         Escape hatches for a *forward sweep* (not the traced/optimised path): ``params={name: value}`` for
-        a concrete solve at explicit values, or ``wavelength`` / ``k_in`` to override those directly."""
-        if params is None and wavelength is None and k_in is None:
+        a concrete solve at explicit values, or ``wavelength`` / ``k_in`` to override those directly.
+
+        ``orders=N`` re-solves at a different Fourier truncation (a fresh engine, the construction ``orders``
+        is untouched) -- for a **convergence sweep** (compare ``.efficiency`` at N vs 1.5·N) or profiling at
+        scale. ``profile=True`` runs the solve eagerly (at the current parameter values) inside a JAX
+        Perfetto trace with per-stage annotations, like ``jno.core.solve(profile=True)`` -- it prints the
+        problem size and wall time and writes the trace to ``./rcwa_traces`` (RCWA time is dominated by the
+        O((2·n_t)³) per-layer eigensolves, which the trace makes explicit)."""
+        forward = params is not None or wavelength is not None or k_in is not None or orders is not None or profile
+        if not forward:
             if self._rpe and self._resample is not None:
                 return _ParametricSol(self, self._rpe)  # parametric -> trace node (crux-differentiable)
             return self._engine().solve(source=self.spec.source)  # parameter-free -> eager concrete
-        eng = self._engine()
-        if params is None:
-            return eng.solve(wavelength=wavelength, k_in=k_in, source=self.spec.source)
-        if self._resample is None:
-            raise RcwaError(
-                "differentiable solve(params=...) needs the analytic re-sampling path, which is only built "
-                "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
-                "permittivity; differentiable nodal re-sampling is not implemented yet."
+        eng = self._engine() if orders is None else self._build_engine(orders)
+
+        def run():  # a concrete (eager) solve at explicit / current values
+            if params is None:
+                return eng.solve(wavelength=wavelength, k_in=k_in, source=self.spec.source)
+            if self._resample is None:
+                raise RcwaError(
+                    "differentiable solve(params=...) needs the analytic re-sampling path, which is only built "
+                    "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
+                    "permittivity; differentiable nodal re-sampling is not implemented yet."
+                )
+            layers, wl, kin, source = self._resample(params)
+            return eng.solve(
+                layers=layers,
+                wavelength=wavelength if wavelength is not None else wl,
+                k_in=k_in if k_in is not None else kin,
+                source=source,
             )
-        layers, wl, kin, source = self._resample(params)
-        return eng.solve(
-            layers=layers,
-            wavelength=wavelength if wavelength is not None else wl,
-            k_in=k_in if k_in is not None else kin,
-            source=source,
-        )
+
+        return _profile_solve(run, eng) if profile else run()
 
 
 def _build_emitter_problem(

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -384,6 +384,60 @@ class _Sol:
         imgs = jax.vmap(one)(S)
         return jnp.sum(W[:, None, None] * imgs, axis=0) / jnp.sum(W)
 
+    def printed(
+        self,
+        NA,
+        source=0.7,
+        defocus=0.0,
+        grid=128,
+        kind="T",
+        polarization=None,
+        threshold=0.3,
+        diffusion=0.0,
+        steepness=50.0,
+    ):
+        """Developed **resist image** (the printed pattern) of this mask -- the aerial image passed through a
+        constant-threshold resist with a linear post-exposure-bake (PEB) diffusion. Closes the computational-
+        lithography chain ``mask → aerial image → resist``, so ``jax.grad`` of a printed-vs-target loss drives
+        **OPC / ILT / SMO** all the way back through development, imaging *and* the rigorous RCWA mask solve.
+
+        The aerial image (see :meth:`aerial`; the imaging arguments ``NA … polarization`` pass straight
+        through) is optionally blurred by the PEB acid diffusion, then developed by a soft threshold:
+        ``sigmoid(steepness · (I_bake − threshold))`` ∈ ``[0, 1]`` -- 1 = clears (positive tone), a smooth
+        stand-in for the printed contour that stays differentiable.
+
+        Parameters
+        ----------
+        threshold:
+            Dose-to-clear fraction on the aerial-intensity scale (an open frame images to ≈ 1). Raising it
+            shrinks a bright feature -- the knob that sets printed CD.
+        diffusion:
+            PEB acid-diffusion length (same length unit as the geometry; ``0`` = no bake). Applied as a
+            periodic Gaussian blur of the aerial image [Mack 2007].
+        steepness:
+            Development contrast -- the sigmoid sharpness (larger → a harder threshold / steeper resist).
+
+        Returns a ``(grid, grid)`` JAX image in ``[0, 1]``. Linear-diffusion + constant-threshold model
+        (Poonawala & Milanfar, *IEEE TIP* **16**, 774, 2007); the full reaction-diffusion PEB and the 3-D
+        development-rate profile are out of scope here (see the standalone photoresist model).
+        """
+        img = self.aerial(NA, source, defocus, grid, kind, polarization)
+        period = (float(self._period[0]), float(self._period[1]))
+        return _develop(img, float(threshold), float(diffusion), float(steepness), period)
+
+
+def _develop(img, threshold, diffusion, steepness, period):
+    """Constant-threshold resist with a linear (Gaussian) PEB diffusion: blur the aerial image by the acid-
+    diffusion length (periodic, in Fourier space -- the image is one period), then soft-threshold. Axis 0 is
+    x (period ``period[0]``), axis 1 is y. Differentiable; ``diffusion == 0`` skips the blur exactly."""
+    if diffusion > 0:  # linear PEB diffusion == a periodic Gaussian blur (heat kernel over the bake)
+        fx = jnp.fft.fftfreq(img.shape[0], d=period[0] / img.shape[0])
+        fy = jnp.fft.fftfreq(img.shape[1], d=period[1] / img.shape[1])
+        FX, FY = jnp.meshgrid(fx, fy, indexing="ij")
+        ker = jnp.exp(-2.0 * (jnp.pi * diffusion) ** 2 * (FX**2 + FY**2))
+        img = jnp.real(jnp.fft.ifft2(jnp.fft.fft2(img) * ker))
+    return jax.nn.sigmoid(steepness * (img - threshold))
+
 
 def _source_grid(source, NA, ns=15):
     """Illumination source as (points, weights) on a pupil grid, for the Abbe sum. ``source`` is a float
@@ -1350,6 +1404,22 @@ class _ParametricSol:
         """The aerial image as a trace node over the mask's ``jno.np.parameter``\\ s -- so ``jax.grad`` of a
         printed-vs-target loss flows back through the imaging AND the RCWA mask solve to the mask design (ILT)."""
         return self._node("aerial", NA, source, defocus, grid, kind, polarization)
+
+    def printed(
+        self,
+        NA,
+        source=0.7,
+        defocus=0.0,
+        grid=128,
+        kind="T",
+        polarization=None,
+        threshold=0.3,
+        diffusion=0.0,
+        steepness=50.0,
+    ):
+        """The developed resist image as a trace node over the mask's ``jno.np.parameter``\\ s -- ``jax.grad``
+        of a printed-vs-target loss flows back through development, imaging AND the RCWA solve to the mask (ILT)."""
+        return self._node("printed", NA, source, defocus, grid, kind, polarization, threshold, diffusion, steepness)
 
     def field(self, *a, **k):
         raise RcwaError(

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -42,6 +42,13 @@ coefficients of the scalar Helmholtz term). A uniaxial PML is exactly a diagonal
 exactly and solved via `fmmax`'s general anisotropic eigensolve — turning a periodic supercell into an
 isolated scatterer (the absorbing frame decouples the walls).
 
+An **internal source** — a dipole / Gaussian emitter — is authored the same way you would drive `jno.fem`
+or a PINN: a forcing term in the residual, ``- f·v`` (scalar) or ``- inner(J, v)`` (vector current). The
+front door detects the trial-free/test-present volume summand, localizes it (centroid → point vs Gaussian
+width; which z-layer), splits the stack at the source plane, and drives `fmmax`'s ``amplitudes_for_source``.
+Then ``sol.power("up"|"down")`` and ``sol.extraction(...)`` give the emitted power and directionality (LED /
+Purcell physics) instead of plane-wave ``T``/``R``.
+
 References:
  * M. G. Moharam & T. K. Gaylord, "Rigorous coupled-wave analysis of planar-grating diffraction",
    J. Opt. Soc. Am. 71, 811 (1981).
@@ -51,6 +58,8 @@ References:
    stretched coordinates", Microw. Opt. Technol. Lett. 7, 599 (1994) — the complex coordinate stretch.
  * Z. S. Sacks, D. M. Kingsland, R. Lee & J.-F. Lee, "A perfectly matched anisotropic absorber for use
    as an absorbing boundary condition", IEEE Trans. Antennas Propag. 43, 1460 (1995) — the uniaxial ε̂/μ̂ PML.
+ * A. Taflove et al. (eds.), "Advances in FDTD Computational Electrodynamics", Artech House (2013), ch. on
+   modal dipole sources in periodic media — the internal-source (``amplitudes_for_source``) formulation.
  * fmmax: https://github.com/facebookresearch/fmmax
 """
 
@@ -131,7 +140,7 @@ def detect_layers(E, z, tol=1e-3, slices=None):
         idx = np.linspace(0, Nz - 1, slices + 1).round().astype(int)
         slabs = [(idx[i], idx[i + 1]) for i in range(len(idx) - 1)]
 
-    layers, report, zmids = [], [], []
+    layers, report, zmids, zspans = [], [], [], []
     for i, (a, b) in enumerate(slabs):
         mid = (a + b) // 2
         var = float(np.max(np.abs(E[a:b] - E[mid])))
@@ -144,11 +153,13 @@ def detect_layers(E, z, tol=1e-3, slices=None):
         kind = "uniform" if np.ptp(eps_xy) < tol else "patterned"
         layers.append((thick, eps_xy))
         zmids.append(float(z[mid]))
+        zspans.append((float(z[a]), float(z[min(b - 1, Nz - 1)])))  # (z_lo, z_hi) -> place an internal source
         report.append(
             f"  layer {i}: z=[{z[a]:.3f},{z[min(b - 1, Nz - 1)]:.3f}] {kind} eps~[{eps_xy.min():.2f},{eps_xy.max():.2f}]"
         )
     detect_layers.last_report = "detected layers:\n" + "\n".join(report)
     detect_layers.last_zmid = zmids  # representative z of each layer -- lets a param sweep re-sample eps
+    detect_layers.last_zspan = zspans  # (z_lo, z_hi) per layer -- lets an internal source split its layer
     return layers
 
 
@@ -255,6 +266,36 @@ class _Sol:
         return slab, [0.0, float(self._period[0]), float(zc.min()), float(zc.max())], layer_z
 
 
+class _EmitterSol:
+    """Readouts for an internal-source (dipole / Gaussian) emission solve: the power radiated **up** (into
+    the superstrate) and **down** (into the substrate), and the **extraction** fraction into either side.
+
+    ``power`` is in the source's own (un-normalised) units, so it scales with the source amplitude² -- useful
+    as a relative objective and differentiable in the amplitude / orientation / design ε. ``extraction`` is
+    the scale-free fraction ``up/(up+down)`` (or ``down/…``) -- the LED/emitter directionality figure of
+    merit. (Purcell / LDOS -- total emitted power ÷ a homogeneous-medium reference -- is future work.)"""
+
+    def __init__(self, up, down):
+        self._up, self._down = up, down
+
+    def power(self, kind="total"):
+        if kind == "up":
+            return self._up
+        if kind == "down":
+            return self._down
+        if kind == "total":
+            return self._up + self._down
+        raise RcwaError(f"power(kind): kind must be 'up' | 'down' | 'total', got {kind!r}")
+
+    def extraction(self, kind="up"):
+        total = self._up + self._down
+        if kind == "up":
+            return self._up / total
+        if kind == "down":
+            return self._down / total
+        raise RcwaError(f"extraction(kind): kind must be 'up' | 'down', got {kind!r}")
+
+
 class Rcwa:
     """A periodic layered RCWA problem with an **explicit** layer stack (the backend engine).
 
@@ -310,23 +351,10 @@ class Rcwa:
         self._ex = fm.generate_expansion(self._lv, approximate_num_terms=orders)
         self._nt = self._ex.num_terms
 
-    def solve(self, inc=None, wavelength=None, k_in=None, layers=None):
-        """Solve the stack and return a :class:`_Sol`. Raises if the wavelength is unknown or energy is
-        not conserved.
-
-        ``layers`` optionally overrides the construction layer stack with ``[(thickness, eps), ...]`` at
-        solve time -- pass JAX permittivity grids here to differentiate the solve in the design (the
-        construction-time shape guards run once, eagerly, so the solve itself stays trace-clean)."""
-        fm = self.fm
-        wl = wavelength if wavelength is not None else self.wavelength
-        if wl is None:
-            raise RcwaError(
-                "wavelength is unknown: pass wavelength= to solve() or at construction; it sets every "
-                "layer's eigenmodes and is never defaulted."
-            )
-        layers_spec = self.layers_spec if layers is None else layers
-        kin = jnp.asarray(self.k_in if k_in is None else k_in, float)  # jax -> incidence angle is differentiable
-        lv, ex, nt = self._lv, self._ex, self._nt  # precomputed eagerly in __init__ (jit-safe)
+    def _eigensolve_stack(self, layers_spec, wl, kin):
+        """Eigensolve every layer (isotropic / anisotropic-ε / general ε&μ, by tuple length) and return the
+        ``LayerSolveResult`` list plus the thickness list. Shared by the plane-wave and internal-source paths."""
+        fm, lv, ex = self.fm, self._lv, self._ex
 
         def _grid(g):
             g = jnp.asarray(g) + 0j  # jax-native so a permittivity grid flows -> differentiable in ε
@@ -364,6 +392,31 @@ class Rcwa:
 
         layers = [solve_layer(e) for _, e in layers_spec]
         thick = [jnp.asarray(1.0 if t is None or t == np.inf else t) for t, _ in layers_spec]
+        return layers, thick
+
+    def solve(self, inc=None, wavelength=None, k_in=None, layers=None, source=None):
+        """Solve the stack and return a :class:`_Sol`. Raises if the wavelength is unknown or energy is
+        not conserved.
+
+        ``layers`` optionally overrides the construction layer stack with ``[(thickness, eps), ...]`` at
+        solve time -- pass JAX permittivity grids here to differentiate the solve in the design (the
+        construction-time shape guards run once, eagerly, so the solve itself stays trace-clean).
+
+        ``source`` (a dict built by the front door) drives an **internal-source** emission solve instead of
+        plane-wave incidence -- see :meth:`_solve_source`; it returns an :class:`_EmitterSol`."""
+        fm = self.fm
+        wl = wavelength if wavelength is not None else self.wavelength
+        if wl is None:
+            raise RcwaError(
+                "wavelength is unknown: pass wavelength= to solve() or at construction; it sets every "
+                "layer's eigenmodes and is never defaulted."
+            )
+        layers_spec = self.layers_spec if layers is None else layers
+        kin = jnp.asarray(self.k_in if k_in is None else k_in, float)  # jax -> incidence angle is differentiable
+        nt = self._nt  # precomputed eagerly in __init__ (jit-safe)
+        if source is not None:
+            return self._solve_source(source, layers_spec, wl, kin)
+        layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
         s = fm.stack_s_matrix(layers, thick)
         # Incidence: excite the genuinely forward-propagating mode in the superstrate and normalise by
         # ITS flux. fmmax sorts eigenmodes by eigenvalue, so index 0 need not be the 0th forward order,
@@ -376,7 +429,7 @@ class Rcwa:
         if _concrete(Pin) and float(Pin) <= 0:
             raise RcwaError("no forward-propagating incident mode in the superstrate; check wavelength/period.")
         fwd = jnp.zeros((2 * nt, 1), complex).at[idx, 0].set(1.0)
-        sol = _Sol(fm, s, layers, ex, nt, Pin, wl, thick=thick, period=self.period)
+        sol = _Sol(fm, s, layers, self._ex, nt, Pin, wl, thick=thick, period=self.period)
         sol._fwd = fwd
         T, R = sol.efficiency("T"), sol.efficiency("R")
         if _concrete(T):  # never-silent runtime guards run on the eager forward pass; they step aside under trace
@@ -393,6 +446,46 @@ class Rcwa:
                 )
         return sol
 
+    def _solve_source(self, source, layers_spec, wl, kin):
+        """Internal-source (dipole / Gaussian) emission solve. ``source`` is a dict from the front door::
+
+            {x0, y0, layer, t_upper, t_lower, kind ('delta'|'gaussian'), fwhm, orient (ox,oy,oz), amp}
+
+        The stack is split at the source plane (layer ``layer`` divided into ``t_upper`` above / ``t_lower``
+        below the source), fmmax builds the dipole current ``(jx,jy,jz) = amp·orient·source_coeffs`` and
+        ``amplitudes_for_source`` propagates it to the ambients. Returns an :class:`_EmitterSol` with the
+        power radiated up / down (differentiable in ``amp``, ``orient`` and the design ε)."""
+        fm, lv, ex = self.fm, self._lv, self._ex
+        layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
+        si = source["layer"]
+        tu, tl = jnp.asarray(source["t_upper"]), jnp.asarray(source["t_lower"])
+        before = layers[: si + 1]
+        after = layers[si:]
+        before_t = [*thick[:si], tu]
+        after_t = [tl, *thick[si + 1 :]]
+        s_before = fm.stack_s_matrix(before, before_t)
+        s_after = fm.stack_s_matrix(after, after_t)
+        loc = jnp.asarray([[float(source["x0"]), float(source["y0"])]])
+        if source["kind"] == "gaussian":
+            base = fm.gaussian_source(jnp.asarray(float(source["fwhm"])), loc, kin, lv, ex)
+        else:
+            base = fm.dirac_delta_source(loc, kin, lv, ex)
+        ox, oy, oz = source["orient"]
+        amp = jnp.asarray(source["amp"]) + 0j
+        jx, jy, jz = amp * ox * base, amp * oy * base, amp * oz * base
+        bwd0, _, _, _, _, fN = fm.amplitudes_for_source(jx, jy, jz, s_before, s_after)
+        # power emitted up = backward-going flux in the superstrate; down = forward-going flux in the substrate
+        _, ub = fm.directional_poynting_flux(jnp.zeros_like(bwd0), bwd0, layers[0])
+        df, _ = fm.directional_poynting_flux(fN, jnp.zeros_like(fN), layers[-1])
+        up = jnp.abs(jnp.sum(jnp.real(ub)))
+        down = jnp.abs(jnp.sum(jnp.real(df)))
+        if _concrete(up) and not (np.isfinite(float(up)) and np.isfinite(float(down))):
+            raise RcwaError(
+                "non-finite emission (NaN/inf): the internal-source solve hit a Γ-point / Rayleigh degeneracy "
+                f"(k_in={tuple(float(k) for k in kin)}). Nudge k_in off exact normal, e.g. k_in=(1e-3, 1e-3)."
+            )
+        return _EmitterSol(up, down)
+
 
 # =====================================================================================
 # Front door: infer an RCWA problem from a jNO constraint list / FEM problem + eps.
@@ -408,6 +501,7 @@ class RcwaSpec:
     source_face: str = ""
     ambient_faces: tuple = ()
     periodic_axes: dict = field(default_factory=dict)
+    source: dict = None  # an internal-source (dipole/Gaussian) emission spec, else None (plane-wave incidence)
 
     def __repr__(self):
         return (
@@ -710,6 +804,76 @@ def _pml_layer_components(mass_node, stretch, period, grid, zmid, params, k0sq):
     return (eps_rel * lam[0], z, z, eps_rel * lam[1], eps_rel * lam[2], lam[0], z, z, lam[1], lam[2])
 
 
+def _extract_volume_source(volume_term):
+    """The **internal-source** forcing in the volume weak form: a summand that carries the TEST function but
+    **no trial** — ``- f·v`` (scalar monopole) or ``- inner(J, v)`` (vector dipole, ``J`` a current density).
+
+    Returns ``(source_node, is_vector)`` or ``None`` when the volume term is a pure operator (no forcing).
+    The sign is dropped (emitted power ∝ |source|², sign-invariant); the node keeps any ``jno.np.parameter``
+    it depends on, so a trainable source amplitude flows through the differentiable solve."""
+    import functools
+    import operator
+
+    from jno.trace import FunctionCall, TestFunction, TrialFunction
+
+    def _test_inner_other(f):  # inner(J, v) / inner(v, J) with a bare test v and J not a trial -> J
+        if not (isinstance(f, FunctionCall) and getattr(f, "_name", None) == "inner" and len(f.args) == 2):
+            return None
+        a0, a1 = f.args
+        if isinstance(a0, TestFunction) and not isinstance(a1, TrialFunction):
+            return a1
+        if isinstance(a1, TestFunction) and not isinstance(a0, TrialFunction):
+            return a0
+        return None
+
+    expr = getattr(volume_term, "expr", volume_term)
+    scal, vect = [], []
+    for _sign, summand in _add_split(expr):
+        if _contains_trial(summand) or not _contains_test(summand):
+            continue  # operator term (has trial) or non-source
+        fac = _mul_factors(summand)
+        jinner = next((f for f in fac if _test_inner_other(f) is not None), None)
+        if jinner is not None:  # vector source inner(J, v): source = (scalar factors)·J
+            J = _test_inner_other(jinner)
+            rest = [f for f in fac if f is not jinner]
+            vect.append(functools.reduce(operator.mul, [*rest, J]) if rest else J)
+        else:  # scalar source f·v: drop the bare test factor
+            rest = [f for f in fac if not isinstance(f, TestFunction)]
+            if rest:
+                scal.append(functools.reduce(operator.mul, rest))
+    if vect and scal:
+        raise RcwaError("RCWA found both a scalar and a vector internal source in the volume term; author one.")
+    if vect:
+        return functools.reduce(operator.add, vect), True
+    if scal:
+        return functools.reduce(operator.add, scal), False
+    return None
+
+
+def _localize_source(src_node, is_vector, period, z_range, grid, nz, params):
+    """Locate an internal source by its ``|·|²`` distribution on the cell volume: the centroid ``(x₀,y₀,z₀)``
+    and lateral width → **point** (``dirac_delta_source``) vs **Gaussian** (``gaussian_source`` with a fwhm).
+    Returns ``dict(x0, y0, z0, kind, fwhm)`` (all static geometry; the amplitude flows separately)."""
+    xs = np.linspace(0, period[0], grid, endpoint=False)
+    ys = np.linspace(0, period[1], grid, endpoint=False)
+    zs = np.linspace(z_range[0], z_range[1], nz)
+    GX, GY, GZ = np.meshgrid(xs, ys, zs, indexing="ij")
+    pts = np.stack([GX.ravel(), GY.ravel(), GZ.ravel()], 1)
+    v = np.asarray(_eval_coeff_points(src_node, pts, params or {}))
+    mag2 = np.sum(np.abs(v) ** 2, axis=-1) if (is_vector and v.ndim > 1) else np.abs(v).reshape(-1) ** 2
+    if float(mag2.max()) <= 0:
+        raise RcwaError("the internal source is identically zero at construction values; check its amplitude.")
+    w = mag2 / mag2.sum()
+    x0, y0, z0 = (float((w * pts[:, k]).sum()) for k in range(3))
+    sx = float(np.sqrt(((pts[:, 0] - x0) ** 2 * w).sum()))
+    sy = float(np.sqrt(((pts[:, 1] - y0) ** 2 * w).sum()))
+    width = 0.5 * (sx + sy)  # lateral std; a point source is narrower than a cell
+    dx = 0.5 * (period[0] + period[1]) / grid
+    if width < 1.5 * dx:
+        return dict(x0=x0, y0=y0, z0=z0, kind="delta", fwhm=0.0)
+    return dict(x0=x0, y0=y0, z0=z0, kind="gaussian", fwhm=2.35482 * width)  # FWHM = 2.355·σ
+
+
 def _has_nodal_field(node):
     """True if the coefficient depends on a per-node field parameter (needs mesh interpolation)."""
     return any(getattr(mc.model, "_fem_field", None) == "node" for mc in _model_calls(node))
@@ -1010,6 +1174,12 @@ class _ParametricSol:
     def order(self, m, n):
         return self._node("order", m, n)
 
+    def power(self, kind="total"):
+        return self._node("power", kind)
+
+    def extraction(self, kind="up"):
+        return self._node("extraction", kind)
+
     def field(self, *a, **k):
         raise RcwaError(
             "field() on a parameterised solve is not a scalar readout; reconstruct it at concrete values "
@@ -1045,12 +1215,13 @@ class _RcwaProblem:
         return self._eng
 
     def _solve_at(self, params):
-        """Concrete solve at explicit parameter values (JAX) -- re-derives eps, wavelength AND k_in."""
+        """Concrete solve at explicit parameter values (JAX) -- re-derives eps, wavelength, k_in AND (for an
+        internal-source problem) the dipole current."""
         eng = self._engine()
         if not params or self._resample is None:
-            return eng.solve()
-        layers, wl, kin = self._resample(params)
-        return eng.solve(layers=layers, wavelength=wl, k_in=kin)
+            return eng.solve(source=self.spec.source)
+        layers, wl, kin, source = self._resample(params)
+        return eng.solve(layers=layers, wavelength=wl, k_in=kin, source=source)
 
     def solve(self, params=None, wavelength=None, k_in=None):
         """Solve.
@@ -1066,22 +1237,138 @@ class _RcwaProblem:
         if params is None and wavelength is None and k_in is None:
             if self._rpe and self._resample is not None:
                 return _ParametricSol(self, self._rpe)  # parametric -> trace node (crux-differentiable)
-            return self._engine().solve()  # parameter-free -> eager concrete
+            return self._engine().solve(source=self.spec.source)  # parameter-free -> eager concrete
         eng = self._engine()
         if params is None:
-            return eng.solve(wavelength=wavelength, k_in=k_in)
+            return eng.solve(wavelength=wavelength, k_in=k_in, source=self.spec.source)
         if self._resample is None:
             raise RcwaError(
                 "differentiable solve(params=...) needs the analytic re-sampling path, which is only built "
                 "for an analytic permittivity (no per-node field). This problem uses a nodal-field "
                 "permittivity; differentiable nodal re-sampling is not implemented yet."
             )
-        layers, wl, kin = self._resample(params)
+        layers, wl, kin, source = self._resample(params)
         return eng.solve(
             layers=layers,
             wavelength=wavelength if wavelength is not None else wl,
             k_in=k_in if k_in is not None else kin,
+            source=source,
         )
+
+
+def _build_emitter_problem(
+    femobj,
+    domain,
+    period,
+    axes,
+    ambients,
+    coeff_node,
+    cparams,
+    coeff_layers,
+    zmids,
+    zspans,
+    z_range,
+    grid,
+    nz,
+    wavelength,
+    orders,
+    formulation,
+    vsrc,
+    is_aniso,
+    is_pml,
+):
+    """Build an internal-source (dipole / Gaussian) emission problem: localize the traced ``- f·v`` /
+    ``- inner(J, v)`` forcing, split its layer, and route it to fmmax's ``amplitudes_for_source``.
+
+    The Floquet-periodic supercell + absorbing z-ambients behaves as an emitter in a layered environment.
+    Scope: scalar Helmholtz layers (no tensor ε̂ / PML yet); the amplitude/orientation (and the design ε) are
+    differentiable, the source *location* is static. ``k_in`` is nudged off the singular Γ-point."""
+    bottom, top = ambients
+    src_node, is_vector = vsrc
+    if is_aniso or is_pml:
+        raise RcwaError("internal-source RCWA supports the scalar Helmholtz form only (no tensor ε̂ / PML yet).")
+    try:  # a boundary plane-wave incidence AND an internal source is an ambiguous double excitation
+        _source_kin(femobj, domain, cparams)
+        raise RcwaError("RCWA found both an internal source and a boundary plane-wave incidence; author one excitation.")
+    except RcwaError as e:
+        if "internal source and a boundary" in str(e):
+            raise
+
+    # order top-first: superstrate (the "up" ambient) = the max-z face; substrate ("down") = min-z
+    o = list(range(len(coeff_layers)))
+    if z_range[0] < z_range[1]:  # detect_layers is z-ascending -> reverse so layers[0] is the top ambient
+        o = o[::-1]
+    cl = [coeff_layers[i] for i in o]
+    zm = [zmids[i] for i in o]
+    zsp = [zspans[i] for i in o]
+
+    super_coeff = float(np.real(cl[0][1]).mean())  # top ambient (vacuum) ⇒ coeff = k0²
+    if wavelength is not None:
+        k0 = 2 * np.pi / float(wavelength)
+    elif super_coeff <= 0:
+        raise RcwaError("cannot infer wavelength: the superstrate permittivity is non-positive; pass wavelength=.")
+    else:
+        k0 = float(np.sqrt(super_coeff))
+    layers = [(t, np.asarray(e) / (k0 * k0)) for t, e in cl]  # scalar relative permittivity
+
+    loc = _localize_source(src_node, is_vector, period, z_range, grid, nz, cparams)
+    si = tu = tl = None
+    for i in range(1, len(zsp) - 1):  # the source sits in a finite (non-ambient) layer
+        lo, hi = zsp[i]
+        if lo - 1e-9 <= loc["z0"] <= hi + 1e-9:
+            si, tu, tl = i, float(hi - loc["z0"]), float(loc["z0"] - lo)
+            break
+    if si is None:
+        raise RcwaError(
+            f"the internal source at z={loc['z0']:.3f} is not inside a finite (non-ambient) layer; place it "
+            "within a slab whose permittivity differs from the ambients (a layer contrast defines the slab)."
+        )
+
+    def comp_at(params):  # the source field's components at the centroid -> the dipole current (jx,jy,jz)
+        val = jnp.reshape(_eval_coeff_points(src_node, np.array([[loc["x0"], loc["y0"], loc["z0"]]]), params), (-1,))
+        if is_vector:
+            return (val[0], val[1], val[2])
+        return (val[0], jnp.asarray(0.0 + 0j), jnp.asarray(0.0 + 0j))  # scalar monopole -> in-plane (x) dipole
+
+    def make_source(params):
+        return dict(
+            x0=loc["x0"],
+            y0=loc["y0"],
+            layer=si,
+            t_upper=tu,
+            t_lower=tl,
+            kind=loc["kind"],
+            fwhm=loc["fwhm"],
+            orient=comp_at(params),
+            amp=1.0,
+        )
+
+    kin = (1e-3, 1e-3)  # nudge off the singular Γ-point (exactly-normal k_in is degenerate for an internal source)
+
+    def resample(params):
+        k0p = jnp.sqrt(jnp.mean(jnp.real(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zm[0]), params))))
+        out = []
+        for (thick, _), zmid in zip(layers, zm):
+            cvals = jnp.reshape(_eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmid), params), (grid, grid))
+            out.append((thick, jnp.real(cvals) / (k0p * k0p)))
+        return out, 2 * jnp.pi / k0p, kin, make_source(params)
+
+    from jno.utils.solver.parametric_helpers import _collect_runtime_parameter_exprs
+
+    rpe = {}
+    _collect_runtime_parameter_exprs(coeff_node, rpe)  # eps / wavelength parameters
+    _collect_runtime_parameter_exprs(src_node, rpe)  # a trainable source amplitude / orientation
+    spec = RcwaSpec(
+        period=period,
+        layers=layers,
+        wavelength=2 * np.pi / k0,
+        k_in=kin,
+        source_face=top,
+        ambient_faces=(bottom, top),
+        periodic_axes=axes,
+        source=make_source(cparams),
+    )
+    return _RcwaProblem(spec, orders=orders, formulation=formulation, resample=resample, rpe=rpe)
 
 
 def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, params=None, formulation="JONES_DIRECT_FOURIER"):
@@ -1096,6 +1383,14 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     is detected and honoured as a diagonal Maxwell ``ε̂``/``μ̂`` — the supercell then behaves as an
     isolated scatterer. Scope: uniaxial (diagonal) in-plane stretch only, scalar Helmholtz, forward
     solve (a design parameter *through* a PML is not yet differentiable — it raises).
+
+    An **internal source** (a ``- f·v`` / ``- inner(J, v)`` volume forcing) switches the solve to an
+    emission problem: the source is localized (point vs Gaussian; dipole orientation from ``J``), the stack
+    is split at the source plane, and ``sol.power("up"|"down"|"total")`` / ``sol.extraction("up"|"down")``
+    give the radiated power and directionality. The amplitude/orientation and design ε are differentiable;
+    the source *location* is static, ``k_in`` is nudged off the singular Γ-point, and the source must sit in
+    a finite (contrast-defined) layer. Scalar Helmholtz only for now; a boundary incidence + internal source
+    together raise.
 
     Parameters
     ----------
@@ -1144,6 +1439,32 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
         C, zs = _sample_grid_direct(coeff_node, grid, nz, period, z_range, cparams)
     coeff_layers = detect_layers(C, zs, slices=slices)
     zmids = list(detect_layers.last_zmid)  # representative z of each layer (both paths) -> re-sampling
+    zspans = list(detect_layers.last_zspan)  # (z_lo, z_hi) per layer -> place an internal source in its layer
+
+    # ---- internal source (dipole / Gaussian emitter): a `- f·v` / `- inner(J, v)` volume forcing ----
+    vsrc = _extract_volume_source(_volume_constraint(femobj))
+    if vsrc is not None:
+        return _build_emitter_problem(
+            femobj,
+            domain,
+            period,
+            axes,
+            (bottom, top),
+            coeff_node,
+            cparams,
+            coeff_layers,
+            zmids,
+            zspans,
+            z_range,
+            grid,
+            nz,
+            wavelength,
+            orders,
+            formulation,
+            vsrc,
+            is_aniso,
+            is_pml,
+        )
 
     face_z, k_in = _source_kin(femobj, domain, cparams)
     source_at_bottom = abs(face_z - _region_centroid(domain, bottom)[2]) < abs(face_z - _region_centroid(domain, top)[2])
@@ -1237,7 +1558,7 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
                 )
                 out.append((thick, jnp.real(cvals) / (k0 * k0)))
         kin = _kin_from_source(src_coeff, period, src_z, params) if src_coeff is not None else jnp.asarray(k_in)
-        return out, 2 * jnp.pi / k0, kin
+        return out, 2 * jnp.pi / k0, kin, None  # source=None: plane-wave incidence, not an internal source
 
     # the trainable jno.np.parameter(s) the permittivity depends on -> solve() returns trace nodes over
     # them (crux threads the values), so the parameterised constraint list is differentiable with no solve

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -209,6 +209,21 @@ class _Sol:
         )
         return (tf[i] + tf[i + self._nt]) / self._Pin
 
+    def _input_pol(self, pol):
+        """0th-order forward incident amplitude for an input polarization (``"x"`` or ``"y"``), built as a
+        UNIFORM real-space plane wave (x-pol E=x̂,H=ŷ; y-pol E=ŷ,H=-x̂, both forward) and decomposed at k_in.
+        Working in the field basis (not the eigenvalue-sorted eigenmode basis) avoids an argmax(flux) pick
+        grabbing the wrong oblique mode for an asymmetric structure. jax-native (traces under grad/jit)."""
+        fm = self._fm
+        gs = fm.min_array_shape_for_expansion(self._ex)
+        _u = jnp.ones((*gs, 1), complex)
+        _z = jnp.zeros((*gs, 1), complex)
+        if pol == "x":
+            return jnp.reshape(fm.amplitudes_for_fields(_u, _z, _z, _u, self._layers[0])[0], (2 * self._nt, 1))
+        if pol == "y":
+            return jnp.reshape(fm.amplitudes_for_fields(_z, _u, -_u, _z, self._layers[0])[0], (2 * self._nt, 1))
+        raise RcwaError(f"polarization must be 'x' or 'y', got {pol!r}")
+
     def jones(self, kind="T"):
         """The 2×2 complex **Jones matrix** at the 0th diffraction order — how the structure maps incident
         polarization to transmitted (``"T"``) or reflected (``"R"``) polarization.
@@ -221,35 +236,13 @@ class _Sol:
         Jones basis — for the 0th order at normal incidence they are the two in-plane axes (≈ x, y); an
         isotropic stack gives a diagonal ``J`` (no conversion), an in-plane-anisotropic one an off-diagonal
         ``J`` (polarization conversion). Differentiable in the design. Returns a JAX ``(2, 2)`` array."""
-        fm = self._fm
-        if kind == "T":
-            smat, out_layer = self._s.s11, self._layers[-1]
-        elif kind == "R":
-            smat, out_layer = self._s.s21, self._layers[0]
-        else:
-            raise RcwaError(f"jones(kind): kind must be 'T' or 'R', got {kind!r}")
-        in_layer = self._layers[0]
-        # Work in the FIELD basis, not the eigenmode basis: the 0th order is expansion index 0 (fmmax orders
-        # the zeroth term first), but the eigenmodes are eigenvalue-sorted, so an argmax(flux) pick grabs the
-        # wrong (oblique) mode for an asymmetric structure. Instead: excite the two 0th-order input plane
-        # waves as UNIFORM real-space fields (x-pol E=x̂,H=ŷ and y-pol E=ŷ,H=-x̂, both forward), and read the
-        # 0th-order component of the output field. For vacuum ambients the flux factors cancel, so |J|² is the
-        # power fraction directly (columns sum to the 0th-order efficiency).
-        gs = fm.min_array_shape_for_expansion(self._ex)
-        _u = jnp.ones((*gs, 1), complex)
-        _z = jnp.zeros((*gs, 1), complex)
-        fwd_x = jnp.reshape(fm.amplitudes_for_fields(_u, _z, _z, _u, in_layer)[0], (2 * self._nt, 1))
-        fwd_y = jnp.reshape(fm.amplitudes_for_fields(_z, _u, -_u, _z, in_layer)[0], (2 * self._nt, 1))
 
-        def out0(fwd_in):  # the 0th-order (E_x, E_y) of the output field for this input plane wave
-            amp = smat @ fwd_in
-            zero = jnp.zeros_like(amp)
-            fa, ba = (amp, zero) if kind == "T" else (zero, amp)  # T -> forward in substrate; R -> backward in super
-            (ex, ey, _ez), _ = fm.fields_from_wave_amplitudes(fa, ba, out_layer)
-            return jnp.reshape(ex, (-1,))[0], jnp.reshape(ey, (-1,))[0]
+        def out0(pol):  # the 0th-order (E_x, E_y) of the output field for this input plane wave
+            ex, ey = self._spectrum(kind, fwd=self._input_pol(pol))
+            return ex[0], ey[0]  # (0,0) is expansion index 0
 
-        exx, eyx = out0(fwd_x)  # input x-pol -> output (E_x, E_y)
-        exy, eyy = out0(fwd_y)  # input y-pol -> output (E_x, E_y)
+        exx, eyx = out0("x")  # input x-pol -> output (E_x, E_y)
+        exy, eyy = out0("y")  # input y-pol -> output (E_x, E_y)
         return jnp.array([[exx, exy], [eyx, eyy]])  # J[out q, in p]
 
     def field(self, y_frac=0.5, nx=80, density=40.0):
@@ -275,18 +268,24 @@ class _Sol:
         layer_z = list(np.cumsum([float(t) for t in self._thick]))[:-1]
         return slab, [0.0, float(self._period[0]), float(zc.min()), float(zc.max())], layer_z
 
-    def _spectrum(self, kind="T"):
+    def _spectrum(self, kind="T", fwd=None):
         """The complex diffraction spectrum for imaging: the transverse E-field Fourier coefficients
-        ``(ex, ey)`` per diffraction order (transmitted ``"T"`` or reflected ``"R"``), read at the corrected
-        0th-order incidence. ``(0,0)`` is expansion index 0 (fmmax orders the zeroth term first)."""
+        ``(ex, ey)`` per diffraction order (transmitted ``"T"`` or reflected ``"R"``), for the corrected
+        0th-order incidence (or a supplied input amplitude ``fwd``). ``(0,0)`` is expansion index 0."""
         fm = self._fm
-        smat = self._s.s11 if kind == "T" else self._s.s21
-        layer = self._layers[-1] if kind == "T" else self._layers[0]
-        fwd = smat @ self._fwd
-        (ex, ey, _ez), _ = fm.fields_from_wave_amplitudes(fwd, jnp.zeros_like(fwd), layer)
+        if kind == "T":
+            smat, layer = self._s.s11, self._layers[-1]
+        elif kind == "R":
+            smat, layer = self._s.s21, self._layers[0]
+        else:
+            raise RcwaError(f"kind must be 'T' or 'R', got {kind!r}")
+        amp = smat @ (self._fwd if fwd is None else fwd)
+        zero = jnp.zeros_like(amp)
+        fa, ba = (amp, zero) if kind == "T" else (zero, amp)  # T -> forward in substrate; R -> backward in super
+        (ex, ey, _ez), _ = fm.fields_from_wave_amplitudes(fa, ba, layer)
         return jnp.reshape(ex, (-1,)), jnp.reshape(ey, (-1,))
 
-    def aerial(self, NA, source=0.7, defocus=0.0, grid=128, kind="T"):
+    def aerial(self, NA, source=0.7, defocus=0.0, grid=128, kind="T", polarization=None):
         """Partially-coherent **aerial image** (wafer-plane intensity) of this mask, by **Abbe** source
         integration -- the litho imaging step on top of the rigorous RCWA mask diffraction.
 
@@ -309,6 +308,11 @@ class _Sol:
             Real-space resolution of the returned image (one period).
         kind:
             ``"T"`` (transmissive DUV mask, default) or ``"R"`` (reflective EUV mask).
+        polarization:
+            ``None`` (default) → **scalar** imaging (uses ``E_x``), correct at low NA. A string turns on the
+            **vector high-NA** model, which rotates each order's transverse ``(E_x, E_y)`` to the 3-D wafer
+            field through the Richards-Wolf/Flagello vector pupil (so the TM component loses contrast at large
+            angles): ``"x"`` / ``"y"`` → linearly polarized illumination; ``"unpolarized"`` → the two averaged.
 
         Returns
         -------
@@ -317,30 +321,67 @@ class _Sol:
 
         Notes
         -----
-        Scalar (uses ``E_x``); the vector (high-NA) form reads both ``E_x, E_y`` with polarization in the
-        pupil -- future work. Uses the shift-invariant (Kirchhoff-like) Abbe sum on this single solve's
-        rigorous spectrum; full angular rigor (re-solving the mask per source point) is a heavier option.
+        Uses the shift-invariant (Kirchhoff-like) Abbe sum on this single solve's rigorous spectrum; full
+        angular rigor (re-solving the mask per source point) is a heavier option. The vector pupil follows
+        Flagello, Milster & Rosenbluth, *J. Opt. Soc. Am. A* **13**, 53 (1996), with the aplanatic
+        ``1/√(cosθ)`` apodization; at NA→0 it reduces to the scalar image.
         """
         wl = self._wl  # may be a tracer (a wavelength parameter) -- keep jax-native
         Px, Py = float(self._period[0]), float(self._period[1])
-        ex, _ey = self._spectrum(kind)  # scalar imaging -> E_x
         bc = np.asarray(self._ex.basis_coefficients)  # (nt, 2) static (m, n)
         M = int(np.abs(bc).max())
         grid = max(int(grid), 2 * M + 2)
-        A = jnp.zeros((2 * M + 1, 2 * M + 1), complex).at[bc[:, 0] + M, bc[:, 1] + M].set(ex)
         ms = jnp.asarray(np.arange(-M, M + 1))
         AX, AY = jnp.meshgrid(ms * wl / Px, ms * wl / Py, indexing="ij")  # α (direction cosine) per order
         S, W = _source_grid(source, float(NA))
         c = grid // 2
 
-        def one(s):  # image from a single source point s (a shift of the order frequencies)
-            r2 = (AX + s[0]) ** 2 + (AY + s[1]) ** 2
-            pupil = jnp.where(r2 <= NA**2, jnp.exp(-1j * jnp.pi * wl * defocus * r2), 0.0)
-            pad = jnp.zeros((grid, grid), complex).at[c - M : c + M + 1, c - M : c + M + 1].set(A * pupil)
-            E = jnp.fft.ifft2(jnp.fft.ifftshift(pad)) * (grid * grid)
-            return jnp.abs(E) ** 2
+        def _grid(vals):  # scatter an order-indexed spectrum onto the (2M+1)² frequency grid
+            return jnp.zeros((2 * M + 1, 2 * M + 1), complex).at[bc[:, 0] + M, bc[:, 1] + M].set(vals)
 
-        imgs = jax.vmap(one)(S)  # (Ns, grid, grid)
+        def _place(Apad):  # embed a pupil-weighted spectrum and inverse-FFT to a real-space field
+            pad = jnp.zeros((grid, grid), complex).at[c - M : c + M + 1, c - M : c + M + 1].set(Apad)
+            return jnp.fft.ifft2(jnp.fft.ifftshift(pad)) * (grid * grid)
+
+        if polarization is None:  # scalar imaging (E_x only)
+            A = _grid(self._spectrum(kind)[0])
+
+            def one(s):  # image from a single source point s (a shift of the order frequencies)
+                r2 = (AX + s[0]) ** 2 + (AY + s[1]) ** 2
+                pupil = jnp.where(r2 <= NA**2, jnp.exp(-1j * jnp.pi * wl * defocus * r2), 0.0)
+                return jnp.abs(_place(A * pupil)) ** 2
+
+            imgs = jax.vmap(one)(S)  # (Ns, grid, grid)
+            return jnp.sum(W[:, None, None] * imgs, axis=0) / jnp.sum(W)
+
+        # Vector (high-NA) imaging: rotate each order's transverse (E_x, E_y) to the 3-D wafer field via the
+        # Richards-Wolf/Flagello vector pupil (below). Average the incoherent images of the requested input
+        # polarizations. At NA→0 the pupil is the identity and this reduces to |E_x|²+|E_y|² == the scalar image.
+        pols = ("x", "y") if polarization == "unpolarized" else (polarization,)
+        specs = [(_grid(ex), _grid(ey)) for ex, ey in (self._spectrum(kind, fwd=self._input_pol(p)) for p in pols)]
+
+        def one(s):
+            ax, ay = AX + s[0], AY + s[1]
+            r2 = ax**2 + ay**2
+            passes = r2 <= NA**2
+            rho = jnp.sqrt(jnp.clip(r2, 0.0, 1.0))  # sinθ (transverse direction-cosine magnitude)
+            cth = jnp.sqrt(jnp.clip(1.0 - r2, 0.0, 1.0))  # cosθ
+            safe = rho > 1e-9
+            cf = jnp.where(safe, ax / jnp.where(safe, rho, 1.0), 1.0)  # cosφ (azimuth)
+            sf = jnp.where(safe, ay / jnp.where(safe, rho, 1.0), 0.0)  # sinφ
+            apod = jnp.where(  # defocus phase × aplanatic 1/√(cosθ), gated by the pupil
+                passes, jnp.exp(-1j * jnp.pi * wl * defocus * r2) / jnp.sqrt(jnp.where(passes, cth, 1.0)), 0.0
+            )
+            m00, m01, m11 = cf**2 * cth + sf**2, cf * sf * (cth - 1.0), sf**2 * cth + cf**2
+            m20, m21 = -rho * cf, -rho * sf
+            tot = jnp.zeros((grid, grid))
+            for Ax, Ay in specs:
+                ux, uy = Ax * apod, Ay * apod
+                ewx, ewy, ewz = _place(m00 * ux + m01 * uy), _place(m01 * ux + m11 * uy), _place(m20 * ux + m21 * uy)
+                tot = tot + jnp.abs(ewx) ** 2 + jnp.abs(ewy) ** 2 + jnp.abs(ewz) ** 2
+            return tot / len(specs)
+
+        imgs = jax.vmap(one)(S)
         return jnp.sum(W[:, None, None] * imgs, axis=0) / jnp.sum(W)
 
 
@@ -1305,10 +1346,10 @@ class _ParametricSol:
     def extraction(self, kind="up"):
         return self._node("extraction", kind)
 
-    def aerial(self, NA, source=0.7, defocus=0.0, grid=128, kind="T"):
+    def aerial(self, NA, source=0.7, defocus=0.0, grid=128, kind="T", polarization=None):
         """The aerial image as a trace node over the mask's ``jno.np.parameter``\\ s -- so ``jax.grad`` of a
         printed-vs-target loss flows back through the imaging AND the RCWA mask solve to the mask design (ILT)."""
-        return self._node("aerial", NA, source, defocus, grid, kind)
+        return self._node("aerial", NA, source, defocus, grid, kind, polarization)
 
     def field(self, *a, **k):
         raise RcwaError(

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -422,17 +422,20 @@ class Rcwa:
             layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
         with _annot("rcwa:s_matrix"):
             s = fm.stack_s_matrix(layers, thick)
-        # Incidence: excite the genuinely forward-propagating mode in the superstrate and normalise by
-        # ITS flux. fmmax sorts eigenmodes by eigenvalue, so index 0 need not be the 0th forward order,
-        # and a one-hot forward amplitude can carry zero forward flux -- pick the max-positive-flux mode.
-        # (The superstrate is design-independent, so this is effectively constant, but stays jax-native so
-        # the whole solve traces under grad/jit.)
-        flux_sup = jnp.real(jnp.reshape(fm.eigenmode_poynting_flux(layers[0]), (-1,)))
-        idx = jnp.argmax(flux_sup)
-        Pin = flux_sup[idx]
+        # Incidence: the 0th diffraction order (at k_in) -- an x-polarised plane wave whose REAL-SPACE field
+        # is uniform. `argmax(eigenmode flux)` is wrong here: the (0,0) order does NOT carry the max eigenmode
+        # flux (the oblique first-ring orders can tie higher), so argmax would excite an oblique mode and tilt
+        # the incidence -- invisible in symmetric problems but wrong for anything direction-sensitive.
+        # `amplitudes_for_fields` divides out the Bloch phase, so a uniform E_x, H_y = E_x field decomposes to
+        # the forward 0th-order amplitude at k_in (jax-native, so the solve still traces under grad/jit).
+        gs = fm.min_array_shape_for_expansion(self._ex)
+        _u = jnp.ones((*gs, 1), complex)
+        _z = jnp.zeros((*gs, 1), complex)
+        fwd_amp, _bwd = fm.amplitudes_for_fields(_u, _z, _z, _u, layers[0])  # x-pol, H=+y -> forward-going
+        fwd = jnp.reshape(fwd_amp, (2 * nt, 1))
+        Pin = jnp.sum(jnp.real(fm.directional_poynting_flux(fwd, jnp.zeros_like(fwd), layers[0])[0]))
         if _concrete(Pin) and float(Pin) <= 0:
             raise RcwaError("no forward-propagating incident mode in the superstrate; check wavelength/period.")
-        fwd = jnp.zeros((2 * nt, 1), complex).at[idx, 0].set(1.0)
         sol = _Sol(fm, s, layers, self._ex, nt, Pin, wl, thick=thick, period=self.period)
         sol._fwd = fwd
         T, R = sol.efficiency("T"), sol.efficiency("R")

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -458,16 +458,16 @@ class Rcwa:
         fm, lv, ex = self.fm, self._lv, self._ex
         layers, thick = self._eigensolve_stack(layers_spec, wl, kin)
         si = source["layer"]
-        tu, tl = jnp.asarray(source["t_upper"]), jnp.asarray(source["t_lower"])
+        tu, tl = jnp.asarray(source["t_upper"]), jnp.asarray(source["t_lower"])  # z-split thicknesses (differentiable)
         before = layers[: si + 1]
         after = layers[si:]
         before_t = [*thick[:si], tu]
         after_t = [tl, *thick[si + 1 :]]
         s_before = fm.stack_s_matrix(before, before_t)
         s_after = fm.stack_s_matrix(after, after_t)
-        loc = jnp.asarray([[float(source["x0"]), float(source["y0"])]])
+        loc = jnp.asarray(source["loc"])  # (1, 2) lateral location -- JAX, so an emitter-placement param flows
         if source["kind"] == "gaussian":
-            base = fm.gaussian_source(jnp.asarray(float(source["fwhm"])), loc, kin, lv, ex)
+            base = fm.gaussian_source(jnp.asarray(source["fwhm"]), loc, kin, lv, ex)
         else:
             base = fm.dirac_delta_source(loc, kin, lv, ex)
         ox, oy, oz = source["orient"]
@@ -1281,8 +1281,10 @@ def _build_emitter_problem(
     ``- inner(J, v)`` forcing, split its layer, and route it to fmmax's ``amplitudes_for_source``.
 
     The Floquet-periodic supercell + absorbing z-ambients behaves as an emitter in a layered environment.
-    Scope: scalar Helmholtz layers (no tensor ε̂ / PML yet); the amplitude/orientation (and the design ε) are
-    differentiable, the source *location* is static. ``k_in`` is nudged off the singular Γ-point."""
+    Scope: scalar Helmholtz layers (no tensor ε̂ / PML yet). The amplitude, orientation, lateral location,
+    z-position (within its layer) and Gaussian width, plus the design ε, are all differentiable — only the
+    *discrete* choices (which layer, point-vs-Gaussian) are frozen at construction. ``k_in`` is nudged off
+    the singular Γ-point."""
     bottom, top = ambients
     src_node, is_vector = vsrc
     if is_aniso or is_pml:
@@ -1312,11 +1314,11 @@ def _build_emitter_problem(
     layers = [(t, np.asarray(e) / (k0 * k0)) for t, e in cl]  # scalar relative permittivity
 
     loc = _localize_source(src_node, is_vector, period, z_range, grid, nz, cparams)
-    si = tu = tl = None
+    si = lo = hi = None
     for i in range(1, len(zsp) - 1):  # the source sits in a finite (non-ambient) layer
-        lo, hi = zsp[i]
-        if lo - 1e-9 <= loc["z0"] <= hi + 1e-9:
-            si, tu, tl = i, float(hi - loc["z0"]), float(loc["z0"] - lo)
+        zlo, zhi = zsp[i]
+        if zlo - 1e-9 <= loc["z0"] <= zhi + 1e-9:
+            si, lo, hi = i, zlo, zhi
             break
     if si is None:
         raise RcwaError(
@@ -1324,22 +1326,36 @@ def _build_emitter_problem(
             "within a slab whose permittivity differs from the ambients (a layer contrast defines the slab)."
         )
 
-    def comp_at(params):  # the source field's components at the centroid -> the dipole current (jx,jy,jz)
-        val = jnp.reshape(_eval_coeff_points(src_node, np.array([[loc["x0"], loc["y0"], loc["z0"]]]), params), (-1,))
-        if is_vector:
-            return (val[0], val[1], val[2])
-        return (val[0], jnp.asarray(0.0 + 0j), jnp.asarray(0.0 + 0j))  # scalar monopole -> in-plane (x) dipole
+    # static volume grid for the DIFFERENTIABLE re-derivation of the source's centroid / width from params
+    _xs = np.linspace(0, period[0], grid, endpoint=False)
+    _ys = np.linspace(0, period[1], grid, endpoint=False)
+    _zs = np.linspace(z_range[0], z_range[1], nz)
+    _GX, _GY, _GZ = np.meshgrid(_xs, _ys, _zs, indexing="ij")
+    _pts = np.stack([_GX.ravel(), _GY.ravel(), _GZ.ravel()], 1)
 
-    def make_source(params):
+    def geom_at(params):  # differentiable centroid (x0,y0,z0) + lateral σ from the |source|² distribution
+        v = _eval_coeff_points(src_node, _pts, params)
+        mag2 = jnp.sum(jnp.abs(v) ** 2, -1) if (is_vector and jnp.ndim(v) > 1) else jnp.abs(jnp.reshape(v, (-1,))) ** 2
+        w = mag2 / jnp.sum(mag2)
+        x0, y0, z0 = (jnp.sum(w * jnp.asarray(_pts[:, k])) for k in range(3))
+        sig = 0.5 * (
+            jnp.sqrt(jnp.sum((jnp.asarray(_pts[:, 0]) - x0) ** 2 * w))
+            + jnp.sqrt(jnp.sum((jnp.asarray(_pts[:, 1]) - y0) ** 2 * w))
+        )
+        return x0, y0, z0, sig
+
+    def make_source(params):  # amplitude/orientation, location (x0,y0), z-split and fwhm all differentiable
+        x0, y0, z0, sig = geom_at(params)
+        val = jnp.reshape(_eval_coeff_points(src_node, jnp.stack([x0, y0, z0]).reshape(1, 3), params), (-1,))
+        orient = (val[0], val[1], val[2]) if is_vector else (val[0], jnp.asarray(0.0 + 0j), jnp.asarray(0.0 + 0j))
         return dict(
-            x0=loc["x0"],
-            y0=loc["y0"],
+            loc=jnp.stack([x0, y0]).reshape(1, 2),
             layer=si,
-            t_upper=tu,
-            t_lower=tl,
+            t_upper=hi - z0,  # toward the top ambient (si, lo, hi fixed eagerly; z0 differentiable within the layer)
+            t_lower=z0 - lo,
             kind=loc["kind"],
-            fwhm=loc["fwhm"],
-            orient=comp_at(params),
+            fwhm=2.35482 * sig,  # FWHM = 2.355·σ (used only when kind == "gaussian")
+            orient=orient,
             amp=1.0,
         )
 
@@ -1381,16 +1397,16 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     is given), and the **incident wave** (illuminated face + transverse angle ``k_in``, from the
     assembled forcing). An **in-plane PML** (a complex coordinate stretch in the stiffness coefficients)
     is detected and honoured as a diagonal Maxwell ``ε̂``/``μ̂`` — the supercell then behaves as an
-    isolated scatterer. Scope: uniaxial (diagonal) in-plane stretch only, scalar Helmholtz, forward
-    solve (a design parameter *through* a PML is not yet differentiable — it raises).
+    isolated scatterer, and a design parameter on the scatterer ε **is differentiable** (inverse design of
+    an isolated structure). Scope: uniaxial (diagonal) in-plane stretch only, scalar Helmholtz.
 
     An **internal source** (a ``- f·v`` / ``- inner(J, v)`` volume forcing) switches the solve to an
     emission problem: the source is localized (point vs Gaussian; dipole orientation from ``J``), the stack
     is split at the source plane, and ``sol.power("up"|"down"|"total")`` / ``sol.extraction("up"|"down")``
-    give the radiated power and directionality. The amplitude/orientation and design ε are differentiable;
-    the source *location* is static, ``k_in`` is nudged off the singular Γ-point, and the source must sit in
-    a finite (contrast-defined) layer. Scalar Helmholtz only for now; a boundary incidence + internal source
-    together raise.
+    give the radiated power and directionality. The amplitude, orientation, lateral location, z-position and
+    Gaussian width, plus the design ε, are all differentiable (only the discrete layer choice is frozen);
+    ``k_in`` is nudged off the singular Γ-point, and the source must sit in a finite (contrast-defined) layer.
+    Scalar Helmholtz only for now; a boundary incidence + internal source together raise.
 
     Parameters
     ----------
@@ -1539,7 +1555,14 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
 
             return {k: (gather(v) if k in nodal_names else jnp.asarray(v)) for k, v in params.items()}
 
-        if is_aniso:  # k0 from the superstrate's xx (isotropic vacuum ⇒ xx = k0²); tensor components per layer
+        if is_pml:  # in-plane PML: k0 at the physical-core centre (Λ=1, ε=1 ⇒ mass = k0²); 10 ε̂/μ̂ grids per layer
+            center_pt = np.array([[period[0] * 0.5, period[1] * 0.5, zmids[0]]])
+            k0 = jnp.sqrt(jnp.real(jnp.reshape(_eval_coeff_points(coeff_node, center_pt, at(0)), (-1,))[0]))
+            out = [
+                (thick, _pml_layer_components(coeff_node, stretch, period, grid, zmid, at(li), k0 * k0))
+                for li, (thick, zmid) in enumerate(zip(thicks, zmids))
+            ]
+        elif is_aniso:  # k0 from the superstrate's xx (isotropic vacuum ⇒ xx = k0²); tensor components per layer
             sup_xx = jnp.reshape(
                 _eval_coeff_points(coeff_node, _cell_grid_at_z(period, grid, zmids[0]), at(0)), (grid, grid, 3, 3)
             )
@@ -1567,14 +1590,9 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     from jno.utils.solver.parametric_helpers import _collect_runtime_parameter_exprs
 
     rpe = {}
-    _collect_runtime_parameter_exprs(coeff_node, rpe)  # eps / wavelength parameters
+    _collect_runtime_parameter_exprs(coeff_node, rpe)  # eps / wavelength parameters (PML: the scatterer ε too)
     if src_coeff is not None:
         _collect_runtime_parameter_exprs(src_coeff, rpe)  # an incidence-angle parameter in the source
-    if is_pml and rpe:  # the eager PML layers solve fine; a design parameter through a PML re-sample is future work
-        raise RcwaError(
-            "differentiable PML is not yet supported: a jno.np.parameter flows through an in-plane PML "
-            f"problem (parameters {sorted(rpe)}). The forward PML solve works; drop the parameter to use it."
-        )
 
     spec = RcwaSpec(
         period=period,

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -579,9 +579,12 @@ class Rcwa:
         """Eigensolve every layer (isotropic / anisotropic-ε / general ε&μ, by tuple length) and return the
         ``LayerSolveResult`` list plus the thickness list. Shared by the plane-wave and internal-source paths."""
         fm, lv, ex = self.fm, self._lv, self._ex
+        kin = jnp.asarray(kin)
+        wl = jnp.asarray(wl).astype(kin.dtype)  # wl at the incidence real precision
+        cdt = jnp.result_type(kin.dtype, jnp.complex64)  # one complex dtype for the eigensolve (robust to a
 
-        def _grid(g):
-            g = jnp.asarray(g) + 0j  # jax-native so a permittivity grid flows -> differentiable in ε
+        def _grid(g):  # float32 design parameter, e.g. when trained through jno.core, vs float64 wavevectors)
+            g = jnp.asarray(g).astype(cdt)  # jax-native so a permittivity grid flows -> differentiable in ε
             return jnp.full((1, 1), g) if g.ndim == 0 else g
 
         def solve_layer(e):

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -69,6 +69,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from jno.litho import Threshold  # default resist for the .develop() / .printed() lithography readout
 from jno.utils.profiling import annotate as _annot  # stage annotator for rc.solve(profile=True)
 
 
@@ -384,59 +385,68 @@ class _Sol:
         imgs = jax.vmap(one)(S)
         return jnp.sum(W[:, None, None] * imgs, axis=0) / jnp.sum(W)
 
-    def printed(
-        self,
-        NA,
-        source=0.7,
-        defocus=0.0,
-        grid=128,
-        kind="T",
-        polarization=None,
-        threshold=0.3,
-        diffusion=0.0,
-        steepness=50.0,
-    ):
-        """Developed **resist image** (the printed pattern) of this mask -- the aerial image passed through a
-        constant-threshold resist with a linear post-exposure-bake (PEB) diffusion. Closes the computational-
-        lithography chain ``mask → aerial image → resist``, so ``jax.grad`` of a printed-vs-target loss drives
-        **OPC / ILT / SMO** all the way back through development, imaging *and* the rigorous RCWA mask solve.
+    def expose(self, NA, source=0.7, defocus=0.0, grid=128, kind="T", polarization=None):
+        """The **optical exposure** of this mask at the wafer plane -- the imaging result before any resist.
 
-        The aerial image (see :meth:`aerial`; the imaging arguments ``NA … polarization`` pass straight
-        through) is optionally blurred by the PEB acid diffusion, then developed by a soft threshold:
-        ``sigmoid(steepness · (I_bake − threshold))`` ∈ ``[0, 1]`` -- 1 = clears (positive tone), a smooth
-        stand-in for the printed contour that stays differentiable.
+        Returns an :class:`_Exposure` (optics only: :meth:`_Exposure.intensity` = the aerial image,
+        :meth:`_Exposure.spectrum` = the diffraction-order angular spectrum). Turn it into a developed
+        pattern with ``exposure.develop(resist)`` for a resist model (:class:`jno.litho.Threshold`, or a
+        rigorous PEB model). The imaging arguments ``NA … polarization`` are exactly :meth:`aerial`'s."""
+        return _Exposure(self, (NA, source, defocus, grid, kind, polarization))
 
-        Parameters
-        ----------
-        threshold:
-            Dose-to-clear fraction on the aerial-intensity scale (an open frame images to ≈ 1). Raising it
-            shrinks a bright feature -- the knob that sets printed CD.
-        diffusion:
-            PEB acid-diffusion length (same length unit as the geometry; ``0`` = no bake). Applied as a
-            periodic Gaussian blur of the aerial image [Mack 2007].
-        steepness:
-            Development contrast -- the sigmoid sharpness (larger → a harder threshold / steeper resist).
-
-        Returns a ``(grid, grid)`` JAX image in ``[0, 1]``. Linear-diffusion + constant-threshold model
-        (Poonawala & Milanfar, *IEEE TIP* **16**, 774, 2007); the full reaction-diffusion PEB and the 3-D
-        development-rate profile are out of scope here (see the standalone photoresist model).
-        """
-        img = self.aerial(NA, source, defocus, grid, kind, polarization)
-        period = (float(self._period[0]), float(self._period[1]))
-        return _develop(img, float(threshold), float(diffusion), float(steepness), period)
+    def printed(self, NA, source=0.7, defocus=0.0, grid=128, kind="T", polarization=None, resist=None):
+        """Developed **resist image** (the printed pattern) -- a one-call shortcut for
+        ``expose(...).develop(resist)``. ``resist`` defaults to :class:`jno.litho.Threshold` (the fast
+        constant-threshold + PEB-diffusion model). Differentiable in the mask + source, so ``jax.grad`` of a
+        printed-vs-target loss drives **OPC / ILT / SMO** back through development, imaging *and* the RCWA
+        mask solve. Pass a different resist model (e.g. a rigorous reaction-diffusion PEB) to swap physics
+        without changing the call."""
+        return self.expose(NA, source, defocus, grid, kind, polarization).develop(resist or Threshold())
 
 
-def _develop(img, threshold, diffusion, steepness, period):
-    """Constant-threshold resist with a linear (Gaussian) PEB diffusion: blur the aerial image by the acid-
-    diffusion length (periodic, in Fourier space -- the image is one period), then soft-threshold. Axis 0 is
-    x (period ``period[0]``), axis 1 is y. Differentiable; ``diffusion == 0`` skips the blur exactly."""
-    if diffusion > 0:  # linear PEB diffusion == a periodic Gaussian blur (heat kernel over the bake)
-        fx = jnp.fft.fftfreq(img.shape[0], d=period[0] / img.shape[0])
-        fy = jnp.fft.fftfreq(img.shape[1], d=period[1] / img.shape[1])
-        FX, FY = jnp.meshgrid(fx, fy, indexing="ij")
-        ker = jnp.exp(-2.0 * (jnp.pi * diffusion) ** 2 * (FX**2 + FY**2))
-        img = jnp.real(jnp.fft.ifft2(jnp.fft.fft2(img) * ker))
-    return jax.nn.sigmoid(steepness * (img - threshold))
+class _Exposure:
+    """The **optical exposure** at the wafer plane (from :meth:`_Sol.expose`) -- optics only, no resist. A
+    resist model (any callable ``exposure -> developed field``) is applied with :meth:`develop`; the fast
+    :class:`jno.litho.Threshold` reads :meth:`intensity`, a rigorous PEB model reads :meth:`spectrum` (the
+    angular spectrum it needs for the standing-wave bulk image). Keeping the exposure resist-agnostic is what
+    lets new resist models plug in without touching the imaging code."""
+
+    def __init__(self, sol, cfg):
+        self._sol, self._cfg = sol, cfg
+        self.period = (float(sol._period[0]), float(sol._period[1]))
+
+    def intensity(self):
+        """The **aerial image** ``|E|²`` at the wafer -- a ``(grid, grid)`` JAX array (see :meth:`_Sol.aerial`;
+        the exposure's imaging config is applied). What a constant-threshold resist develops."""
+        return self._sol.aerial(*self._cfg)
+
+    def spectrum(self, polarization="x"):
+        """The **coherent diffraction-order spectrum** entering the pupil: complex transverse fields
+        ``(ex, ey)`` per order for the given input polarization, with the order indices and wavelength. This
+        is the input a rigorous resist propagates into the resist film (Fresnel + substrate → standing-wave
+        bulk image). Partial-coherence (source) integration and the film propagation itself are the resist's
+        responsibility. Returns ``(orders(nt, 2), ex(nt,), ey(nt,), wavelength, period)``."""
+        ex, ey = self._sol._spectrum(self._cfg[4], fwd=self._sol._input_pol(polarization))
+        orders = np.asarray(self._sol._ex.basis_coefficients)
+        return _Spectrum(orders, ex, ey, self._sol._wl, self.period)
+
+    def develop(self, resist):
+        """Apply a **resist model** -- any callable ``exposure -> developed field`` (the fast
+        :class:`jno.litho.Threshold`, or a rigorous PEB model). Equivalent to ``resist(self)``."""
+        return resist(self)
+
+
+@dataclass
+class _Spectrum:
+    """The coherent diffraction-order spectrum from :meth:`_Exposure.spectrum` -- the contract a rigorous
+    (bulk-image) resist reads. ``orders`` are the (m, n) Fourier indices; ``ex``/``ey`` the complex transverse
+    fields per order; direction cosines are ``orders * wavelength / period``."""
+
+    orders: np.ndarray
+    ex: jnp.ndarray
+    ey: jnp.ndarray
+    wavelength: float
+    period: tuple
 
 
 def _source_grid(source, NA, ns=15):
@@ -1405,21 +1415,18 @@ class _ParametricSol:
         printed-vs-target loss flows back through the imaging AND the RCWA mask solve to the mask design (ILT)."""
         return self._node("aerial", NA, source, defocus, grid, kind, polarization)
 
-    def printed(
-        self,
-        NA,
-        source=0.7,
-        defocus=0.0,
-        grid=128,
-        kind="T",
-        polarization=None,
-        threshold=0.3,
-        diffusion=0.0,
-        steepness=50.0,
-    ):
+    def printed(self, NA, source=0.7, defocus=0.0, grid=128, kind="T", polarization=None, resist=None):
         """The developed resist image as a trace node over the mask's ``jno.np.parameter``\\ s -- ``jax.grad``
-        of a printed-vs-target loss flows back through development, imaging AND the RCWA solve to the mask (ILT)."""
-        return self._node("printed", NA, source, defocus, grid, kind, polarization, threshold, diffusion, steepness)
+        of a printed-vs-target loss flows back through development, imaging AND the RCWA solve to the mask (ILT).
+        ``resist`` defaults to :class:`jno.litho.Threshold`; pass another resist model to swap physics."""
+        return self._node("printed", NA, source, defocus, grid, kind, polarization, resist or Threshold())
+
+    def expose(self, *a, **k):
+        raise RcwaError(
+            "expose() returns an optics object, not a scalar readout, so it is not a parametric trace node. "
+            "For a differentiable printed-resist loss use rc.solve().printed(resist=...); to inspect an "
+            "exposure at concrete values use rc.solve(params={...}).expose(...)."
+        )
 
     def field(self, *a, **k):
         raise RcwaError(

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -403,13 +403,48 @@ class _Sol:
         without changing the call."""
         return self.expose(NA, source, defocus, grid, kind, polarization).develop(resist or Threshold())
 
+    def _bulk(self, cfg, film):
+        """Standing-wave **bulk image** ``|E(x, y, z)|²`` inside the resist film. Each diffraction order (a
+        plane wave at direction cosine ``(α, β)``) is refracted into the film (``k_z = k0·√(n_r² − α² − β²)``,
+        complex ⇒ absorption) and interferes with its substrate reflection ``r_s``, producing the vertical
+        standing wave. Reuses the aerial Abbe sum with a per-order depth factor; returns ``(grid, grid, nz)``.
+        Scalar (``E_x``); single-substrate-reflection model (the dominant standing wave)."""
+        NA, source, defocus, grid, kind, _polarization = cfg
+        wl = self._wl
+        Px, Py = float(self._period[0]), float(self._period[1])
+        bc = np.asarray(self._ex.basis_coefficients)
+        M = int(np.abs(bc).max())
+        grid = max(int(grid), 2 * M + 2)
+        A = jnp.zeros((2 * M + 1, 2 * M + 1), complex).at[bc[:, 0] + M, bc[:, 1] + M].set(self._spectrum(kind)[0])
+        ms = jnp.asarray(np.arange(-M, M + 1))
+        AX, AY = jnp.meshgrid(ms * wl / Px, ms * wl / Py, indexing="ij")
+        S, W = _source_grid(source, float(NA))
+        c = grid // 2
+        k0 = 2.0 * jnp.pi / wl
+        n_r, n_s, n_top = complex(film.n_resist), complex(film.n_substrate), complex(getattr(film, "n_top", 1.0))
+        d, nz = float(film.thickness), int(getattr(film, "nz", 16))
+        zs = jnp.linspace(0.0, d, nz)
+        r_s, t_top = (n_r - n_s) / (n_r + n_s), 2.0 * n_top / (n_top + n_r)  # substrate reflection + top transmission
+
+        def plane(s, z):  # one source point, one depth -> |E(x, y, z)|²
+            a2 = (AX + s[0]) ** 2 + (AY + s[1]) ** 2
+            kz = k0 * jnp.sqrt(n_r**2 - a2 + 0j)  # z-wavevector in the resist (complex ⇒ depth absorption)
+            fz = t_top * (jnp.exp(1j * kz * z) + r_s * jnp.exp(1j * kz * (2.0 * d - z)))  # down + substrate-reflected up
+            pupil = jnp.where(a2 <= NA**2, jnp.exp(-1j * jnp.pi * wl * defocus * a2) * fz, 0.0)
+            pad = jnp.zeros((grid, grid), complex).at[c - M : c + M + 1, c - M : c + M + 1].set(A * pupil)
+            return jnp.abs(jnp.fft.ifft2(jnp.fft.ifftshift(pad)) * (grid * grid)) ** 2
+
+        imgs = jax.vmap(lambda s: jax.vmap(lambda z: plane(s, z))(zs))(S)  # (Ns, nz, grid, grid)
+        vol = jnp.sum(W[:, None, None, None] * imgs, axis=0) / jnp.sum(W)  # (nz, grid, grid)
+        return jnp.moveaxis(vol, 0, -1)  # (grid, grid, nz): x, y, depth
+
 
 class _Exposure:
     """The **optical exposure** at the wafer plane (from :meth:`_Sol.expose`) -- optics only, no resist. A
     resist model (any callable ``exposure -> developed field``) is applied with :meth:`develop`; the fast
-    :class:`jno.litho.Threshold` reads :meth:`intensity`, a rigorous PEB model reads :meth:`spectrum` (the
-    angular spectrum it needs for the standing-wave bulk image). Keeping the exposure resist-agnostic is what
-    lets new resist models plug in without touching the imaging code."""
+    :class:`jno.litho.Threshold` reads :meth:`intensity`, a depth-resolved resist reads :meth:`bulk` (the
+    standing-wave field inside the film). Keeping the exposure resist-agnostic is what lets new resist models
+    plug in without touching the imaging code."""
 
     def __init__(self, sol, cfg):
         self._sol, self._cfg = sol, cfg
@@ -420,33 +455,20 @@ class _Exposure:
         the exposure's imaging config is applied). What a constant-threshold resist develops."""
         return self._sol.aerial(*self._cfg)
 
-    def spectrum(self, polarization="x"):
-        """The **coherent diffraction-order spectrum** entering the pupil: complex transverse fields
-        ``(ex, ey)`` per order for the given input polarization, with the order indices and wavelength. This
-        is the input a rigorous resist propagates into the resist film (Fresnel + substrate → standing-wave
-        bulk image). Partial-coherence (source) integration and the film propagation itself are the resist's
-        responsibility. Returns ``(orders(nt, 2), ex(nt,), ey(nt,), wavelength, period)``."""
-        ex, ey = self._sol._spectrum(self._cfg[4], fwd=self._sol._input_pol(polarization))
-        orders = np.asarray(self._sol._ex.basis_coefficients)
-        return _Spectrum(orders, ex, ey, self._sol._wl, self.period)
+    def bulk(self, film):
+        """The **standing-wave bulk image** ``|E(x, y, z)|²`` inside the resist ``film`` -- the aerial spectrum
+        propagated into the film so each order interferes with its substrate reflection (the vertical standing
+        wave) and decays by absorption (a complex resist index). ``film`` supplies ``n_resist`` (complex for
+        absorption), ``thickness``, ``n_substrate``, optional ``n_top`` (default 1) and ``nz`` (depth samples;
+        default 16) -- e.g. :class:`jno.litho.Film`. Returns a ``(grid, grid, nz)`` JAX array. At ``z = 0`` with
+        no substrate reflection it equals :meth:`intensity`. The depth-resolved input a rigorous 3-D resist
+        develops; scalar (``E_x``), single-substrate-reflection model (full multilayer Airy is a refinement)."""
+        return self._sol._bulk(self._cfg, film)
 
     def develop(self, resist):
         """Apply a **resist model** -- any callable ``exposure -> developed field`` (the fast
         :class:`jno.litho.Threshold`, or a rigorous PEB model). Equivalent to ``resist(self)``."""
         return resist(self)
-
-
-@dataclass
-class _Spectrum:
-    """The coherent diffraction-order spectrum from :meth:`_Exposure.spectrum` -- the contract a rigorous
-    (bulk-image) resist reads. ``orders`` are the (m, n) Fourier indices; ``ex``/``ey`` the complex transverse
-    fields per order; direction cosines are ``orders * wavelength / period``."""
-
-    orders: np.ndarray
-    ex: jnp.ndarray
-    ey: jnp.ndarray
-    wavelength: float
-    period: tuple
 
 
 def _source_grid(source, NA, ns=15):

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -35,11 +35,22 @@ concrete fix. Two `fmmax` conventions are baked in: the Poynting flux is summed 
 ``abs()`` sum over-counts and yields ``T+R>1``), and ``JONES_DIRECT_FOURIER`` is the default
 factorization (the naive rule converges poorly for high-contrast dielectrics such as a-Si).
 
+Beyond a scalar ε, the front door also infers a **tensor permittivity** ``ε̂`` (from ``inner(ε̂ @ u, v)``)
+and an **in-plane PML** (a complex coordinate stretch ``S = 1 + iσ/k`` written into the stiffness
+coefficients of the scalar Helmholtz term). A uniaxial PML is exactly a diagonal Maxwell ``ε̂`` and ``μ̂``
+(``ε̂ = ε·Λ``, ``μ̂ = Λ``, ``Λ = diag(SᵧS_z/Sₓ, SₓS_z/Sᵧ, SₓSᵧ/S_z)``), so the traced stretch is honoured
+exactly and solved via `fmmax`'s general anisotropic eigensolve — turning a periodic supercell into an
+isolated scatterer (the absorbing frame decouples the walls).
+
 References:
  * M. G. Moharam & T. K. Gaylord, "Rigorous coupled-wave analysis of planar-grating diffraction",
    J. Opt. Soc. Am. 71, 811 (1981).
  * M. G. Moharam, D. A. Pommet, E. B. Grann & T. K. Gaylord, "Stable implementation of the enhanced
    transmittance matrix approach", J. Opt. Soc. Am. A 12, 1077 (1995).
+ * W. C. Chew & W. H. Weedon, "A 3D perfectly matched medium from modified Maxwell's equations with
+   stretched coordinates", Microw. Opt. Technol. Lett. 7, 599 (1994) — the complex coordinate stretch.
+ * Z. S. Sacks, D. M. Kingsland, R. Lee & J.-F. Lee, "A perfectly matched anisotropic absorber for use
+   as an absorbing boundary condition", IEEE Trans. Antennas Propag. 43, 1460 (1995) — the uniaxial ε̂/μ̂ PML.
  * fmmax: https://github.com/facebookresearch/fmmax
 """
 
@@ -633,6 +644,72 @@ def _extract_permittivity_coeff(volume_term):
     return functools.reduce(operator.add, mass)
 
 
+def _extract_pml_stretch(volume_term):
+    """Recover an in-plane uniaxial PML coordinate-stretch from a scalar Helmholtz volume term.
+
+    A PML writes the stiffness with anisotropic diagonal coefficients::
+
+        c_xx·∂ₓu ∂ₓv + c_yy·∂ᵧu ∂ᵧv + c_zz·∂_zu ∂_zv
+
+    where ``(c_xx, c_yy, c_zz) = Λ = diag(SᵧS_z/Sₓ, SₓS_z/Sᵧ, SₓSᵧ/S_z)`` is the coordinate-stretch
+    tensor (``S_i = 1 + iσ_i/k``, ramping in the absorbing frame, ``1`` in the physical core). This is
+    exactly the Maxwell uniaxial PML: ``ε̂ = ε·Λ``, ``μ̂ = Λ``. We honour whatever stretch the user traced.
+
+    Returns ``{axis: Λ_axis_node}`` (axis ``0/1/2`` ↦ ``x/y/z``) when a stretch is present, or ``{}`` when
+    every stiffness summand is a bare ``∂u·∂v`` (no PML). Raises on an off-diagonal stiffness
+    (``∂ᵢu ∂ⱼv``, i≠j) — only a diagonal (uniaxial) stretch is supported."""
+    import functools
+    import operator
+
+    from jno.trace import Jacobian
+
+    expr = getattr(volume_term, "expr", volume_term)
+    per_axis = {}  # axis -> list of coefficient nodes (None = a bare, coefficient-less ∂u·∂v)
+    saw_stiffness = False
+    for _sign, summand in _add_split(expr):
+        fac = _mul_factors(summand)
+        jt = [f for f in fac if isinstance(f, Jacobian) and _contains_trial(f.target)]
+        je = [f for f in fac if isinstance(f, Jacobian) and _contains_test(f.target)]
+        if not (jt and je):
+            continue  # mass / source / other channel -- not a stiffness summand
+        if len(jt) != 1 or len(je) != 1:
+            raise RcwaError("RCWA PML: expected one trial-gradient and one test-gradient per stiffness term.")
+        saw_stiffness = True
+        axt, axe = jt[0].variables[0].dim[0], je[0].variables[0].dim[0]
+        if axt != axe:
+            raise RcwaError(
+                "RCWA sees an off-diagonal stiffness term (∂ᵢu ∂ⱼv, i≠j) -> a non-diagonal coordinate "
+                "stretch. Only a diagonal (uniaxial) in-plane PML is supported."
+            )
+        coeff_factors = [f for f in fac if f is not jt[0] and f is not je[0]]
+        per_axis.setdefault(axt, []).append(functools.reduce(operator.mul, coeff_factors) if coeff_factors else None)
+    if not saw_stiffness or all(c is None for cs in per_axis.values() for c in cs):
+        return {}  # no stiffness, or every stiffness term is a bare ∂u·∂v -> not a PML
+    return {  # a bare contribution on a stretched axis counts as Λ += 1
+        ax: functools.reduce(operator.add, [(c if c is not None else 1.0) for c in cs]) for ax, cs in per_axis.items()
+    }
+
+
+def _pml_layer_components(mass_node, stretch, period, grid, zmid, params, k0sq):
+    """The 10 relative-permittivity/permeability grids ``(ε_xx,ε_xy,ε_yx,ε_yy,ε_zz, μ_xx,μ_xy,μ_yx,μ_yy,μ_zz)``
+    of an in-plane uniaxial PML layer at height ``zmid``.
+
+    ``Λ = diag(c_xx, c_yy, c_zz)`` is read off the stiffness coefficients (``stretch``); the Maxwell PML is
+    ``ε̂ = ε·Λ``, ``μ̂ = Λ`` with ``ε = (K0²·ε·SₓSᵧS_z)/k0² / (c_xx·c_yy·c_zz)`` since
+    ``SₓSᵧS_z = c_xx·c_yy·c_zz``. Off-diagonal components are zero (uniaxial)."""
+    pts = _cell_grid_at_z(period, grid, zmid)
+
+    def samp(node):
+        v = jnp.full((grid * grid,), node) if np.isscalar(node) else _eval_coeff_points(node, pts, params)
+        return jnp.reshape(v, (grid, grid)) + 0j
+
+    lam = [samp(stretch[ax]) for ax in (0, 1, 2)]
+    m = jnp.reshape(_eval_coeff_points(mass_node, pts, params), (grid, grid)) + 0j
+    eps_rel = (m / k0sq) / (lam[0] * lam[1] * lam[2])
+    z = jnp.zeros((grid, grid), complex)
+    return (eps_rel * lam[0], z, z, eps_rel * lam[1], eps_rel * lam[2], lam[0], z, z, lam[1], lam[2])
+
+
 def _has_nodal_field(node):
     """True if the coefficient depends on a per-node field parameter (needs mesh interpolation)."""
     return any(getattr(mc.model, "_fem_field", None) == "node" for mc in _model_calls(node))
@@ -1012,9 +1089,13 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
 
     Everything is read out of the traced problem: **periodicity + period** (Floquet ties — absent ⇒
     raise), the **super/substrate ambients**, the **permittivity** (the ``K0**2*eps`` coefficient
-    recovered from the scalar Helmholtz volume term, sampled along z), the **wavelength** (``k0`` from
-    the vacuum superstrate, unless ``wavelength`` is given), and the **incident wave** (illuminated face
-    + transverse angle ``k_in``, from the assembled forcing).
+    recovered from the scalar Helmholtz volume term, sampled along z; a tensor ``ε̂`` from
+    ``inner(ε̂ @ u, v)``), the **wavelength** (``k0`` from the vacuum superstrate, unless ``wavelength``
+    is given), and the **incident wave** (illuminated face + transverse angle ``k_in``, from the
+    assembled forcing). An **in-plane PML** (a complex coordinate stretch in the stiffness coefficients)
+    is detected and honoured as a diagonal Maxwell ``ε̂``/``μ̂`` — the supercell then behaves as an
+    isolated scatterer. Scope: uniaxial (diagonal) in-plane stretch only, scalar Helmholtz, forward
+    solve (a design parameter *through* a PML is not yet differentiable — it raises).
 
     Parameters
     ----------
@@ -1050,6 +1131,10 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     cparams = _param_values(femobj, coeff_node)
     cparams.update({k: jnp.asarray(v) for k, v in (params or {}).items()})
     is_aniso = _coeff_is_tensor(coeff_node, period, z_range, cparams)  # 3×3 ε̂ vs scalar ε
+    stretch = _extract_pml_stretch(_volume_constraint(femobj))  # {axis: Λ node} for an in-plane PML, else {}
+    is_pml = bool(stretch)
+    if is_pml and is_aniso:
+        raise RcwaError("RCWA sees both an in-plane PML stretch and a tensor ε̂ mass term; combine them by hand.")
     if _has_nodal_field(coeff_node):  # per-node design field -> interpolate off the mesh
         coeff_nodes = _eval_expr_nodes(coeff_node, domain)
         if np.iscomplexobj(coeff_nodes) and np.max(np.abs(coeff_nodes.imag)) < 1e-9:
@@ -1068,8 +1153,14 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     if not source_at_bottom:
         coeff_layers = list(reversed(coeff_layers))
         zmids = list(reversed(zmids))
-    # k0 from the superstrate (vacuum ⇒ coeff = k0^2), unless wavelength is given
-    super_coeff = float(np.real(coeff_layers[0][1]).mean())
+    # k0 from the superstrate (vacuum ⇒ coeff = k0^2), unless wavelength is given. With a PML the superstrate
+    # is a vacuum framed by the absorber, so its transverse MEAN is stretched; read k0 at the physical-core
+    # centre instead (there Λ=1 and ε=1, so the mass coefficient is exactly k0²).
+    if is_pml:
+        center = np.array([[period[0] * 0.5, period[1] * 0.5, zmids[0]]])
+        super_coeff = float(np.real(_eval_coeff_points(coeff_node, center, cparams)).reshape(-1)[0])
+    else:
+        super_coeff = float(np.real(coeff_layers[0][1]).mean())
     if wavelength is not None:
         k0 = 2 * np.pi / float(wavelength)
     elif super_coeff <= 0:
@@ -1079,7 +1170,12 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     else:
         k0 = float(np.sqrt(super_coeff))
     k0sq = k0 * k0
-    if is_aniso:  # relative-permittivity TENSOR per layer: (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz)
+    if is_pml:  # in-plane uniaxial PML: general-anisotropic layer (ε̂ AND μ̂), 10 grids per layer
+        layers = [
+            (t, tuple(np.asarray(c) for c in _pml_layer_components(coeff_node, stretch, period, grid, zm, cparams, k0sq)))
+            for (t, _), zm in zip(coeff_layers, zmids)
+        ]
+    elif is_aniso:  # relative-permittivity TENSOR per layer: (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz)
         layers = [
             (t, tuple(np.asarray(c) for c in _tensor_components(coeff_node, period, grid, zm, cparams, k0sq)))
             for (t, _), zm in zip(coeff_layers, zmids)
@@ -1153,6 +1249,11 @@ def rcwa(problem, *, orders, wavelength=None, grid=64, nz=64, slices=None, param
     _collect_runtime_parameter_exprs(coeff_node, rpe)  # eps / wavelength parameters
     if src_coeff is not None:
         _collect_runtime_parameter_exprs(src_coeff, rpe)  # an incidence-angle parameter in the source
+    if is_pml and rpe:  # the eager PML layers solve fine; a design parameter through a PML re-sample is future work
+        raise RcwaError(
+            "differentiable PML is not yet supported: a jno.np.parameter flows through an in-plane PML "
+            f"problem (parameters {sorted(rpe)}). The forward PML solve works; drop the parameter to use it."
+        )
 
     spec = RcwaSpec(
         period=period,

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -267,6 +267,93 @@ class _Sol:
         layer_z = list(np.cumsum([float(t) for t in self._thick]))[:-1]
         return slab, [0.0, float(self._period[0]), float(zc.min()), float(zc.max())], layer_z
 
+    def _spectrum(self, kind="T"):
+        """The complex diffraction spectrum for imaging: the transverse E-field Fourier coefficients
+        ``(ex, ey)`` per diffraction order (transmitted ``"T"`` or reflected ``"R"``), read at the corrected
+        0th-order incidence. ``(0,0)`` is expansion index 0 (fmmax orders the zeroth term first)."""
+        fm = self._fm
+        smat = self._s.s11 if kind == "T" else self._s.s21
+        layer = self._layers[-1] if kind == "T" else self._layers[0]
+        fwd = smat @ self._fwd
+        (ex, ey, _ez), _ = fm.fields_from_wave_amplitudes(fwd, jnp.zeros_like(fwd), layer)
+        return jnp.reshape(ex, (-1,)), jnp.reshape(ey, (-1,))
+
+    def aerial(self, NA, source=0.7, defocus=0.0, grid=128, kind="T"):
+        """Partially-coherent **aerial image** (wafer-plane intensity) of this mask, by **Abbe** source
+        integration -- the litho imaging step on top of the rigorous RCWA mask diffraction.
+
+        The mask's diffraction orders (this solution's spectrum) are projected through a lens of numerical
+        aperture ``NA``, summed over the illumination ``source``. Everything (wavelength, period, the complex
+        mask spectrum) is read from the solve; only the optics are yours.
+
+        Parameters
+        ----------
+        NA:
+            Numerical aperture of the projection lens (an order passes the pupil when its direction cosine
+            ``|α| ≤ NA``).
+        source:
+            Illumination. A **float** ``σ`` → conventional (a filled disk of partial-coherence radius ``σ``);
+            a **(σ_in, σ_out) tuple** → annular; a raw **array** of pupil weights (differentiable, for
+            source-mask optimization).
+        defocus:
+            Defocus (same length unit as the geometry); applies the quadratic pupil phase.
+        grid:
+            Real-space resolution of the returned image (one period).
+        kind:
+            ``"T"`` (transmissive DUV mask, default) or ``"R"`` (reflective EUV mask).
+
+        Returns
+        -------
+        A ``(grid, grid)`` JAX intensity array over one period -- differentiable in the mask design and the
+        source, so ``jax.grad`` of a printed-vs-target loss drives OPC / ILT / SMO.
+
+        Notes
+        -----
+        Scalar (uses ``E_x``); the vector (high-NA) form reads both ``E_x, E_y`` with polarization in the
+        pupil -- future work. Uses the shift-invariant (Kirchhoff-like) Abbe sum on this single solve's
+        rigorous spectrum; full angular rigor (re-solving the mask per source point) is a heavier option.
+        """
+        wl = self._wl  # may be a tracer (a wavelength parameter) -- keep jax-native
+        Px, Py = float(self._period[0]), float(self._period[1])
+        ex, _ey = self._spectrum(kind)  # scalar imaging -> E_x
+        bc = np.asarray(self._ex.basis_coefficients)  # (nt, 2) static (m, n)
+        M = int(np.abs(bc).max())
+        grid = max(int(grid), 2 * M + 2)
+        A = jnp.zeros((2 * M + 1, 2 * M + 1), complex).at[bc[:, 0] + M, bc[:, 1] + M].set(ex)
+        ms = jnp.asarray(np.arange(-M, M + 1))
+        AX, AY = jnp.meshgrid(ms * wl / Px, ms * wl / Py, indexing="ij")  # α (direction cosine) per order
+        S, W = _source_grid(source, float(NA))
+        c = grid // 2
+
+        def one(s):  # image from a single source point s (a shift of the order frequencies)
+            r2 = (AX + s[0]) ** 2 + (AY + s[1]) ** 2
+            pupil = jnp.where(r2 <= NA**2, jnp.exp(-1j * jnp.pi * wl * defocus * r2), 0.0)
+            pad = jnp.zeros((grid, grid), complex).at[c - M : c + M + 1, c - M : c + M + 1].set(A * pupil)
+            E = jnp.fft.ifft2(jnp.fft.ifftshift(pad)) * (grid * grid)
+            return jnp.abs(E) ** 2
+
+        imgs = jax.vmap(one)(S)  # (Ns, grid, grid)
+        return jnp.sum(W[:, None, None] * imgs, axis=0) / jnp.sum(W)
+
+
+def _source_grid(source, NA, ns=15):
+    """Illumination source as (points, weights) on a pupil grid, for the Abbe sum. ``source`` is a float
+    (conventional disk of coherence radius σ), a (σ_in, σ_out) tuple (annular), or a raw weight array."""
+    if not np.isscalar(source) and not isinstance(source, tuple):  # a raw pupil-weight array
+        w = jnp.asarray(source).reshape(-1)
+        ns = int(round(float(w.size) ** 0.5))
+    sp = np.linspace(-NA, NA, ns)
+    SX, SY = np.meshgrid(sp, sp, indexing="ij")
+    S = jnp.asarray(np.stack([SX.ravel(), SY.ravel()], 1))  # (ns², 2)
+    rn = np.hypot(np.asarray(SX).ravel(), np.asarray(SY).ravel()) / NA  # coherence radius σ per point
+    if np.isscalar(source):
+        W = jnp.asarray((rn <= float(source)).astype(float))  # conventional disk
+    elif isinstance(source, tuple):
+        W = jnp.asarray(((rn >= source[0]) & (rn <= source[1])).astype(float))  # annular
+    else:
+        W = jnp.asarray(source).reshape(-1)  # arbitrary (differentiable for SMO)
+    return S, W
+
 
 class _EmitterSol:
     """Readouts for an internal-source (dipole / Gaussian) emission solve: the power radiated **up** (into
@@ -1209,6 +1296,11 @@ class _ParametricSol:
 
     def extraction(self, kind="up"):
         return self._node("extraction", kind)
+
+    def aerial(self, NA, source=0.7, defocus=0.0, grid=128, kind="T"):
+        """The aerial image as a trace node over the mask's ``jno.np.parameter``\\ s -- so ``jax.grad`` of a
+        printed-vs-target loss flows back through the imaging AND the RCWA mask solve to the mask design (ILT)."""
+        return self._node("aerial", NA, source, defocus, grid, kind)
 
     def field(self, *a, **k):
         raise RcwaError(

--- a/jno/rcwa.py
+++ b/jno/rcwa.py
@@ -221,28 +221,36 @@ class _Sol:
         Jones basis — for the 0th order at normal incidence they are the two in-plane axes (≈ x, y); an
         isotropic stack gives a diagonal ``J`` (no conversion), an in-plane-anisotropic one an off-diagonal
         ``J`` (polarization conversion). Differentiable in the design. Returns a JAX ``(2, 2)`` array."""
-        fm, nt = self._fm, self._nt
+        fm = self._fm
         if kind == "T":
             smat, out_layer = self._s.s11, self._layers[-1]
         elif kind == "R":
             smat, out_layer = self._s.s21, self._layers[0]
         else:
             raise RcwaError(f"jones(kind): kind must be 'T' or 'R', got {kind!r}")
-        flux_in = jnp.abs(jnp.real(jnp.reshape(fm.eigenmode_poynting_flux(self._layers[0]), (-1,))))
-        flux_out = jnp.abs(jnp.real(jnp.reshape(fm.eigenmode_poynting_flux(out_layer), (-1,))))
-        # fmmax orders eigenmodes by eigenvalue, not by Fourier order — the 0th order's two polarizations are
-        # the two most-forward (largest-flux) ambient modes. The ambient is design-independent, so the two
-        # indices are fixed geometry (read eagerly); the amplitudes/normalisation stay JAX (differentiable).
-        order = np.argsort(-np.asarray(flux_in))
-        pa, pb = int(order[0]), int(order[1])
-        if _concrete(flux_in) and float(flux_in[pb]) <= 1e-9 * float(flux_in[pa] + 1e-30):
-            raise RcwaError("only one forward-propagating polarization at the 0th order; the Jones matrix is degenerate.")
+        in_layer = self._layers[0]
+        # Work in the FIELD basis, not the eigenmode basis: the 0th order is expansion index 0 (fmmax orders
+        # the zeroth term first), but the eigenmodes are eigenvalue-sorted, so an argmax(flux) pick grabs the
+        # wrong (oblique) mode for an asymmetric structure. Instead: excite the two 0th-order input plane
+        # waves as UNIFORM real-space fields (x-pol E=x̂,H=ŷ and y-pol E=ŷ,H=-x̂, both forward), and read the
+        # 0th-order component of the output field. For vacuum ambients the flux factors cancel, so |J|² is the
+        # power fraction directly (columns sum to the 0th-order efficiency).
+        gs = fm.min_array_shape_for_expansion(self._ex)
+        _u = jnp.ones((*gs, 1), complex)
+        _z = jnp.zeros((*gs, 1), complex)
+        fwd_x = jnp.reshape(fm.amplitudes_for_fields(_u, _z, _z, _u, in_layer)[0], (2 * self._nt, 1))
+        fwd_y = jnp.reshape(fm.amplitudes_for_fields(_z, _u, -_u, _z, in_layer)[0], (2 * self._nt, 1))
 
-        def col(p):  # transmitted/reflected 0th-order amplitudes for a unit-power input in polarization p
-            amp = jnp.reshape(smat @ jnp.zeros((2 * nt, 1), complex).at[p, 0].set(1.0), (-1,))
-            return jnp.stack([amp[pa] * jnp.sqrt(flux_out[pa] / flux_in[p]), amp[pb] * jnp.sqrt(flux_out[pb] / flux_in[p])])
+        def out0(fwd_in):  # the 0th-order (E_x, E_y) of the output field for this input plane wave
+            amp = smat @ fwd_in
+            zero = jnp.zeros_like(amp)
+            fa, ba = (amp, zero) if kind == "T" else (zero, amp)  # T -> forward in substrate; R -> backward in super
+            (ex, ey, _ez), _ = fm.fields_from_wave_amplitudes(fa, ba, out_layer)
+            return jnp.reshape(ex, (-1,))[0], jnp.reshape(ey, (-1,))[0]
 
-        return jnp.stack([col(pa), col(pb)], axis=1)  # (out q, in p)
+        exx, eyx = out0(fwd_x)  # input x-pol -> output (E_x, E_y)
+        exy, eyy = out0(fwd_y)  # input y-pol -> output (E_x, E_y)
+        return jnp.array([[exx, exy], [eyx, eyy]])  # J[out q, in p]
 
     def field(self, y_frac=0.5, nx=80, density=40.0):
         """Reconstruct the real-space electric field on a vertical (x–z) slice at ``y = y_frac·Py``.

--- a/jno/utils/profiling.py
+++ b/jno/utils/profiling.py
@@ -1,0 +1,48 @@
+"""Shared JAX performance profiling for jno ``.solve(profile=True)`` — used by ``jno.fem``, ``jno.fdm``
+and ``jno.rcwa``, mirroring ``jno.core.solve(profile=True)``.
+
+``profile_solve`` runs a solve **eagerly** inside a JAX Perfetto trace, prints a one-line size/time
+summary, and writes the trace to ``./jno_traces`` (open at ``chrome://tracing`` or the Perfetto UI).
+``annotate`` labels a solve stage in that trace (a no-op unless a profile session is active)."""
+
+import os
+import time
+from contextlib import nullcontext
+
+import jax
+
+
+def annotate(name):
+    """A ``jax.profiler.TraceAnnotation`` labelling a solve stage when a profile session is active; a no-op
+    context otherwise, so wrapping a hot stage in it never costs anything outside profiling."""
+    from jax._src import profiler as _jp
+
+    return jax.profiler.TraceAnnotation(name) if _jp._profile_state.profile_session is not None else nullcontext()
+
+
+def profile_solve(run, *, label, warm=True):
+    """Run ``run()`` eagerly inside a JAX Perfetto trace, print ``label`` + wall time, write the trace to
+    ``./jno_traces``, and return the result.
+
+    ``warm`` runs ``run()`` once first so the timing excludes XLA compilation; pass ``warm=False`` when a
+    re-run would be unsafe (e.g. an in-place adaptive remesh). A deferred (trace-node) result has nothing to
+    block on, so the timing then reflects graph construction, not the numeric solve — profile a concrete
+    forward solve for a meaningful number."""
+    trace_dir = os.path.join(os.getcwd(), "jno_traces")
+    os.makedirs(trace_dir, exist_ok=True)
+
+    def _block(result):
+        try:
+            jax.block_until_ready(result)  # force the async DAG to finish so the timer/trace see real work
+        except (TypeError, ValueError, AttributeError):
+            pass  # a non-array result (a deferred trace node) has no arrays to block on
+        return result
+
+    if warm:
+        _block(run())
+    t0 = time.perf_counter()
+    with jax.profiler.trace(trace_dir, create_perfetto_trace=True):
+        result = _block(run())
+    dt = time.perf_counter() - t0
+    print(f"[{label}]  wall {dt * 1e3:.1f} ms  ·  Perfetto trace → {trace_dir}")
+    return result

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -492,12 +492,14 @@ class TestDomainInference:
         crux = jno.core([pde])
         assert crux.domain is dom
 
-    def test_no_variables_raises(self):
-        # Pure parametric loss — no Variables means no domain to resolve.
+    def test_no_variables_uses_trivial_domain(self):
+        # Pure parametric / data-fit loss — no Variables, so no domain to sample. jno.core now treats this
+        # as a parameter-only fit (an inverse problem, or an ILT loss over a jno.fn-wrapped solver) and
+        # supplies a trivial domain instead of raising, so no placeholder domain is needed.
         param = jnn.parameter((1,), key=jax.random.PRNGKey(0), name="a")
         loss = (param - 1.0).mse
-        with pytest.raises(ValueError, match="no Variables or TensorTags"):
-            jno.core([loss])
+        crux = jno.core([loss])  # must NOT raise
+        assert crux.domain is not None  # a trivial domain was supplied
 
     def test_multi_domain_raises(self):
         dom_a, pde_a = self._tiny_domain_and_loss(mesh_size=0.1, key_seed=1)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,51 @@
+"""jno.fem / jno.fdm ``.solve(profile=True)`` — JAX performance profiling, mirroring jno.core / jno.rcwa.
+
+A concrete forward solve is run inside a JAX Perfetto trace; a one-line size/time summary is printed and the
+trace is written to ``./jno_traces``. Shared machinery (``jno.utils.profiling``) across fem / fdm / rcwa.
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+import jno.jnp_ops as jnn  # noqa: E402
+
+pytest.importorskip("pygmsh", reason="pygmsh required for meshing")
+
+
+def test_fem_solve_profile(tmp_path, monkeypatch, capsys):
+    """fem.solve(profile=True) profiles the linear solve: returns the field, prints a summary, writes a trace."""
+    monkeypatch.chdir(tmp_path)
+    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
+    u, phi = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
+    f = 2.0 * (xi * (1 - xi) + yi * (1 - yi))
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0], quad_degree=3)
+    sol = np.asarray(fem.solve(profile=True))
+    assert sol.shape[0] == fem.dofs and np.all(np.isfinite(sol))
+    assert "fem profile" in capsys.readouterr().out
+    assert (tmp_path / "jno_traces").is_dir() and any((tmp_path / "jno_traces").iterdir())
+
+
+def test_fdm_solve_profile(tmp_path, monkeypatch, capsys):
+    """fdm.solve(profile=True) profiles the strong-form Newton solve — same summary + trace contract."""
+    monkeypatch.chdir(tmp_path)
+    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).domain()
+    x, y, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    u = d.unknown()
+    ui = u.bind(x=x, y=y)
+    f = 2 * np.pi**2 * jnn.sin(np.pi * x) * jnn.sin(np.pi * y)
+    sol = np.asarray(jno.fdm([-ui.d2(x) - ui.d2(y) - f, u(xb, yb) - 0.0]).solve(profile=True)).reshape(-1)
+    assert np.all(np.isfinite(sol)) and sol.size > 0
+    assert "fdm profile" in capsys.readouterr().out
+    assert (tmp_path / "jno_traces").is_dir() and any((tmp_path / "jno_traces").iterdir())

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -179,11 +179,9 @@ def test_vector_pol_shapes_run():
     assert np.allclose(iu, 0.5 * (ix + iy), rtol=1e-6, atol=1e-9)
 
 
-@needs_fmmax
-def test_aerial_is_differentiable_ilt():
-    """The aerial image is differentiable in the mask design (inverse lithography): rc.solve().aerial() is a
-    trace node, and jax.grad of an image functional w.r.t. a mask parameter matches a finite difference —
-    the gradient flows through the imaging AND the RCWA mask solve."""
+def _ilt_cons():
+    """A mask parameterised by the line permittivity `ep` (a jno.np.parameter), for the inverse-lithography
+    gradient tests. Returns (constraint list, the ep parameter)."""
     d = _sbox()
     u, phi = d.fem_symbols()
     xi, yi, zi, _ = d.variable("interior", split=True)
@@ -211,16 +209,93 @@ def test_aerial_is_differentiable_ilt():
         ul - ur,
         uf - ub,
     ]
-    rc = jno.rcwa(cons, orders=60, grid=56, params={"ep": 2.0})
-    node = rc.solve().aerial(NA=0.6, source=0.5)
-    assert isinstance(node, FunctionCall)
+    return cons, ep
+
+
+def _grad_vs_fd(node, ep):
+    """jax.grad of mean(node²) w.r.t. the ep parameter, and the central finite difference, at ep=2."""
 
     def loss(v):
         mod = eqx.tree_at(lambda m: m.value, ep.model.module, jnp.asarray(v))
         return jnp.mean(TraceEvaluator({ep.model.layer_id: mod}).evaluate(node) ** 2)
 
-    g = float(jax.grad(loss)(2.0))
     h = 1e-2
-    fd = (float(loss(2.0 + h)) - float(loss(2.0 - h))) / (2 * h)
+    return float(jax.grad(loss)(2.0)), (float(loss(2.0 + h)) - float(loss(2.0 - h))) / (2 * h)
+
+
+@needs_fmmax
+def test_aerial_is_differentiable_ilt():
+    """The aerial image is differentiable in the mask design (inverse lithography): rc.solve().aerial() is a
+    trace node, and jax.grad of an image functional w.r.t. a mask parameter matches a finite difference —
+    the gradient flows through the imaging AND the RCWA mask solve."""
+    cons, ep = _ilt_cons()
+    node = jno.rcwa(cons, orders=60, grid=56, params={"ep": 2.0}).solve().aerial(NA=0.6, source=0.5)
+    assert isinstance(node, FunctionCall)
+    g, fd = _grad_vs_fd(node, ep)
     assert g == pytest.approx(fd, rel=3e-3)
+    assert abs(g) > 1e-3
+
+
+def _linewidth(img):  # fraction of the (y-averaged) x-profile that prints as a feature (> 0.5)
+    return float((np.asarray(img).mean(1) > 0.5).mean())
+
+
+def _aerial_band(sol, **kw):  # the (min, max, span) of this mask's aerial intensity — a weak dielectric
+    a = np.asarray(sol.aerial(**kw))  # grating modulates around ~1, so a threshold must sit INSIDE this band
+    lo, hi = float(a.min()), float(a.max())
+    return lo, hi, max(hi - lo, 1e-9)
+
+
+@needs_fmmax
+def test_printed_is_in_range_and_structured():
+    """The developed resist image (sol.printed) is a soft mask in [0, 1] and thresholds the line grating into
+    a printed feature — both cleared (≈0) and remaining (≈1) resist are present."""
+    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
+    lo, hi, span = _aerial_band(sol, NA=0.6, source=0.4)
+    img = np.asarray(sol.printed(NA=0.6, source=0.4, threshold=0.5 * (lo + hi), steepness=24.0 / span))
+    assert img.min() >= 0.0 and img.max() <= 1.0 and np.all(np.isfinite(img))
+    assert img.min() < 0.05 and img.max() > 0.95  # a real bilevel pattern, not a flat grey
+
+
+@needs_fmmax
+def test_threshold_sets_linewidth():
+    """Raising the dose-to-clear threshold shrinks the printed feature — the CD knob is monotone."""
+    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
+    lo, _hi, span = _aerial_band(sol, NA=0.6, source=0.4)
+    k = 24.0 / span
+    w_lo = _linewidth(sol.printed(NA=0.6, source=0.4, threshold=lo + 0.35 * span, steepness=k))
+    w_hi = _linewidth(sol.printed(NA=0.6, source=0.4, threshold=lo + 0.65 * span, steepness=k))
+    assert w_lo > w_hi  # higher threshold -> narrower printed feature
+
+
+@needs_fmmax
+def test_peb_diffusion_smooths():
+    """A larger PEB diffusion length blurs the aerial image before development, so its modulation shrinks and
+    the printed pattern loses contrast (max−min) — the defining effect of acid diffusion."""
+
+    def contrast(img):
+        a = np.asarray(img)
+        return float(a.max() - a.min())
+
+    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
+    lo, hi, span = _aerial_band(sol, NA=0.6, source=0.4)
+    thr, k = 0.5 * (lo + hi), 12.0 / span
+    c0 = contrast(sol.printed(NA=0.6, source=0.4, threshold=thr, steepness=k, diffusion=0.0))
+    c1 = contrast(sol.printed(NA=0.6, source=0.4, threshold=thr, steepness=k, diffusion=1.0))
+    assert c1 < c0
+
+
+@needs_fmmax
+def test_printed_is_differentiable_ilt():
+    """The full computational-lithography chain is differentiable: jax.grad of a printed-resist functional
+    w.r.t. the mask permittivity matches finite difference — the gradient flows through development, imaging
+    AND the RCWA mask solve (the point of the resist model: ILT/SMO with the resist in the loop)."""
+    cons, ep = _ilt_cons()
+    rc = jno.rcwa(cons, orders=60, grid=56, params={"ep": 2.0})
+    lo, hi, span = _aerial_band(rc.solve(params={"ep": 2.0}), NA=0.6, source=0.5)  # band at the eval point
+    thr, k = 0.5 * (lo + hi), 6.0 / span  # threshold in-band + moderate contrast -> the sigmoid stays active
+    node = rc.solve().printed(NA=0.6, source=0.5, threshold=thr, diffusion=0.1, steepness=k)
+    assert isinstance(node, FunctionCall)
+    g, fd = _grad_vs_fd(node, ep)
+    assert g == pytest.approx(fd, rel=5e-3)
     assert abs(g) > 1e-3

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -394,3 +394,43 @@ def test_bulk_absorption_decays():
     vol = np.asarray(exp.bulk(jno.litho.Film(n_resist=1.7 + 0.15j, thickness=2.0, n_substrate=1.7 + 0.15j, nz=12)))
     depth_mean = vol.mean((0, 1))  # mean over (x, y) at each depth
     assert depth_mean[-1] < depth_mean[0]  # absorbed with depth
+
+
+class _FakeExposure:  # a stub exposure carrying a prescribed bulk image, for testing the 3-D PEB directly
+    def __init__(self, bulk, period):
+        self._bulk, self.period = bulk, period
+
+    def bulk(self, film):
+        return self._bulk
+
+
+def test_caresist_3d_develops_exposed_stripe():
+    """The 3-D CAResist (a jno.Shape box, periodic in x,y, species diffusing in x,y AND z) develops a printed
+    pattern: seeded from a bulk image with a bright exposed stripe in x, the exposed region clears more. A stub
+    exposure gives unambiguous contrast — fast, deterministic, no RCWA solve needed."""
+    G, nz = 24, 6
+    xs = (np.arange(G) + 0.5) / G
+    band = np.where((xs > 0.3) & (xs < 0.7), 1.0, 0.05)  # bright exposed stripe in x, uniform in y and z
+    bulk = jnp.asarray(band[:, None, None] * np.ones((1, G, nz)))
+    film = jno.litho.Film(n_resist=1.6, thickness=0.6, nz=nz)
+    resist = jno.litho.CAResist(n=16, t_peb=20.0, steps=6, dill_c=4.0, diffusion_length=(0.12, 0.08), film=film)
+    dev = np.asarray(resist(_FakeExposure(bulk, (1.2, 1.2))))
+    assert dev.shape == (16, 16, nz) and np.all(np.isfinite(dev))
+    assert dev.min() >= -0.05 and dev.max() <= 1.05  # small P1 overshoot at the sharp synthetic band edge
+    prof, nn = dev.mean((1, 2)), dev.shape[0]  # x-profile
+    mid = prof[nn // 4 : 3 * nn // 4].mean()  # exposed stripe (centre in x)
+    edge = np.concatenate([prof[: nn // 4], prof[3 * nn // 4 :]]).mean()
+    assert mid > edge + 0.02  # exposed stripe clears more than the unexposed edges
+
+
+@needs_fmmax
+def test_caresist_3d_end_to_end():
+    """The 3-D PEB wires end to end through the real optics: exp.develop(CAResist(film=...)) reads the
+    standing-wave bulk image, solves the 3-D reaction-diffusion PEB on a jno.Shape box (periodic x,y via a
+    conforming remesh), and returns a finite developed (n, n, nz) volume in [0, 1]."""
+    exp = jno.rcwa(_cons(_line), orders=40, grid=40).solve().expose(NA=0.6, source=0.4)
+    film = jno.litho.Film(n_resist=1.6, thickness=0.6, n_substrate=4.0, nz=6)
+    resist = jno.litho.CAResist(n=14, t_peb=15.0, steps=4, dill_c=4.0, diffusion_length=(0.12, 0.08), film=film)
+    dev = np.asarray(exp.develop(resist))
+    assert dev.shape == (14, 14, 6) and np.all(np.isfinite(dev))
+    assert dev.min() >= -1e-3 and dev.max() <= 1.0 + 1e-3

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -1,0 +1,183 @@
+"""jno.rcwa aerial imaging — sol.aerial(): the partially-coherent litho image on top of the rigorous mask.
+
+The RCWA solve gives the mask's diffraction spectrum; ``sol.aerial(NA, source, …)`` projects it through a
+lens (NA + pupil) and sums over the illumination (Abbe) to form the wafer-plane intensity. Validated against
+the imaging limits (open frame → uniform; partial coherence reduces contrast) and differentiable in the mask
+design (ILT) — jax.grad of an image functional matches finite difference.
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
+
+import equinox as eqx  # noqa: E402
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+from jno.trace import FunctionCall  # noqa: E402
+from jno.trace_evaluator import TraceEvaluator  # noqa: E402
+from jno.utils.solver.fem_adapt import _domain_from_arrays  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+K0 = 2 * jnp.pi
+LZ = 3.0
+P = 2.8  # mask period (non-integer × wavelength -> avoids a Rayleigh anomaly)
+
+
+def _sbox(dx=0.07, ny=5):
+    xs = np.linspace(0, P, int(round(P / dx)) + 1)
+    ys = np.linspace(0, P, ny)
+    zs = np.linspace(0, LZ, int(round(LZ / 0.2)) + 1)
+    nx, nyy, nz = len(xs), len(ys), len(zs)
+    X, Y, Z = np.meshgrid(xs, ys, zs, indexing="ij")
+    Pt = np.stack([X.ravel(), Y.ravel(), Z.ravel()], 1)
+    vid = lambda i, j, k: (i * nyy + j) * nz + k  # noqa: E731
+    CUBE = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0), (0, 0, 1), (1, 0, 1), (0, 1, 1), (1, 1, 1)]
+    TE = [(0, 1, 3, 7), (0, 1, 5, 7), (0, 2, 3, 7), (0, 2, 6, 7), (0, 4, 5, 7), (0, 4, 6, 7)]
+    tets = []
+    for i in range(nx - 1):
+        for j in range(nyy - 1):
+            for k in range(nz - 1):
+                c = [vid(i + a, j + b, k + cc) for (a, b, cc) in CUBE]
+                tets += [[c[t[0]], c[t[1]], c[t[2]], c[t[3]]] for t in TE]
+    tets = np.asarray(tets)
+    F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
+    uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
+    d = _domain_from_arrays(
+        jno.domain.cube(x_range=(0, P), y_range=(0, P), z_range=(0, LZ), mesh_size=0.2), Pt, tets, uq[cnt == 1], copy=True
+    )
+    e = 1e-6
+    for nm, f in [
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > LZ - e),
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > P - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > P - e),
+    ]:
+        d.tag(nm, f)
+    return d
+
+
+def _cons(eps_fn, amp=None):
+    d = _sbox()
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def fc(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = fc("bottom")
+    utp, vtp = fc("top")
+    ul, _ = fc("left")
+    ur, _ = fc("right")
+    uf, _ = fc("front")
+    ub, _ = fc("back")
+    eps = jno.fn(eps_fn, [xi, yi, zi])
+    return [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ub,
+    ]
+
+
+def _line(x, y, z):  # a 1-D line/space grating (lines in x, uniform in y), eps=2 lines
+    return jnp.where((jnp.abs(x - P / 2) < P * 0.28) & (z >= 1.0) & (z < 1.2), 2.0, 1.0)
+
+
+def _open(x, y, z):  # open frame (uniform vacuum -> a clear mask)
+    return 1.0 + 0.0 * z
+
+
+def _contrast(img):
+    prof = np.asarray(img).mean(1)  # average over y (grating uniform in y)
+    return (prof.max() - prof.min()) / (prof.max() + prof.min())
+
+
+@needs_fmmax
+def test_open_frame_gives_uniform_image():
+    """A clear (open-frame) mask images to a UNIFORM aerial image — no structure to diffract."""
+    img = np.asarray(jno.rcwa(_cons(_open), orders=40, grid=48).solve().aerial(NA=0.6, source=0.5))
+    assert (img.max() - img.min()) / (img.mean() + 1e-12) < 1e-3
+
+
+@needs_fmmax
+def test_partial_coherence_reduces_contrast():
+    """Increasing the partial-coherence factor σ (a larger conventional source) reduces the image contrast —
+    the defining behaviour of partially-coherent imaging."""
+    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
+    c_lo = _contrast(sol.aerial(NA=0.6, source=0.2))
+    c_hi = _contrast(sol.aerial(NA=0.6, source=0.9))
+    assert c_lo > c_hi > 0.0  # contrast drops with σ, but the grating is still resolved
+
+
+@needs_fmmax
+def test_source_shapes_run():
+    """Conventional (float), annular (tuple), and a raw pupil-weight array all form a valid image."""
+    sol = jno.rcwa(_cons(_line), orders=40, grid=48).solve()
+    conv = sol.aerial(NA=0.6, source=0.5)
+    ann = sol.aerial(NA=0.6, source=(0.4, 0.8))
+    arr = sol.aerial(NA=0.6, source=np.ones((15, 15)))  # freeform pupil
+    for im in (conv, ann, arr):
+        im = np.asarray(im)
+        assert im.shape == (128, 128) and np.all(np.isfinite(im)) and im.min() >= 0.0
+
+
+@needs_fmmax
+def test_aerial_is_differentiable_ilt():
+    """The aerial image is differentiable in the mask design (inverse lithography): rc.solve().aerial() is a
+    trace node, and jax.grad of an image functional w.r.t. a mask parameter matches a finite difference —
+    the gradient flows through the imaging AND the RCWA mask solve."""
+    d = _sbox()
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def fc(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = fc("bottom")
+    utp, vtp = fc("top")
+    ul, _ = fc("left")
+    ur, _ = fc("right")
+    uf, _ = fc("front")
+    ub, _ = fc("back")
+    ep = jno.np.parameter((), name="ep").initialize(jax.nn.initializers.constant(2.0))
+    ind = jno.fn(
+        lambda x, y, z: jnp.where((jnp.abs(x - P / 2) < P * 0.28) & (z >= 1.0) & (z < 1.2), 1.0, 0.0), [xi, yi, zi]
+    )
+    eps = 1.0 + ind * (ep - 1.0)
+    cons = [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ub,
+    ]
+    rc = jno.rcwa(cons, orders=60, grid=56, params={"ep": 2.0})
+    node = rc.solve().aerial(NA=0.6, source=0.5)
+    assert isinstance(node, FunctionCall)
+
+    def loss(v):
+        mod = eqx.tree_at(lambda m: m.value, ep.model.module, jnp.asarray(v))
+        return jnp.mean(TraceEvaluator({ep.model.layer_id: mod}).evaluate(node) ** 2)
+
+    g = float(jax.grad(loss)(2.0))
+    h = 1e-2
+    fd = (float(loss(2.0 + h)) - float(loss(2.0 - h))) / (2 * h)
+    assert g == pytest.approx(fd, rel=3e-3)
+    assert abs(g) > 1e-3

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -320,3 +320,28 @@ def test_printed_is_differentiable_ilt():
     g, fd = _grad_vs_fd(node, ep)
     assert g == pytest.approx(fd, rel=5e-3)
     assert abs(g) > 1e-3
+
+
+def test_caresist_validation():
+    """CAResist rejects a bad tone or a wrong-length rate-constant tuple (cheap — no solve)."""
+    with pytest.raises(ValueError):
+        jno.litho.CAResist(tone="sideways")
+    with pytest.raises(ValueError):
+        jno.litho.CAResist(k=(0.5, 0.005, 0.005))  # needs (k1..k5)
+
+
+@needs_fmmax
+def test_caresist_develops_exposed_band():
+    """The rigorous 3-species reaction-diffusion PEB resist plugs into the same develop() seam and prints:
+    exp.develop(CAResist) runs the coupled transient jno.fem PEB seeded by the Dill latent acid from this
+    exposure, returns a developed pattern in [0, 1], and the exposed (grating-line) band clears more than the
+    unexposed edges (positive tone: exposure -> acid -> deprotection -> soluble)."""
+    exp = jno.rcwa(_cons(_line), orders=40, grid=40).solve().expose(NA=0.6, source=0.4)
+    resist = jno.litho.CAResist(n=20, t_peb=20.0, steps=8, dill_c=4.0, diffusion_length=(0.12, 0.08))
+    dev = np.asarray(exp.develop(resist))
+    assert dev.shape == (20, 20) and np.all(np.isfinite(dev))
+    assert dev.min() >= -1e-3 and dev.max() <= 1.0 + 1e-3  # developed fraction in [0, 1]
+    prof, nn = dev.mean(1), dev.shape[0]  # x-profile (grating uniform in y)
+    mid = prof[nn // 4 : 3 * nn // 4].mean()  # the exposed line band (centre in x)
+    edge = np.concatenate([prof[: nn // 4], prof[3 * nn // 4 :]]).mean()
+    assert mid > edge + 0.02  # exposed band clears more than the unexposed edges

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -136,6 +136,49 @@ def test_source_shapes_run():
         assert im.shape == (128, 128) and np.all(np.isfinite(im)) and im.min() >= 0.0
 
 
+def _nrm(img):  # image normalised to unit mean, to compare shape/contrast independent of total energy
+    a = np.asarray(img)
+    return a / (a.mean() + 1e-12)
+
+
+@needs_fmmax
+def test_vector_reduces_to_scalar_as_na_drops():
+    """The vector (high-NA) image must reduce to the scalar one as NA→0: the pupil becomes the identity and
+    E_z→0. So the (energy-normalised) x-polarised vector image departs from the scalar image LESS at low NA
+    than at high NA -- the defining consistency check of the Richards-Wolf/Flagello vector model."""
+    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
+
+    def dev(NA):  # normalised L2 departure of the vector-x image from the scalar image
+        sc, vx = _nrm(sol.aerial(NA=NA, source=0.3)), _nrm(sol.aerial(NA=NA, source=0.3, polarization="x"))
+        return float(np.linalg.norm(vx - sc) / np.linalg.norm(sc))
+
+    assert dev(0.4) < dev(0.75)  # closer to scalar at lower NA (smaller ray angles)
+
+
+@needs_fmmax
+def test_vector_tm_te_contrast_split():
+    """The vector signature at high NA: for a grating periodic in x (orders spread in the x–z plane), x-pol is
+    TM (E tilts with the ray → the interfering beams lose projection → lower contrast) and y-pol is TE (E stays
+    parallel → full contrast). So TE contrast must exceed TM contrast at high NA."""
+    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
+    c_tm = _contrast(sol.aerial(NA=0.9, source=0.3, polarization="x"))  # TM (E in plane of incidence)
+    c_te = _contrast(sol.aerial(NA=0.9, source=0.3, polarization="y"))  # TE (E out of plane)
+    assert c_te > c_tm > 0.0
+
+
+@needs_fmmax
+def test_vector_pol_shapes_run():
+    """'x', 'y' and 'unpolarized' all form a valid image, and the unpolarized image is exactly the mean of the
+    two linear-polarization images (incoherent averaging)."""
+    sol = jno.rcwa(_cons(_line), orders=40, grid=48).solve()
+    ix = np.asarray(sol.aerial(NA=0.7, source=0.5, polarization="x"))
+    iy = np.asarray(sol.aerial(NA=0.7, source=0.5, polarization="y"))
+    iu = np.asarray(sol.aerial(NA=0.7, source=0.5, polarization="unpolarized"))
+    for im in (ix, iy, iu):
+        assert im.shape == (128, 128) and np.all(np.isfinite(im)) and im.min() >= 0.0
+    assert np.allclose(iu, 0.5 * (ix + iy), rtol=1e-6, atol=1e-9)
+
+
 @needs_fmmax
 def test_aerial_is_differentiable_ilt():
     """The aerial image is differentiable in the mask design (inverse lithography): rc.solve().aerial() is a

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -360,3 +360,37 @@ def test_caresist_is_differentiable_ilt():
     g, fd = _grad_vs_fd(node, ep)
     assert g == pytest.approx(fd, rel=5e-3)
     assert abs(g) > 1e-4
+
+
+@needs_fmmax
+def test_bulk_reduces_to_aerial_at_top():
+    """The standing-wave bulk image reduces to the aerial image at the top of a vacuum film (z=0, no substrate
+    reflection): exposure.bulk(vacuum)[:, :, 0] == exposure.intensity()."""
+    exp = jno.rcwa(_cons(_line), orders=40, grid=40).solve().expose(NA=0.6, source=0.4)
+    aer = np.asarray(exp.intensity())
+    vol = np.asarray(exp.bulk(jno.litho.Film(n_resist=1.0, thickness=1.0, n_substrate=1.0, nz=6)))
+    assert vol.shape == (aer.shape[0], aer.shape[1], 6)
+    assert np.allclose(vol[:, :, 0], aer, rtol=1e-6, atol=1e-9)
+
+
+@needs_fmmax
+def test_bulk_standing_wave_period():
+    """A reflective substrate makes each order interfere with its reflection → a vertical STANDING WAVE of
+    period λ/(2·n_resist). Open frame (single order), n_resist=1.7, wl=1 (K0=2π) → period ≈ 0.294."""
+    nr, d, nz = 1.7, 2.0, 64
+    exp = jno.rcwa(_cons(_open), orders=20, grid=24).solve().expose(NA=0.4, source=0.3)
+    vol = np.asarray(exp.bulk(jno.litho.Film(n_resist=nr, thickness=d, n_substrate=4.0, nz=nz)))
+    Iz = vol[vol.shape[0] // 2, vol.shape[1] // 2, :]  # I(z) at a pixel
+    Iz = Iz - Iz.mean()
+    period = 1.0 / np.fft.rfftfreq(nz, d=d / (nz - 1))[1:][np.argmax(np.abs(np.fft.rfft(Iz))[1:])]
+    assert period == pytest.approx(1.0 / (2 * nr), rel=0.15)
+
+
+@needs_fmmax
+def test_bulk_absorption_decays():
+    """An absorbing resist (complex n_resist), index-matched to the substrate (no reflection), attenuates the
+    field with depth: the depth-averaged intensity at the film bottom is below the top."""
+    exp = jno.rcwa(_cons(_open), orders=20, grid=24).solve().expose(NA=0.4, source=0.3)
+    vol = np.asarray(exp.bulk(jno.litho.Film(n_resist=1.7 + 0.15j, thickness=2.0, n_substrate=1.7 + 0.15j, nz=12)))
+    depth_mean = vol.mean((0, 1))  # mean over (x, y) at each depth
+    assert depth_mean[-1] < depth_mean[0]  # absorbed with depth

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -322,6 +322,24 @@ def test_printed_is_differentiable_ilt():
     assert abs(g) > 1e-3
 
 
+@needs_fmmax
+def test_vector_printed_is_differentiable_ilt():
+    """**Vector high-NA** imaging is differentiable inside the parametric ILT node: jax.grad of an
+    unpolarized (TE+TM) printed-resist functional w.r.t. the mask permittivity matches finite difference —
+    so vector high-NA ILT/SMO trains, not just the scalar model. Guards the vector-pupil sqrt(0) safe-guard
+    (the gradient is NaN without it) and, at a converged truncation, the (hypersensitive) y-polarization path."""
+    cons, ep = _ilt_cons()
+    rc = jno.rcwa(cons, orders=60, grid=56, params={"ep": 2.0})
+    lo, hi, span = _aerial_band(rc.solve(params={"ep": 2.0}), NA=0.6, source=0.5, polarization="unpolarized")
+    resist = jno.litho.Threshold(threshold=0.5 * (lo + hi), diffusion=0.1, steepness=6.0 / span)
+    node = rc.solve().printed(NA=0.6, source=0.5, polarization="unpolarized", resist=resist)
+    assert isinstance(node, FunctionCall)
+    g, fd = _grad_vs_fd(node, ep)
+    assert np.isfinite(g)  # sqrt(0) in the vector pupil makes this NaN without the safe-sqrt guard
+    assert g == pytest.approx(fd, rel=1e-2)
+    assert abs(g) > 1e-3
+
+
 def test_caresist_validation():
     """CAResist rejects a bad tone or a wrong-length rate-constant tuple (cheap — no solve)."""
     with pytest.raises(ValueError):

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -345,3 +345,18 @@ def test_caresist_develops_exposed_band():
     mid = prof[nn // 4 : 3 * nn // 4].mean()  # the exposed line band (centre in x)
     edge = np.concatenate([prof[: nn // 4], prof[3 * nn // 4 :]]).mean()
     assert mid > edge + 0.02  # exposed band clears more than the unexposed edges
+
+
+@needs_fmmax
+def test_caresist_is_differentiable_ilt():
+    """ILT through the RIGOROUS resist: jax.grad of a developed-pattern loss w.r.t. the mask permittivity
+    matches finite difference through the WHOLE chain — RCWA mask solve → aerial image → Dill latent acid →
+    transient reaction-diffusion PEB → developed M. This end-to-end gradient (design the mask against the
+    physically-baked pattern) is exactly what a forward-only litho simulator cannot provide."""
+    cons, ep = _ilt_cons()
+    resist = jno.litho.CAResist(n=12, t_peb=15.0, steps=4, dill_c=4.0, diffusion_length=(0.12, 0.08))
+    node = jno.rcwa(cons, orders=30, grid=24, params={"ep": 2.0}).solve().printed(NA=0.6, source=0.5, resist=resist)
+    assert isinstance(node, FunctionCall)
+    g, fd = _grad_vs_fd(node, ep)
+    assert g == pytest.approx(fd, rel=5e-3)
+    assert abs(g) > 1e-4

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -246,13 +246,33 @@ def _aerial_band(sol, **kw):  # the (min, max, span) of this mask's aerial inten
     return lo, hi, max(hi - lo, 1e-9)
 
 
+def _aerial_band_exp(exp):  # same band, read from an exposure object's intensity
+    a = np.asarray(exp.intensity())
+    lo, hi = float(a.min()), float(a.max())
+    return lo, hi, max(hi - lo, 1e-9)
+
+
+@needs_fmmax
+def test_develop_matches_printed_shortcut():
+    """The exposure/develop seam and the printed() shortcut are the same computation: exposing then
+    developing with a Threshold resist equals printed(resist=that Threshold)."""
+    sol = jno.rcwa(_cons(_line), orders=40, grid=48).solve()
+    r = jno.litho.Threshold(threshold=0.3, diffusion=0.02, steepness=40.0)
+    exp = sol.expose(NA=0.6, source=0.4)
+    via_develop = np.asarray(exp.develop(r))
+    via_printed = np.asarray(sol.printed(NA=0.6, source=0.4, resist=r))
+    assert np.allclose(via_develop, via_printed, rtol=1e-10, atol=1e-12)
+    assert np.allclose(np.asarray(exp.intensity()), np.asarray(sol.aerial(NA=0.6, source=0.4)))  # optics = aerial
+
+
 @needs_fmmax
 def test_printed_is_in_range_and_structured():
-    """The developed resist image (sol.printed) is a soft mask in [0, 1] and thresholds the line grating into
-    a printed feature — both cleared (≈0) and remaining (≈1) resist are present."""
+    """The developed resist image (via a Threshold resist) is a soft mask in [0, 1] and thresholds the line
+    grating into a printed feature — both cleared (≈0) and remaining (≈1) resist are present."""
     sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
     lo, hi, span = _aerial_band(sol, NA=0.6, source=0.4)
-    img = np.asarray(sol.printed(NA=0.6, source=0.4, threshold=0.5 * (lo + hi), steepness=24.0 / span))
+    r = jno.litho.Threshold(threshold=0.5 * (lo + hi), steepness=24.0 / span)
+    img = np.asarray(sol.expose(NA=0.6, source=0.4).develop(r))
     assert img.min() >= 0.0 and img.max() <= 1.0 and np.all(np.isfinite(img))
     assert img.min() < 0.05 and img.max() > 0.95  # a real bilevel pattern, not a flat grey
 
@@ -260,11 +280,11 @@ def test_printed_is_in_range_and_structured():
 @needs_fmmax
 def test_threshold_sets_linewidth():
     """Raising the dose-to-clear threshold shrinks the printed feature — the CD knob is monotone."""
-    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
-    lo, _hi, span = _aerial_band(sol, NA=0.6, source=0.4)
+    exp = jno.rcwa(_cons(_line), orders=60, grid=56).solve().expose(NA=0.6, source=0.4)
+    lo, _hi, span = _aerial_band_exp(exp)
     k = 24.0 / span
-    w_lo = _linewidth(sol.printed(NA=0.6, source=0.4, threshold=lo + 0.35 * span, steepness=k))
-    w_hi = _linewidth(sol.printed(NA=0.6, source=0.4, threshold=lo + 0.65 * span, steepness=k))
+    w_lo = _linewidth(exp.develop(jno.litho.Threshold(threshold=lo + 0.35 * span, steepness=k)))
+    w_hi = _linewidth(exp.develop(jno.litho.Threshold(threshold=lo + 0.65 * span, steepness=k)))
     assert w_lo > w_hi  # higher threshold -> narrower printed feature
 
 
@@ -277,11 +297,11 @@ def test_peb_diffusion_smooths():
         a = np.asarray(img)
         return float(a.max() - a.min())
 
-    sol = jno.rcwa(_cons(_line), orders=60, grid=56).solve()
-    lo, hi, span = _aerial_band(sol, NA=0.6, source=0.4)
+    exp = jno.rcwa(_cons(_line), orders=60, grid=56).solve().expose(NA=0.6, source=0.4)
+    lo, hi, span = _aerial_band_exp(exp)
     thr, k = 0.5 * (lo + hi), 12.0 / span
-    c0 = contrast(sol.printed(NA=0.6, source=0.4, threshold=thr, steepness=k, diffusion=0.0))
-    c1 = contrast(sol.printed(NA=0.6, source=0.4, threshold=thr, steepness=k, diffusion=1.0))
+    c0 = contrast(exp.develop(jno.litho.Threshold(threshold=thr, steepness=k, diffusion=0.0)))
+    c1 = contrast(exp.develop(jno.litho.Threshold(threshold=thr, steepness=k, diffusion=1.0)))
     assert c1 < c0
 
 
@@ -294,7 +314,8 @@ def test_printed_is_differentiable_ilt():
     rc = jno.rcwa(cons, orders=60, grid=56, params={"ep": 2.0})
     lo, hi, span = _aerial_band(rc.solve(params={"ep": 2.0}), NA=0.6, source=0.5)  # band at the eval point
     thr, k = 0.5 * (lo + hi), 6.0 / span  # threshold in-band + moderate contrast -> the sigmoid stays active
-    node = rc.solve().printed(NA=0.6, source=0.5, threshold=thr, diffusion=0.1, steepness=k)
+    resist = jno.litho.Threshold(threshold=thr, diffusion=0.1, steepness=k)
+    node = rc.solve().printed(NA=0.6, source=0.5, resist=resist)
     assert isinstance(node, FunctionCall)
     g, fd = _grad_vs_fd(node, ep)
     assert g == pytest.approx(fd, rel=5e-3)

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -434,3 +434,18 @@ def test_caresist_3d_end_to_end():
     dev = np.asarray(exp.develop(resist))
     assert dev.shape == (14, 14, 6) and np.all(np.isfinite(dev))
     assert dev.min() >= -1e-3 and dev.max() <= 1.0 + 1e-3
+
+
+@needs_fmmax
+def test_caresist_3d_is_differentiable_ilt():
+    """ILT through the 3-D PEB: jax.grad of a developed-volume loss w.r.t. the mask permittivity matches
+    finite difference through the WHOLE chain — RCWA solve → standing-wave bulk image → 3-D reaction-diffusion
+    PEB on a jno.Shape box → developed volume. The rigorous depth-resolved resist stays fully differentiable."""
+    cons, ep = _ilt_cons()
+    film = jno.litho.Film(n_resist=1.6, thickness=0.6, n_substrate=4.0, nz=4)
+    resist = jno.litho.CAResist(n=8, t_peb=10.0, steps=3, dill_c=4.0, diffusion_length=(0.12, 0.08), film=film)
+    node = jno.rcwa(cons, orders=30, grid=24, params={"ep": 2.0}).solve().printed(NA=0.6, source=0.5, resist=resist)
+    assert isinstance(node, FunctionCall)
+    g, fd = _grad_vs_fd(node, ep)
+    assert g == pytest.approx(fd, rel=5e-3)
+    assert abs(g) > 1e-4

--- a/tests/test_rcwa_general_anisotropic.py
+++ b/tests/test_rcwa_general_anisotropic.py
@@ -1,0 +1,79 @@
+"""jno.rcwa engine with a GENERAL anisotropic layer — both ε̂ and μ̂ tensors, via fmmax's
+``eigensolve_general_anisotropic_media`` (10 component grids: ε_xx..ε_zz, μ_xx..μ_zz).
+
+This is the engine foundation for an in-plane uniaxial PML (a coordinate stretch is a diagonal ε̂ AND
+μ̂) and for magnetic / magneto-optic media. A general layer with μ̂ = I must reduce exactly to the
+ε-only anisotropic path; a genuine μ̂ ≠ I must change the result (magnetic response actually enters).
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
+
+import jax  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+from jno.rcwa import Rcwa  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+
+PERIOD = (0.6, 0.6)
+WL, ORDERS, D = 1.0, 60, 0.35
+EPS = 6.0
+
+
+def _T(layers):
+    sol = Rcwa(layers, period=PERIOD, orders=ORDERS, wavelength=WL, assume_periodic=True).solve()
+    return float(sol.efficiency("T")), float(sol.efficiency("R"))
+
+
+def _iso(eps):
+    return [(float("inf"), 1.0), (D, eps), (float("inf"), 1.0)]
+
+
+def _aniso5(eps):  # (ε_xx, ε_xy, ε_yx, ε_yy, ε_zz)
+    return [(float("inf"), 1.0), (D, (eps, 0.0, 0.0, eps, eps)), (float("inf"), 1.0)]
+
+
+def _general10(eps, mu):  # (ε_xx..ε_zz, μ_xx..μ_zz) with diagonal μ̂ = μ·I
+    slab = (eps, 0.0, 0.0, eps, eps, mu, 0.0, 0.0, mu, mu)
+    return [(float("inf"), 1.0), (D, slab), (float("inf"), 1.0)]
+
+
+@needs_fmmax
+def test_general_mu_one_reduces_to_anisotropic():
+    """μ̂ = I in the 10-tuple general layer must give exactly the ε-only anisotropic (5-tuple) result —
+    the general eigensolve reduces to the anisotropic one when the medium is non-magnetic."""
+    Tg, Rg = _T(_general10(EPS, 1.0))
+    Ta, Ra = _T(_aniso5(EPS))
+    assert Tg == pytest.approx(Ta, abs=1e-6)
+    assert Rg == pytest.approx(Ra, abs=1e-6)
+
+
+@needs_fmmax
+def test_general_mu_one_matches_isotropic():
+    """And with ε̂ = ε·I, μ̂ = I it matches the plain isotropic slab — full reduction to the scalar path."""
+    Tg, Rg = _T(_general10(EPS, 1.0))
+    Ti, Ri = _T(_iso(EPS))
+    assert Tg == pytest.approx(Ti, abs=1e-6)
+    assert Rg == pytest.approx(Ri, abs=1e-6)
+
+
+@needs_fmmax
+def test_magnetic_mu_changes_result():
+    """A genuine μ̂ ≠ I changes the response: μ alters the wave impedance √(μ/ε), so reflection differs from
+    the non-magnetic slab. Proves μ actually enters the solve (not silently dropped)."""
+    Tn, Rn = _T(_general10(EPS, 1.0))
+    Tm, Rm = _T(_general10(EPS, 2.0))
+    assert abs(Rm - Rn) > 1e-2
+
+
+@needs_fmmax
+def test_general_lossless_conserves_energy():
+    """A lossless general-anisotropic slab (real ε̂, μ̂) conserves energy: T + R ≈ 1."""
+    T, R = _T(_general10(EPS, 2.0))
+    assert T + R == pytest.approx(1.0, abs=5e-3)

--- a/tests/test_rcwa_incidence.py
+++ b/tests/test_rcwa_incidence.py
@@ -1,0 +1,122 @@
+"""Regression for the RCWA incident-mode fix (excite the true 0th order, not the max-flux eigenmode).
+
+The engine used to pick its incident plane wave by argmax(eigenmode_poynting_flux). That is only correct for
+a subwavelength (single propagating order) cell; once the period exceeds the wavelength, several ambient
+orders propagate and the (0,0) order does NOT carry the max eigenmode flux, so argmax excited an OBLIQUE
+order. This test uses period > λ (multiple orders) and checks the uniform slab transmits per the analytic
+Airy formula at NORMAL incidence -- which the old code got wrong (it gave the oblique-angle transmission).
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+from jno.utils.solver.fem_adapt import _domain_from_arrays  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+K0 = 2 * jnp.pi
+LZ = 3.0
+EPS = 6.0  # a-Si-like slab
+Z0, Z1 = 1.0, 2.0  # slab z-range (structured mesh puts nodes on 1.0 and 2.0)
+
+
+def _slab_sol(period, orders=80, grid=64):
+    """A uniform (laterally featureless) slab of the given transverse period, on a structured mesh."""
+    P = period
+    xs = np.linspace(0, P, int(round(P / 0.1)) + 1)
+    zs = np.linspace(0, LZ, int(round(LZ / 0.2)) + 1)
+    ny, nz = len(xs), len(zs)
+    X, Y, Z = np.meshgrid(xs, xs, zs, indexing="ij")
+    Pt = np.stack([X.ravel(), Y.ravel(), Z.ravel()], 1)
+    vid = lambda i, j, k: (i * ny + j) * nz + k  # noqa: E731
+    CUBE = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0), (0, 0, 1), (1, 0, 1), (0, 1, 1), (1, 1, 1)]
+    TE = [(0, 1, 3, 7), (0, 1, 5, 7), (0, 2, 3, 7), (0, 2, 6, 7), (0, 4, 5, 7), (0, 4, 6, 7)]
+    tets = []
+    for i in range(len(xs) - 1):
+        for j in range(len(xs) - 1):
+            for k in range(nz - 1):
+                c = [vid(i + a, j + b, k + cc) for (a, b, cc) in CUBE]
+                tets += [[c[t[0]], c[t[1]], c[t[2]], c[t[3]]] for t in TE]
+    tets = np.asarray(tets)
+    F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
+    uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
+    d = _domain_from_arrays(
+        jno.domain.cube(x_range=(0, P), y_range=(0, P), z_range=(0, LZ), mesh_size=0.2), Pt, tets, uq[cnt == 1], copy=True
+    )
+    e = 1e-6
+    for nm, f in [
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > LZ - e),
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > P - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > P - e),
+    ]:
+        d.tag(nm, f)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def fc(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = fc("bottom")
+    utp, vtp = fc("top")
+    ul, _ = fc("left")
+    ur, _ = fc("right")
+    uf, _ = fc("front")
+    ub, _ = fc("back")
+    eps = jno.fn(lambda x, y, z: jnp.where((z >= Z0) & (z < Z1), EPS, 1.0), [xi, yi, zi])
+    cons = [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ub,
+    ]
+    return jno.rcwa(cons, orders=orders, grid=grid)
+
+
+def _airy_T(n, d, cos_theta=1.0):
+    """Analytic slab transmission at incidence angle with cosine ``cos_theta`` (1 = normal)."""
+    k0 = float(K0)
+    kz = n * k0 * cos_theta  # simplistic angle handling for the discriminator (normal vs oblique)
+    r = (1 - n) / (1 + n)
+    ph = np.exp(2j * kz * d)
+    rho = r * (1 - ph) / (1 - r**2 * ph)
+    return float(1 - abs(rho) ** 2)
+
+
+@needs_fmmax
+def test_multi_order_slab_matches_normal_incidence_airy():
+    """Period 1.6 > λ=1 -> the (±1,0),(0,±1) ambient orders propagate. The uniform slab must still transmit
+    per the exact Airy formula at NORMAL incidence (matched at the slab's inferred thickness). The old
+    argmax-flux incident excited an oblique order and would give the wrong-angle transmission here."""
+    rc = _slab_sol(period=1.6)
+    n_eff = float(np.sqrt(np.real(np.mean(np.asarray(rc.spec.layers[1][1])))))
+    d_eff = float(rc.spec.layers[1][0])
+    T = float(rc.solve().efficiency("T"))
+    assert T == pytest.approx(_airy_T(n_eff, d_eff, cos_theta=1.0), abs=2e-3)  # normal-incidence Airy
+
+
+@needs_fmmax
+def test_subwavelength_slab_still_matches_airy():
+    """Control: a subwavelength cell (single order) also matches normal Airy -- the fix leaves the case the
+    old code already handled unchanged."""
+    rc = _slab_sol(period=0.5, orders=20, grid=24)
+    n_eff = float(np.sqrt(np.real(np.mean(np.asarray(rc.spec.layers[1][1])))))
+    d_eff = float(rc.spec.layers[1][0])
+    assert float(rc.solve().efficiency("T")) == pytest.approx(_airy_T(n_eff, d_eff), abs=2e-3)

--- a/tests/test_rcwa_pml.py
+++ b/tests/test_rcwa_pml.py
@@ -19,6 +19,7 @@ import os
 
 os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
 
+import equinox as eqx  # noqa: E402
 import jax  # noqa: E402
 import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
@@ -28,6 +29,8 @@ jax.config.update("jax_enable_x64", True)
 
 import jno  # noqa: E402
 from jno.rcwa import RcwaError  # noqa: E402
+from jno.trace import FunctionCall  # noqa: E402
+from jno.trace_evaluator import TraceEvaluator  # noqa: E402
 from jno.utils.solver.fem_adapt import _domain_from_arrays  # noqa: E402
 
 HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
@@ -162,6 +165,61 @@ def test_pml_absorbs_laterally_scattered_light():
     Ta, Ra = _TR(_constraints(1.4, 3.0, _scatterer))  # real absorber -> lateral loss
     assert T0 + R0 == pytest.approx(1.0, abs=1e-2)  # σ=0 supercell conserves energy
     assert Ta + Ra < 0.98  # the PML drained laterally-diffracted power
+
+
+@needs_fmmax
+def test_pml_scatterer_is_differentiable():
+    """A design parameter on the SCATTERER inside a PML supercell flows through the solve: the PML layers are
+    re-derived from the parameter (ε̂ = ε·Λ, μ̂ = Λ), rc.solve() is a trace node, and jax.grad of transmission
+    matches a finite difference. This is inverse design of an isolated scatterer."""
+    Lx = 1.4
+    w = 0.35 * Lx
+    d = _structured_box(Lx)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    sx = 3.0 * (relu(w - xi) ** 2 + relu(xi - (Lx - w)) ** 2) / w**2
+    sy = 3.0 * (relu(w - yi) ** 2 + relu(yi - (Lx - w)) ** 2) / w**2
+    Sx, Sy = 1.0 + 1j * sx / K0, 1.0 + 1j * sy / K0
+    ep = jno.np.parameter((), name="ep").initialize(jax.nn.initializers.constant(6.0))  # scatterer ε inside the PML
+    ind = jno.fn(
+        lambda x, y, z: jnp.where(
+            (jnp.abs(x - Lx / 2) < 0.18) & (jnp.abs(y - Lx / 2) < 0.18) & (z >= 1.0) & (z < 2.0), 1.0, 0.0
+        ),
+        [xi, yi, zi],
+    )
+    eps = 1.0 + ind * (ep - 1.0)
+    vol = (
+        (Sy / Sx) * (ui.x * vi.x)
+        + (Sx / Sy) * (ui.y * vi.y)
+        + (Sx * Sy) * (ui.z * vi.z)
+        - K0**2 * (Sx * Sy) * eps * (u * vi)
+    )
+    cons = [vol, -(1j * K0 * utp) * vtp, -(1j * K0 * ubt - 2j * K0) * vbt, ul - ur, uf - ub]
+    rc = jno.rcwa(cons, orders=60, grid=30, params={"ep": 6.0})
+    node = rc.solve().efficiency("T")
+    assert isinstance(node, FunctionCall)
+
+    def T(v):
+        mod = eqx.tree_at(lambda m: m.value, ep.model.module, jnp.asarray(v))
+        return TraceEvaluator({ep.model.layer_id: mod}).evaluate(node)
+
+    g = float(jax.grad(T)(6.0))
+    h = 1e-2
+    fd = (float(T(6.0 + h)) - float(T(6.0 - h))) / (2 * h)
+    assert g == pytest.approx(fd, rel=3e-2)
+    assert abs(g) > 1e-3
 
 
 @needs_fmmax

--- a/tests/test_rcwa_pml.py
+++ b/tests/test_rcwa_pml.py
@@ -1,0 +1,189 @@
+"""jno.rcwa with an in-plane PERFECTLY MATCHED LAYER (PML), inferred from the traced weak form.
+
+A PML is a complex coordinate stretch ``S = 1 + iσ/k`` written straight into the scalar Helmholtz
+volume term as anisotropic stiffness coefficients::
+
+    (Sy/Sx)·∂ₓu∂ₓv + (Sx/Sy)·∂ᵧu∂ᵧv + (Sx·Sy)·∂_zu∂_zv − k0²·(Sx·Sy)·ε·(u·v)
+
+The front door reads the stretch Λ = diag(Sy/Sx, Sx/Sy, Sx·Sy) off the stiffness, forms the Maxwell
+uniaxial PML (ε̂ = ε·Λ, μ̂ = Λ), and routes it to fmmax's general anisotropic eigensolve. The Floquet
+ties stay (fmmax is periodic); the PML frame just makes the supercell walls non-coupling, so the cell
+behaves like an isolated scatterer.
+
+Checks: (A) a trivial stretch (σ=0 ⇒ Λ=I) reduces EXACTLY to the scalar no-PML result; (B) a real
+absorber laterally absorbs light diffracted by a scatterer, so T+R drops below 1 while σ=0 conserves it.
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+from jno.rcwa import RcwaError  # noqa: E402
+from jno.utils.solver.fem_adapt import _domain_from_arrays  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+K0 = 2 * jnp.pi
+Z0, Z1, LZ = 1.0, 2.0, 3.0  # slab occupies z in [1, 2]; box height 3
+relu = lambda z: jno.np.maximum(z, 0.0)  # noqa: E731
+
+
+def _structured_box(Lx, dx=0.1, dz=0.2):
+    """A structured tet mesh of an [0,Lx]²×[0,LZ] box (z-nodes land on the layer boundaries)."""
+    xs = np.linspace(0, Lx, int(round(Lx / dx)) + 1)
+    zs = np.linspace(0, LZ, int(round(LZ / dz)) + 1)
+    ny, nz = len(xs), len(zs)
+    X, Y, Z = np.meshgrid(xs, xs, zs, indexing="ij")
+    P = np.stack([X.ravel(), Y.ravel(), Z.ravel()], 1)
+    vid = lambda i, j, k: (i * ny + j) * nz + k  # noqa: E731
+    CUBE = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0), (0, 0, 1), (1, 0, 1), (0, 1, 1), (1, 1, 1)]
+    TETS6 = [(0, 1, 3, 7), (0, 1, 5, 7), (0, 2, 3, 7), (0, 2, 6, 7), (0, 4, 5, 7), (0, 4, 6, 7)]
+    tets = []
+    for i in range(len(xs) - 1):
+        for j in range(len(xs) - 1):
+            for k in range(nz - 1):
+                c = [vid(i + a, j + b, k + cc) for (a, b, cc) in CUBE]
+                tets += [[c[t[0]], c[t[1]], c[t[2]], c[t[3]]] for t in TETS6]
+    tets = np.asarray(tets)
+    F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
+    uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
+    d = _domain_from_arrays(
+        jno.domain.cube(x_range=(0, Lx), y_range=(0, Lx), z_range=(0, LZ), mesh_size=0.2), P, tets, uq[cnt == 1], copy=True
+    )
+    e = 1e-6
+    for nm, f in [
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > LZ - e),
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > Lx - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > Lx - e),
+    ]:
+        d.tag(nm, f)
+    return d
+
+
+def _constraints(Lx, sigma0, eps_fn, w=None):
+    """Scalar Helmholtz on the supercell with an in-plane PML frame of width ``w`` and strength ``sigma0``
+    (``sigma0=0`` ⇒ no absorption). ``eps_fn(x,y,z)`` is the permittivity."""
+    if w is None:
+        w = 0.25 * Lx
+    d = _structured_box(Lx)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    sx = sigma0 * (relu(w - xi) ** 2 + relu(xi - (Lx - w)) ** 2) / w**2  # quadratic profile near x-walls
+    sy = sigma0 * (relu(w - yi) ** 2 + relu(yi - (Lx - w)) ** 2) / w**2
+    Sx, Sy = 1.0 + 1j * sx / K0, 1.0 + 1j * sy / K0  # complex coordinate stretch (=1 in the core)
+    eps = jno.fn(eps_fn, [xi, yi, zi])
+    vol = (
+        (Sy / Sx) * (ui.x * vi.x)
+        + (Sx / Sy) * (ui.y * vi.y)
+        + (Sx * Sy) * (ui.z * vi.z)  # uniaxial 3-D stretch, Sz = 1
+        - K0**2 * (Sx * Sy) * eps * (u * vi)
+    )
+    return [vol, -(1j * K0 * utp) * vtp, -(1j * K0 * ubt - 2j * K0) * vbt, ul - ur, uf - ub]
+
+
+def _uniform(x, y, z):
+    return jnp.where((z >= Z0) & (z < Z1), 6.0, 1.0)  # a-Si slab, no lateral structure
+
+
+def _scatterer(x, y, z):  # a localized off-centre pillar -> diffracts light laterally
+    inpill = (jnp.abs(x - 0.55) < 0.18) & (jnp.abs(y - 0.55) < 0.18)
+    return jnp.where((z >= Z0) & (z < Z1) & inpill, 4.0, 1.0)
+
+
+def _TR(cons, orders=80, grid=32):
+    sol = jno.rcwa(cons, orders=orders, grid=grid).solve()
+    return float(sol.efficiency("T")), float(sol.efficiency("R"))
+
+
+@needs_fmmax
+def test_zero_sigma_pml_reduces_to_scalar():
+    """A PML with σ=0 (S=1 ⇒ Λ=I, μ̂=I, ε̂=ε·I) must give EXACTLY the plain scalar-ε result — the PML
+    detection + general-anisotropic routing reduces correctly when the stretch is trivial."""
+    Tp, Rp = _TR(_constraints(1.2, 0.0, _uniform))  # PML form, σ=0
+    Ts, Rs = _TR([c for c in _scalar_slab(1.2)])  # plain scalar Helmholtz, same slab
+    assert Tp == pytest.approx(Ts, abs=1e-5)
+    assert Rp == pytest.approx(Rs, abs=1e-5)
+
+
+def _scalar_slab(Lx):
+    """The scalar no-PML reference: same box + slab, plain Laplacian stiffness."""
+    d = _structured_box(Lx)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    eps = jno.fn(_uniform, [xi, yi, zi])
+    vol = ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi)
+    return [vol, -(1j * K0 * utp) * vtp, -(1j * K0 * ubt - 2j * K0) * vbt, ul - ur, uf - ub]
+
+
+@needs_fmmax
+def test_pml_absorbs_laterally_scattered_light():
+    """The decisive PML check: for a scatterer that diffracts light into the plane, a real absorber
+    (σ>0) removes the laterally-scattered power, so T+R < 1; with σ=0 the same cell conserves energy
+    (T+R ≈ 1). Proves the PML actually absorbs (it is not a no-op)."""
+    T0, R0 = _TR(_constraints(1.4, 0.0, _scatterer))  # no absorber -> energy conserved
+    Ta, Ra = _TR(_constraints(1.4, 3.0, _scatterer))  # real absorber -> lateral loss
+    assert T0 + R0 == pytest.approx(1.0, abs=1e-2)  # σ=0 supercell conserves energy
+    assert Ta + Ra < 0.98  # the PML drained laterally-diffracted power
+
+
+@needs_fmmax
+def test_pml_raises_on_offdiagonal_stretch():
+    """A cross ∂ₓu ∂ᵧv stiffness term (a non-diagonal stretch) is rejected — only uniaxial PML is supported."""
+    d = _structured_box(1.2)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    eps = jno.fn(_uniform, [xi, yi, zi])
+    vol = ui.x * vi.x + (1.0 + 1j) * (ui.x * vi.y) + ui.z * vi.z - K0**2 * eps * (u * vi)  # off-diagonal ∂ₓu ∂ᵧv
+    cons = [vol, -(1j * K0 * utp) * vtp, -(1j * K0 * ubt - 2j * K0) * vbt, ul - ur, uf - ub]
+    with pytest.raises(RcwaError, match="off-diagonal"):
+        jno.rcwa(cons, orders=20, grid=16)

--- a/tests/test_rcwa_profile.py
+++ b/tests/test_rcwa_profile.py
@@ -1,0 +1,98 @@
+"""rc.solve(orders=…, profile=…) — re-solve at a different Fourier truncation, and JAX performance profiling.
+
+``orders=N`` builds a fresh engine at truncation N (the construction ``orders`` is untouched) — for a
+convergence sweep or profiling at scale. ``profile=True`` runs the solve eagerly inside a JAX Perfetto trace
+(per-stage annotated), prints the problem size + wall time, and writes the trace — mirroring
+``jno.core.solve(profile=True)``.
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+K0 = 2 * jnp.pi
+P, LZ = 1.1, 3.2
+
+
+def _slab_cons():
+    """A uniform a-Si slab (no lateral structure -> converges at tiny truncation, fast)."""
+    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    e = 1e-6
+    for nm, f in [
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > P - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > P - e),
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > LZ - e),
+    ]:
+        d.tag(nm, f)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    eps = jno.fn(lambda x, y, z: jnp.where((z >= 0.8) & (z < 1.15), 6.0, 1.0), [xi, yi, zi])
+    return [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ub,
+    ]
+
+
+@needs_fmmax
+def test_solve_orders_override_matches_construction():
+    """rc.solve(orders=N) re-solves at truncation N and matches an engine built at N — the construction
+    orders is just a default, overridable per solve (for a convergence sweep or profiling)."""
+    cons = _slab_cons()
+    rc = jno.rcwa(cons, orders=20, grid=24)
+    t_over = float(rc.solve(orders=40).efficiency("T"))
+    t_con = float(jno.rcwa(_slab_cons(), orders=40, grid=24).solve().efficiency("T"))
+    assert t_over == pytest.approx(t_con, abs=1e-9)
+    # the construction default is untouched: a plain solve still uses orders=20
+    assert float(rc.solve().efficiency("T")) == pytest.approx(float(rc.solve(orders=20).efficiency("T")), abs=1e-9)
+
+
+@needs_fmmax
+def test_solve_orders_sweep_converges():
+    """A uniform slab is truncation-insensitive: T at orders 8, 16, 32 agree — the sweep the caller uses to
+    check convergence (Richardson: compare N vs ~1.5N)."""
+    rc = jno.rcwa(_slab_cons(), orders=8, grid=24)
+    ts = [float(rc.solve(orders=o).efficiency("T")) for o in (8, 16, 32)]
+    assert max(ts) - min(ts) < 1e-3
+
+
+@needs_fmmax
+def test_solve_profile_runs_and_writes_trace(tmp_path, monkeypatch, capsys):
+    """profile=True runs an eager solve inside a JAX Perfetto trace, returns a valid solution, prints a
+    size/time summary, and writes the trace to ./rcwa_traces."""
+    monkeypatch.chdir(tmp_path)  # keep the trace out of the repo
+    rc = jno.rcwa(_slab_cons(), orders=20, grid=24)
+    sol = rc.solve(profile=True)
+    assert 0.0 <= float(sol.efficiency("T")) <= 1.0  # a real, usable solution
+    assert "[rcwa profile]" in capsys.readouterr().out
+    assert (tmp_path / "rcwa_traces").is_dir() and any((tmp_path / "rcwa_traces").iterdir())

--- a/tests/test_rcwa_profile.py
+++ b/tests/test_rcwa_profile.py
@@ -94,5 +94,5 @@ def test_solve_profile_runs_and_writes_trace(tmp_path, monkeypatch, capsys):
     rc = jno.rcwa(_slab_cons(), orders=20, grid=24)
     sol = rc.solve(profile=True)
     assert 0.0 <= float(sol.efficiency("T")) <= 1.0  # a real, usable solution
-    assert "[rcwa profile]" in capsys.readouterr().out
-    assert (tmp_path / "rcwa_traces").is_dir() and any((tmp_path / "rcwa_traces").iterdir())
+    assert "rcwa profile" in capsys.readouterr().out
+    assert (tmp_path / "jno_traces").is_dir() and any((tmp_path / "jno_traces").iterdir())

--- a/tests/test_rcwa_smoothing.py
+++ b/tests/test_rcwa_smoothing.py
@@ -1,0 +1,169 @@
+"""Subpixel permittivity smoothing in jno.rcwa (``smoothing=k``).
+
+Each RCWA pixel is supersampled ``k×k`` and the permittivity area-averaged, anti-aliasing material
+boundaries. The point is inverse design: a point-sampled ε staircases as a boundary sweeps (the rasterized
+fill is piecewise-constant, jumping only when the edge crosses a grid line), which makes the gradient
+w.r.t. a boundary-moving parameter jumpy; area-averaging makes the fill — and the gradient — vary smoothly.
+Default is off (``smoothing=1``) so existing results are unchanged; it is differentiable and opt-in.
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
+
+import equinox as eqx  # noqa: E402
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+from jno.rcwa import RcwaError, _sample_grid_direct  # noqa: E402
+from jno.trace import FunctionCall  # noqa: E402
+from jno.trace_evaluator import TraceEvaluator  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+K0 = 2 * jnp.pi
+P, LZ = 1.1, 3.2
+
+
+def _pillar_cons(d, hw=0.22, eps_val=1.5):
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    eps = jno.fn(
+        lambda x, y, z: jnp.where(
+            (jnp.abs(x - P / 2) < hw) & (jnp.abs(y - P / 2) < hw) & (z >= 0.8) & (z < 1.15), eps_val, 1.0
+        ),
+        [xi, yi, zi],
+    )
+    return [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ub,
+    ]
+
+
+def _dom():
+    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    e = 1e-6  # explicit face predicates -> multidirectional (x AND y) periodicity needs tagged faces
+    d.tag("left", lambda x, y, z: x < e)
+    d.tag("right", lambda x, y, z: x > P - e)
+    d.tag("front", lambda x, y, z: y < e)
+    d.tag("back", lambda x, y, z: y > P - e)
+    d.tag("bottom", lambda x, y, z: z < e)
+    d.tag("top", lambda x, y, z: z > LZ - e)
+    return d
+
+
+@needs_fmmax
+def test_smoothing_off_is_default():
+    """smoothing=1 (the default) must give EXACTLY the same result as omitting it — subpixel smoothing is
+    strictly opt-in and never silently changes an existing problem."""
+    cons = _pillar_cons(_dom())
+    t_default = float(jno.rcwa(cons, orders=80, grid=48).solve().efficiency("T"))
+    t_one = float(jno.rcwa(_pillar_cons(_dom()), orders=80, grid=48, smoothing=1).solve().efficiency("T"))
+    assert t_one == pytest.approx(t_default, abs=1e-12)
+
+
+def test_smoothing_reduces_rasterization_staircasing():
+    """The core effect (no solve needed): as a hard pillar's half-width sweeps, the *point-sampled* rasterized
+    permittivity staircases (piecewise-constant, big jumps when the edge crosses a grid line); area-averaging
+    (sub>1) shrinks those jumps, so the fill — and any boundary gradient — varies smoothly."""
+    xi, yi, zi, _ = _dom().variable("interior", split=True)
+
+    def fill(hw, sub):
+        eps = jno.fn(
+            lambda x, y, z, hw=hw: jnp.where(
+                (jnp.abs(x - P / 2) < hw) & (jnp.abs(y - P / 2) < hw) & (z >= 0.8) & (z < 1.15), 6.0, 1.0
+            ),
+            [xi, yi, zi],
+        )
+        C, _ = _sample_grid_direct(eps, 32, 48, (P, P), (0.0, LZ), {}, sub=sub)
+        return float(np.real(C).sum())
+
+    hws = np.linspace(0.20, 0.26, 25)
+    jump1 = np.abs(np.diff([fill(h, 1) for h in hws])).max()
+    jump4 = np.abs(np.diff([fill(h, 4) for h in hws])).max()
+    assert jump4 < 0.6 * jump1  # subpixel averaging markedly reduces the worst staircase jump
+
+
+@needs_fmmax
+def test_smoothing_solve_conserves_energy():
+    """A smoothed solve is still physical: a lossless pillar conserves energy (T + R ≈ 1)."""
+    sol = jno.rcwa(_pillar_cons(_dom()), orders=80, grid=48, smoothing=2).solve()
+    assert float(sol.efficiency("T")) + float(sol.efficiency("R")) == pytest.approx(1.0, abs=5e-3)
+
+
+@needs_fmmax
+def test_smoothing_preserves_differentiability():
+    """A design parameter still flows through a smoothed solve: rc.solve() is a trace node and jax.grad of T
+    w.r.t. the scatterer ε matches a finite difference (subpixel averaging is a plain mean — differentiable)."""
+    d = _dom()
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    ep = jno.np.parameter((), name="ep").initialize(jax.nn.initializers.constant(1.5))
+    ind = jno.fn(
+        lambda x, y, z: jnp.where(
+            (jnp.abs(x - P / 2) < 0.22) & (jnp.abs(y - P / 2) < 0.22) & (z >= 0.8) & (z < 1.15), 1.0, 0.0
+        ),
+        [xi, yi, zi],
+    )
+    eps = 1.0 + ind * (ep - 1.0)
+    cons = [
+        ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi),
+        -(1j * K0 * utp) * vtp,
+        -(1j * K0 * ubt - 2j * K0) * vbt,
+        ul - ur,
+        uf - ub,
+    ]
+    rc = jno.rcwa(cons, orders=80, grid=48, smoothing=2, params={"ep": 1.5})
+    node = rc.solve().efficiency("T")
+    assert isinstance(node, FunctionCall)
+
+    def T(v):
+        mod = eqx.tree_at(lambda m: m.value, ep.model.module, jnp.asarray(v))
+        return TraceEvaluator({ep.model.layer_id: mod}).evaluate(node)
+
+    g = float(jax.grad(T)(1.5))
+    h = 1e-2
+    fd = (float(T(1.5 + h)) - float(T(1.5 - h))) / (2 * h)
+    assert g == pytest.approx(fd, rel=5e-2)
+
+
+@needs_fmmax
+def test_smoothing_invalid_raises():
+    """smoothing must be a positive integer."""
+    with pytest.raises(RcwaError, match="smoothing must be a positive integer"):
+        jno.rcwa(_pillar_cons(_dom()), orders=40, grid=40, smoothing=0)

--- a/tests/test_rcwa_source.py
+++ b/tests/test_rcwa_source.py
@@ -1,0 +1,201 @@
+"""jno.rcwa with an INTERNAL SOURCE (dipole / Gaussian emitter) inferred from a volume forcing term.
+
+An emitter is authored exactly as in the FEM/PINN world — a forcing term in the residual: ``- src·v``
+(scalar monopole) or ``- inner(J, v)`` (vector dipole). The front door detects it (trial-free, test-present
+volume summand), localizes it (centroid → point vs Gaussian; which z-layer), and routes it to fmmax's
+``amplitudes_for_source`` (splitting the stack at the source plane). Readouts: power radiated up / down and
+the extraction fraction — the LED / Purcell / emitter observables. Differentiable in the source amplitude
+and the design permittivity.
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small GPU at these orders
+
+import equinox as eqx  # noqa: E402
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+import jno  # noqa: E402
+from jno.rcwa import Rcwa, RcwaError  # noqa: E402
+from jno.trace import FunctionCall  # noqa: E402
+from jno.trace_evaluator import TraceEvaluator  # noqa: E402
+from jno.utils.solver.fem_adapt import _domain_from_arrays  # noqa: E402
+
+HAS_FMMAX = importlib.util.find_spec("fmmax") is not None
+needs_fmmax = pytest.mark.skipif(not HAS_FMMAX, reason="fmmax (jno.rcwa backend) not installed")
+pytest.importorskip("pygmsh", reason="pygmsh required for box meshing")
+
+K0 = 2 * jnp.pi
+LZ = 3.0
+inner, vec = jno.np.inner, jno.np.vector
+
+
+# ----------------------------- engine-level (explicit layers, no meshing) -----------------------------
+def _engine_emit(eps_sub, orient=(1, 0, 0), amp=1.0, kind="delta", fwhm=0.2):
+    layers = [(float("inf"), 1.0), (1.0, 1.0), (float("inf"), eps_sub)]  # super vac / vac slab / substrate
+    rc = Rcwa(layers, period=(1.0, 1.0), orders=60, wavelength=1.0, k_in=(1e-3, 1e-3), assume_periodic=True)
+    src = dict(x0=0.5, y0=0.5, layer=1, t_upper=0.5, t_lower=0.5, kind=kind, fwhm=fwhm, orient=orient, amp=amp)
+    s = rc.solve(source=src)
+    return float(s.power("up")), float(s.power("down")), float(s.extraction("up"))
+
+
+@needs_fmmax
+def test_engine_vacuum_emits_symmetrically():
+    """An x-dipole at the centre of a vacuum slab radiates equally up and down (symmetric environment)."""
+    up, down, extr = _engine_emit(1.0)
+    assert up == pytest.approx(down, rel=1e-6)
+    assert extr == pytest.approx(0.5, abs=1e-6)
+
+
+@needs_fmmax
+def test_engine_orientation_matters():
+    """A z-oriented dipole radiates differently from an in-plane (x) dipole — orientation is a real knob."""
+    up_x, _, _ = _engine_emit(1.0, orient=(1, 0, 0))
+    up_z, _, _ = _engine_emit(1.0, orient=(0, 0, 1))
+    assert abs(up_z - up_x) > 1e-2
+
+
+@needs_fmmax
+def test_engine_power_scales_with_amplitude_squared():
+    """Emitted power is quadratic in the source amplitude (|amp·source|²) — the differentiable scaling."""
+    up1, _, _ = _engine_emit(1.0, amp=1.0)
+    up2, _, _ = _engine_emit(1.0, amp=2.0)
+    assert up2 / up1 == pytest.approx(4.0, rel=1e-5)
+
+
+# ----------------------------- front door (author the emitter in the weak form) -----------------------------
+def _sbox(Lx, dx=0.12, dz=0.2):
+    xs = np.linspace(0, Lx, int(round(Lx / dx)) + 1)
+    zs = np.linspace(0, LZ, int(round(LZ / dz)) + 1)
+    ny, nz = len(xs), len(zs)
+    X, Y, Z = np.meshgrid(xs, xs, zs, indexing="ij")
+    P = np.stack([X.ravel(), Y.ravel(), Z.ravel()], 1)
+    vid = lambda i, j, k: (i * ny + j) * nz + k  # noqa: E731
+    CUBE = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0), (0, 0, 1), (1, 0, 1), (0, 1, 1), (1, 1, 1)]
+    TE = [(0, 1, 3, 7), (0, 1, 5, 7), (0, 2, 3, 7), (0, 2, 6, 7), (0, 4, 5, 7), (0, 4, 6, 7)]
+    tets = []
+    for i in range(len(xs) - 1):
+        for j in range(len(xs) - 1):
+            for k in range(nz - 1):
+                c = [vid(i + a, j + b, k + cc) for (a, b, cc) in CUBE]
+                tets += [[c[t[0]], c[t[1]], c[t[2]], c[t[3]]] for t in TE]
+    tets = np.asarray(tets)
+    F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
+    uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
+    d = _domain_from_arrays(
+        jno.domain.cube(x_range=(0, Lx), y_range=(0, Lx), z_range=(0, LZ), mesh_size=0.2), P, tets, uq[cnt == 1], copy=True
+    )
+    e = 1e-6
+    for nm, f in [
+        ("bottom", lambda x, y, z: z < e),
+        ("top", lambda x, y, z: z > LZ - e),
+        ("left", lambda x, y, z: x < e),
+        ("right", lambda x, y, z: x > Lx - e),
+        ("front", lambda x, y, z: y < e),
+        ("back", lambda x, y, z: y > Lx - e),
+    ]:
+        d.tag(nm, f)
+    return d
+
+
+def _emitter_cons(d, Lx, eps_sub=1.0, amp=None):
+    """Scalar Helmholtz on the supercell with an internal Gaussian emitter in the eps=6 slab (z∈[1,2]);
+    substrate eps_sub below, vacuum above. ``amp`` (an optional parameter) scales the source amplitude."""
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    eps = jno.fn(lambda x, y, z: jnp.where((z >= 1.0) & (z < 2.0), 6.0, jnp.where(z < 1.0, eps_sub, 1.0)), [xi, yi, zi])
+    A = 1.0 if amp is None else amp
+    profile = jno.np.exp(-(((xi - Lx / 2) ** 2 + (yi - Lx / 2) ** 2 + (zi - 1.5) ** 2) / (2 * 0.12**2)))
+    vol = ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi) - A * profile * vi
+    return [vol, -(1j * K0 * utp) * vtp, -(1j * K0 * ubt) * vbt, ul - ur, uf - ub]
+
+
+@needs_fmmax
+def test_frontdoor_emitter_readouts_finite_and_bounded():
+    """Author a Gaussian emitter as a `- src·v` volume forcing: the front door infers it and returns finite
+    up/down power with an extraction fraction in (0, 1)."""
+    Lx = 1.4
+    rc = jno.rcwa(_emitter_cons(_sbox(Lx), Lx, eps_sub=1.0), orders=50, grid=28)
+    assert rc.spec.source is not None and rc.spec.source["kind"] == "gaussian"
+    s = rc.solve()
+    up, down, extr = float(s.power("up")), float(s.power("down")), float(s.extraction("up"))
+    assert np.isfinite(up) and np.isfinite(down) and up > 0 and down > 0
+    assert 0.0 < extr < 1.0
+    assert float(s.power("total")) == pytest.approx(up + down, rel=1e-6)
+
+
+@needs_fmmax
+def test_frontdoor_high_index_substrate_biases_emission_down():
+    """A higher-index substrate pulls emission downward — extraction into the top (up) drops. Classic
+    substrate-emission physics, inferred from the traced problem."""
+    Lx = 1.4
+    extr_vac = float(jno.rcwa(_emitter_cons(_sbox(Lx), Lx, eps_sub=1.0), orders=50, grid=28).solve().extraction("up"))
+    extr_hi = float(jno.rcwa(_emitter_cons(_sbox(Lx), Lx, eps_sub=9.0), orders=50, grid=28).solve().extraction("up"))
+    assert extr_hi < extr_vac - 1e-2
+
+
+@needs_fmmax
+def test_source_amplitude_is_differentiable():
+    """A trainable source amplitude (jno.np.parameter) flows through the emission solve: rc.solve().power is a
+    trace node over it, and jax.grad matches a finite difference (power ∝ amp²)."""
+    Lx = 1.4
+    amp = jno.np.parameter((), name="amp").initialize(jax.nn.initializers.constant(1.0))
+    rc = jno.rcwa(_emitter_cons(_sbox(Lx), Lx, eps_sub=2.5, amp=amp), orders=40, grid=28, params={"amp": 1.0})
+    node = rc.solve().power("up")  # NO solve args -> trace node over the amplitude
+    assert isinstance(node, FunctionCall)
+
+    def P(v):
+        mod = eqx.tree_at(lambda m: m.value, amp.model.module, jnp.asarray(v))
+        return TraceEvaluator({amp.model.layer_id: mod}).evaluate(node)
+
+    g = float(jax.grad(P)(1.3))
+    h = 1e-3
+    fd = (float(P(1.3 + h)) - float(P(1.3 - h))) / (2 * h)
+    assert g == pytest.approx(fd, rel=2e-3)
+    assert abs(g) > 1e-6  # the amplitude genuinely drives the power
+
+
+@needs_fmmax
+def test_source_outside_finite_layer_raises():
+    """A source that lands in a semi-infinite ambient (no permittivity contrast to define a finite slab) is
+    rejected with a concrete fix."""
+    Lx = 1.4
+    d = _sbox(Lx)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    eps = jno.fn(lambda x, y, z: 1.0 + 0.0 * z, [xi, yi, zi])  # uniform vacuum -> no finite layer anywhere
+    src = jno.np.exp(-(((xi - Lx / 2) ** 2 + (yi - Lx / 2) ** 2 + (zi - 1.5) ** 2) / (2 * 0.12**2)))
+    vol = ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi) - src * vi
+    cons = [vol, -(1j * K0 * utp) * vtp, -(1j * K0 * ubt) * vbt, ul - ur, uf - ub]
+    with pytest.raises(RcwaError, match="not inside a finite"):
+        jno.rcwa(cons, orders=40, grid=28)

--- a/tests/test_rcwa_source.py
+++ b/tests/test_rcwa_source.py
@@ -40,7 +40,7 @@ inner, vec = jno.np.inner, jno.np.vector
 def _engine_emit(eps_sub, orient=(1, 0, 0), amp=1.0, kind="delta", fwhm=0.2):
     layers = [(float("inf"), 1.0), (1.0, 1.0), (float("inf"), eps_sub)]  # super vac / vac slab / substrate
     rc = Rcwa(layers, period=(1.0, 1.0), orders=60, wavelength=1.0, k_in=(1e-3, 1e-3), assume_periodic=True)
-    src = dict(x0=0.5, y0=0.5, layer=1, t_upper=0.5, t_lower=0.5, kind=kind, fwhm=fwhm, orient=orient, amp=amp)
+    src = dict(loc=[[0.5, 0.5]], layer=1, t_upper=0.5, t_lower=0.5, kind=kind, fwhm=fwhm, orient=orient, amp=amp)
     s = rc.solve(source=src)
     return float(s.power("up")), float(s.power("down")), float(s.extraction("up"))
 
@@ -171,6 +171,48 @@ def test_source_amplitude_is_differentiable():
     fd = (float(P(1.3 + h)) - float(P(1.3 - h))) / (2 * h)
     assert g == pytest.approx(fd, rel=2e-3)
     assert abs(g) > 1e-6  # the amplitude genuinely drives the power
+
+
+@needs_fmmax
+def test_source_width_is_differentiable():
+    """The emitter's Gaussian WIDTH (a jno.np.parameter) flows through the localization + emission solve: a
+    wider soft source couples less into the propagating modes, and jax.grad of the emitted power w.r.t. the
+    width matches a finite difference."""
+    Lx = 1.4
+    d = _sbox(Lx)
+    u, phi = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), phi.bind(x=xi, y=yi, z=zi)
+
+    def face(n):
+        c = d.variable(n, split=True)
+        return u.bind(x=c[0], y=c[1], z=c[2]), phi.bind(x=c[0], y=c[1], z=c[2])
+
+    ubt, vbt = face("bottom")
+    utp, vtp = face("top")
+    ul, _ = face("left")
+    ur, _ = face("right")
+    uf, _ = face("front")
+    ub, _ = face("back")
+    eps = jno.fn(lambda x, y, z: jnp.where((z >= 1.0) & (z < 2.0), 6.0, jnp.where(z < 1.0, 3.0, 1.0)), [xi, yi, zi])
+    w = jno.np.parameter((), name="w").initialize(jax.nn.initializers.constant(0.14))
+    src = jno.np.exp(-(((xi - Lx / 2) ** 2 + (yi - Lx / 2) ** 2 + (zi - 1.5) ** 2) / (2 * w**2)))
+    vol = ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - K0**2 * eps * (u * vi) - src * vi
+    rc = jno.rcwa(
+        [vol, -(1j * K0 * utp) * vtp, -(1j * K0 * ubt) * vbt, ul - ur, uf - ub], orders=40, grid=28, params={"w": 0.14}
+    )
+    node = rc.solve().power("up")
+    assert isinstance(node, FunctionCall)
+
+    def P(v):
+        mod = eqx.tree_at(lambda m: m.value, w.model.module, jnp.asarray(v))
+        return TraceEvaluator({w.model.layer_id: mod}).evaluate(node)
+
+    g = float(jax.grad(P)(0.14))
+    h = 2e-3
+    fd = (float(P(0.14 + h)) - float(P(0.14 - h))) / (2 * h)
+    assert g == pytest.approx(fd, rel=5e-3)
+    assert abs(g) > 1e-2  # the width genuinely changes the emission
 
 
 @needs_fmmax


### PR DESCRIPTION
Builds a full, differentiable computational-lithography pipeline on top of `jno.rcwa`: rigorous mask diffraction → partially-coherent (vector high-NA) imaging → resist development → inverse lithography, with an optional rigorous 3-D post-exposure-bake for sign-off. Everything from the mask parameter to the printed pattern is one differentiable graph, so `jax.grad` of a printed-vs-target loss is ILT/SMO.

## Imaging (`jno.rcwa`)
- **Incident-mode fix** — excite the true 0th-order plane wave (via its real-space field) instead of `argmax(eigenmode flux)`, which picked an oblique order once the period exceeds the wavelength. Regression test compares a multi-order slab to the normal-incidence Airy formula.
- **`sol.aerial(...)`** — partially-coherent aerial image (Abbe source integration) on the rigorous mask spectrum; conventional / annular / freeform (SMO) sources; differentiable in mask + source.
- **Vector high-NA imaging** — `aerial(polarization=...)` rotates each order's transverse `(E_x,E_y)` to the 3-D wafer field through the Richards-Wolf/Flagello vector pupil (TM contrast loss at high NA); reduces to the scalar image at NA→0.
- **`jones()`** rebuilt in the field basis (same incident-mode root cause).

## Resist models (`jno.litho`)
- **`exposure.develop(resist)` seam** — `sol.expose(...)` returns an optics-only exposure; a resist is any callable `exposure → developed field`, so physics is injected rather than hardcoded. `sol.printed(resist=...)` is the one-call shortcut.
- **`Threshold`** — fast constant-threshold + Gaussian PEB-diffusion resist for the design loop (Poonawala & Milanfar 2007; Mack 2007).
- **`CAResist`** — rigorous 3-species reaction-diffusion PEB (dos Santos), authored as one transient `jno.fem` system; seeds the latent acid from the exposure via Dill kinetics. 2-D (aerial-driven) and **3-D** (`film=Film(...)`, geometry via `jno.Shape` extrude+stitch, species diffusing in x, y, z; consumes the standing-wave `bulk` image).
- **`exposure.bulk(film)`** — depth-resolved standing-wave bulk image inside the resist film (`jno.litho.Film` stack); validated against the aerial reduction, the `λ/(2·n)` ripple period, and depth absorption.
- ILT gradients verified end-to-end through both the 2-D and 3-D PEB solves (`jax.grad` vs finite difference).

## Core enablers (general improvements)
- **`fix(domain)`** — re-expand the time axis after a periodic conforming remesh, so periodic + transient nodal problems work on a `jno.Shape` box.
- **`fix(rcwa)`** — derive one eigensolve precision from the incidence and cast ε/μ to it, so an RCWA forward trains through `jno.core` (which supplies float32 parameters by default). No change under pure x64.
- **`feat(core)`** — `jno.core([loss])` works without a domain for parameter-only fits (a pure data-fit / ILT loss references no domain Variable); warns so a PINN loss that accidentally omits its Variable is still surfaced.

## Also included
- Earlier RCWA front-door features on this branch: general anisotropic (ε and μ) eigensolve, inferred in-plane PML, internal dipole/Gaussian sources, subpixel permittivity smoothing, `solve(orders=…, profile=True)` (shared `profile=True` perf trace with `jno.fem`/`jno.fdm`).

## Testing
- New: `test_rcwa_aerial.py` (aerial, vector, resist, bulk, 2-D/3-D CAResist, ILT-gradient checks), plus incidence/anisotropic/PML/source/smoothing/profile suites.
- `ruff format --check` and `ruff check` clean; affected suites green on CPU. RCWA tests run on CPU (the fmmax solve OOMs on an 8 GB GPU).

## Known limitation
- Vector high-NA `polarization=` works on a concrete solve but trips `wl=nan` inside the differentiable *parametric* node (vector imaging and the parametric-resample path were never exercised together); the ILT loop uses scalar imaging. Follow-up.