### PR TITLE
feat(solve/precond): scalable H(curl) AMS preconditioner + matrix-free solver stack

### DIFF
--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -701,7 +701,11 @@ def _complex_operator(A_r: Any, A_i: Any) -> Any:
 
 
 def _solve_complex_block(
-    ops: Any, solve_fn: Optional[Callable] = None, periodic: Optional[dict] = None, complex_solve: Optional[Callable] = None
+    ops: Any,
+    solve_fn: Optional[Callable] = None,
+    periodic: Optional[dict] = None,
+    complex_solve: Optional[Callable] = None,
+    from_slots: bool = False,
 ) -> Any:
     """Solve a complex linear FEM system via the real-equivalent block (everything was
     assembled as two *real* systems)::
@@ -770,8 +774,14 @@ def _solve_complex_block(
         rhs = jnp.concatenate([b_r, b_i])
         is_sparse = hasattr(A_r, "indices") and hasattr(A_i, "indices")
 
-        if solve_fn is not None:
-            # user solver receives the densified block (dense/direct back-compat path)
+        if solve_fn is not None and from_slots and is_sparse:
+            # Slot-composed solver on a non-complex-native precond (gmres + jacobi/form/amg): hand it the
+            # SPARSE 2n BCOO block [[A_r,-A_i],[A_i,A_r]] rather than densifying — keeps it O(nnz) AND lets
+            # the composed solver's extreme-magnitude normalization fire (a dense block has no .bcoo, so a
+            # mass-dominated eddy system would otherwise stall the Krylov Arnoldi at real scale).
+            sol = jnp.asarray(solve_fn(_complex_block_bcoo(A_r, A_i, n), rhs))
+        elif solve_fn is not None:
+            # raw user solver (or a dense-leg fallback) receives the densified block (dense/direct back-compat)
             Ar_d = jnp.asarray(A_r.todense() if hasattr(A_r, "todense") else A_r)
             Ai_d = jnp.asarray(A_i.todense() if hasattr(A_i, "todense") else A_i)
             sol = jnp.asarray(solve_fn(jnp.block([[Ar_d, -Ai_d], [Ai_d, Ar_d]]), rhs))
@@ -1258,7 +1268,7 @@ class FEM:
             # densified); real-equivalent preconditioners (form/jacobi/…) stay on the 2n-block path.
             if from_slots and getattr(precond, "complex_native", False):
                 return _solve_complex_block(self._op, periodic=self._periodic, complex_solve=solve_fn)
-            return _solve_complex_block(self._op, solve_fn, periodic=self._periodic)
+            return _solve_complex_block(self._op, solve_fn, periodic=self._periodic, from_slots=from_slots)
         if self._mode == "complex_transient":
             return _solve_complex_transient(self._op, save_ts=kwargs.get("save_ts"), periodic=self._periodic)
         if self._mode == "linear" and not isinstance(self._op, FemLinearSystem):

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -685,7 +685,24 @@ def _complex_block_bcoo(A_r: Any, A_i: Any, n: int) -> Any:
     return jsp.BCOO((data, indices), shape=(2 * n, 2 * n))
 
 
-def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic: Optional[dict] = None) -> Any:
+def _complex_operator(A_r: Any, A_i: Any) -> Any:
+    """Fuse the real/imag legs into one complex operator ``A_r + i·A_i`` — as a **complex BCOO** when
+    the legs are sparse (so an iterative complex solve never densifies), else a dense complex array.
+    This is the operator a slot-composed complex solver (``linear=gmres, precond=ams``) runs on."""
+    if hasattr(A_r, "indices") and hasattr(A_i, "indices"):
+        from jax.experimental import sparse as jsp
+
+        indices = jnp.concatenate([A_r.indices, A_i.indices], axis=0)
+        data = jnp.concatenate([A_r.data + 0j, 1j * A_i.data])  # +0j promotes to the complex dtype
+        return jsp.BCOO((data, indices), shape=A_r.shape).sum_duplicates()
+    Ar = A_r.todense() if hasattr(A_r, "todense") else A_r
+    Ai = A_i.todense() if hasattr(A_i, "todense") else A_i
+    return jnp.asarray(Ar) + 1j * jnp.asarray(Ai)
+
+
+def _solve_complex_block(
+    ops: Any, solve_fn: Optional[Callable] = None, periodic: Optional[dict] = None, complex_solve: Optional[Callable] = None
+) -> Any:
     """Solve a complex linear FEM system via the real-equivalent block (everything was
     assembled as two *real* systems)::
 
@@ -738,6 +755,18 @@ def _solve_complex_block(ops: Any, solve_fn: Optional[Callable] = None, periodic
             return _bloch_solve(args)
         (A_r, b_r), (A_i, b_i) = _ab(ops[0], args), _ab(ops[1], args)
         n = b_r.shape[0]
+
+        if complex_solve is not None:
+            # Slot-composed iterative path (linear=/precond=): solve the COMPLEX system directly on the
+            # sparse operator A_r + i·A_i (never the dense 2n block), e.g. gmres + jno.precond.ams.
+            A_c = _complex_operator(A_r, A_i)
+            u = complex_solve(A_c, b_r + 1j * b_i)
+            return (
+                u
+                if periodic is None
+                else prolong_periodic(periodic, jnp.real(u)) + 1j * prolong_periodic(periodic, jnp.imag(u))
+            )
+
         rhs = jnp.concatenate([b_r, b_i])
         is_sparse = hasattr(A_r, "indices") and hasattr(A_i, "indices")
 
@@ -1192,6 +1221,10 @@ class FEM:
         else:
             from_slots = False
         if self._mode == "complex":
+            # A complex-native preconditioner (AMS) solves the sparse COMPLEX operator directly (never
+            # densified); real-equivalent preconditioners (form/jacobi/…) stay on the 2n-block path.
+            if from_slots and getattr(precond, "complex_native", False):
+                return _solve_complex_block(self._op, periodic=self._periodic, complex_solve=solve_fn)
             return _solve_complex_block(self._op, solve_fn, periodic=self._periodic)
         if self._mode == "complex_transient":
             return _solve_complex_transient(self._op, save_ts=kwargs.get("save_ts"), periodic=self._periodic)

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1116,7 +1116,9 @@ class FEM:
             raise KeyError(f"FEM.block_index: trial field {getattr(field, 'name', fk)!r} is not part of this system.")
         return keys.index(fk)
 
-    def solve(self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, **kwargs) -> Any:
+    def solve(
+        self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, time=None, **kwargs
+    ) -> Any:
         """Differentiable forward solve as a trace node — the inverse-problem entry.
 
         Pass ``adapt=AdaptSpec(...)`` to run the **adaptive** loop
@@ -1192,7 +1194,7 @@ class FEM:
         invalidates warm starts and cached preconditioner setups — pass ``solve_fn=`` there).
         """
         result = self._solve_dispatch(
-            solve_fn, adapt=adapt, x0=x0, nonlinear=nonlinear, linear=linear, precond=precond, **kwargs
+            solve_fn, adapt=adapt, x0=x0, nonlinear=nonlinear, linear=linear, precond=precond, time=time, **kwargs
         )
         if isinstance(result, Placeholder):
             # Tag the solve node with its domain so jno.core can infer the domain straight from the graph
@@ -1200,9 +1202,17 @@ class FEM:
             result._domain = self.domain
         return result
 
-    def _solve_dispatch(self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, **kwargs):
+    def _solve_dispatch(
+        self, solve_fn=None, *, adapt=None, x0=None, nonlinear=None, linear=None, precond=None, time=None, **kwargs
+    ):
         """Mode dispatch for :meth:`solve` — returns the solution array or a differentiable trace node."""
-        has_slots = (x0 is not None) or (nonlinear is not None) or (linear is not None) or (precond is not None)
+        has_slots = (
+            (x0 is not None)
+            or (nonlinear is not None)
+            or (linear is not None)
+            or (precond is not None)
+            or (time is not None)
+        )
         if adapt is not None:
             if has_slots:
                 raise NotImplementedError(
@@ -1215,7 +1225,7 @@ class FEM:
             return run_adaptive_solve(self, adapt, solve_fn=solve_fn, **kwargs)
         if has_slots:
             solve_fn, kwargs = self._compose_slots(
-                solve_fn, x0=x0, nonlinear=nonlinear, linear=linear, precond=precond, kwargs=kwargs
+                solve_fn, x0=x0, nonlinear=nonlinear, linear=linear, precond=precond, time=time, kwargs=kwargs
             )
             from_slots = True
         else:
@@ -1301,14 +1311,18 @@ class FEM:
             return self._op.solve(solve_fn, **kwargs).fn()
         return self._op.solve(solve_fn, **kwargs)
 
-    def _compose_slots(self, solve_fn, *, x0, nonlinear, linear, precond, kwargs):
+    def _compose_slots(self, solve_fn, *, x0, nonlinear, linear, precond, time=None, kwargs):
         """Compose the solver slots into the mode-appropriate ``solve_fn`` (see :meth:`solve`)."""
         from .utils.solver.solver_api import compose_linear_solve_fn, compose_nonlinear_solve_fn
 
         if solve_fn is not None:
             raise ValueError(
                 "fem.solve: pass either solve_fn= (the total override) or the solver slots "
-                "(x0/nonlinear/linear/precond), not both."
+                "(x0/nonlinear/linear/precond/time), not both."
+            )
+        if time is not None and self._mode != "transient":
+            raise ValueError(
+                f"fem.solve(time=...) picks a time-integration scheme, but this problem is {self._mode}, not transient."
             )
         if self._mode == "complex_transient":
             raise NotImplementedError(
@@ -1331,6 +1345,8 @@ class FEM:
             lin_s, nonlin_s = compose_transient_step_solvers(nonlinear, linear, precond, self, self._op)
 
             def _stepper(block, args, save_ts):
+                if time is not None:  # jno.solve.theta(...) / jno.solve.exponential(...)
+                    return time.integrate(block, args, save_ts, linear_solve=lin_s, nonlinear_solve=nonlin_s)
                 return _default_transient_integrate(block, args, save_ts, linear_solve=lin_s, nonlinear_solve=nonlin_s)
 
             return _stepper, kwargs

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1414,6 +1414,25 @@ class FEM:
             raise AttributeError(f"FEM is {self._mode}; .b is only for a steady linear problem (see .operator / .M).")
         return _as_flat(self._b)
 
+    def eigs(self, *, mass, k: int = 6, which: str = "smallest"):
+        """Generalized eigenproblem ``K x = λ M x`` on this fem: ``K`` is this **source-less** fem's
+        operator (its stiffness bilinear form) and ``M`` is the ``mass`` bilinear form assembled on the
+        same space. Returns ``(λ, X)`` — the ``k`` eigenvalues at ``which`` (``'smallest'``/``'largest'``)
+        and their **M-orthonormal** eigenvectors. Eigenvalues are differentiable (see :func:`jno.solve.eigs`).
+
+        Modal analysis, buckling, EM cavity/waveguide resonances, photonic band structure::
+
+            u, v = d.fem_symbols(); ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+            K = jno.fem([ui.x * vi.x + ui.y * vi.y])      # stiffness (no source term)
+            lam, X = K.eigs(mass=[ui * vi], k=6)          # K x = λ M x  → λ = ω² (Neumann box)
+        """
+        if self._mode != "linear":
+            raise AttributeError(f"FEM.eigs needs a steady-linear (source-less) bilinear form; this fem is {self._mode}.")
+        from . import solve as _solve
+
+        M = fem(list(mass)).operator[0]  # mass matrix on the same FE space
+        return _solve.eigs(k=k, which=which)(self.operator[0], M)
+
     # -- domain-decomposition coupling (`jno.core([...])`): the region this subdomain owns + a pinned solve --
     def _dd_region(self):
         # The weak-form coordinates are retagged for quadrature, so read the region from `classification`

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -394,6 +394,8 @@ def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smooth
 class _AMS:
     """Spec for the H(curl) auxiliary-space Maxwell (AMS) preconditioner; see :func:`ams`."""
 
+    complex_native = True  # solve the COMPLEX operator directly (not the real-equivalent 2n block)
+
     def __init__(self, aux):
         self.aux = aux  # jno.solve LinearSolver for the nodal auxiliary solves (None -> lu())
         self._G = None  # discrete gradient (node->edge), built once from the mesh topology

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -497,11 +497,21 @@ def ams(*, aux=None) -> _AMS:
 
     ``G`` and ``Π`` come from the N1E edge topology (:mod:`jno.utils.solver.ams`); the auxiliary
     operators are assembled once on the host from the concrete matrix and solved with ``aux`` —
-    **any** ``jno.solve`` solver (default :func:`jno.solve.lu`). Passing a multigrid inner solver
-    makes the whole preconditioner scalable (the auxiliary problems are ordinary nodal Poisson-like
-    systems). The same spec handles the **real** curl-curl+mass and the **complex** eddy operator
-    ``νK + jωσM`` — dtype follows the assembled matrix; pair it with :func:`jno.solve.gmres`
-    (complex-correct) for the eddy case.
+    **any** ``jno.solve`` solver (default :func:`jno.solve.lu`). Because the auxiliary problems are
+    ordinary **nodal Poisson-like** systems, an algebraic-multigrid ``aux`` makes the whole
+    preconditioner scalable at ``O(n)``. A GPU realisation is NVIDIA AmgX via ``jaxamg``: build each
+    auxiliary hierarchy **once per operator** (``jaxamg.with_cache(A, is_symmetric=True)``) and reuse
+    it across outer iterations — the AMS applier calls ``aux`` with the same operator each iteration,
+    so caching on the operator gives factor-once setup with a pure-JAX apply.
+
+    **Outer solver.** An *exact* ``aux`` (``lu``) is a fixed linear map, so it pairs with ``cg``; an
+    *inexact/iterative* ``aux`` (multigrid, an inexact ``cg``) is a **variable** preconditioner and
+    needs a **flexible** outer solver — :func:`jno.solve.fgmres` (real) — or ``cg`` stalls.
+
+    The same spec handles the **real** curl-curl+mass and the **complex** eddy operator ``νK + jωσM``
+    — dtype follows the assembled matrix; pair it with :func:`jno.solve.gmres` (complex-correct) for
+    the eddy case. (An AmgX ``aux`` is real-only, so a complex auxiliary needs a real reformulation —
+    factor ``jω`` out of the gradient block; a real proxy for the Π block.)
 
     Requirements & scope:
 

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -32,7 +32,7 @@ from .utils.solver.solver_api import (  # noqa: F401  (PrecondContext re-exporte
     materialize_precond,
 )
 
-__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg", "cached"]
+__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg", "jaxamg", "cached"]
 
 
 class _Spec:
@@ -400,6 +400,49 @@ def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smooth
     spec for very large ones.
     """
     return _AMG(cycles, max_levels, coarse_size, smoother_degree)
+
+
+class _JaxAMG(_Spec):
+    """Spec for the GPU AMG preconditioner via jaxamg (NVIDIA AmgX); see :func:`jaxamg`."""
+
+    def __init__(self, config):
+        self.config = config
+
+    def materialize(self, ctx: PrecondContext):
+        from .solve import _require_jaxamg  # reuse the lazy import + install-requirements error
+
+        A = ctx.A.bcoo
+        if A is None:
+            raise ValueError(
+                "jno.precond.jaxamg needs an assembled (sparse) operator — it cannot build an AMG "
+                "hierarchy from a matrix-free operator."
+            )
+        jax_amg = _require_jaxamg()
+        cfg = dict(self.config) if self.config is not None else {"solver": "AMG"}
+        apply = jax_amg.make_preconditioner(A, config=cfg)  # build-once M⁻¹ apply (single AMG cycle)
+        return PrecondApplier(lambda v: apply(v))
+
+    def __repr__(self):
+        return "jno.precond.jaxamg()"
+
+
+def jaxamg(*, config: "dict | None" = None) -> _JaxAMG:
+    """GPU AMG **preconditioner** via jaxamg (NVIDIA AmgX wrapped as a JAX primitive) — the
+    on-device counterpart of :func:`amg`, and the natural smoother for large elliptic blocks or the
+    auxiliary nodal solves of an H(curl) AMS preconditioner on the GPU.
+
+    Builds the AMG hierarchy with ``jaxamg.make_preconditioner`` and applies a single cycle as
+    ``M⁻¹`` — a proper build-once/apply-many preconditioner (unlike ``jno.precond.inner(jno.solve.amg())``,
+    which re-solves each application). Wrap in ``.cached()`` to reuse the hierarchy across solves::
+
+        fem.solve(linear=jno.solve.fgmres(), precond=jno.precond.jaxamg().cached())
+
+    ``config`` is a full AmgX-format dict (default ``{"solver": "AMG"}``). Needs an **assembled**
+    operator. Optional dependency — jaxamg (AmgX 2.5+, CUDA 12+, mpi4py/mpi4jax) is imported lazily.
+
+    Reference: Liu, Fan & Wang, arXiv:2606.09001 (2026), wrapping NVIDIA AmgX (Naumov et al., 2015).
+    """
+    return _JaxAMG(config)
 
 
 _MISS = object()  # sentinel so the first materialize always builds

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -421,8 +421,18 @@ class _AMS:
         self._frozen = None  # host-assembled auxiliary operators, set by .build() for traced solves
 
     def prepare(self, fem):
-        """Eager one-time build of the mesh-only transfer operators G, Π (parameter-independent)."""
+        """Eager setup at compose time (outside any trace): the mesh transfer operators G, Π, **and** —
+        whenever the operator is concrete here (the forward *and* native parametric-inverse solves) — the
+        frozen auxiliaries too, so an AMS-preconditioned solve is differentiable **automatically**, no
+        explicit ``.build`` required. If only a tracer is available at this point (a raw ``jit``/``vmap``
+        of ``fem.solve``, where there is no concrete operator to freeze from), freezing is deferred and
+        :meth:`build` is the escape hatch — :meth:`materialize` says so."""
         self._transfer(fem.domain)
+        if self._frozen is None:
+            try:
+                self.build(fem)  # auto-freeze when the operator is concrete & complete here
+            except Exception:  # noqa: BLE001 — a tracer / a parameter-incomplete operator: fall through,
+                pass  # and materialize either assembles from the concrete ctx or asks for an explicit .build
 
     def build(self, fem) -> "_AMS":
         """Eager host setup from a **concrete** ``fem`` — required to use AMS inside a **traced** solve
@@ -469,8 +479,10 @@ class _AMS:
         except Exception as e:  # a traced operator (parametric/complex-inverse) can't be host-assembled
             raise RuntimeError(
                 "jno.precond.ams assembles the nodal auxiliaries on the host from a concrete matrix, so it "
-                "cannot run under a trace (jit/vmap/parametric-inverse). Build it once eagerly first — "
-                "jno.precond.ams().build(fem) — and the frozen preconditioner then differentiates through."
+                "cannot run under a trace (jit/vmap/parametric-inverse). Freeze it once from a CONCRETE "
+                "reference first — spec = jno.precond.ams().build(fem0), with fem0 the (non-parametric) fem "
+                "at your reference parameters — then reuse that spec; the frozen preconditioner then runs "
+                "and differentiates through (the gradient flows through the operator, not the preconditioner)."
             ) from e
         G_sp = sp.csr_matrix(np.asarray(self._G.todense()))
         Pi_sp = [sp.csr_matrix(np.asarray(P.todense())) for P in self._Pis]
@@ -577,11 +589,20 @@ def ams(*, aux=None) -> _AMS:
     *inexact/iterative* ``aux`` (multigrid, an inexact ``cg``) is a **variable** preconditioner and
     needs a **flexible** outer solver — :func:`jno.solve.fgmres` (real) — or ``cg`` stalls.
 
-    **Differentiable / traced solves.** The host aux-assembly cannot run under a trace, so for a
-    ``jit`` / ``vmap`` / **parametric-inverse** (design-loop) solve, build it once eagerly first —
-    ``jno.precond.ams().build(fem)`` — freezing the auxiliaries; the solve then runs *and*
-    differentiates (the gradient flows through the traced operator by implicit differentiation, not
-    through the frozen preconditioner). Without ``.build`` the forward (concrete) solve still works.
+    **Differentiable / traced solves.** The host aux-assembly cannot run under a trace. A **forward**
+    (concrete) solve freezes the auxiliaries automatically at compose time, so it is already
+    differentiable-ready — nothing to do. For a solve whose **operator itself is traced** — a ``jit`` /
+    ``vmap``, or a **parametric-inverse** design loop where ``A(θ)`` carries a ``jno.np.parameter`` —
+    freeze once from a **concrete reference** and reuse it::
+
+        spec = jno.precond.ams().build(fem0)          # fem0 = the fem at your reference parameters θ₀
+        node = fem_of(theta).solve(precond=spec)      # parametric solve; node is differentiable
+
+    The frozen preconditioner stays valid as ``A(θ)`` drifts (speed degrades, correctness never), and
+    ``∂/∂θ`` flows through the **operator** by implicit differentiation — never through the
+    preconditioner (a preconditioner cannot change the solution, so differentiating its setup would be
+    pure waste). You cannot auto-freeze from the parametric fem itself because ``θ₀`` is only resolved
+    at solve time; the one-line concrete reference is that choice made explicit.
 
     The same spec handles the **real** curl-curl+mass and the **complex** eddy operator ``νK + jωσM``
     — dtype follows the assembled matrix; pair it with :func:`jno.solve.gmres` (complex-correct) for

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -503,8 +503,19 @@ class _AMS(_Spec):
             self._transfer(ctx.fem.domain)
 
         A = ctx.A.bcoo if ctx.A.bcoo is not None else ctx.A.dense()
+
+        def _csr(M):
+            # BCOO -> scipy CSR through its COO triplets: O(nnz), never densify. `.todense()` here would
+            # materialize the full edge x edge operator (~80 GB at 70k edges) before re-sparsifying.
+            # Duplicate indices sum, matching BCOO semantics; a traced operator's tracer .data raises under
+            # np.asarray and is caught below as "cannot host-assemble under a trace".
+            if hasattr(M, "indices") and hasattr(M, "data"):
+                idx = np.asarray(M.indices)
+                return sp.csr_matrix((np.asarray(M.data), (idx[:, 0], idx[:, 1])), shape=tuple(M.shape))
+            return sp.csr_matrix(np.asarray(M))
+
         try:
-            A_sp = sp.csr_matrix(np.asarray(A.todense() if hasattr(A, "todense") else A))
+            A_sp = _csr(A)
         except Exception as e:  # a traced operator (parametric/complex-inverse) can't be host-assembled
             raise RuntimeError(
                 "jno.precond.ams assembles the nodal auxiliaries on the host from a concrete matrix, so it "
@@ -513,8 +524,8 @@ class _AMS(_Spec):
                 "at your reference parameters — then reuse that spec; the frozen preconditioner then runs "
                 "and differentiates through (the gradient flows through the operator, not the preconditioner)."
             ) from e
-        G_sp = sp.csr_matrix(np.asarray(self._G.todense()))
-        Pi_sp = [sp.csr_matrix(np.asarray(P.todense())) for P in self._Pis]
+        G_sp = _csr(self._G)
+        Pi_sp = [_csr(P) for P in self._Pis]
 
         A_G = (G_sp.T @ A_sp @ G_sp).tocsr()  # gradient-space auxiliary operator GᵀAG
         g_scale = float(np.abs(A_G.data).max()) if A_G.nnz else 0.0

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -31,7 +31,7 @@ from .utils.solver.solver_api import (  # noqa: F401  (PrecondContext re-exporte
     PrecondContext,
 )
 
-__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg"]
+__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg", "ams"]
 
 
 class _Jacobi:
@@ -389,6 +389,127 @@ def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smooth
     spec for very large ones.
     """
     return _AMG(cycles, max_levels, coarse_size, smoother_degree)
+
+
+class _AMS:
+    """Spec for the H(curl) auxiliary-space Maxwell (AMS) preconditioner; see :func:`ams`."""
+
+    def __init__(self, aux):
+        self.aux = aux  # jno.solve LinearSolver for the nodal auxiliary solves (None -> lu())
+        self._G = None  # discrete gradient (node->edge), built once from the mesh topology
+        self._Pis = None  # (Π_x, Π_y, Π_z) nodal->edge vector interpolation
+
+    def prepare(self, fem):
+        """Eager one-time build of the mesh-only transfer operators G, Π (parameter-independent)."""
+        self._transfer(fem.domain)
+
+    def _transfer(self, domain):
+        from .utils.solver.ams import discrete_gradient, nodal_vector_interpolation
+
+        topo = domain._fem_nonnodal_topology
+        self._G = discrete_gradient(topo)
+        self._Pis = nodal_vector_interpolation(topo)
+
+    def materialize(self, ctx: PrecondContext):
+        import numpy as np
+        import scipy.sparse as sp
+        from jax.experimental import sparse as jsp
+
+        from . import solve as _solve
+        from .utils.solver.solver_api import LinearOperator
+
+        if self._G is None:
+            if ctx.fem is None:
+                raise TypeError(
+                    "jno.precond.ams needs the owning FEM to read the N1E edge topology — "
+                    "use it via fem.solve(precond=jno.precond.ams()), not on a bare operator."
+                )
+            self._transfer(ctx.fem.domain)
+        aux = self.aux if self.aux is not None else _solve.lu()
+
+        A = ctx.A.bcoo if ctx.A.bcoo is not None else ctx.A.dense()
+        try:
+            A_sp = sp.csr_matrix(np.asarray(A.todense() if hasattr(A, "todense") else A))
+        except Exception as e:  # a traced operator (parametric/complex-inverse) can't be host-assembled
+            raise RuntimeError(
+                "jno.precond.ams assembles the nodal auxiliary operators on the host from a concrete "
+                "matrix; it does not run under a trace (jit/vmap/parametric-inverse solve)."
+            ) from e
+        G_sp = sp.csr_matrix(np.asarray(self._G.todense()))
+        Pi_sp = [sp.csr_matrix(np.asarray(P.todense())) for P in self._Pis]
+
+        A_G = (G_sp.T @ A_sp @ G_sp).tocsr()  # gradient-space auxiliary operator GᵀAG
+        g_scale = float(np.abs(A_G.data).max()) if A_G.nnz else 0.0
+        if g_scale < 1e-12 * (float(np.abs(A_sp.data).max()) or 1.0):
+            raise ValueError(
+                "jno.precond.ams: the gradient auxiliary GᵀAG is ~0 — a pure curl-curl operator has no "
+                "coercivity on the gradient space. Add a mass term (σ/ε-gauge: jω·ε·⟨A,v⟩) so it is "
+                "non-singular; see the AMS docs."
+            )
+
+        def pin0(M):  # pin node 0 → remove the constant nodal mode so an exact aux solve is non-singular
+            L = M.tolil()
+            L[0, :] = 0.0
+            L[:, 0] = 0.0
+            L[0, 0] = 1.0
+            return L.tocsr()
+
+        def to_op(M):  # scipy -> jno LinearOperator over a BCOO
+            coo = pin0(M).tocoo()
+            idx = jnp.asarray(np.stack([coo.row, coo.col], axis=1))
+            return LinearOperator(jsp.BCOO((jnp.asarray(coo.data), idx), shape=coo.shape))
+
+        # G's constant null-space (G·1 = 0) is exact; each Π_α's constant mode is redundant with it
+        # (Π_α·1 = G·coordₐ is a gradient), so pinning node 0 in every auxiliary operator is correct.
+        g_op = to_op(A_G)
+        p_ops = [to_op((P.T @ A_sp @ P).tocsr()) for P in Pi_sp]
+
+        G, Pis = self._G, self._Pis
+        GT, PisT = G.T, [P.T for P in Pis]
+        dinv = 1.0 / ctx.diag()  # Jacobi smoother (complex diagonal on a complex operator)
+
+        def apply(r):
+            x = dinv * r
+            x = x + G @ aux(g_op, (GT @ r).at[0].set(0.0))  # gradient-space correction
+            for P, PT, p_op in zip(Pis, PisT, p_ops):
+                x = x + P @ aux(p_op, (PT @ r).at[0].set(0.0))  # solenoidal correction (per component)
+            return x
+
+        return PrecondApplier(apply)
+
+    def __repr__(self):
+        return f"jno.precond.ams(aux={self.aux!r})"
+
+
+def ams(*, aux=None) -> _AMS:
+    """**AMS** — the auxiliary-space Maxwell preconditioner for H(curl) (Nédélec/N1E) curl-curl
+    systems (Hiptmair & Xu, *SIAM J. Numer. Anal.* 45(6):2483, 2007; Kolev & Vassilevski,
+    *J. Comput. Math.* 27(5):604, 2009).
+
+    Plain point/AMG smoothing cannot damp the huge **gradient near-null-space** of a curl-curl
+    operator (``curl∘grad = 0``), so its condition number leaks into the iteration count. AMS adds
+    two corrections on cheaper **nodal** auxiliary problems — one on the discrete-gradient space
+    ``G``, one on the vector-nodal space ``Π`` — restoring near mesh-independent convergence::
+
+        M⁻¹ r = D⁻¹ r  +  G (GᵀAG)⁻¹ Gᵀ r  +  Σ_α Π_α (Π_αᵀAΠ_α)⁻¹ Π_αᵀ r
+
+    ``G`` and ``Π`` come from the N1E edge topology (:mod:`jno.utils.solver.ams`); the auxiliary
+    operators are assembled once on the host from the concrete matrix and solved with ``aux`` —
+    **any** ``jno.solve`` solver (default :func:`jno.solve.lu`). Passing a multigrid inner solver
+    makes the whole preconditioner scalable (the auxiliary problems are ordinary nodal Poisson-like
+    systems). The same spec handles the **real** curl-curl+mass and the **complex** eddy operator
+    ``νK + jωσM`` — dtype follows the assembled matrix; pair it with :func:`jno.solve.gmres`
+    (complex-correct) for the eddy case.
+
+    Requirements & scope:
+
+    * The operator must be **coercive on the gradient space** — a bare curl-curl is singular there;
+      a mass term (conductivity, or the σ=0-in-air **ε-gauge** ``jω·ε·⟨A,v⟩``) is what makes
+      ``GᵀAG`` invertible. The spec raises if that term is missing.
+    * ``G``/``Π`` are built from the **full** edge topology, so this targets weak/penalty (PEC-style)
+      boundary terms; Dirichlet-**eliminated** DOFs would need row-masking — out of scope here.
+    """
+    return _AMS(aux)
 
 
 def chebyshev(

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -391,6 +391,24 @@ def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smooth
     return _AMG(cycles, max_levels, coarse_size, smoother_degree)
 
 
+def _fem_concrete_operator(fem):
+    """Concrete assembled operator of a linear/complex ``fem`` (real: the BCOO/dense matrix; complex:
+    ``A_r + i·A_i``), evaluated at the current parameters — for eager preconditioner setup (``.build``)."""
+
+    def _leg(o):  # a raw (A, b) or a parametric FemLinearSystem → its concrete matrix A
+        A, _ = o.evaluate(None) if hasattr(o, "evaluate") else o
+        return A
+
+    op = fem.operator
+    if getattr(fem, "_mode", None) == "complex":
+        from ._fem import _complex_operator
+
+        return _complex_operator(_leg(op[0]), _leg(op[1]))
+    if hasattr(op, "evaluate"):  # a bare parametric FemLinearSystem
+        return _leg(op)
+    return _leg(op[0]) if hasattr(op[0], "evaluate") else op[0]  # (A, b) or (FemLinearSystem, …)
+
+
 class _AMS:
     """Spec for the H(curl) auxiliary-space Maxwell (AMS) preconditioner; see :func:`ams`."""
 
@@ -400,10 +418,25 @@ class _AMS:
         self.aux = aux  # jno.solve LinearSolver for the nodal auxiliary solves (None -> lu())
         self._G = None  # discrete gradient (node->edge), built once from the mesh topology
         self._Pis = None  # (Π_x, Π_y, Π_z) nodal->edge vector interpolation
+        self._frozen = None  # host-assembled auxiliary operators, set by .build() for traced solves
 
     def prepare(self, fem):
         """Eager one-time build of the mesh-only transfer operators G, Π (parameter-independent)."""
         self._transfer(fem.domain)
+
+    def build(self, fem) -> "_AMS":
+        """Eager host setup from a **concrete** ``fem`` — required to use AMS inside a **traced** solve
+        (``jit`` / ``vmap`` / a **parametric-inverse** design loop), where the host scipy assembly of the
+        nodal auxiliaries cannot run under the trace. It freezes the auxiliary operators once (from the
+        operator at the current parameters); the frozen preconditioner stays valid while ``A(θ)`` drifts
+        (speed degrades gracefully, correctness never), so the solve — **and its gradient**, which flows
+        through the traced operator by implicit differentiation, not through the preconditioner — runs
+        differentiably. Returns ``self`` (chainable): ``fem.solve(precond=jno.precond.ams().build(fem))``."""
+        self._transfer(fem.domain)
+        from .utils.solver.solver_api import LinearOperator, PrecondContext
+
+        self._frozen = self._assemble_aux(PrecondContext(LinearOperator(_fem_concrete_operator(fem)), fem))
+        return self
 
     def _transfer(self, domain):
         from .utils.solver.ams import discrete_gradient, nodal_vector_interpolation
@@ -412,12 +445,14 @@ class _AMS:
         self._G = discrete_gradient(topo)
         self._Pis = nodal_vector_interpolation(topo)
 
-    def materialize(self, ctx: PrecondContext):
+    def _assemble_aux(self, ctx: PrecondContext) -> dict:
+        """Host (scipy) assembly of the nodal auxiliary operators from a **concrete** matrix — the part
+        that cannot run under a trace. Returns frozen jno ``LinearOperator``s; :meth:`materialize` builds
+        the (pure-JAX, differentiable) applier from these plus the smoother diagonal."""
         import numpy as np
         import scipy.sparse as sp
         from jax.experimental import sparse as jsp
 
-        from . import solve as _solve
         from .utils.solver.solver_api import LinearOperator
 
         if self._G is None:
@@ -427,15 +462,15 @@ class _AMS:
                     "use it via fem.solve(precond=jno.precond.ams()), not on a bare operator."
                 )
             self._transfer(ctx.fem.domain)
-        aux = self.aux if self.aux is not None else _solve.lu()
 
         A = ctx.A.bcoo if ctx.A.bcoo is not None else ctx.A.dense()
         try:
             A_sp = sp.csr_matrix(np.asarray(A.todense() if hasattr(A, "todense") else A))
         except Exception as e:  # a traced operator (parametric/complex-inverse) can't be host-assembled
             raise RuntimeError(
-                "jno.precond.ams assembles the nodal auxiliary operators on the host from a concrete "
-                "matrix; it does not run under a trace (jit/vmap/parametric-inverse solve)."
+                "jno.precond.ams assembles the nodal auxiliaries on the host from a concrete matrix, so it "
+                "cannot run under a trace (jit/vmap/parametric-inverse). Build it once eagerly first — "
+                "jno.precond.ams().build(fem) — and the frozen preconditioner then differentiates through."
             ) from e
         G_sp = sp.csr_matrix(np.asarray(self._G.todense()))
         Pi_sp = [sp.csr_matrix(np.asarray(P.todense())) for P in self._Pis]
@@ -461,15 +496,36 @@ class _AMS:
             idx = jnp.asarray(np.stack([coo.row, coo.col], axis=1))
             return LinearOperator(jsp.BCOO((jnp.asarray(coo.data), idx), shape=coo.shape))
 
-        G, Pis = self._G, self._Pis
-        GT, PisT = G.T, [P.T for P in Pis]
-        dinv = 1.0 / ctx.diag()  # Jacobi smoother (complex diagonal on a complex operator)
-
         # G's constant null-space (G·1 = 0) is exact; each Π_α's constant mode is redundant with it
         # (Π_α·1 = G·coordₐ is a gradient), so pinning node 0 in every auxiliary operator is correct.
         if not np.iscomplexobj(A_sp.data):
-            g_op = to_op(pin0(A_G))
-            p_ops = [to_op(pin0((P.T @ A_sp @ P).tocsr())) for P in Pi_sp]
+            return {
+                "complex": False,
+                "g_op": to_op(pin0(A_G)),
+                "p_ops": [to_op(pin0((P.T @ A_sp @ P).tocsr())) for P in Pi_sp],
+            }
+        # Complex eddy operator (νK + jωσM): AmgX-style multigrid aux solvers are real-only, so each complex
+        # auxiliary is reformulated as a REAL problem the aux solves *exactly* — gradient GᵀA_cG = jω·R
+        # (Re=0, GᵀKG=0) → -j·(Im A_G)⁻¹; solenoidal ΠᵀA_cΠ = S+jT → the real 2n block [[S,-T],[T,S]].
+        b_ops, nvs = [], []
+        for P in Pi_sp:
+            Ap = pin0((P.T @ A_sp @ P).tocsr())
+            b_ops.append(to_op(sp.bmat([[Ap.real, -Ap.imag], [Ap.imag, Ap.real]]).tocsr()))
+            nvs.append(Ap.shape[0])
+        return {"complex": True, "rg_op": to_op(pin0(sp.csr_matrix(A_G.imag))), "b_ops": b_ops, "nvs": nvs}
+
+    def materialize(self, ctx: PrecondContext):
+        from . import solve as _solve
+
+        aux = self.aux if self.aux is not None else _solve.lu()
+        f = self._frozen if self._frozen is not None else self._assemble_aux(ctx)  # frozen (built) or eager
+
+        G, Pis = self._G, self._Pis
+        GT, PisT = G.T, [P.T for P in Pis]
+        dinv = 1.0 / ctx.diag()  # Jacobi smoother — the traced diagonal carries A(θ) under a trace
+
+        if not f["complex"]:
+            g_op, p_ops = f["g_op"], f["p_ops"]
 
             def apply(r):
                 x = dinv * r
@@ -478,16 +534,7 @@ class _AMS:
                     x = x + P @ aux(p_op, (PT @ r).at[0].set(0.0))  # solenoidal correction (per component)
                 return x
         else:
-            # Complex eddy operator (νK + jωσM): AmgX-style multigrid aux solvers are real-only, so each
-            # complex auxiliary is reformulated as a REAL problem the aux solves *exactly*:
-            #   • gradient   GᵀA_cG = jω·R  (real part vanishes, GᵀKG = 0) → A_G⁻¹ = -j·(Im A_G)⁻¹  [real AMG on Im A_G]
-            #   • solenoidal ΠᵀA_cΠ = S + jT → the real-equivalent 2n block [[S,-T],[T,S]]
-            rg_op = to_op(pin0(sp.csr_matrix(A_G.imag)))
-            b_ops, nvs = [], []
-            for P in Pi_sp:
-                Ap = pin0((P.T @ A_sp @ P).tocsr())
-                b_ops.append(to_op(sp.bmat([[Ap.real, -Ap.imag], [Ap.imag, Ap.real]]).tocsr()))
-                nvs.append(Ap.shape[0])
+            rg_op, b_ops, nvs = f["rg_op"], f["b_ops"], f["nvs"]
 
             def apply(r):
                 x = dinv * r
@@ -529,6 +576,12 @@ def ams(*, aux=None) -> _AMS:
     **Outer solver.** An *exact* ``aux`` (``lu``) is a fixed linear map, so it pairs with ``cg``; an
     *inexact/iterative* ``aux`` (multigrid, an inexact ``cg``) is a **variable** preconditioner and
     needs a **flexible** outer solver — :func:`jno.solve.fgmres` (real) — or ``cg`` stalls.
+
+    **Differentiable / traced solves.** The host aux-assembly cannot run under a trace, so for a
+    ``jit`` / ``vmap`` / **parametric-inverse** (design-loop) solve, build it once eagerly first —
+    ``jno.precond.ams().build(fem)`` — freezing the auxiliaries; the solve then runs *and*
+    differentiates (the gradient flows through the traced operator by implicit differentiation, not
+    through the frozen preconditioner). Without ``.build`` the forward (concrete) solve still works.
 
     The same spec handles the **real** curl-curl+mass and the **complex** eddy operator ``νK + jωσM``
     — dtype follows the assembled matrix; pair it with :func:`jno.solve.gmres` (complex-correct) for

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -35,7 +35,17 @@ from .utils.solver.solver_api import (  # noqa: F401  (PrecondContext re-exporte
 __all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg", "cached"]
 
 
-class _Jacobi:
+class _Spec:
+    """Base for ``jno.precond.*`` specs — gives every preconditioner a fluent ``.cached()``."""
+
+    def cached(self, *, refresh: bool = False):
+        """Wrap this preconditioner so its setup is built **once** and reused across solves — the
+        fluent form of :func:`cached`. E.g. ``jno.precond.amg().cached()``. ``refresh`` controls
+        invalidation (``False`` frozen, ``True`` on shape/sparsity change, or a ``ctx -> key`` callable)."""
+        return _Cached(self, refresh)
+
+
+class _Jacobi(_Spec):
     """Spec for the diagonal (Jacobi) preconditioner; see :func:`jacobi`."""
 
     def materialize(self, ctx: PrecondContext):
@@ -48,7 +58,7 @@ class _Jacobi:
         return "jno.precond.jacobi()"
 
 
-class _Chebyshev:
+class _Chebyshev(_Spec):
     """Spec for the fixed-degree Chebyshev polynomial preconditioner; see :func:`chebyshev`."""
 
     def __init__(self, degree, lmin, lmax, lmin_ratio, safety, bound_iters):
@@ -94,7 +104,7 @@ def jacobi() -> _Jacobi:
     return _Jacobi()
 
 
-class _Form:
+class _Form(_Spec):
     """Spec assembling an auxiliary weak form as the preconditioner operator; see :func:`form`."""
 
     def __init__(self, terms, inner_solver, quad_degree):
@@ -154,7 +164,7 @@ def form(terms, *, inner=None, quad_degree: int = 2) -> _Form:
     return _Form(terms, inner, quad_degree)
 
 
-class _InnerSolve:
+class _InnerSolve(_Spec):
     """Spec using a configured linear solver as the ``M^{-1}`` application; see :func:`inner`."""
 
     def __init__(self, solver):
@@ -219,7 +229,7 @@ def _prepare_pairs(pairs, fem):
             prep(fem)
 
 
-class _BlockDiag:
+class _BlockDiag(_Spec):
     def __init__(self, pairs):
         self.pairs = pairs
 
@@ -247,7 +257,7 @@ class _BlockDiag:
         return f"jno.precond.block_diag(<{len(self.pairs)} blocks>)"
 
 
-class _Triangular:
+class _Triangular(_Spec):
     def __init__(self, pairs):
         self.pairs = pairs
 
@@ -320,7 +330,7 @@ def triangular(*pairs) -> _Triangular:
     return _Triangular(list(pairs))
 
 
-class _AMG:
+class _AMG(_Spec):
     """Spec for the hybrid (pyamg-setup / pure-JAX-apply) AMG preconditioner; see :func:`amg`."""
 
     def __init__(self, cycles, max_levels, coarse_size, smoother_degree):
@@ -395,7 +405,7 @@ def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smooth
 _MISS = object()  # sentinel so the first materialize always builds
 
 
-class _Cached:
+class _Cached(_Spec):
     """Spec that memoises another spec's setup across solves; see :func:`cached`."""
 
     def __init__(self, spec, refresh):
@@ -403,6 +413,9 @@ class _Cached:
         self.refresh = refresh  # False → frozen | True → rebuild on sparsity change | callable ctx→key
         self._applier = None
         self._key = _MISS
+
+    def cached(self, *, refresh: bool = False):
+        return self  # already cached — .cached() is idempotent (no double-wrapping)
 
     def prepare(self, fem):  # forward the eager (out-of-trace) build hook, if the inner spec has one
         prep = getattr(self.spec, "prepare", None)

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -359,13 +359,18 @@ class _AMG(_Spec):
         return self
 
     def materialize(self, ctx: PrecondContext):
-        from .utils.solver.amg import vcycle_apply
+        from .utils.solver.amg import build_hierarchy, vcycle_apply
 
-        if self._levels is None:
+        levels = self._levels  # persisted ONLY by an explicit eager .build(); None → rebuilt THIS solve
+        if levels is None:
             A = ctx.A.bcoo if ctx.A.bcoo is not None else ctx.A.dense()
-            self.build(A)  # raises with .build() guidance when A is traced
-        levels, cycles = self._levels, self.cycles
-        A_op = ctx.A
+            # Rebuild each solve (NOT persisted): the hierarchy depends on the operator *values*, so
+            # silently reusing a stale one across solves would quietly cost iterations. Wrap in
+            # ``.cached()`` (or call ``.build()`` eagerly) to reuse it explicitly. Raises on a tracer.
+            levels = build_hierarchy(
+                A, max_levels=self.max_levels, coarse_size=self.coarse_size, smoother_degree=self.smoother_degree
+            )
+        cycles, A_op = self.cycles, ctx.A
 
         def apply(r):
             x = vcycle_apply(levels, r)
@@ -385,19 +390,20 @@ def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smooth
     a pure-JAX V-cycle with Chebyshev polynomial smoothing (Adams et al., JCP 188, 2003) — see
     :mod:`jno.utils.solver.amg`.
 
-    The setup runs **once on the host** (eagerly) and freezes fixed-pattern level operators; the
-    per-application V-cycle is then ``jit``/``vmap``-native and a fixed *linear* map, so it may
-    precondition ``cg``/``minres`` as well as ``bicgstab``/``fgmres``. The mesh-independent
-    convergence of multigrid makes this *the* preconditioner for large elliptic blocks — heat,
-    diffusion, elasticity, the (Picard-lagged) velocity block of a saddle system inside
-    :func:`triangular`.
+    The host-side setup builds fixed-pattern level operators; the per-application V-cycle is then
+    ``jit``/``vmap``-native and a fixed *linear* map, so it may precondition ``cg``/``minres`` as
+    well as ``bicgstab``/``fgmres``. The mesh-independent convergence of multigrid makes this *the*
+    preconditioner for large elliptic blocks — heat, diffusion, elasticity, the (Picard-lagged)
+    velocity block of a saddle system inside :func:`triangular`.
 
-    Inside traced contexts (jit, vmap, a parametric inverse solve) call ``spec.build(fem.A)``
-    once, eagerly, first; the frozen hierarchy is a legitimate preconditioner while operator
-    values change (speed degrades gracefully, correctness never). pyamg is imported lazily —
-    without it, a clear ``ImportError`` explains the install. On a matvec-only sub-block the
-    matrix is recovered via the (dense) block view — fine for moderate blocks; pass a pre-built
-    spec for very large ones.
+    **Caching is explicit.** The hierarchy is (re)built at each solve — it depends on the operator
+    *values*, so silently reusing a stale one would quietly cost iterations. To amortise the setup
+    over a sweep / Newton loop / inverse solve, say so: ``jno.precond.amg().cached()``. Inside a
+    **traced** context (jit, vmap, a parametric inverse) pyamg cannot run under the trace, so build
+    once eagerly first — ``spec.build(fem.A)`` — and the frozen hierarchy is reused (a legitimate
+    preconditioner while values drift: speed degrades gracefully, correctness never). pyamg is
+    imported lazily — without it a clear ``ImportError`` explains the install. On a matvec-only
+    sub-block the matrix is recovered via the (dense) block view.
     """
     return _AMG(cycles, max_levels, coarse_size, smoother_degree)
 

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -29,9 +29,10 @@ import jax.numpy as jnp
 from .utils.solver.solver_api import (  # noqa: F401  (PrecondContext re-exported for user specs)
     PrecondApplier,
     PrecondContext,
+    materialize_precond,
 )
 
-__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg"]
+__all__ = ["PrecondContext", "jacobi", "chebyshev", "form", "inner", "block_diag", "triangular", "amg", "cached"]
 
 
 class _Jacobi:
@@ -389,6 +390,66 @@ def amg(*, cycles: int = 1, max_levels: int = 10, coarse_size: int = 100, smooth
     spec for very large ones.
     """
     return _AMG(cycles, max_levels, coarse_size, smoother_degree)
+
+
+_MISS = object()  # sentinel so the first materialize always builds
+
+
+class _Cached:
+    """Spec that memoises another spec's setup across solves; see :func:`cached`."""
+
+    def __init__(self, spec, refresh):
+        self.spec = spec
+        self.refresh = refresh  # False → frozen | True → rebuild on sparsity change | callable ctx→key
+        self._applier = None
+        self._key = _MISS
+
+    def prepare(self, fem):  # forward the eager (out-of-trace) build hook, if the inner spec has one
+        prep = getattr(self.spec, "prepare", None)
+        if callable(prep):
+            prep(fem)
+
+    def _key_of(self, ctx):
+        if self.refresh is False:
+            return "frozen"
+        if callable(self.refresh):
+            return self.refresh(ctx)
+        A = ctx.A  # refresh=True → key on the operator's shape + sparsity size
+        return (A.shape, int(A.bcoo.nse)) if A.bcoo is not None else (A.shape,)
+
+    def materialize(self, ctx: PrecondContext):
+        key = self._key_of(ctx)
+        if self._applier is None or key != self._key:
+            self._applier = materialize_precond(self.spec, ctx)  # build the wrapped preconditioner once
+            self._key = key
+        return self._applier  # same applier object (and its .T) reused on later solves
+
+    def __repr__(self):
+        return f"jno.precond.cached({self.spec!r}, refresh={self.refresh}, built={self._applier is not None})"
+
+
+def cached(spec, *, refresh: bool = False):
+    """Memoise any preconditioner's setup so it is built **once** and reused across solves — the
+    plug-and-play way to amortise an expensive setup (a multigrid hierarchy, an assembled auxiliary
+    operator, a jaxamg/AmgX coloring) over a frequency sweep, a Newton loop, or an inverse-problem
+    optimisation, *regardless of which backend does the work*.
+
+    Wraps any spec (``jacobi``, ``amg``, ``form``, a jaxamg-backed preconditioner, or a user
+    ``ctx -> M⁻¹`` callable). ``refresh=False`` (default) freezes the setup from the first solve and
+    reuses it forever — the standard frozen-preconditioner trade (a preconditioner only changes
+    convergence *speed*, never the solution, so reusing a slightly-stale setup is always correct and
+    usually cheap). ``refresh=True`` rebuilds when the operator's shape/sparsity changes (values may
+    still drift under the frozen setup); pass a callable ``ctx -> hashable`` for a custom invalidation
+    key. The wrapped spec's eager ``prepare(fem)`` hook (if any) is forwarded, so it composes with the
+    ``jit``/``vmap``/parametric-inverse build-eagerly requirement unchanged.
+
+    Reuse the SAME ``cached(...)`` object across the solves you want to share the setup::
+
+        M = jno.precond.cached(jno.precond.amg())          # backend-agnostic — pyamg or jaxamg alike
+        for f in freqs:
+            u = build_fem(f).solve(linear=jno.solve.fgmres(), precond=M)   # hierarchy built once
+    """
+    return _Cached(spec, refresh)
 
 
 def chebyshev(

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -456,26 +456,48 @@ class _AMS:
             L[0, 0] = 1.0
             return L.tocsr()
 
-        def to_op(M):  # scipy -> jno LinearOperator over a BCOO
-            coo = pin0(M).tocoo()
+        def to_op(M):  # a pre-pinned scipy matrix -> jno LinearOperator over a BCOO
+            coo = M.tocoo()
             idx = jnp.asarray(np.stack([coo.row, coo.col], axis=1))
             return LinearOperator(jsp.BCOO((jnp.asarray(coo.data), idx), shape=coo.shape))
-
-        # G's constant null-space (G·1 = 0) is exact; each Π_α's constant mode is redundant with it
-        # (Π_α·1 = G·coordₐ is a gradient), so pinning node 0 in every auxiliary operator is correct.
-        g_op = to_op(A_G)
-        p_ops = [to_op((P.T @ A_sp @ P).tocsr()) for P in Pi_sp]
 
         G, Pis = self._G, self._Pis
         GT, PisT = G.T, [P.T for P in Pis]
         dinv = 1.0 / ctx.diag()  # Jacobi smoother (complex diagonal on a complex operator)
 
-        def apply(r):
-            x = dinv * r
-            x = x + G @ aux(g_op, (GT @ r).at[0].set(0.0))  # gradient-space correction
-            for P, PT, p_op in zip(Pis, PisT, p_ops):
-                x = x + P @ aux(p_op, (PT @ r).at[0].set(0.0))  # solenoidal correction (per component)
-            return x
+        # G's constant null-space (G·1 = 0) is exact; each Π_α's constant mode is redundant with it
+        # (Π_α·1 = G·coordₐ is a gradient), so pinning node 0 in every auxiliary operator is correct.
+        if not np.iscomplexobj(A_sp.data):
+            g_op = to_op(pin0(A_G))
+            p_ops = [to_op(pin0((P.T @ A_sp @ P).tocsr())) for P in Pi_sp]
+
+            def apply(r):
+                x = dinv * r
+                x = x + G @ aux(g_op, (GT @ r).at[0].set(0.0))  # gradient-space correction
+                for P, PT, p_op in zip(Pis, PisT, p_ops):
+                    x = x + P @ aux(p_op, (PT @ r).at[0].set(0.0))  # solenoidal correction (per component)
+                return x
+        else:
+            # Complex eddy operator (νK + jωσM): AmgX-style multigrid aux solvers are real-only, so each
+            # complex auxiliary is reformulated as a REAL problem the aux solves *exactly*:
+            #   • gradient   GᵀA_cG = jω·R  (real part vanishes, GᵀKG = 0) → A_G⁻¹ = -j·(Im A_G)⁻¹  [real AMG on Im A_G]
+            #   • solenoidal ΠᵀA_cΠ = S + jT → the real-equivalent 2n block [[S,-T],[T,S]]
+            rg_op = to_op(pin0(sp.csr_matrix(A_G.imag)))
+            b_ops, nvs = [], []
+            for P in Pi_sp:
+                Ap = pin0((P.T @ A_sp @ P).tocsr())
+                b_ops.append(to_op(sp.bmat([[Ap.real, -Ap.imag], [Ap.imag, Ap.real]]).tocsr()))
+                nvs.append(Ap.shape[0])
+
+            def apply(r):
+                x = dinv * r
+                rg = (GT @ r).at[0].set(0.0)
+                x = x + G @ (-1j * (aux(rg_op, jnp.real(rg)) + 1j * aux(rg_op, jnp.imag(rg))))  # -j (Im A_G)⁻¹ rg
+                for P, PT, b_op, nv in zip(Pis, PisT, b_ops, nvs):
+                    rp = (PT @ r).at[0].set(0.0)
+                    s = aux(b_op, jnp.concatenate([jnp.real(rp), jnp.imag(rp)]))  # real 2n-block solve
+                    x = x + P @ (s[:nv] + 1j * s[nv:])
+                return x
 
         return PrecondApplier(apply)
 
@@ -510,8 +532,12 @@ def ams(*, aux=None) -> _AMS:
 
     The same spec handles the **real** curl-curl+mass and the **complex** eddy operator ``νK + jωσM``
     — dtype follows the assembled matrix; pair it with :func:`jno.solve.gmres` (complex-correct) for
-    the eddy case. (An AmgX ``aux`` is real-only, so a complex auxiliary needs a real reformulation —
-    factor ``jω`` out of the gradient block; a real proxy for the Π block.)
+    the eddy case. For a complex operator each auxiliary is reformulated so a **real-only** ``aux``
+    (AmgX/multigrid) still applies, *exactly*: the gradient block ``GᵀA_cG = jω·R`` is pure imaginary
+    (``GᵀKG = 0``) so ``A_G⁻¹ = -j·(Im A_G)⁻¹``; the Π block ``S + jT`` becomes the real 2n block
+    ``[[S,-T],[T,S]]`` (non-symmetric → the ``aux`` must be non-symmetric-capable, e.g. AMG with
+    ``is_symmetric=False``). Complex GMRES is not flexible, so solve the complex ``aux`` **tightly**
+    (near-exact) — a strong multigrid or ``lu``, not a single V-cycle.
 
     Requirements & scope:
 

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -468,14 +468,19 @@ def theta(theta: float = 1.0):
     return _ThetaScheme(theta)
 
 
-def exponential(*, order: int = 40, mass: str = "lumped"):
+def exponential(*, order: int = 40, mass: str = "lumped", symmetric: bool = True):
     """Matrix-**exponential** time scheme for ``fem.solve(time=...)`` — advances a *linear autonomous*
-    parabolic block ``M u̇ + A u = c`` by ``u(t+dt) = exp(-dt·M⁻¹A) u(t) (+ φ₁ forcing)``, computed
-    matrix-free by Lanczos (:func:`applyfun`, needs ``matfree``). **Exact in time and unconditionally
-    stable**, so it takes large stiff steps a θ-step cannot. ``order`` is the Krylov size. ``mass=
-    'lumped'`` (default) is the row-sum diagonal — cheapest, discrete maximum principle; ``mass=
-    'consistent'`` uses the full ``M`` (no lumping error) via a matrix-free M-inner-product Lanczos. Both
-    are matrix-free and differentiable. Time-varying coefficients / nonlinear → use :func:`theta`."""
+    parabolic block ``M u̇ + A u = c`` by ``u(t+dt) = exp(-dt·M⁻¹A) u(t) (+ φ₁ forcing)``, matrix-free.
+    **Exact in time and unconditionally stable**, so it takes large stiff steps a θ-step cannot. ``order``
+    is the Krylov size. ``mass='lumped'`` (default) is the row-sum diagonal — cheapest, discrete maximum
+    principle; ``mass='consistent'`` uses the full ``M`` (no lumping error) via a matrix-free
+    M-inner-product Lanczos.
+
+    ``symmetric=True`` (default, ``A = Aᵀ``) uses Lanczos. ``symmetric=False`` handles a **non-symmetric**
+    operator (**advection–diffusion / transport**): it advances by Arnoldi + a differentiable **Padé**
+    exponential, with forcing carried exactly through an augmented generator — still matrix-free, GPU, and
+    reverse-mode differentiable. All paths are differentiable; time-varying coefficients / nonlinear → use
+    :func:`theta`."""
     from .utils.solver.timeschemes import _ExponentialScheme
 
-    return _ExponentialScheme(order, mass)
+    return _ExponentialScheme(order, mass, symmetric)

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -428,11 +428,11 @@ def trace(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
 
 def applyfun(A, v, *, fun, order: int = 30, symmetric: bool = True):
     """Matrix-free ``f(A)·v`` — e.g. one exact exponential-integrator step ``exp(-dt·A)·v`` with
-    ``fun=lambda z: jnp.exp(-dt*z)``. ``symmetric=True`` (default, Lanczos) is differentiable;
-    ``symmetric=False`` (Arnoldi) handles a **non-symmetric** ``A`` **forward-exact** but is **CPU-only and
-    not differentiable** (relies on ``jax.scipy.linalg.schur``) — for a differentiable, GPU non-symmetric
-    time step use ``fem.solve(time=jno.solve.exponential())``. Optional ``matfree``.
-    See :func:`jno.utils.solver.matfun.applyfun`."""
+    ``fun=lambda z: jnp.exp(-dt*z)``. ``symmetric=True`` (default, Lanczos) assumes ``A = Aᵀ``;
+    ``symmetric=False`` (Arnoldi + an eigendecomposition of the Hessenberg with an analytic Daleckii–Krein
+    derivative) handles a **non-symmetric** ``A`` (advection–diffusion). Both are **differentiable and
+    GPU-capable** — the non-symmetric path for any **holomorphic** ``fun`` on a **diagonalizable** ``A``.
+    Optional ``matfree``. See :func:`jno.utils.solver.matfun.applyfun`."""
     from .utils.solver.matfun import applyfun as _applyfun
 
     return _applyfun(A, v, fun=fun, order=order, symmetric=symmetric)

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -447,9 +447,9 @@ def exponential(*, order: int = 40, mass: str = "lumped"):
     parabolic block ``M u̇ + A u = c`` by ``u(t+dt) = exp(-dt·M⁻¹A) u(t) (+ φ₁ forcing)``, computed
     matrix-free by Lanczos (:func:`applyfun`, needs ``matfree``). **Exact in time and unconditionally
     stable**, so it takes large stiff steps a θ-step cannot. ``order`` is the Krylov size. ``mass=
-    'lumped'`` (default) is the row-sum diagonal — matrix-free, differentiable, discrete maximum
-    principle; ``mass='consistent'`` factors the full ``M = L Lᵀ`` **once** for no lumping error (needs a
-    concrete operator; denser setup). Time-varying coefficients / nonlinear → use :func:`theta`."""
+    'lumped'`` (default) is the row-sum diagonal — cheapest, discrete maximum principle; ``mass=
+    'consistent'`` uses the full ``M`` (no lumping error) via a matrix-free M-inner-product Lanczos. Both
+    are matrix-free and differentiable. Time-varying coefficients / nonlinear → use :func:`theta`."""
     from .utils.solver.timeschemes import _ExponentialScheme
 
     return _ExponentialScheme(order, mass)

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -446,8 +446,10 @@ def exponential(*, order: int = 40, mass: str = "lumped"):
     """Matrix-**exponential** time scheme for ``fem.solve(time=...)`` — advances a *linear autonomous*
     parabolic block ``M u̇ + A u = c`` by ``u(t+dt) = exp(-dt·M⁻¹A) u(t) (+ φ₁ forcing)``, computed
     matrix-free by Lanczos (:func:`applyfun`, needs ``matfree``). **Exact in time and unconditionally
-    stable**, so it takes large stiff steps a θ-step cannot. ``order`` is the Krylov size; ``mass``
-    is ``'lumped'`` (V1). Time-varying coefficients / nonlinear terms → use :func:`theta` instead."""
+    stable**, so it takes large stiff steps a θ-step cannot. ``order`` is the Krylov size. ``mass=
+    'lumped'`` (default) is the row-sum diagonal — matrix-free, differentiable, discrete maximum
+    principle; ``mass='consistent'`` factors the full ``M = L Lᵀ`` **once** for no lumping error (needs a
+    concrete operator; denser setup). Time-varying coefficients / nonlinear → use :func:`theta`."""
     from .utils.solver.timeschemes import _ExponentialScheme
 
     return _ExponentialScheme(order, mass)

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -49,6 +49,9 @@ __all__ = [
     "newton",
     "picard",
     "eigs",
+    "logdet",
+    "trace",
+    "applyfun",
 ]
 
 
@@ -397,3 +400,32 @@ def eigs(*, k: int = 6, which: str = "smallest"):
         return dense_geneigh(K, M, k, which)
 
     return _fn
+
+
+def logdet(A, *, samples: int = 32, order: int = 25, key=None):
+    """Differentiable, matrix-free ``log det A`` (symmetric positive-definite) — stochastic Lanczos
+    quadrature via the optional ``matfree`` package. Scales where a direct factorisation cannot; the
+    key use is **Bayesian log-evidence / marginal likelihood** of a FEM precision operator. Returns an
+    unbiased estimate (variance ↓ with ``samples``, bias ↓ with ``order``). See
+    :func:`jno.utils.solver.matfun.logdet`."""
+    from .utils.solver.matfun import logdet as _logdet
+
+    return _logdet(A, samples=samples, order=order, key=key)
+
+
+def trace(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
+    """Differentiable, matrix-free ``tr A`` (Hutchinson) or ``tr f(A)`` (``fun=``, Lanczos quadrature) —
+    e.g. ``fun=lambda z: 1/z`` for ``tr(A⁻¹)`` (uncertainty / effective degrees of freedom). Optional
+    ``matfree``. See :func:`jno.utils.solver.matfun.trace`."""
+    from .utils.solver.matfun import trace as _trace
+
+    return _trace(A, fun=fun, samples=samples, order=order, key=key)
+
+
+def applyfun(A, v, *, fun, order: int = 30):
+    """Matrix-free ``f(A)·v`` for a symmetric ``A`` (Lanczos) — e.g. one exact exponential-integrator
+    step ``exp(-dt·A)·v`` with ``fun=lambda z: jnp.exp(-dt*z)``. Differentiable; optional ``matfree``.
+    See :func:`jno.utils.solver.matfun.applyfun`."""
+    from .utils.solver.matfun import applyfun as _applyfun
+
+    return _applyfun(A, v, fun=fun, order=order)

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -52,6 +52,8 @@ __all__ = [
     "logdet",
     "trace",
     "applyfun",
+    "theta",
+    "exponential",
 ]
 
 
@@ -429,3 +431,23 @@ def applyfun(A, v, *, fun, order: int = 30):
     from .utils.solver.matfun import applyfun as _applyfun
 
     return _applyfun(A, v, fun=fun, order=order)
+
+
+def theta(theta: float = 1.0):
+    """θ-method **time scheme** for ``fem.solve(time=...)``: ``θ=1`` backward Euler (default),
+    ``θ=1/2`` Crank–Nicolson / trapezoidal (2nd-order accurate), ``θ=0`` forward Euler. Overrides the
+    scheme the assembly picks; composes with ``linear=``/``precond=`` (the per-step solve)."""
+    from .utils.solver.timeschemes import _ThetaScheme
+
+    return _ThetaScheme(theta)
+
+
+def exponential(*, order: int = 40, mass: str = "lumped"):
+    """Matrix-**exponential** time scheme for ``fem.solve(time=...)`` — advances a *linear autonomous*
+    parabolic block ``M u̇ + A u = c`` by ``u(t+dt) = exp(-dt·M⁻¹A) u(t) (+ φ₁ forcing)``, computed
+    matrix-free by Lanczos (:func:`applyfun`, needs ``matfree``). **Exact in time and unconditionally
+    stable**, so it takes large stiff steps a θ-step cannot. ``order`` is the Krylov size; ``mass``
+    is ``'lumped'`` (V1). Time-varying coefficients / nonlinear terms → use :func:`theta` instead."""
+    from .utils.solver.timeschemes import _ExponentialScheme
+
+    return _ExponentialScheme(order, mass)

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -48,6 +48,7 @@ __all__ = [
     "amg",
     "newton",
     "picard",
+    "eigs",
 ]
 
 
@@ -370,3 +371,29 @@ def picard(
         ls_max=ls_max,
         ls_c=ls_c,
     )
+
+
+def eigs(*, k: int = 6, which: str = "smallest"):
+    """Generalized **symmetric eigensolver** ``K x = λ M x`` (K symmetric, M SPD). Returns a callable
+    ``(K, M=None) -> (λ, X)``: the ``k`` eigenvalues at the requested end (``which='smallest'`` /
+    ``'largest'``) and their **M-orthonormal** eigenvectors (``Xᵀ M X = I``). ``M=None`` is the standard
+    problem ``K x = λ x``.
+
+    Use it for modal analysis (vibration), buckling, EM cavity/waveguide resonances and photonic band
+    structure — everything that is ``Kx=λMx`` rather than ``Ax=b``. Build ``K``/``M`` as source-less
+    ``jno.fem`` bilinear forms (or via :meth:`FEM.eigs`).
+
+    **Differentiable.** V1a reduces the pencil densely (Cholesky ``M=LLᵀ`` → ``jnp.linalg.eigh`` on
+    ``L⁻¹KL⁻ᵀ``), so ``∂λ/∂θ`` flows for free — for **simple** eigenvalues (degenerate/crossing
+    eigenvalues make the eigen-JVP singular; use the trace of a degenerate cluster there). Preconditioned
+    LOBPCG (reusing ``jno.precond.*``) and shift-invert to a target ``σ`` are the planned scale paths.
+    """
+    if which not in ("smallest", "largest", "SM", "LM", "SA", "LA"):
+        raise ValueError(f"jno.solve.eigs: which={which!r} — use 'smallest' or 'largest'.")
+
+    def _fn(K, M=None):
+        from .utils.solver.eigen import dense_geneigh
+
+        return dense_geneigh(K, M, k, which)
+
+    return _fn

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -45,6 +45,7 @@ __all__ = [
     "fgmres",
     "minres",
     "chebyshev",
+    "amg",
     "newton",
     "picard",
 ]
@@ -204,6 +205,69 @@ def chebyshev(
         return _firewalled(raw, op, b, M=M, x0=x0, symmetric=True, name="chebyshev")
 
     return LinearSolver(_fn, name="chebyshev")
+
+
+def _require_jaxamg():
+    try:
+        import jaxamg
+    except ImportError as e:  # optional GPU dependency — see the message for the system requirements
+        raise ImportError(
+            "jno.solve.amg() needs the optional dependency `jaxamg` (NVIDIA AmgX wrapped as a JAX "
+            "primitive). It requires a prebuilt AmgX 2.5+, CUDA Toolkit 12+, JAX-with-CUDA, and an MPI "
+            "stack (mpi4py / mpi4jax). Install those into your environment, then retry."
+        ) from e
+    return jaxamg
+
+
+def amg(
+    *, tol: float = 1e-6, maxiter: int = 500, krylov: Optional[str] = "PBICGSTAB", config: Optional[dict] = None
+) -> LinearSolver:
+    """GPU algebraic-multigrid solve via **jaxamg** (NVIDIA AmgX wrapped as a JAX primitive).
+
+    A self-contained solver: it runs an AMG-preconditioned Krylov iteration (or pure AMG) entirely on
+    the GPU/device — the on-device counterpart to the host-side pyamg used by ``jno.precond.amg``.
+    Ideal for large H¹-elliptic systems (Poisson, diffusion, elasticity) and, via
+    ``jno.precond.inner(jno.solve.amg(...))``, as the smoother inside an outer flexible-Krylov solve
+    (e.g. the auxiliary nodal solves of a future H(curl) AMS preconditioner). Plain AMG will **not**
+    converge on a raw curl-curl (H(curl)) system — that needs AMS on top.
+
+    ``config`` (a full AmgX-format dict) overrides the convenience args entirely; otherwise a config is
+    built from ``tol``/``maxiter``/``krylov`` (``krylov=None`` → pure AMG, else an AMG-preconditioned
+    ``krylov`` Krylov, e.g. ``"PBICGSTAB"``/``"GMRES"``/``"PCG"``). Needs an **assembled** operator
+    (hands the sparse matrix to jaxamg); errors on a matrix-free operator. Direct-style: takes no outer
+    ``precond=`` (it owns its AMG preconditioner) and ignores ``x0``.
+
+    Optional dependency — jaxamg is imported lazily; see :func:`_require_jaxamg` for the requirements.
+
+    Reference: Liu, Fan & Wang, *JAX-AMG: A GPU-Accelerated Differentiable Sparse Linear Solver Library
+    for JAX*, arXiv:2606.09001 (2026); wraps NVIDIA AmgX (Naumov et al., 2015).
+    """
+
+    def _fn(op: LinearOperator, b, *, M, x0):
+        A = op.bcoo
+        if A is None:
+            raise ValueError(
+                "jno.solve.amg() needs an assembled (sparse) operator — it cannot solve a matrix-free "
+                "operator. Use a Krylov solver (cg/bicgstab/fgmres) for matrix-free systems."
+            )
+        jaxamg = _require_jaxamg()
+        if config is not None:
+            cfg = dict(config)
+        elif krylov:
+            cfg = {
+                "solver": krylov,
+                "preconditioner": {"solver": "AMG"},
+                "tolerance": float(tol),
+                "max_iters": int(maxiter),
+            }
+        else:
+            cfg = {"solver": "AMG", "tolerance": float(tol), "max_iters": int(maxiter)}
+        x, _info = jaxamg.solve(A, b, config=cfg)
+        return jnp.asarray(x).reshape(-1)
+
+    # AmgX owns the solve; treat as direct (no outer preconditioner). vmap left "no" (AmgX/MPI primitive
+    # is not a pure-JAX batching op) — loop for batched solves.
+    return LinearSolver(_fn, name="amg", direct=True, traits={"vmap": "no"})
 
 
 def _root_driver(

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -52,6 +52,7 @@ __all__ = [
     "logdet",
     "trace",
     "applyfun",
+    "diagonal",
     "theta",
     "exponential",
 ]
@@ -431,6 +432,17 @@ def applyfun(A, v, *, fun, order: int = 30):
     from .utils.solver.matfun import applyfun as _applyfun
 
     return _applyfun(A, v, fun=fun, order=order)
+
+
+def diagonal(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
+    """Differentiable, matrix-free estimate of the **diagonal** of ``A`` (Hutchinson) or ``f(A)`` (``fun=``,
+    ``A`` symmetric) — the per-DOF **field** counterpart of :func:`trace`. The key use is
+    ``fun=lambda z: 1/z`` → ``diag(A⁻¹)``, the **pointwise posterior variance / uncertainty map** of a FEM
+    precision, plottable on the mesh. Stochastic (variance ↓ ``samples``, bias ↓ ``order``); optional
+    ``matfree``. See :func:`jno.utils.solver.matfun.diagonal`."""
+    from .utils.solver.matfun import diagonal as _diagonal
+
+    return _diagonal(A, fun=fun, samples=samples, order=order, key=key)
 
 
 def theta(theta: float = 1.0):

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -425,13 +425,16 @@ def trace(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
     return _trace(A, fun=fun, samples=samples, order=order, key=key)
 
 
-def applyfun(A, v, *, fun, order: int = 30):
-    """Matrix-free ``f(A)·v`` for a symmetric ``A`` (Lanczos) — e.g. one exact exponential-integrator
-    step ``exp(-dt·A)·v`` with ``fun=lambda z: jnp.exp(-dt*z)``. Differentiable; optional ``matfree``.
+def applyfun(A, v, *, fun, order: int = 30, symmetric: bool = True):
+    """Matrix-free ``f(A)·v`` — e.g. one exact exponential-integrator step ``exp(-dt·A)·v`` with
+    ``fun=lambda z: jnp.exp(-dt*z)``. ``symmetric=True`` (default, Lanczos) is differentiable;
+    ``symmetric=False`` (Arnoldi) handles a **non-symmetric** ``A`` **forward-exact** but is **CPU-only and
+    not differentiable** (relies on ``jax.scipy.linalg.schur``) — for a differentiable, GPU non-symmetric
+    time step use ``fem.solve(time=jno.solve.exponential())``. Optional ``matfree``.
     See :func:`jno.utils.solver.matfun.applyfun`."""
     from .utils.solver.matfun import applyfun as _applyfun
 
-    return _applyfun(A, v, fun=fun, order=order)
+    return _applyfun(A, v, fun=fun, order=order, symmetric=symmetric)
 
 
 def diagonal(A, *, fun=None, samples: int = 32, order: int = 25, key=None):

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -53,6 +53,7 @@ __all__ = [
     "trace",
     "applyfun",
     "diagonal",
+    "lstsq",
     "theta",
     "exponential",
 ]
@@ -446,6 +447,16 @@ def diagonal(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
     from .utils.solver.matfun import diagonal as _diagonal
 
     return _diagonal(A, fun=fun, samples=samples, order=order, key=key)
+
+
+def lstsq(A, b, *, damp: float = 0.0, atol: float = 1e-6, btol: float = 1e-6, maxiter: int = 100_000, x0=None):
+    """Differentiable, matrix-free **least-squares** ``min_x ‖A x − b‖²`` for a **rectangular** ``A`` (LSMR) —
+    the gap left by the square ``Ax=b`` solvers. ``damp`` adds Tikhonov ``+ damp²‖x‖²`` (ill-posed /
+    rank-deficient inverse problems); ``x0`` an initial guess. Real operators; optional ``matfree``.
+    See :func:`jno.utils.solver.matfun.lstsq`."""
+    from .utils.solver.matfun import lstsq as _lstsq
+
+    return _lstsq(A, b, damp=damp, atol=atol, btol=btol, maxiter=maxiter, x0=x0)
 
 
 def theta(theta: float = 1.0):

--- a/jno/utils/solver/ams.py
+++ b/jno/utils/solver/ams.py
@@ -46,3 +46,41 @@ def discrete_gradient(topology: Mapping) -> jsparse.BCOO:
     data = np.tile(np.asarray([-1.0, 1.0]), n_edges)  # -φ(lo) + φ(hi)
     indices = jnp.asarray(np.stack([rows, cols], axis=1))
     return jsparse.BCOO((jnp.asarray(data), indices), shape=(n_edges, n_verts))
+
+
+def nodal_vector_interpolation(topology: Mapping) -> tuple[jsparse.BCOO, jsparse.BCOO, jsparse.BCOO]:
+    """Nodal→edge vector interpolation ``(Π_x, Π_y, Π_z)`` for a Nédélec first-kind (N1E) space.
+
+    AMS corrects a *second* near-null-space — the solenoidal (divergence-free) modes the discrete
+    gradient misses — on an auxiliary **vector nodal** problem. The link is ``Π``, which maps a
+    piecewise-linear nodal vector field to N1E edge DOFs: the DOF on edge ``e`` is the circulation
+    ``∫_e v·dl ≈ v(mid)·t_e`` with ``t_e = x_hi − x_lo`` (midpoint rule), and ``v(mid) = ½(v_lo + v_hi)``
+    for a linear field, so ``Π_α[e, lo] = Π_α[e, hi] = ½ t_e[α]``. Following Kolev & Vassilevski
+    (*J. Comput. Math.* 27(5):604–623, 2009, §3) the three scalar components are kept separate — each
+    gets its own scalar auxiliary solve ``(Π_αᵀ A Π_α)⁻¹`` — which is cheaper than one coupled 3n-vector
+    solve and works as well in practice.
+
+    A key consistency property, exact by construction, is that ``Π`` reproduces constant vector fields
+    and ties back to the discrete gradient: ``Π_α · 1 = G · coords[:, α] = t_e[α]``.
+
+    Args:
+        topology: the ``domain._fem_nonnodal_topology`` dict; needs ``n_edges``, ``n_verts``, the
+            canonical ``edge_vertices`` pairs and ``vertex_points``.
+
+    Returns:
+        A 3-tuple of ``(n_edges, n_verts)`` BCOO blocks — one per Cartesian component.
+    """
+    n_edges = int(topology["n_edges"])
+    n_verts = int(topology["n_verts"])
+    ev = np.asarray(topology["edge_vertices"], dtype=np.int64)  # (n_edges, 2) canonical (lo, hi)
+    vpts = np.asarray(topology["vertex_points"], dtype=float)
+    lo, hi = ev[:, 0], ev[:, 1]
+    t = vpts[hi] - vpts[lo]  # (n_edges, 3) edge vectors x_hi − x_lo
+    rows = np.repeat(np.arange(n_edges, dtype=np.int64), 2)
+    cols = np.stack([lo, hi], axis=1).reshape(-1)  # [lo_0, hi_0, lo_1, hi_1, ...]
+    indices = jnp.asarray(np.stack([rows, cols], axis=1))
+    blocks = tuple(
+        jsparse.BCOO((jnp.asarray(np.repeat(0.5 * t[:, a], 2)), indices), shape=(n_edges, n_verts))
+        for a in range(3)  # both endpoints of an edge share ½ t_α
+    )
+    return blocks

--- a/jno/utils/solver/ams.py
+++ b/jno/utils/solver/ams.py
@@ -1,0 +1,48 @@
+"""Auxiliary-space building blocks for H(curl) (Nédélec / N1E) preconditioning.
+
+The auxiliary-space Maxwell solver **AMS** (Hiptmair & Xu, *SIAM J. Numer. Anal.* 45(6):2483–2509,
+2007, §5; Kolev & Vassilevski, *J. Comput. Math.* 27(5):604–623, 2009) preconditions a curl-curl
+system by correcting its near-null-space on a cheaper *nodal* auxiliary problem. The first ingredient
+is the **discrete gradient** ``G`` — the node→edge incidence matrix whose columns span exactly the
+kernel of the curl-curl operator (``∇×∇φ = 0`` discretely). Plain point/Jacobi smoothing cannot damp
+that gradient sub-space, so its condition number leaks into the iteration count; the AMS correction
+``G (GᵀAG)⁻¹ Gᵀ`` restores it. This module builds ``G`` from the N1E edge topology the non-nodal
+assembler stashes on the domain.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import jax.experimental.sparse as jsparse
+import jax.numpy as jnp
+import numpy as np
+
+
+def discrete_gradient(topology: Mapping) -> jsparse.BCOO:
+    """Discrete gradient ``G`` (node→edge incidence) for a Nédélec first-kind (N1E) space.
+
+    Row ``e`` of ``G`` maps a nodal field ``φ`` to the tangential moment of ``∇φ`` on edge ``e``. With
+    the canonical ``edge_vertices[e] = (lo, hi)`` orientation the N1E assembler uses — the lo→hi edge
+    tangent — that moment is ``φ(hi) − φ(lo)``, so ``G[e, lo] = -1`` and ``G[e, hi] = +1``. The columns
+    of ``G`` therefore span the discrete gradient space, i.e. the kernel of the curl-curl operator
+    (``curl(G φ) = 0``) — the near-null-space AMS corrects on a nodal auxiliary problem.
+
+    Args:
+        topology: the ``domain._fem_nonnodal_topology`` dict the N1E assembler stashes; needs
+            ``n_edges``, ``n_verts`` and the canonical ``edge_vertices`` pairs.
+
+    Returns:
+        The ``(n_edges, n_verts)`` incidence as a ``BCOO`` — so it drops straight into a traced
+        auxiliary operator ``Gᵀ A G`` without a host round-trip.
+    """
+    n_edges = int(topology["n_edges"])
+    n_verts = int(topology["n_verts"])
+    ev = np.asarray(topology["edge_vertices"], dtype=np.int64)  # (n_edges, 2) canonical (lo, hi)
+    if ev.shape != (n_edges, 2):
+        raise ValueError(f"discrete_gradient: edge_vertices has shape {ev.shape}, expected {(n_edges, 2)}.")
+    rows = np.repeat(np.arange(n_edges, dtype=np.int64), 2)
+    cols = ev.reshape(-1)  # [lo_0, hi_0, lo_1, hi_1, ...]
+    data = np.tile(np.asarray([-1.0, 1.0]), n_edges)  # -φ(lo) + φ(hi)
+    indices = jnp.asarray(np.stack([rows, cols], axis=1))
+    return jsparse.BCOO((jnp.asarray(data), indices), shape=(n_edges, n_verts))

--- a/jno/utils/solver/backend_blocks.py
+++ b/jno/utils/solver/backend_blocks.py
@@ -327,7 +327,7 @@ def _block_time_grid(block):
     return jnp.linspace(t0, t1, n_steps + 1)
 
 
-def _default_transient_integrate(block, args, save_ts, *, linear_solve=None, nonlinear_solve=None):
+def _default_transient_integrate(block, args, save_ts, *, linear_solve=None, nonlinear_solve=None, theta=None):
     """Default transient integrator: backward Euler at the block's *own* assembled step ``dt``,
     advanced with ``jax.lax.scan`` (reverse-mode differentiable) and sampled at ``save_ts`` by
     linear interpolation, so the integration step is always the assembled ``dt`` and never an
@@ -359,7 +359,8 @@ def _default_transient_integrate(block, args, save_ts, *, linear_solve=None, non
     # that step (theta-method for a linear block, backward-Euler Newton for a nonlinear one); read
     # theta from the block so a linear step uses the assembled scheme. Operators are only applied as
     # matvecs inside block.step, so a BCOO operator stays sparse.
-    theta = float(block.metadata.get("theta", 1.0)) if getattr(block, "metadata", None) else 1.0
+    if theta is None:  # jno.solve.theta(...) overrides the assembly's default (1 backward-Euler / ½ trapezoidal)
+        theta = float(block.metadata.get("theta", 1.0)) if getattr(block, "metadata", None) else 1.0
 
     def step(w, t_next):
         wn = block.step(

--- a/jno/utils/solver/eigen.py
+++ b/jno/utils/solver/eigen.py
@@ -35,12 +35,12 @@ def dense_geneigh(K, M, k: int, which: str = "smallest"):
     """
     Kd = _as_dense(K)
     Kd = 0.5 * (Kd + Kd.T)  # symmetrise away assembly roundoff
-    Md = _as_dense(M)
-    if Md is None:
+    if _as_dense(M) is None:
         lam, V = jnp.linalg.eigh(Kd)
     else:
-        Md = 0.5 * (Md + Md.T)
-        L = jnp.linalg.cholesky(Md)
+        from .mass import cholesky_spd
+
+        L = cholesky_spd(M)  # M = L Lᵀ (shared with the consistent-mass exponential integrator)
         C = solve_triangular(L, solve_triangular(L, Kd, lower=True).T, lower=True)  # L⁻¹ K L⁻ᵀ
         lam, Y = jnp.linalg.eigh(0.5 * (C + C.T))
         V = solve_triangular(L.T, Y, lower=False)  # x = L⁻ᵀ y  →  M-orthonormal

--- a/jno/utils/solver/eigen.py
+++ b/jno/utils/solver/eigen.py
@@ -1,0 +1,51 @@
+"""Generalized symmetric eigensolver ``K x = λ M x`` (K symmetric, M symmetric positive-definite).
+
+V1a is a **dense** reduction: Cholesky ``M = L Lᵀ`` turns the pencil into the standard problem for
+``C = L⁻¹ K L⁻ᵀ`` (solved by :func:`jax.numpy.linalg.eigh`, which carries a JVP, so the eigenvalues are
+**differentiable for free**), then maps the eigenvectors back ``x = L⁻ᵀ y`` — leaving them
+**M-orthonormal** (``XᵀMX = I``), the invariant every iterative variant must also preserve. Exact and
+cheap for the small problems where you want the whole low spectrum; :mod:`jno.solve` exposes it as
+``jno.solve.eigs`` and adds a preconditioned LOBPCG path for scale.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax.scipy.linalg import solve_triangular
+
+
+def _as_dense(A):
+    if A is None:
+        return None
+    return jnp.asarray(A.todense() if hasattr(A, "todense") else A)
+
+
+def dense_geneigh(K, M, k: int, which: str = "smallest"):
+    """The ``k`` eigenpairs of ``K x = λ M x`` at the requested end of the spectrum.
+
+    Args:
+        K: symmetric operator (dense / BCOO / anything with ``.todense()``).
+        M: symmetric positive-definite mass operator, or ``None`` for the standard problem ``Kx=λx``.
+        k: number of eigenpairs.
+        which: ``"smallest"`` (default) or ``"largest"`` by algebraic value.
+
+    Returns:
+        ``(λ, X)`` — eigenvalues ``(k,)`` ascending (or descending), and M-orthonormal eigenvectors
+        ``(n, k)`` (columns), so ``Xᵀ M X = I``.
+    """
+    Kd = _as_dense(K)
+    Kd = 0.5 * (Kd + Kd.T)  # symmetrise away assembly roundoff
+    Md = _as_dense(M)
+    if Md is None:
+        lam, V = jnp.linalg.eigh(Kd)
+    else:
+        Md = 0.5 * (Md + Md.T)
+        L = jnp.linalg.cholesky(Md)
+        C = solve_triangular(L, solve_triangular(L, Kd, lower=True).T, lower=True)  # L⁻¹ K L⁻ᵀ
+        lam, Y = jnp.linalg.eigh(0.5 * (C + C.T))
+        V = solve_triangular(L.T, Y, lower=False)  # x = L⁻ᵀ y  →  M-orthonormal
+    order = jnp.argsort(lam)
+    if which in ("largest", "LM", "LA"):
+        order = order[::-1]
+    idx = order[:k]
+    return lam[idx], V[:, idx]

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -1691,3 +1691,50 @@ def n1e_field_at_centroids(points: np.ndarray, cells: np.ndarray, top: EdgeTopol
         return jnp.einsum("a,ad->d", c, phi[0])  # (2,)
 
     return jax.vmap(_val)(cells_j, signs, coeffs)
+
+
+def n1e_field_at_tet_centroids(
+    points: np.ndarray, cells: np.ndarray, top: EdgeTopology, u_edge: jnp.ndarray, *, curl: bool = False
+):
+    """Evaluate the 3-D Nédélec (H(curl)) field ``u_h`` (and optionally its curl) at each tet centroid.
+
+    The tetrahedral counterpart of :func:`n1e_field_at_centroids`. Tabulates the 6-DOF N1E tet basis at
+    the reference centroid, covariant-Piola-maps value and (physical) gradient per cell with the same
+    edge-orientation signs used in assembly, and contracts with the cell's six edge-DOF coefficients
+    ``u_edge[cell_edges]``. With ``curl=True`` the vector curl is recovered from the antisymmetric parts
+    of the physical gradient (the invariant :func:`piola_covariant_grad` provides) — this is how one reads
+    ``B = curl A`` off a magnetic-vector-potential solve.
+
+    Returns ``values`` ``(n_cells, 3)``, or ``(values, curls)`` (each ``(n_cells, 3)``) when ``curl=True``.
+    Complex ``u_edge`` gives complex outputs (the map is linear).
+    """
+    import basix
+
+    from .fem_elements import piola_covariant, piola_covariant_grad
+
+    elem = basix.create_element(basix.ElementFamily.N1E, basix.CellType.tetrahedron, 1)
+    tab = elem.tabulate(1, np.array([[0.25, 0.25, 0.25]]))  # (4, 1, 6, 3): [values, d/dξ0, d/dξ1, d/dξ2]
+    rv = jnp.asarray(tab[0])  # (1, 6, 3)
+    rg = jnp.asarray(np.stack([tab[1], tab[2], tab[3]], axis=-1))  # (1, 6, 3, 3): ref grad d(Phi)_i/dξ_m
+    pts = jnp.asarray(points)
+    cells_j = jnp.asarray(np.asarray(cells), dtype=jnp.int32)
+    signs = jnp.asarray(top.cell_edge_signs.astype(np.float64))
+    ce = jnp.asarray(top.cell_edges, dtype=jnp.int32)
+    coeffs = u_edge[ce]  # (n_cells, 6)
+
+    def _tet_jac(verts):
+        J = jnp.stack([verts[1] - verts[0], verts[2] - verts[0], verts[3] - verts[0]], axis=1)  # (3, 3)
+        return J, jnp.linalg.det(J)
+
+    def _val(cell, sgn, c):
+        J, detJ = _tet_jac(pts[cell])
+        phi, _ = piola_covariant(rv, None, J, detJ, sgn)  # (1, 6, 3)
+        val = jnp.einsum("a,ad->d", c, phi[0])  # (3,)
+        if not curl:
+            return val
+        grad = piola_covariant_grad(rg, J, detJ, sgn)  # (1, 6, 3, 3): d(Phi)_i/dx_l
+        g = jnp.einsum("a,ail->il", c, grad[0])  # (3, 3) physical gradient of u_h
+        crl = jnp.stack([g[2, 1] - g[1, 2], g[0, 2] - g[2, 0], g[1, 0] - g[0, 1]])  # curl = antisymmetric parts
+        return val, crl
+
+    return jax.vmap(_val)(cells_j, signs, coeffs)

--- a/jno/utils/solver/fem_nonnodal.py
+++ b/jno/utils/solver/fem_nonnodal.py
@@ -408,7 +408,14 @@ def assemble_fem_nonnodal(
 
     cdofs = [_field_cdofs(i) for i in range(len(fields))]
 
-    def _cell_fields(c, u_blocks):
+    def _cell_local_sols(c, u_blocks):
+        """This cell's LOCAL DOF values per field: ``u_blocks[i][cdofs[i][c] - offs[i]]``. Decoupling the
+        per-cell slice from the global vector is what lets the matrix be assembled per element (``jacfwd``
+        w.r.t. these local dofs) instead of via one global ``jacfwd`` that materialises an O(n_dof × n_cell)
+        tangent."""
+        return [u_blocks[i][cdofs[i][c] - offs[i]] for i in range(len(fields))]
+
+    def _cell_fields(c, cell_sols):
         verts = pts[cells_j[c]]
         J = jnp.stack([verts[k] - verts[0] for k in range(1, dim + 1)], axis=1)  # (dim, dim): 2x2 tri / 3x3 tet
         detJ = jnp.linalg.det(J)
@@ -425,7 +432,7 @@ def assemble_fem_nonnodal(
                         "shape_vals": phi,
                         "shape_grads": grad,
                         "shape_hess": hess,
-                        "cell_sol": u_blocks[i][cdofs[i][c] - offs[i]][:, None],
+                        "cell_sol": cell_sols[i][:, None],
                         "space": "Lagrange",
                     }
                 )
@@ -437,7 +444,7 @@ def assemble_fem_nonnodal(
                         "shape_vals": phi,
                         "shape_grads": grad,
                         "shape_hess": hess,
-                        "cell_sol": u_blocks[i][cdofs[i][c] - offs[i]][:, None],  # this cell's 21 local DOFs
+                        "cell_sol": cell_sols[i][:, None],  # this cell's 21 local DOFs
                         "space": "Lagrange",
                     }
                 )
@@ -449,7 +456,7 @@ def assemble_fem_nonnodal(
                         "shape_vals": phi,
                         "shape_grads": grad,
                         "shape_hess": hess,
-                        "cell_sol": u_blocks[i][cdofs[i][c] - offs[i]][:, None],  # this cell's 6 local DOFs
+                        "cell_sol": cell_sols[i][:, None],  # this cell's 6 local DOFs
                         "space": "Lagrange",
                     }
                 )
@@ -457,13 +464,13 @@ def assemble_fem_nonnodal(
                 rval, rdop, rgr, pf, pgf = edge_ref[s]
                 phi, _d = pf(rval, rdop, J, detJ, esigns[c])  # (n_quad, 3, 2)
                 grad = pgf(rgr, J, detJ, esigns[c])  # (n_quad, 3, 2, 2)
-                per.append({"shape_vals": phi, "shape_grads": grad, "cell_sol": u_blocks[i][ce[c]], "space": s})
+                per.append({"shape_vals": phi, "shape_grads": grad, "cell_sol": cell_sols[i], "space": s})
             else:  # P0: a single constant DOF per cell
                 per.append(
                     {
                         "shape_vals": jnp.ones((n_quad, 1)),
                         "shape_grads": jnp.zeros((n_quad, 1, dim, dim)),
-                        "cell_sol": u_blocks[i][c][None],
+                        "cell_sol": cell_sols[i],
                         "space": "P0",
                     }
                 )
@@ -502,7 +509,7 @@ def assemble_fem_nonnodal(
             for coeff, tfi in typed:
 
                 def _cell(c, e=coeff, _sc=rt_scalar, _fv=field_vals):
-                    per, xq, meas = _cell_fields(c, u_blocks)
+                    per, xq, meas = _cell_fields(c, _cell_local_sols(c, u_blocks))
                     vol_vars = tuple(
                         (_fv[name][cells_j[c]] if name in _field_param_names else _sc[name])  # field: 3 vertex values
                         for name in runtime_parameter_tags
@@ -687,7 +694,7 @@ def assemble_fem_nonnodal(
                 u0_blocks = [jnp.zeros(offs[i + 1] - offs[i]) for i in range(len(fields))]
 
                 def _ic_cell(cidx):
-                    per, xq, meas = _cell_fields(cidx, u0_blocks)
+                    per, xq, meas = _cell_fields(cidx, _cell_local_sols(cidx, u0_blocks))
                     u0 = jnp.asarray(_eval_value_node_at(u0_node, xq)).reshape(n_quad)
                     return jnp.einsum("q,qn,q->n", qw * meas, per[0]["shape_vals"], u0)
 
@@ -907,11 +914,80 @@ def assemble_fem_nonnodal(
             offs,
         )
 
-    # --- steady linear (non-parametric): A u = b (byte-identical to before the refactor) ---
+    # --- steady linear (non-parametric): A u = b ---
+    b = -full_residual(zeros)  # spatial + natural-BC load (constant part of the residual)
+
+    # RT/N1E/P0 (edge & cell DOFs): assemble the matrix SPARSELY, one element at a time. Each cell's block
+    # is ``jacfwd`` of its element residual w.r.t. that cell's LOCAL dofs — an ``(n_test, n_local_all)`` block
+    # — scattered as COO triplets into a BCOO. A single global ``jacfwd(full_residual)`` (the dense path
+    # below) instead materialises an ``O(n_edges × n_cells)`` tangent tensor that overflows the 2³¹ XLA
+    # element limit past ~10⁴ edges; per-element AD keeps every intermediate element-sized. Mirrors the
+    # native (Lagrange) assembler `fem_native._make_jacobian`. The vertex C0/C1 families
+    # (Hermite/Argyris/Morley) keep the dense path — small 2-D problems whose Hessian-shape element
+    # assembly is not ported — so their behaviour is byte-identical to before this refactor.
+    if not has_vertex:
+        import jax.experimental.sparse as _jsparse
+
+        cell_all_dofs = jnp.concatenate([cdofs[i] for i in range(len(fields))], axis=1)  # (n_cells, n_local_all)
+        _sizes = [int(cdofs[i].shape[1]) for i in range(len(fields))]
+        _splits = list(np.cumsum([0] + _sizes))  # per-field slice bounds within a cell's local vector
+
+        typed = []  # (lowered coeff, test-field index) — same typing as `_make_residual`
+        for bare in volume_terms:
+            for sign, sub in _split_additive_terms(domain, bare):
+                coeff = _lower_statefield_to_trial(_apply_sign(domain, sign, sub), {})
+                tfi = _test_field_index(coeff, field_index)
+                if tfi is None:
+                    raise ValueError("jno.fem (non-nodal): each weak term must contain exactly one test field.")
+                typed.append((coeff, tfi))
+
+        def _elem_res(c, la, coeff, tfi):
+            """This cell's element residual (n_test of field ``tfi``,) from its local dof vector ``la``."""
+            cell_sols = [la[_splits[i] : _splits[i + 1]] for i in range(len(fields))]
+            per, xq, meas = _cell_fields(c, cell_sols)
+            local = {
+                "physical_quad_points": xq,
+                "fields": per,
+                "field_index": field_index,
+                "tag": "fem_gauss",
+                "surface": False,
+                "domain_context": ctx,
+                "temporal_tags": (),
+                "runtime_parameter_tags": (),
+                "volume_vars": (),
+            }
+            return _integrate_term(domain, coeff, local, qw * meas)
+
+        rows_l, cols_l, data_l = [], [], []
+        local_zero = jnp.zeros((n_cells, cell_all_dofs.shape[1]), zeros.dtype)  # assemble at u=0 (linear)
+        for coeff, tfi in typed:
+
+            def _ke(c, la, _e=coeff, _t=tfi):
+                return jax.jacfwd(lambda v: _elem_res(c, v, _e, _t))(la)
+
+            Ke = jax.vmap(_ke)(jnp.arange(n_cells), local_zero)  # (n_cells, n_test_tfi, n_local_all)
+            r = jnp.broadcast_to(cdofs[tfi][:, :, None], Ke.shape)
+            cc = jnp.broadcast_to(cell_all_dofs[:, None, :], Ke.shape)
+            rows_l.append(r.reshape(-1))
+            cols_l.append(cc.reshape(-1))
+            data_l.append(Ke.reshape(-1))
+
+        rows, cols, data = jnp.concatenate(rows_l), jnp.concatenate(cols_l), jnp.concatenate(data_l)
+        if surf_mass is not None:  # fold in the tangential-trace surface mass (BCOO add = triplet concat; dups sum)
+            sm = _jsparse.BCOO.fromdense(jnp.asarray(surf_mass))
+            rows = jnp.concatenate([rows, sm.indices[:, 0]])
+            cols = jnp.concatenate([cols, sm.indices[:, 1]])
+            data = jnp.concatenate([data, sm.data])
+        idx = jnp.stack([rows.astype(jnp.int32), cols.astype(jnp.int32)], axis=1)
+        A = _jsparse.BCOO((data, idx), shape=(total, total))
+        if pins:  # symmetric elimination; `_apply_dirichlet_symmetric` keeps a BCOO sparse
+            A, b = _apply_dirichlet_symmetric(A, b, pins)
+        return (A, b), "linear", offs
+
+    # vertex C0/C1 families (Hermite/Argyris/Morley): dense global jacfwd (small 2-D problems)
     A = jax.jacfwd(full_residual)(zeros)
     if surf_mass is not None:  # add the tangential-trace surface mass (impedance / absorbing BC) to the stiffness
         A = A + surf_mass
-    b = -full_residual(zeros)
     if pins:
         A, b = _apply_dirichlet_symmetric(jnp.asarray(A), jnp.asarray(b), pins)
     return (A, b), "linear", offs

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -995,8 +995,9 @@ def _eval_integrand(domain, node, local):
         if node.region not in mask_names or idx >= len(volume_vars):
             raise NotImplementedError(
                 f"jno.fem per-region integration: the per-cell mask for region '{node.region}' was not "
-                f"threaded into this assembly path. Sub-region terms are currently wired for the steady "
-                f"linear single-field path; nonlinear / transient / multifield / parametric are not yet."
+                f"threaded into this assembly path. Per-region terms ARE supported in steady, nonlinear, "
+                f"transient, multifield, parametric and 3D forms (see tests/test_fem_per_region.py); if you "
+                f"reach this on such a form, the mask wiring for that specific path is missing — please report it."
             )
         return jnp.reshape(jnp.asarray(volume_vars[idx]), (-1,))[0]
 

--- a/jno/utils/solver/mass.py
+++ b/jno/utils/solver/mass.py
@@ -28,3 +28,36 @@ def cholesky_spd(M):
     ``L⁻¹``/``L⁻ᵀ`` (triangular solves). Symmetrised for roundoff. Dense (moderate ``n``)."""
     Md = _dense(M)
     return jnp.linalg.cholesky(0.5 * (Md + Md.T))
+
+
+def m_inner_funm(L_mv, m_inner, e0, v, fun, order):
+    """``f(L)·v`` where ``L`` is self-adjoint in the **M-inner-product** ``m_inner(a,b) = aᵀ M b`` — via a
+    generalized (M-orthonormal) **Lanczos** iteration. Fully **matrix-free** (``L_mv`` applies ``L=M⁻¹A``,
+    ``m_inner`` uses only an M-matvec) and **differentiable** (the recurrence unrolls, ``eigh`` of the small
+    tridiagonal is differentiable) — the scalable, autodiff-friendly consistent-mass path, with no dense
+    factorization and no host-side interior extraction. ``e0`` is a fixed M-unit fallback for a null start.
+
+    The three-term recurrence ``β_{j+1} q_{j+1} = L q_j − α_j q_j − β_j q_{j-1}`` uses the M-inner-product
+    throughout (``α_j = ⟨q_j, L q_j⟩_M``), giving a symmetric tridiagonal ``T``; then
+    ``f(L) v = ‖v‖_M · Q f(T) e_1``. ``order`` is the Krylov size."""
+    beta0 = jnp.sqrt(jnp.maximum(m_inner(v, v), 0.0))
+    q = jnp.where(beta0 > 1e-300, v / jnp.where(beta0 > 1e-300, beta0, 1.0), e0)
+    Q, alphas, betas = [q], [], []
+    q_prev, beta = jnp.zeros_like(q), jnp.zeros((), q.dtype)
+    for _j in range(order):  # unrolled (order small) so full reorthogonalization is straightforward
+        w = L_mv(q)
+        alpha = m_inner(q, w)
+        w = w - alpha * q - beta * q_prev
+        for qk in Q:  # FULL M-reorthogonalization — without it ghost eigenvalues corrupt the gradient
+            w = w - m_inner(qk, w) * qk
+        beta_next = jnp.sqrt(jnp.maximum(m_inner(w, w), 0.0))
+        q_prev, beta = q, beta_next
+        q = jnp.where(beta_next > 1e-300, w / jnp.where(beta_next > 1e-300, beta_next, 1.0), q)
+        alphas.append(alpha)
+        betas.append(beta_next)
+        Q.append(q)
+    alphas, betas = jnp.stack(alphas), jnp.stack(betas)
+    T = jnp.diag(alphas) + jnp.diag(betas[:-1], 1) + jnp.diag(betas[:-1], -1)
+    evals, evecs = jnp.linalg.eigh(0.5 * (T + T.T))
+    fT_e1 = evecs @ (fun(evals) * evecs[0, :])
+    return beta0 * (jnp.stack(Q[:order]).T @ fT_e1)  # ‖v‖_M · Q f(T) e₁

--- a/jno/utils/solver/mass.py
+++ b/jno/utils/solver/mass.py
@@ -1,0 +1,30 @@
+"""Mass-matrix handling shared by the schemes that reduce a symmetric-definite pencil ``· = λ M ·`` (or
+``M u̇ = ...``) to a plain symmetric form — the generalized eigensolver and the exponential integrator.
+
+Two treatments:
+
+* **lumped** — the row-sum diagonal ``d_i = Σ_j M_ij = ∫ φ_i`` (partition of unity): matrix-free, and it
+  gives a discrete maximum principle. ``M^{-1/2}`` is then ``1/√d`` — trivial.
+* **consistent** — the full ``M`` via a dense Cholesky ``M = L Lᵀ``: no lumping error, at the cost of a
+  factorization (done **once**; a matrix-free M-inner-product Lanczos is the large-``n`` alternative).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+
+def _dense(M):
+    return jnp.asarray(M.todense() if hasattr(M, "todense") else M)
+
+
+def lumped_diagonal(M):
+    """Row-sum (lumped) mass diagonal ``d`` — one matvec, matrix-free."""
+    return M @ jnp.ones(M.shape[0], _dense(M).dtype if not hasattr(M, "data") else jnp.asarray(M.data).dtype)
+
+
+def cholesky_spd(M):
+    """Lower Cholesky factor ``L`` of an SPD (sub)matrix ``M = L Lᵀ`` — the symmetric reduction applies
+    ``L⁻¹``/``L⁻ᵀ`` (triangular solves). Symmetrised for roundoff. Dense (moderate ``n``)."""
+    Md = _dense(M)
+    return jnp.linalg.cholesky(0.5 * (Md + Md.T))

--- a/jno/utils/solver/matfun.py
+++ b/jno/utils/solver/matfun.py
@@ -74,15 +74,27 @@ def trace(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
     return estimate(mv, _key(key))
 
 
-def applyfun(A, v, *, fun, order: int = 30):
-    """``f(A)·v`` for a symmetric ``A``, matrix-free via Lanczos (Krylov) approximation — e.g.
+def applyfun(A, v, *, fun, order: int = 30, symmetric: bool = True):
+    """``f(A)·v``, matrix-free via a Krylov (Lanczos/Arnoldi) approximation — e.g.
     ``fun=lambda z: jnp.exp(-dt*z)`` is one exact exponential-integrator step ``exp(-dt·A)·v``.
-    Deterministic (no probes); ``order`` sets the Krylov subspace size."""
+    Deterministic (no probes); ``order`` sets the Krylov subspace size.
+
+    ``symmetric=True`` (default) uses **Lanczos** (short recurrence, cheap), assumes ``A = Aᵀ`` (the common
+    FEM case), is **differentiable**, and runs on **GPU**. ``symmetric=False`` uses **Arnoldi** for a
+    **non-symmetric** operator (advection–diffusion / non-self-adjoint transport): it evaluates ``fun`` on
+    the small Hessenberg matrix by a Schur decomposition, so it is **forward-exact for any analytic ``fun``**
+    but comes with two limits from ``jax.scipy.linalg.schur`` — it is **CPU-only** (raises on GPU) and
+    **not differentiable** (JAX has no ``schur`` derivative). For a **differentiable, GPU** non-symmetric
+    time step, use the exponential integrator ``fem.solve(time=jno.solve.exponential())``, which routes the
+    non-symmetric matrix exponential through a differentiable Padé approximation instead."""
     _require_matfree()
     from matfree import decomp, funm
 
     mv, _n, _dtype = _operator(A)
-    f = funm.funm_lanczos_sym(funm.dense_funm_sym_eigh(fun), decomp.tridiag_sym(order))
+    if symmetric:
+        f = funm.funm_lanczos_sym(funm.dense_funm_sym_eigh(fun), decomp.tridiag_sym(order))
+    else:  # non-symmetric: Arnoldi Hessenberg + Schur f(H). Forward-exact; Schur blocks the JAX gradient.
+        f = funm.funm_arnoldi(funm.dense_funm_schur(fun), decomp.hessenberg(order, reortho="full"))
     return f(mv, jnp.asarray(v))
 
 

--- a/jno/utils/solver/matfun.py
+++ b/jno/utils/solver/matfun.py
@@ -98,6 +98,20 @@ def applyfun(A, v, *, fun, order: int = 30, symmetric: bool = True):
     return f(mv, jnp.asarray(v))
 
 
+def expmv(A, v, *, order: int = 30):
+    """``exp(A)·v`` for a possibly **non-symmetric** ``A``, via Arnoldi + a differentiable **Padé**
+    approximation of the small Hessenberg exponential. Unlike ``applyfun(..., symmetric=False)`` (Schur:
+    CPU-only, forward-only, any ``fun``) this is limited to the **exponential** but is **reverse-mode
+    differentiable and GPU-capable** — the engine of the non-symmetric exponential time integrator. Scale
+    ``A`` into its matvec to get ``exp(dt·A)·v``."""
+    _require_matfree()
+    from matfree import decomp, funm
+
+    mv, _n, _dtype = _operator(A)
+    f = funm.funm_arnoldi(funm.dense_funm_pade_exp(), decomp.hessenberg(order, reortho="full"))
+    return f(mv, jnp.asarray(v))
+
+
 def diagonal(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
     """Differentiable stochastic estimate of the **diagonal** of ``A`` (Hutchinson), or of ``f(A)`` when
     ``fun`` is given (``A`` symmetric; ``f(A)·probe`` via Lanczos). Unlike :func:`trace` (a scalar) this

--- a/jno/utils/solver/matfun.py
+++ b/jno/utils/solver/matfun.py
@@ -1,0 +1,86 @@
+"""Matrix functions and spectral quantities — **log-determinant, trace, and ``f(A)·v``** — for large
+operators, via the optional **matfree** package (N. Krämer, MIT; https://pnkraemer.github.io/matfree/).
+
+Everything here is **matrix-free** (it touches the operator only through its matvec, so it scales to
+problems too large to factor) and **differentiable** (matfree carries the JVP/VJP through its Lanczos /
+Arnoldi iterations — no hand-written adjoint). ``logdet`` / ``trace`` are *stochastic* estimators
+(Hutchinson probes + stochastic Lanczos quadrature): the return value is an unbiased estimate whose
+variance falls with ``samples`` (probe vectors) and whose bias falls with ``order`` (Lanczos steps).
+
+These unlock, differentiably, things ``Ax=b`` solvers cannot express: Bayesian **log-evidence /
+marginal likelihood** (``logdet`` of a FEM precision), **uncertainty / effective-DOF** diagnostics
+(``trace``), and **exponential time integrators** (``exp(-dt·A)·u`` via ``applyfun``).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+
+def _require_matfree():
+    try:
+        import matfree  # noqa: F401
+    except ImportError as e:  # optional dependency — keep core jNO lean
+        raise ImportError(
+            "jno.solve.logdet / trace / applyfun need the optional 'matfree' package (MIT, pure JAX). "
+            "Install it with:  pip install matfree"
+        ) from e
+
+
+def _operator(A):
+    """(matvec, n, dtype) for a jNO ``LinearOperator`` / BCOO / dense matrix — the matrix-free view."""
+    from .solver_api import LinearOperator
+
+    mv = A.mv if isinstance(A, LinearOperator) or hasattr(A, "mv") else (lambda v: A @ v)
+    n = A.shape[0]
+    dtype = jax.eval_shape(mv, jnp.zeros(n)).dtype  # matches the operator's field (real / complex)
+    return mv, n, dtype
+
+
+def _key(key):
+    return jax.random.PRNGKey(0) if key is None else key
+
+
+def logdet(A, *, samples: int = 32, order: int = 25, key=None):
+    """Differentiable stochastic estimate of ``log det A`` for a symmetric positive-definite ``A``
+    (stochastic Lanczos quadrature). ``samples`` probe vectors, ``order`` Lanczos steps."""
+    _require_matfree()
+    from matfree import decomp, funm, stochtrace
+
+    mv, n, dtype = _operator(A)
+    integrand = funm.monte_carlo_funm_sym_logdet(decomp.tridiag_sym(order))
+    estimate = stochtrace.estimator_monte_carlo(
+        integrand, sampler=stochtrace.sampler_normal(jnp.zeros(n, dtype), num=samples)
+    )
+    return estimate(mv, _key(key))
+
+
+def trace(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
+    """Differentiable stochastic estimate of ``tr A`` (Hutchinson), or ``tr f(A)`` when ``fun`` is a
+    scalar function (via stochastic Lanczos quadrature; ``A`` symmetric). ``fun=jnp.log`` reproduces
+    :func:`logdet`; ``fun=lambda z: 1/z`` gives ``tr(A⁻¹)``."""
+    _require_matfree()
+    from matfree import decomp, funm, stochtrace
+
+    mv, n, dtype = _operator(A)
+    if fun is None:
+        integrand = stochtrace.monte_carlo_trace()
+    else:
+        integrand = funm.monte_carlo_funm_sym(funm.dense_funm_sym_eigh(fun), decomp.tridiag_sym(order))
+    estimate = stochtrace.estimator_monte_carlo(
+        integrand, sampler=stochtrace.sampler_normal(jnp.zeros(n, dtype), num=samples)
+    )
+    return estimate(mv, _key(key))
+
+
+def applyfun(A, v, *, fun, order: int = 30):
+    """``f(A)·v`` for a symmetric ``A``, matrix-free via Lanczos (Krylov) approximation — e.g.
+    ``fun=lambda z: jnp.exp(-dt*z)`` is one exact exponential-integrator step ``exp(-dt·A)·v``.
+    Deterministic (no probes); ``order`` sets the Krylov subspace size."""
+    _require_matfree()
+    from matfree import decomp, funm
+
+    mv, _n, _dtype = _operator(A)
+    f = funm.funm_lanczos_sym(funm.dense_funm_sym_eigh(fun), decomp.tridiag_sym(order))
+    return f(mv, jnp.asarray(v))

--- a/jno/utils/solver/matfun.py
+++ b/jno/utils/solver/matfun.py
@@ -23,7 +23,7 @@ def _require_matfree():
         import matfree  # noqa: F401
     except ImportError as e:  # optional dependency — keep core jNO lean
         raise ImportError(
-            "jno.solve.logdet / trace / applyfun / diagonal need the optional 'matfree' package "
+            "jno.solve.logdet / trace / applyfun / diagonal / lstsq need the optional 'matfree' package "
             "(MIT, pure JAX). Install it with:  pip install matfree"
         ) from e
 
@@ -122,3 +122,25 @@ def diagonal(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
         sampler=stochtrace.sampler_normal(jnp.zeros(n, dtype), num=samples),
     )
     return estimate(matvec, _key(key))
+
+
+def lstsq(A, b, *, damp: float = 0.0, atol: float = 1e-6, btol: float = 1e-6, maxiter: int = 100_000, x0=None):
+    """Differentiable, matrix-free **least-squares** ``min_x ‖A x − b‖²`` for a **rectangular** ``A``
+    (over- or under-determined), via LSMR — the gap left by the square ``Ax=b`` solvers. ``damp`` adds
+    Tikhonov regularisation ``+ damp²‖x‖²`` (well-posed for rank-deficient / ill-posed inverse problems);
+    ``x0`` an initial guess. ``A`` may be a dense/sparse matrix or a jNO ``LinearOperator`` (only its
+    matvec and transpose are used — matrix-free). Returns the solution ``x``.
+
+    Scope: **real** operators (LSMR's complex path is untested here). Convergence is controlled by
+    ``atol``/``btol``/``maxiter`` — a stalled solve returns its best iterate, so check the residual."""
+    _require_matfree()
+    from matfree import lstsq as _lstsq
+
+    m, n = A.shape
+    mv = A.mv if hasattr(A, "mv") else (lambda v: A @ v)
+    dtype = jax.eval_shape(mv, jnp.zeros(n)).dtype
+    # LSMR wants the vector–matrix product v ↦ vᵀA; get it as the transpose of the matvec (matrix-free)
+    vecmat = lambda v: jax.linear_transpose(mv, jnp.zeros(n, dtype))(v)[0]  # noqa: E731
+    solve = _lstsq.lsmr(atol=atol, btol=btol, maxiter=maxiter)
+    out = solve(vecmat, jnp.asarray(b), x0=x0, damp=damp)
+    return out[0] if isinstance(out, tuple) else out

--- a/jno/utils/solver/matfun.py
+++ b/jno/utils/solver/matfun.py
@@ -74,35 +74,76 @@ def trace(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
     return estimate(mv, _key(key))
 
 
+def _dense_funm_eig(fun):
+    """A **GPU-capable, differentiable** dense matrix function ``f(H) = V diag(f(λ)) V⁻¹`` for the Arnoldi
+    path, replacing ``matfree``'s Schur one (which is CPU-only *and* non-differentiable). The forward uses
+    ``jnp.linalg.eig`` (GPU-capable where ``jax.scipy.linalg.schur`` is not); the derivative is supplied
+    **analytically** by the Daleckii–Krein / divided-difference formula rather than by differentiating
+    through ``eig`` — so it sidesteps JAX's missing non-symmetric-eigenvector derivative. A ``custom_jvp``
+    (built only from matmuls, hence transposable ⇒ reverse-mode works too):
+
+        ``L_f(H)[E] = V ( Γ ∘ (V⁻¹ E V) ) V⁻¹``,   ``Γ_ij = (f(λ_i)−f(λ_j))/(λ_i−λ_j)``  (``= f′(λ_i)`` if ``i=j``)
+
+    Requires ``fun`` **holomorphic** (for ``f′`` on the diagonal) and ``H`` **diagonalizable** (generic;
+    a defective operator makes ``eig`` ill-conditioned)."""
+    fp = jax.grad(fun, holomorphic=True)  # complex derivative for the divided-difference diagonal
+
+    @jax.custom_jvp
+    def dense_funm(H):
+        real_in = not jnp.iscomplexobj(H)
+        lam, V = jnp.linalg.eig(H)
+        out = (V * fun(lam)) @ jnp.linalg.inv(V)
+        return out.real.astype(H.dtype) if real_in else out
+
+    @dense_funm.defjvp
+    def _jvp(primals, tangents):
+        (H,), (dH,) = primals, tangents
+        real_in = not jnp.iscomplexobj(H)
+        lam, V = jnp.linalg.eig(H)
+        Vinv = jnp.linalg.inv(V)
+        fl = fun(lam)
+        out = (V * fl) @ Vinv
+        den = lam[:, None] - lam[None, :]
+        deg = jnp.abs(den) < 1e-12  # coincident eigenvalues ⇒ divided difference → f′
+        gamma = jnp.where(
+            deg, jax.vmap(fp)(lam)[:, None] * jnp.ones_like(den), (fl[:, None] - fl[None, :]) / jnp.where(deg, 1.0, den)
+        )
+        dout = V @ (gamma * (Vinv @ dH.astype(V.dtype) @ V)) @ Vinv
+        if real_in:
+            out, dout = out.real.astype(H.dtype), dout.real.astype(H.dtype)
+        return out, dout
+
+    return dense_funm
+
+
 def applyfun(A, v, *, fun, order: int = 30, symmetric: bool = True):
     """``f(A)·v``, matrix-free via a Krylov (Lanczos/Arnoldi) approximation — e.g.
     ``fun=lambda z: jnp.exp(-dt*z)`` is one exact exponential-integrator step ``exp(-dt·A)·v``.
-    Deterministic (no probes); ``order`` sets the Krylov subspace size.
+    Deterministic (no probes); ``order`` sets the Krylov subspace size. Both paths are **differentiable**
+    and **GPU-capable**.
 
-    ``symmetric=True`` (default) uses **Lanczos** (short recurrence, cheap), assumes ``A = Aᵀ`` (the common
-    FEM case), is **differentiable**, and runs on **GPU**. ``symmetric=False`` uses **Arnoldi** for a
-    **non-symmetric** operator (advection–diffusion / non-self-adjoint transport): it evaluates ``fun`` on
-    the small Hessenberg matrix by a Schur decomposition, so it is **forward-exact for any analytic ``fun``**
-    but comes with two limits from ``jax.scipy.linalg.schur`` — it is **CPU-only** (raises on GPU) and
-    **not differentiable** (JAX has no ``schur`` derivative). For a **differentiable, GPU** non-symmetric
-    time step, use the exponential integrator ``fem.solve(time=jno.solve.exponential())``, which routes the
-    non-symmetric matrix exponential through a differentiable Padé approximation instead."""
+    ``symmetric=True`` (default) uses **Lanczos** (short recurrence, cheap) and assumes ``A = Aᵀ`` (the common
+    FEM case). ``symmetric=False`` uses **Arnoldi** for a **non-symmetric** operator (advection–diffusion /
+    non-self-adjoint transport), with ``f(H)`` on the small Hessenberg matrix computed by an
+    eigendecomposition and differentiated analytically (Daleckii–Krein), so it is forward-exact *and*
+    reverse-mode differentiable for any **holomorphic** ``fun`` on a **diagonalizable** ``A``."""
     _require_matfree()
     from matfree import decomp, funm
 
     mv, _n, _dtype = _operator(A)
     if symmetric:
         f = funm.funm_lanczos_sym(funm.dense_funm_sym_eigh(fun), decomp.tridiag_sym(order))
-    else:  # non-symmetric: Arnoldi Hessenberg + Schur f(H). Forward-exact; Schur blocks the JAX gradient.
-        f = funm.funm_arnoldi(funm.dense_funm_schur(fun), decomp.hessenberg(order, reortho="full"))
+    else:  # non-symmetric: Arnoldi Hessenberg + eig f(H) — GPU-capable, differentiable (Daleckii–Krein JVP)
+        f = funm.funm_arnoldi(_dense_funm_eig(fun), decomp.hessenberg(order, reortho="full"))
     return f(mv, jnp.asarray(v))
 
 
 def expmv(A, v, *, order: int = 30):
     """``exp(A)·v`` for a possibly **non-symmetric** ``A``, via Arnoldi + a differentiable **Padé**
-    approximation of the small Hessenberg exponential. Unlike ``applyfun(..., symmetric=False)`` (Schur:
-    CPU-only, forward-only, any ``fun``) this is limited to the **exponential** but is **reverse-mode
-    differentiable and GPU-capable** — the engine of the non-symmetric exponential time integrator. Scale
+    approximation of the small Hessenberg exponential (GPU, reverse-mode differentiable). It is limited to
+    the **exponential** (where ``applyfun(..., symmetric=False)`` takes any holomorphic ``fun``), but Padé
+    needs **no diagonalizability** — robust on defective/near-defective Hessenbergs where the eig-based
+    ``applyfun`` path is ill-conditioned. The engine of the non-symmetric exponential time integrator; scale
     ``A`` into its matvec to get ``exp(dt·A)·v``."""
     _require_matfree()
     from matfree import decomp, funm

--- a/jno/utils/solver/matfun.py
+++ b/jno/utils/solver/matfun.py
@@ -23,8 +23,8 @@ def _require_matfree():
         import matfree  # noqa: F401
     except ImportError as e:  # optional dependency — keep core jNO lean
         raise ImportError(
-            "jno.solve.logdet / trace / applyfun need the optional 'matfree' package (MIT, pure JAX). "
-            "Install it with:  pip install matfree"
+            "jno.solve.logdet / trace / applyfun / diagonal need the optional 'matfree' package "
+            "(MIT, pure JAX). Install it with:  pip install matfree"
         ) from e
 
 
@@ -84,3 +84,29 @@ def applyfun(A, v, *, fun, order: int = 30):
     mv, _n, _dtype = _operator(A)
     f = funm.funm_lanczos_sym(funm.dense_funm_sym_eigh(fun), decomp.tridiag_sym(order))
     return f(mv, jnp.asarray(v))
+
+
+def diagonal(A, *, fun=None, samples: int = 32, order: int = 25, key=None):
+    """Differentiable stochastic estimate of the **diagonal** of ``A`` (Hutchinson), or of ``f(A)`` when
+    ``fun`` is given (``A`` symmetric; ``f(A)·probe`` via Lanczos). Unlike :func:`trace` (a scalar) this
+    returns the **per-DOF field** — the pointwise version of the same probe estimator. The key use is the
+    diagonal of the inverse, ``fun=lambda z: 1/z`` → ``diag(A⁻¹)``: the **pointwise posterior variance /
+    uncertainty map** of a FEM precision ``A``, a spatial field you can plot on the mesh.
+
+    Stochastic: an unbiased estimate whose variance falls with ``samples`` and (for ``fun``) whose bias
+    falls with ``order`` — **not** exact. Cost is ``samples`` matvecs (``fun=None``) or ``samples×order``
+    (``fun`` given, a Lanczos per probe)."""
+    _require_matfree()
+    from matfree import decomp, funm, stochtrace
+
+    mv, n, dtype = _operator(A)
+    if fun is None:
+        matvec = mv
+    else:  # diag f(A): each probe gets f(A)·probe by Lanczos, then Hutchinson takes the diagonal
+        f = funm.funm_lanczos_sym(funm.dense_funm_sym_eigh(fun), decomp.tridiag_sym(order))
+        matvec = lambda v: f(mv, v)  # noqa: E731
+    estimate = stochtrace.estimator_monte_carlo(
+        stochtrace.monte_carlo_diagonal(),
+        sampler=stochtrace.sampler_normal(jnp.zeros(n, dtype), num=samples),
+    )
+    return estimate(matvec, _key(key))

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -361,6 +361,40 @@ def prepare_precond(spec: Any, fem: Any) -> None:
         prep(fem)
 
 
+_KRYLOV_SCALE_THRESHOLD = 1e8  # normalize the system only when the operator magnitude is genuinely extreme
+
+
+def _normalize_extreme_scale(op, b, precond):
+    """Guard the Krylov path against extreme operator magnitude. A mass-dominated eddy operator
+    (``|A| ~ jωσ ~ 1e12``) makes jax's GMRES Arnoldi break down and return ~0 *regardless of the
+    preconditioner* (plain Jacobi stalls identically). Scale the operator and RHS by a concrete scalar
+    ``α`` so the iteration runs on an ``O(1)`` system; the solution is invariant (``Â x = b̂ ⟺ A x = b``),
+    so nothing downstream changes and no un-scaling is needed.
+
+    Fires ONLY for a **concrete** BCOO operator (a forward solve) whose magnitude exceeds the threshold —
+    a traced/parametric operator (its magnitude is a tracer, so ``float(...)`` raises) and a normally
+    scaled one are returned untouched. A frozen AMS auxiliary (assembled from the *un-scaled* operator) is
+    reset so the coming ``materialize`` re-freezes it from the scaled operator; that reset only happens on
+    this concrete forward path, so a traced/parametric ``.build()`` is never disturbed."""
+    import math
+
+    import jax.experimental.sparse as jsp
+
+    bc = getattr(op, "bcoo", None)
+    if bc is None:
+        return op, b
+    try:
+        alpha = float(jnp.max(jnp.abs(bc.data)))  # concrete forward operator only; a tracer raises here
+    except Exception:  # noqa: BLE001 — traced operator: leave the frozen-aux path untouched
+        return op, b
+    if not math.isfinite(alpha) or alpha <= _KRYLOV_SCALE_THRESHOLD:
+        return op, b
+    op_scaled = LinearOperator(jsp.BCOO((bc.data / alpha, bc.indices), shape=bc.shape))
+    if precond is not None and getattr(precond, "_frozen", None) is not None:
+        precond._frozen = None  # re-freeze the AMS auxiliaries from the scaled operator (forward path only)
+    return op_scaled, jnp.asarray(b) / alpha
+
+
 def compose_linear_solve_fn(linear, precond, x0, fem=None) -> Callable:
     """Compose the linear-mode slots into the classic ``(A, b) -> x`` ``solve_fn`` contract.
 
@@ -379,6 +413,9 @@ def compose_linear_solve_fn(linear, precond, x0, fem=None) -> Callable:
 
     def composed(A, b):
         op = A if isinstance(A, LinearOperator) else LinearOperator(A)
+        # Extreme-magnitude systems (the physical eddy regime) break the Krylov Arnoldi; scale to O(1)
+        # first — solution-invariant, and a no-op for normally scaled / traced operators.
+        op, b = _normalize_extreme_scale(op, b, precond)
         M = materialize_precond(precond, PrecondContext(op, fem)) if precond is not None else None
         return linear(op, jnp.asarray(b).reshape(-1), M=M, x0=x0_flat)
 

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -467,10 +467,17 @@ def compose_transient_step_solvers(nonlinear, linear, precond, fem, block):
     if nonlinear is not None:
         raise ValueError("fem.solve: nonlinear= given, but this transient block is linear (no linearization).")
 
+    if linear is None and precond is None:
+        # No linear/precond slots: defer to SemidiscreteTimeBlock.step's built-in per-step solve, a
+        # Jacobi-preconditioned BiCGStab at tol=1e-10. The historic default here was a *bare* bicgstab()
+        # with NO preconditioner, which silently under-converged each step — invisible on homogeneous
+        # decay (the warm-start is already near the answer) but corrupting any forced/growing solution.
+        return None, None
+
     if linear is None:
         from ... import solve as _solve_ns
 
-        solver = _solve_ns.bicgstab()  # the historic per-step default
+        solver = _solve_ns.bicgstab()
     else:
         solver = linear
     if precond is not None:
@@ -491,6 +498,10 @@ def compose_transient_step_solvers(nonlinear, linear, precond, fem, block):
         else:
             op = LinearOperator.from_matvec(matvec, diag_fn=diag_fn, shape=(rhs.shape[0], rhs.shape[0]))
             M = materialize_precond(precond, PrecondContext(op, fem)) if precond is not None else None
+        if M is None:  # never run the per-step solve unpreconditioned: default to Jacobi (the step diagonal)
+            diag = op.diag() if hasattr(op, "diag") else diag_fn()
+            inv = 1.0 / jnp.where(jnp.abs(diag) > 1e-30, diag, 1.0)
+            M = lambda x: inv * x  # noqa: E731
         return solver(op, rhs, M=M, x0=x0)
 
     return step_solve, None

--- a/jno/utils/solver/timeschemes.py
+++ b/jno/utils/solver/timeschemes.py
@@ -85,7 +85,26 @@ def _exponential_integrate(block, args, save_ts, *, order, mass, symmetric):
     if block.affine_bias is not None:
         c = c + jnp.asarray(block.affine_bias, dtype).reshape(-1)
     if block.forcing_vector_fn is not None:
-        c = c + jnp.asarray(block.forcing_vector_fn(float(grid[0]), args or {}), dtype).reshape(-1)
+        f0 = jnp.asarray(block.forcing_vector_fn(float(grid[0]), args or {}), dtype).reshape(-1)
+        c = c + f0
+        # The exponential step is exact-in-time only for an AUTONOMOUS system with TIME-INDEPENDENT
+        # forcing; a time-varying source would be silently frozen at t0 here. Probe f at a few times and
+        # fail loud if it drifts (concrete-args case; under traced/parametric args the probe is skipped).
+        probes = [float(grid[k]) for k in (len(grid) // 2, -1)]
+        try:
+            drift = max(
+                float(jnp.linalg.norm(jnp.asarray(block.forcing_vector_fn(t, args or {}), dtype).reshape(-1) - f0))
+                for t in probes
+            )
+            scale = float(jnp.linalg.norm(f0)) + 1e-30
+        except Exception:  # traced args: cannot concretely compare — documented scope limit
+            drift, scale = 0.0, 1.0
+        if drift > 1e-9 * scale:
+            raise NotImplementedError(
+                "jno.solve.exponential integrates an AUTONOMOUS system with time-INDEPENDENT forcing (it is "
+                "exact-in-time only then); this problem's source f(t) varies in time, which the exponential "
+                "step would silently freeze at t0. Use jno.solve.theta(...) for a time-varying source."
+            )
     has_forcing = bool(block.affine_bias is not None or block.forcing_vector_fn is not None)
 
     def _exp(lam):

--- a/jno/utils/solver/timeschemes.py
+++ b/jno/utils/solver/timeschemes.py
@@ -47,10 +47,15 @@ class _ExponentialScheme:
 def _exponential_integrate(block, args, save_ts, *, order, mass):
     """Advance ``M u̇ + A u = c`` exactly per step via ``exp(-dt·M⁻¹A)`` (+ ``φ₁`` forcing).
 
-    Lumped mass ``D`` (row sums of ``M``) makes ``L̃ = D^{-1/2} A D^{-1/2}`` symmetric, so we integrate the
-    ODE ``ẇ = -L̃ w + g`` in the variable ``w = D^{1/2} u`` (``g = D^{-1/2} c``) with :func:`applyfun`'s
-    symmetric Lanczos, then map back ``u = D^{-1/2} w``. Reverse-mode differentiable."""
+    Both mass treatments reduce the pencil to a **symmetric** operator ``C`` in a transformed variable
+    ``w``, integrate ``ẇ = -C w + g`` with :func:`applyfun`'s Lanczos, and map ``w`` back to the field
+    ``u`` — ``lumped`` uses ``C = D^{-1/2} A D^{-1/2}`` (``w = D^{1/2} u``, matrix-free), ``consistent``
+    factors ``M = L Lᵀ`` once and uses ``C = L⁻¹ A L⁻ᵀ`` (``w = Lᵀ u``). Reverse-mode differentiable
+    (``lumped``); ``consistent`` needs a concrete operator (host Cholesky)."""
+    import numpy as np
+
     from .backend_blocks import _block_time_grid
+    from .mass import _dense, cholesky_spd, lumped_diagonal
     from .matfun import applyfun
     from .solver_api import LinearOperator
 
@@ -63,8 +68,8 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
             "jno.solve.exponential needs time-INDEPENDENT M and A (an autonomous system). For time-varying "
             "coefficients use jno.solve.theta(...)."
         )
-    if mass != "lumped":
-        raise NotImplementedError("jno.solve.exponential supports mass='lumped' (V1); consistent-mass is planned.")
+    if mass not in ("lumped", "consistent"):
+        raise ValueError(f"jno.solve.exponential: mass={mass!r} — use 'lumped' or 'consistent'.")
 
     Mop, Aop = block.M, block.A
     s0 = jnp.asarray(block.state0).reshape(-1)
@@ -73,21 +78,47 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
     dt = float(block.dt)
     grid = jnp.asarray(_block_time_grid(block), dtype)
 
-    d = Mop @ jnp.ones(n, dtype)  # row-sum (lumped) mass diagonal
-    # Dirichlet DOFs carry NO mass (d=0) — they are algebraic (u=0), not ODEs. Zeroing s_inv there
-    # restricts the exponential to the interior and holds the (homogeneous) boundary at 0.
-    interior = d > 1e-12 * jnp.max(d)
-    s = jnp.sqrt(d)
-    s_inv = jnp.where(interior, 1.0 / jnp.where(interior, s, 1.0), 0.0)
-    Ltilde = LinearOperator.from_matvec(lambda w: s_inv * (Aop @ (s_inv * w)), shape=(n, n))  # symmetric
-
     c = jnp.zeros(n, dtype)  # constant forcing c = affine_bias + forcing(t0)
     if block.affine_bias is not None:
         c = c + jnp.asarray(block.affine_bias, dtype).reshape(-1)
     if block.forcing_vector_fn is not None:
         c = c + jnp.asarray(block.forcing_vector_fn(float(grid[0]), args or {}), dtype).reshape(-1)
     has_forcing = bool(block.affine_bias is not None or block.forcing_vector_fn is not None)
-    g = s_inv * c
+
+    d = lumped_diagonal(Mop)  # Dirichlet DOFs carry NO mass (d=0) — algebraic (u=0), not ODEs.
+    if mass == "lumped":
+        interior = d > 1e-12 * jnp.max(d)
+        s = jnp.sqrt(d)
+        s_inv = jnp.where(interior, 1.0 / jnp.where(interior, s, 1.0), 0.0)  # 0 on the boundary
+        C = LinearOperator.from_matvec(lambda w: s_inv * (Aop @ (s_inv * w)), shape=(n, n))
+        w0, g = s * s0, s_inv * c
+        to_field = lambda w: s_inv * w  # u = D^{-1/2} w (boundary → 0)
+        e0 = interior.astype(dtype)
+    else:  # consistent: restrict to the interior (zero-mass Dirichlet DOFs), Cholesky M_ii = L Lᵀ (once)
+        from jax.scipy.linalg import solve_triangular
+
+        try:
+            interior_np = np.asarray(d) > 1e-12 * float(np.asarray(d).max())
+        except Exception as e:
+            raise RuntimeError(
+                "jno.solve.exponential(mass='consistent') factors M on the host from a concrete operator; it "
+                "cannot run under a trace (parametric solve). Use mass='lumped' there."
+            ) from e
+        idx = np.where(interior_np)[0]
+        idxj = jnp.asarray(idx)
+        Md, Ad = _dense(Mop), _dense(Aop)
+        L = cholesky_spd(Md[idxj][:, idxj])
+        A_ii = Ad[idxj][:, idxj]
+        C = LinearOperator.from_matvec(
+            lambda w: solve_triangular(L, A_ii @ solve_triangular(L.T, w, lower=False), lower=True),
+            shape=(len(idx), len(idx)),
+        )
+        w0 = L.T @ s0[idxj]
+        g = solve_triangular(L, c[idxj], lower=True)  # L⁻¹ c_i
+        to_field = lambda w: jnp.zeros(n, dtype).at[idxj].set(solve_triangular(L.T, w, lower=False))  # boundary → 0
+        e0 = jnp.ones(len(idx), dtype)
+
+    e0 = e0 / jnp.linalg.norm(e0)  # fixed nonzero unit vector — fallback for a null/decayed Lanczos start
 
     def _exp(lam):
         return jnp.exp(-dt * lam)
@@ -96,15 +127,12 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
         z = -dt * lam
         return jnp.where(jnp.abs(z) < 1e-7, 1.0 + 0.5 * z, jnp.expm1(z) / z)
 
-    e0 = interior.astype(dtype)
-    e0 = e0 / jnp.linalg.norm(e0)  # a fixed nonzero interior unit vector (fallback for a null start)
-
     def _apply(vec, fun):
-        # f(L̃)·vec by Lanczos, but applied to the NORMALISED vector and scaled back — Lanczos divides by
-        # the start-vector norm, so a zero/decayed vec would give NaN; this is exact (linearity) and 0 at 0.
+        # f(C)·vec by Lanczos, applied to the NORMALISED vector and scaled back — Lanczos divides by the
+        # start-vector norm, so a zero/decayed vec would give NaN; this is exact (linearity) and 0 at 0.
         nrm = jnp.linalg.norm(vec)
         unit = jnp.where(nrm > 1e-300, vec / jnp.where(nrm > 1e-300, nrm, 1.0), e0)
-        return nrm * applyfun(Ltilde, unit, fun=fun, order=order)
+        return nrm * applyfun(C, unit, fun=fun, order=order)
 
     def step(w, _t):
         wn = _apply(w, _exp)
@@ -112,7 +140,7 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
             wn = wn + dt * _apply(g, _phi1)
         return wn, wn
 
-    _, ws = jax.lax.scan(step, s * s0, grid[1:])  # scan in w = D^{1/2} u
-    traj_u = jnp.concatenate([(s * s0)[None, :], ws], axis=0) * s_inv[None, :]  # back to u = D^{-1/2} w
+    _, ws = jax.lax.scan(step, w0, grid[1:])
+    traj_u = jax.vmap(to_field)(jnp.concatenate([w0[None, :], ws], axis=0))  # each w-row → the full field u
     save_ts = jnp.asarray(save_ts, dtype)
     return jax.vmap(lambda col: jnp.interp(save_ts, grid, col), in_axes=1, out_axes=1)(traj_u)

--- a/jno/utils/solver/timeschemes.py
+++ b/jno/utils/solver/timeschemes.py
@@ -1,0 +1,118 @@
+"""Time-integration schemes for the transient path, selected with ``fem.solve(time=...)``.
+
+Default (``time=None``): the θ-method the assembly picks — backward Euler for a first-order system,
+trapezoidal for second-order. ``jno.solve.theta(θ)`` overrides θ (``1`` backward Euler, ``1/2``
+Crank–Nicolson, ``0`` forward Euler). ``jno.solve.exponential(...)`` advances a **linear autonomous**
+parabolic block with the **matrix exponential** — exact in time and unconditionally stable, so it takes
+large stiff steps that an implicit θ-step cannot; it reuses :func:`jno.solve.applyfun` (matfree Lanczos).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+
+class _ThetaScheme:
+    """θ-method scheme (see :func:`jno.solve.theta`) — reuses the default stepper with an explicit θ."""
+
+    def __init__(self, theta: float):
+        self.theta = float(theta)
+
+    def integrate(self, block, args, save_ts, *, linear_solve, nonlinear_solve):
+        from .backend_blocks import _default_transient_integrate
+
+        return _default_transient_integrate(
+            block, args, save_ts, linear_solve=linear_solve, nonlinear_solve=nonlinear_solve, theta=self.theta
+        )
+
+    def __repr__(self):
+        return f"jno.solve.theta({self.theta})"
+
+
+class _ExponentialScheme:
+    """Matrix-exponential scheme (see :func:`jno.solve.exponential`) — linear autonomous parabolic only."""
+
+    def __init__(self, order: int, mass: str):
+        self.order = int(order)
+        self.mass = mass
+
+    def integrate(self, block, args, save_ts, *, linear_solve=None, nonlinear_solve=None):
+        return _exponential_integrate(block, args, save_ts, order=self.order, mass=self.mass)
+
+    def __repr__(self):
+        return f"jno.solve.exponential(order={self.order}, mass={self.mass!r})"
+
+
+def _exponential_integrate(block, args, save_ts, *, order, mass):
+    """Advance ``M u̇ + A u = c`` exactly per step via ``exp(-dt·M⁻¹A)`` (+ ``φ₁`` forcing).
+
+    Lumped mass ``D`` (row sums of ``M``) makes ``L̃ = D^{-1/2} A D^{-1/2}`` symmetric, so we integrate the
+    ODE ``ẇ = -L̃ w + g`` in the variable ``w = D^{1/2} u`` (``g = D^{-1/2} c``) with :func:`applyfun`'s
+    symmetric Lanczos, then map back ``u = D^{-1/2} w``. Reverse-mode differentiable."""
+    from .backend_blocks import _block_time_grid
+    from .matfun import applyfun
+    from .solver_api import LinearOperator
+
+    if not block.is_linear():
+        raise NotImplementedError(
+            "jno.solve.exponential integrates a LINEAR block only; use a θ-scheme for a nonlinear one."
+        )
+    if block.operator_fn is not None or block.mass_fn is not None:
+        raise NotImplementedError(
+            "jno.solve.exponential needs time-INDEPENDENT M and A (an autonomous system). For time-varying "
+            "coefficients use jno.solve.theta(...)."
+        )
+    if mass != "lumped":
+        raise NotImplementedError("jno.solve.exponential supports mass='lumped' (V1); consistent-mass is planned.")
+
+    Mop, Aop = block.M, block.A
+    s0 = jnp.asarray(block.state0).reshape(-1)
+    dtype = s0.dtype
+    n = s0.shape[0]
+    dt = float(block.dt)
+    grid = jnp.asarray(_block_time_grid(block), dtype)
+
+    d = Mop @ jnp.ones(n, dtype)  # row-sum (lumped) mass diagonal
+    # Dirichlet DOFs carry NO mass (d=0) — they are algebraic (u=0), not ODEs. Zeroing s_inv there
+    # restricts the exponential to the interior and holds the (homogeneous) boundary at 0.
+    interior = d > 1e-12 * jnp.max(d)
+    s = jnp.sqrt(d)
+    s_inv = jnp.where(interior, 1.0 / jnp.where(interior, s, 1.0), 0.0)
+    Ltilde = LinearOperator.from_matvec(lambda w: s_inv * (Aop @ (s_inv * w)), shape=(n, n))  # symmetric
+
+    c = jnp.zeros(n, dtype)  # constant forcing c = affine_bias + forcing(t0)
+    if block.affine_bias is not None:
+        c = c + jnp.asarray(block.affine_bias, dtype).reshape(-1)
+    if block.forcing_vector_fn is not None:
+        c = c + jnp.asarray(block.forcing_vector_fn(float(grid[0]), args or {}), dtype).reshape(-1)
+    has_forcing = bool(block.affine_bias is not None or block.forcing_vector_fn is not None)
+    g = s_inv * c
+
+    def _exp(lam):
+        return jnp.exp(-dt * lam)
+
+    def _phi1(lam):  # φ₁(z) = (eᶻ − 1)/z at z = −dt·λ (Taylor near 0 for stability)
+        z = -dt * lam
+        return jnp.where(jnp.abs(z) < 1e-7, 1.0 + 0.5 * z, jnp.expm1(z) / z)
+
+    e0 = interior.astype(dtype)
+    e0 = e0 / jnp.linalg.norm(e0)  # a fixed nonzero interior unit vector (fallback for a null start)
+
+    def _apply(vec, fun):
+        # f(L̃)·vec by Lanczos, but applied to the NORMALISED vector and scaled back — Lanczos divides by
+        # the start-vector norm, so a zero/decayed vec would give NaN; this is exact (linearity) and 0 at 0.
+        nrm = jnp.linalg.norm(vec)
+        unit = jnp.where(nrm > 1e-300, vec / jnp.where(nrm > 1e-300, nrm, 1.0), e0)
+        return nrm * applyfun(Ltilde, unit, fun=fun, order=order)
+
+    def step(w, _t):
+        wn = _apply(w, _exp)
+        if has_forcing:
+            wn = wn + dt * _apply(g, _phi1)
+        return wn, wn
+
+    _, ws = jax.lax.scan(step, s * s0, grid[1:])  # scan in w = D^{1/2} u
+    traj_u = jnp.concatenate([(s * s0)[None, :], ws], axis=0) * s_inv[None, :]  # back to u = D^{-1/2} w
+    save_ts = jnp.asarray(save_ts, dtype)
+    return jax.vmap(lambda col: jnp.interp(save_ts, grid, col), in_axes=1, out_axes=1)(traj_u)

--- a/jno/utils/solver/timeschemes.py
+++ b/jno/utils/solver/timeschemes.py
@@ -4,7 +4,9 @@ Default (``time=None``): the θ-method the assembly picks — backward Euler for
 trapezoidal for second-order. ``jno.solve.theta(θ)`` overrides θ (``1`` backward Euler, ``1/2``
 Crank–Nicolson, ``0`` forward Euler). ``jno.solve.exponential(...)`` advances a **linear autonomous**
 parabolic block with the **matrix exponential** — exact in time and unconditionally stable, so it takes
-large stiff steps that an implicit θ-step cannot; it reuses :func:`jno.solve.applyfun` (matfree Lanczos).
+large stiff steps that an implicit θ-step cannot. For a symmetric operator it reuses the Lanczos
+:func:`jno.solve.applyfun`; for a **non-symmetric** one (``symmetric=False``, advection–diffusion) it uses
+an Arnoldi + differentiable **Padé** exponential (:func:`jno.utils.solver.matfun.expmv`), all matfree.
 """
 
 from __future__ import annotations
@@ -33,18 +35,19 @@ class _ThetaScheme:
 class _ExponentialScheme:
     """Matrix-exponential scheme (see :func:`jno.solve.exponential`) — linear autonomous parabolic only."""
 
-    def __init__(self, order: int, mass: str):
+    def __init__(self, order: int, mass: str, symmetric: bool):
         self.order = int(order)
         self.mass = mass
+        self.symmetric = bool(symmetric)
 
     def integrate(self, block, args, save_ts, *, linear_solve=None, nonlinear_solve=None):
-        return _exponential_integrate(block, args, save_ts, order=self.order, mass=self.mass)
+        return _exponential_integrate(block, args, save_ts, order=self.order, mass=self.mass, symmetric=self.symmetric)
 
     def __repr__(self):
-        return f"jno.solve.exponential(order={self.order}, mass={self.mass!r})"
+        return f"jno.solve.exponential(order={self.order}, mass={self.mass!r}, symmetric={self.symmetric})"
 
 
-def _exponential_integrate(block, args, save_ts, *, order, mass):
+def _exponential_integrate(block, args, save_ts, *, order, mass, symmetric):
     """Advance ``M u̇ + A u = c`` exactly per step via ``exp(-dt·M⁻¹A)`` (+ ``φ₁`` forcing).
 
     * ``lumped`` — symmetric ``L̃ = D^{-1/2} A D^{-1/2}`` (``D`` = row-sum mass); integrate ``w = D^{1/2} u``
@@ -56,7 +59,7 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
     held at 0 by *masking* (a multiply — trace-safe), never a host-side extraction."""
     from .backend_blocks import _block_time_grid
     from .mass import lumped_diagonal, m_inner_funm
-    from .matfun import applyfun
+    from .matfun import applyfun, expmv
     from .solver_api import LinearOperator
 
     if not block.is_linear():
@@ -95,43 +98,71 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
     d = lumped_diagonal(Mop)  # Dirichlet DOFs carry NO mass (d=0) — algebraic (u=0), not ODEs
     mask = (d > 1e-12 * jnp.max(d)).astype(dtype)  # 1 interior / 0 boundary — a *multiply* (trace-safe)
 
-    if mass == "lumped":
-        # symmetric L̃ = D^{-1/2} A D^{-1/2}; integrate w = D^{1/2} u with the Euclidean Lanczos of applyfun
-        s = jnp.sqrt(d)
-        s_inv = jnp.where(mask > 0, 1.0 / jnp.where(mask > 0, s, 1.0), 0.0)  # 0 on the boundary
-        Ctil = LinearOperator.from_matvec(lambda w: s_inv * (Aop @ (s_inv * w)), shape=(n, n))
-        e0 = mask / jnp.linalg.norm(mask)
-
-        def apply_f(vec, fun):  # f(L̃)·vec, on the *normalised* vector (Lanczos divides by ‖·‖ → NaN at 0)
-            nrm = jnp.linalg.norm(vec)
-            unit = jnp.where(nrm > 1e-300, vec / jnp.where(nrm > 1e-300, nrm, 1.0), e0)
-            return nrm * applyfun(Ctil, unit, fun=fun, order=order)
-
-        w0, g = s * s0, s_inv * c
-        to_field = lambda w: s_inv * w  # u = D^{-1/2} w (boundary → 0)
-    else:  # consistent — matrix-free M-inner-product Lanczos on L = M⁻¹A: scalable AND differentiable
+    def _consistent_m_solve():
+        """A masked, Jacobi-preconditioned CG solve for ``M⁻¹·(mask·rhs)`` — used by the consistent-mass
+        paths (boundary → 0, since the masked rhs vanishes there). Reverse-mode differentiable."""
         from jax.scipy.sparse.linalg import cg as _cg
 
         from .linear import matrix_diagonal
 
         Mreg = lambda x: Mop @ x + (1.0 - mask) * x  # M + (1-mask)·I — SPD (boundary block is identity)
         jac = 1.0 / (matrix_diagonal(Mop) + (1.0 - mask))  # Jacobi preconditioner for the CG M-solve
+        return lambda rhs: _cg(Mreg, mask * rhs, tol=1e-10, maxiter=300, M=lambda z: jac * z)[0]
 
-        def m_solve(rhs):  # M⁻¹·rhs on the interior (boundary → 0, since the masked rhs is 0 there)
-            return _cg(Mreg, rhs, tol=1e-10, maxiter=300, M=lambda z: jac * z)[0]
+    if not symmetric:
+        # NON-symmetric A (advection–diffusion): L = M⁻¹A is not self-adjoint, so neither the symmetric
+        # similarity nor the M-inner Lanczos applies. Advance with exp(-dt·L) by **Arnoldi + a differentiable
+        # Padé** exponential (:func:`expmv`, GPU + reverse-mode diff). Forcing enters *exactly* through the
+        # augmented generator G = [[-L, g], [0, 0]]: exp(dt·G)·[u; 1] = [exp(-dtL)u + dt·φ₁(-dtL)g ; 1] — one
+        # exponential covers both the homogeneous decay and the φ₁ forcing, and ‖[u;1]‖ ≥ 1 never vanishes.
+        if mass == "lumped":
+            d_inv = jnp.where(mask > 0, 1.0 / jnp.where(mask > 0, d, 1.0), 0.0)  # 0 on the boundary
+            m_inv = lambda r: d_inv * r
+        else:
+            m_solve = _consistent_m_solve()
+            m_inv = m_solve
+        L_mv = lambda x: m_inv(Aop @ x)  # M⁻¹A x (interior; boundary held at 0 by m_inv)
+        g = m_inv(c)
+        w0, to_field = mask * s0, lambda u: u
 
-        L_mv = lambda x: m_solve(mask * (Aop @ x))  # M⁻¹A x (interior)
-        m_inner = lambda a, b: a @ (Mop @ b)  # ⟨a,b⟩_M — M already zeros the boundary
-        e0 = mask / jnp.sqrt(m_inner(mask, mask))  # a fixed M-unit interior vector
-        apply_f = lambda vec, fun: m_inner_funm(L_mv, m_inner, e0, vec, fun, order)
-        w0, g = mask * s0, m_solve(mask * c)  # integrate u directly (homogeneous boundary); forcing M⁻¹c
-        to_field = lambda u: u
+        def step(w, _t):
+            y0 = jnp.concatenate([w, jnp.ones((1,), dtype)])  # augment with the constant "1" row
 
-    def step(w, _t):
-        wn = apply_f(w, _exp)
-        if has_forcing:
-            wn = wn + dt * apply_f(g, _phi1)
-        return wn, wn
+            def gen(y):  # dt·G·[x; a] = dt·[-L x + a·g ; 0]
+                x, a = y[:n], y[n]
+                return dt * jnp.concatenate([-L_mv(x) + a * g, jnp.zeros((1,), dtype)])
+
+            wn = expmv(LinearOperator.from_matvec(gen, shape=(n + 1, n + 1)), y0, order=order)[:n]
+            return wn, wn
+    else:
+        if mass == "lumped":
+            # symmetric L̃ = D^{-1/2} A D^{-1/2}; integrate w = D^{1/2} u with the Euclidean Lanczos of applyfun
+            s = jnp.sqrt(d)
+            s_inv = jnp.where(mask > 0, 1.0 / jnp.where(mask > 0, s, 1.0), 0.0)  # 0 on the boundary
+            Ctil = LinearOperator.from_matvec(lambda w: s_inv * (Aop @ (s_inv * w)), shape=(n, n))
+            e0 = mask / jnp.linalg.norm(mask)
+
+            def apply_f(vec, fun):  # f(L̃)·vec, on the *normalised* vector (Lanczos divides by ‖·‖ → NaN at 0)
+                nrm = jnp.linalg.norm(vec)
+                unit = jnp.where(nrm > 1e-300, vec / jnp.where(nrm > 1e-300, nrm, 1.0), e0)
+                return nrm * applyfun(Ctil, unit, fun=fun, order=order)
+
+            w0, g = s * s0, s_inv * c
+            to_field = lambda w: s_inv * w  # u = D^{-1/2} w (boundary → 0)
+        else:  # consistent — matrix-free M-inner-product Lanczos on L = M⁻¹A: scalable AND differentiable
+            m_solve = _consistent_m_solve()
+            L_mv = lambda x: m_solve(Aop @ x)  # M⁻¹A x (interior)
+            m_inner = lambda a, b: a @ (Mop @ b)  # ⟨a,b⟩_M — M already zeros the boundary
+            e0 = mask / jnp.sqrt(m_inner(mask, mask))  # a fixed M-unit interior vector
+            apply_f = lambda vec, fun: m_inner_funm(L_mv, m_inner, e0, vec, fun, order)
+            w0, g = mask * s0, m_solve(c)  # integrate u directly (homogeneous boundary); forcing M⁻¹c
+            to_field = lambda u: u
+
+        def step(w, _t):
+            wn = apply_f(w, _exp)
+            if has_forcing:
+                wn = wn + dt * apply_f(g, _phi1)
+            return wn, wn
 
     _, ws = jax.lax.scan(step, w0, grid[1:])
     traj_u = jax.vmap(to_field)(jnp.concatenate([w0[None, :], ws], axis=0))  # each row → the full field u

--- a/jno/utils/solver/timeschemes.py
+++ b/jno/utils/solver/timeschemes.py
@@ -47,15 +47,15 @@ class _ExponentialScheme:
 def _exponential_integrate(block, args, save_ts, *, order, mass):
     """Advance ``M u̇ + A u = c`` exactly per step via ``exp(-dt·M⁻¹A)`` (+ ``φ₁`` forcing).
 
-    Both mass treatments reduce the pencil to a **symmetric** operator ``C`` in a transformed variable
-    ``w``, integrate ``ẇ = -C w + g`` with :func:`applyfun`'s Lanczos, and map ``w`` back to the field
-    ``u`` — ``lumped`` uses ``C = D^{-1/2} A D^{-1/2}`` (``w = D^{1/2} u``, matrix-free), ``consistent``
-    factors ``M = L Lᵀ`` once and uses ``C = L⁻¹ A L⁻ᵀ`` (``w = Lᵀ u``). Reverse-mode differentiable
-    (``lumped``); ``consistent`` needs a concrete operator (host Cholesky)."""
-    import numpy as np
+    * ``lumped`` — symmetric ``L̃ = D^{-1/2} A D^{-1/2}`` (``D`` = row-sum mass); integrate ``w = D^{1/2} u``
+      with the Euclidean Lanczos of :func:`applyfun`. Matrix-free.
+    * ``consistent`` — ``L = M⁻¹A`` applied by a **matrix-free M-inner-product Lanczos** (:func:`m_inner_funm`,
+      an M-solve per matvec via CG). No lumping error, no factorization.
 
+    Both are **matrix-free and reverse-mode differentiable**; the Dirichlet boundary (zero-mass DOFs) is
+    held at 0 by *masking* (a multiply — trace-safe), never a host-side extraction."""
     from .backend_blocks import _block_time_grid
-    from .mass import _dense, cholesky_spd, lumped_diagonal
+    from .mass import lumped_diagonal, m_inner_funm
     from .matfun import applyfun
     from .solver_api import LinearOperator
 
@@ -85,41 +85,6 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
         c = c + jnp.asarray(block.forcing_vector_fn(float(grid[0]), args or {}), dtype).reshape(-1)
     has_forcing = bool(block.affine_bias is not None or block.forcing_vector_fn is not None)
 
-    d = lumped_diagonal(Mop)  # Dirichlet DOFs carry NO mass (d=0) — algebraic (u=0), not ODEs.
-    if mass == "lumped":
-        interior = d > 1e-12 * jnp.max(d)
-        s = jnp.sqrt(d)
-        s_inv = jnp.where(interior, 1.0 / jnp.where(interior, s, 1.0), 0.0)  # 0 on the boundary
-        C = LinearOperator.from_matvec(lambda w: s_inv * (Aop @ (s_inv * w)), shape=(n, n))
-        w0, g = s * s0, s_inv * c
-        to_field = lambda w: s_inv * w  # u = D^{-1/2} w (boundary → 0)
-        e0 = interior.astype(dtype)
-    else:  # consistent: restrict to the interior (zero-mass Dirichlet DOFs), Cholesky M_ii = L Lᵀ (once)
-        from jax.scipy.linalg import solve_triangular
-
-        try:
-            interior_np = np.asarray(d) > 1e-12 * float(np.asarray(d).max())
-        except Exception as e:
-            raise RuntimeError(
-                "jno.solve.exponential(mass='consistent') factors M on the host from a concrete operator; it "
-                "cannot run under a trace (parametric solve). Use mass='lumped' there."
-            ) from e
-        idx = np.where(interior_np)[0]
-        idxj = jnp.asarray(idx)
-        Md, Ad = _dense(Mop), _dense(Aop)
-        L = cholesky_spd(Md[idxj][:, idxj])
-        A_ii = Ad[idxj][:, idxj]
-        C = LinearOperator.from_matvec(
-            lambda w: solve_triangular(L, A_ii @ solve_triangular(L.T, w, lower=False), lower=True),
-            shape=(len(idx), len(idx)),
-        )
-        w0 = L.T @ s0[idxj]
-        g = solve_triangular(L, c[idxj], lower=True)  # L⁻¹ c_i
-        to_field = lambda w: jnp.zeros(n, dtype).at[idxj].set(solve_triangular(L.T, w, lower=False))  # boundary → 0
-        e0 = jnp.ones(len(idx), dtype)
-
-    e0 = e0 / jnp.linalg.norm(e0)  # fixed nonzero unit vector — fallback for a null/decayed Lanczos start
-
     def _exp(lam):
         return jnp.exp(-dt * lam)
 
@@ -127,20 +92,48 @@ def _exponential_integrate(block, args, save_ts, *, order, mass):
         z = -dt * lam
         return jnp.where(jnp.abs(z) < 1e-7, 1.0 + 0.5 * z, jnp.expm1(z) / z)
 
-    def _apply(vec, fun):
-        # f(C)·vec by Lanczos, applied to the NORMALISED vector and scaled back — Lanczos divides by the
-        # start-vector norm, so a zero/decayed vec would give NaN; this is exact (linearity) and 0 at 0.
-        nrm = jnp.linalg.norm(vec)
-        unit = jnp.where(nrm > 1e-300, vec / jnp.where(nrm > 1e-300, nrm, 1.0), e0)
-        return nrm * applyfun(C, unit, fun=fun, order=order)
+    d = lumped_diagonal(Mop)  # Dirichlet DOFs carry NO mass (d=0) — algebraic (u=0), not ODEs
+    mask = (d > 1e-12 * jnp.max(d)).astype(dtype)  # 1 interior / 0 boundary — a *multiply* (trace-safe)
+
+    if mass == "lumped":
+        # symmetric L̃ = D^{-1/2} A D^{-1/2}; integrate w = D^{1/2} u with the Euclidean Lanczos of applyfun
+        s = jnp.sqrt(d)
+        s_inv = jnp.where(mask > 0, 1.0 / jnp.where(mask > 0, s, 1.0), 0.0)  # 0 on the boundary
+        Ctil = LinearOperator.from_matvec(lambda w: s_inv * (Aop @ (s_inv * w)), shape=(n, n))
+        e0 = mask / jnp.linalg.norm(mask)
+
+        def apply_f(vec, fun):  # f(L̃)·vec, on the *normalised* vector (Lanczos divides by ‖·‖ → NaN at 0)
+            nrm = jnp.linalg.norm(vec)
+            unit = jnp.where(nrm > 1e-300, vec / jnp.where(nrm > 1e-300, nrm, 1.0), e0)
+            return nrm * applyfun(Ctil, unit, fun=fun, order=order)
+
+        w0, g = s * s0, s_inv * c
+        to_field = lambda w: s_inv * w  # u = D^{-1/2} w (boundary → 0)
+    else:  # consistent — matrix-free M-inner-product Lanczos on L = M⁻¹A: scalable AND differentiable
+        from jax.scipy.sparse.linalg import cg as _cg
+
+        from .linear import matrix_diagonal
+
+        Mreg = lambda x: Mop @ x + (1.0 - mask) * x  # M + (1-mask)·I — SPD (boundary block is identity)
+        jac = 1.0 / (matrix_diagonal(Mop) + (1.0 - mask))  # Jacobi preconditioner for the CG M-solve
+
+        def m_solve(rhs):  # M⁻¹·rhs on the interior (boundary → 0, since the masked rhs is 0 there)
+            return _cg(Mreg, rhs, tol=1e-10, maxiter=300, M=lambda z: jac * z)[0]
+
+        L_mv = lambda x: m_solve(mask * (Aop @ x))  # M⁻¹A x (interior)
+        m_inner = lambda a, b: a @ (Mop @ b)  # ⟨a,b⟩_M — M already zeros the boundary
+        e0 = mask / jnp.sqrt(m_inner(mask, mask))  # a fixed M-unit interior vector
+        apply_f = lambda vec, fun: m_inner_funm(L_mv, m_inner, e0, vec, fun, order)
+        w0, g = mask * s0, m_solve(mask * c)  # integrate u directly (homogeneous boundary); forcing M⁻¹c
+        to_field = lambda u: u
 
     def step(w, _t):
-        wn = _apply(w, _exp)
+        wn = apply_f(w, _exp)
         if has_forcing:
-            wn = wn + dt * _apply(g, _phi1)
+            wn = wn + dt * apply_f(g, _phi1)
         return wn, wn
 
     _, ws = jax.lax.scan(step, w0, grid[1:])
-    traj_u = jax.vmap(to_field)(jnp.concatenate([w0[None, :], ws], axis=0))  # each w-row → the full field u
+    traj_u = jax.vmap(to_field)(jnp.concatenate([w0[None, :], ws], axis=0))  # each row → the full field u
     save_ts = jnp.asarray(save_ts, dtype)
     return jax.vmap(lambda col: jnp.interp(save_ts, grid, col), in_axes=1, out_axes=1)(traj_u)

--- a/pixi.lock
+++ b/pixi.lock
@@ -41,11 +41,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.34.1-py313hf481762_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyamg-5.3.0-py313hfaae9d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.26.1-py313h843e2db_0.conda
@@ -165,7 +167,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/18/0c4060f99abfbdf4caa72ee6492d726801d5b1daf31d48e899ecdb306035/fenics_basix-0.10.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
@@ -273,6 +274,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.34.1-py313hf481762_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyamg-5.3.0-py313hfaae9d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py313hcd51b16_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
@@ -281,6 +283,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
@@ -437,7 +440,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/18/0c4060f99abfbdf4caa72ee6492d726801d5b1daf31d48e899ecdb306035/fenics_basix-0.10.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
@@ -516,12 +518,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.34.1-py313hf481762_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyamg-5.3.0-py313hfaae9d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.26.1-py313h843e2db_0.conda
@@ -631,7 +635,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5e/c6/82669e70cef67c803852285ba6f59d7e3d102983c0ab4be8269c14756677/tensorstore-0.1.84-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/53/6a81a6ebb1739f19c32002139719d4ee021a349d5bdbe066910feed327a1/optimistix-0.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/f3/c13ae1422434baeefe4d4f306a1cc77f024fe96d2abab3c212cfa1bf3ff8/pyamg-5.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6c/48/c42f657f3d6b4d9d9674c9bc48e763d024511ea4cc1d6e0c68c7b4380c43/diffrax-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/67/9d4ac4b0d683aaa4170da59a1980740b281fd38fc253e1830fde4dac3d4f/pygmsh-7.1.17-py3-none-any.whl
@@ -665,7 +668,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/18/0c4060f99abfbdf4caa72ee6492d726801d5b1daf31d48e899ecdb306035/fenics_basix-0.10.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
@@ -708,11 +710,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.34.1-py313hf481762_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyamg-5.3.0-py313hfaae9d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.26.1-py313h843e2db_0.conda
@@ -836,7 +840,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/18/0c4060f99abfbdf4caa72ee6492d726801d5b1daf31d48e899ecdb306035/fenics_basix-0.10.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
@@ -879,11 +882,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-7.34.1-py313hf481762_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyamg-5.3.0-py313hfaae9d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wandb-0.26.1-py313h843e2db_0.conda
@@ -1004,7 +1009,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/18/0c4060f99abfbdf4caa72ee6492d726801d5b1daf31d48e899ecdb306035/fenics_basix-0.10.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
@@ -2516,6 +2520,24 @@ packages:
   run_exports: {}
   size: 8252
   timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyamg-5.3.0-py313hfaae9d9_1.conda
+  sha256: acbf6802d9c57577d0c4ad6de762efd68a9ba1bace510fd3a8d63ea5815ecffd
+  md5: 6d308eafec3de495f6b06ebe69c990ed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - scipy >=1.11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyamg?source=hash-mapping
+  run_exports: {}
+  size: 1633474
+  timestamp: 1756931935791
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
   sha256: d6705962afa2655cc22edcd075ce1f7e67c4407c005137d6d63c0dc5eaa76f47
   md5: ef0f9efec6ec28b17e22f787c7672c67
@@ -2719,6 +2741,30 @@ packages:
   - pkg:pypi/ruff?source=compressed-mapping
   size: 9340598
   timestamp: 1779388159173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+  sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
+  md5: a32f88181ff9a3451c71be1f17a7c799
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=compressed-mapping
+  run_exports: {}
+  size: 17171066
+  timestamp: 1781912954186
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -4472,14 +4518,6 @@ packages:
   - pytest>=8.3.5 ; extra == 'tests'
   - sif2jax ; extra == 'tests'
   requires_python: ~=3.11
-- pypi: https://files.pythonhosted.org/packages/63/f3/c13ae1422434baeefe4d4f306a1cc77f024fe96d2abab3c212cfa1bf3ff8/pyamg-5.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-  name: pyamg
-  version: 5.3.0
-  sha256: 5cc223c66a7aca06fba898eb5e8ede6bb7974a9ddf7b8a98f56143c829e63631
-  requires_dist:
-  - numpy
-  - scipy>=1.11.0
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl
   name: nvidia-nccl-cu12
   version: 2.30.4
@@ -5086,50 +5124,6 @@ packages:
   - sphinx-book-theme ; extra == 'docs'
   - sphinx-remove-toctrees ; extra == 'docs'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-  name: scipy
-  version: 1.17.1
-  sha256: 581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464
-  requires_dist:
-  - numpy>=1.26.4,<2.7
-  - pytest>=8.0.0 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-timeout ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - asv ; extra == 'test'
-  - mpmath ; extra == 'test'
-  - gmpy2 ; extra == 'test'
-  - threadpoolctl ; extra == 'test'
-  - scikit-umfpack ; extra == 'test'
-  - pooch ; extra == 'test'
-  - hypothesis>=6.30 ; extra == 'test'
-  - array-api-strict>=2.3.1 ; extra == 'test'
-  - cython ; extra == 'test'
-  - meson ; extra == 'test'
-  - ninja ; sys_platform != 'emscripten' and extra == 'test'
-  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
-  - intersphinx-registry ; extra == 'doc'
-  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
-  - sphinx-copybutton ; extra == 'doc'
-  - sphinx-design>=0.4.0 ; extra == 'doc'
-  - matplotlib>=3.5 ; extra == 'doc'
-  - numpydoc ; extra == 'doc'
-  - jupytext ; extra == 'doc'
-  - myst-nb>=1.2.0 ; extra == 'doc'
-  - pooch ; extra == 'doc'
-  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
-  - jupyterlite-pyodide-kernel ; extra == 'doc'
-  - linkify-it-py ; extra == 'doc'
-  - tabulate ; extra == 'doc'
-  - click<8.3.0 ; extra == 'dev'
-  - spin ; extra == 'dev'
-  - mypy==1.10.0 ; extra == 'dev'
-  - typing-extensions ; extra == 'dev'
-  - types-psutil ; extra == 'dev'
-  - pycodestyle ; extra == 'dev'
-  - ruff>=0.12.0 ; extra == 'dev'
-  - cython-lint>=0.12.2 ; extra == 'dev'
-  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/f6/f9/57a9a2b706e706cdf89c46e2a3875c9a63b4824c7327d980799f11a49aa2/paramax-0.0.5-py3-none-any.whl
   name: paramax
   version: 0.0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ mkdocstrings-python = ">=1.10"
 pre-commit = ">=4.0"
 pymdown-extensions = ">=10.0"
 wandb = ">=0.26.1,<0.27"
+pyamg = ">=5.3.0,<6"
 
 [tool.pixi.feature.dev.dependencies]
 matplotlib = ">=3.11.0,<4"

--- a/tests/test_fem_ams_gradient.py
+++ b/tests/test_fem_ams_gradient.py
@@ -1,0 +1,95 @@
+"""AMS Milestone 1 — the discrete gradient ``G`` and the gradient-space correction it enables.
+
+Two guards: (1) the discrete de Rham identity — the pure curl-curl operator annihilates every column
+of ``G`` (``curl∘grad = 0``), which pins the edge-sign convention against jNO's actual N1E assembly;
+(2) the go/no-go itself — ``Jacobi + G(GᵀAG)⁻¹Gᵀ`` collapses the CG iteration count and, unlike plain
+Jacobi, keeps it ~independent of the mass weight β (the ill-conditioning of the gradient near-null
+space). See Hiptmair & Xu (2007) / Kolev & Vassilevski (2009) and :mod:`jno.utils.solver.ams`.
+"""
+
+import importlib.util
+
+import jax
+import numpy as np
+import pytest
+
+import jno
+from jno.utils.solver.ams import discrete_gradient
+
+_HAS_SCIPY = importlib.util.find_spec("scipy") is not None
+inner = jno.np.inner
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _curlcurl(mesh_size, beta):
+    """Assembled dense curl-curl (+ β·mass) N1E operator and its discrete gradient G."""
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    x, y, z = c[0], c[1], c[2]
+    ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
+    cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
+    term = inner(cu, cv) if beta == 0 else inner(cu, cv) + beta * inner(ui, vi)
+    fem = jno.fem([term])
+    A = np.asarray(fem.operator[0])  # small mesh → assembled dense
+    G = discrete_gradient(d._fem_nonnodal_topology)
+    return A, np.asarray(G.todense())
+
+
+def test_discrete_gradient_lies_in_curl_curl_kernel():
+    """Discrete de Rham: ``curl(∇φ) = 0`` ⇒ the pure curl-curl operator annihilates every column of G.
+
+    A few flipped edge signs would leave ``K·G`` small-but-nonzero — the iteration test below would
+    still pass, so this exact identity is the real regression guard on the sign convention."""
+    K, G = _curlcurl(0.3, beta=0)
+    rel = np.linalg.norm(K @ G) / np.linalg.norm(K)
+    assert rel < 1e-9, f"‖K·G‖/‖K‖ = {rel:.2e} — G is not in the curl-curl kernel (edge signs?)"
+
+
+@pytest.mark.skipif(not _HAS_SCIPY, reason="needs scipy.sparse.linalg for the CG iteration count")
+def test_gradient_correction_collapses_and_is_beta_independent():
+    """The AMS go/no-go: the gradient-space correction collapses the CG count and holds it ~flat in β,
+    where plain Jacobi degrades as β→0 (the gradient modes stiffen). A direct (pinv) auxiliary solve
+    isolates the mechanism — no AMG needed for the mechanism to show."""
+    import scipy.sparse as sp
+    import scipy.sparse.linalg as spla
+
+    def counts(mesh_size, beta):
+        A, G = _curlcurl(mesh_size, beta)
+        n = A.shape[0]
+        Asp, Gsp = sp.csr_matrix(A), sp.csr_matrix(G)
+        b = np.random.default_rng(0).standard_normal(n)
+        dinv = 1.0 / np.diag(A)
+        aux_pinv = np.linalg.pinv((Gsp.T @ Asp @ Gsp).toarray())  # (GᵀAG)⁺; const null-space is harmless
+
+        def cg_iters(matvec):
+            k = [0]
+            spla.cg(
+                Asp,
+                b,
+                M=spla.LinearOperator((n, n), matvec=matvec),
+                rtol=1e-8,
+                maxiter=3000,
+                callback=lambda _x: k.__setitem__(0, k[0] + 1),
+            )
+            return k[0]
+
+        jac = cg_iters(lambda r: dinv * r)
+        ams = cg_iters(lambda r: dinv * r + Gsp @ (aux_pinv @ (Gsp.T @ r)))
+        return jac, ams
+
+    jac_hi, ams_hi = counts(0.3, 1e-2)  # mild ill-conditioning
+    jac_lo, ams_lo = counts(0.3, 1e-6)  # severe: gradient modes nearly null
+
+    assert ams_hi * 4 < jac_hi and ams_lo * 4 < jac_lo  # correction collapses the count (≥4×)
+    assert ams_lo < 1.5 * ams_hi  # AMS-lite: ~flat in β (the auxiliary correction absorbs it)
+    assert jac_lo > 1.3 * jac_hi  # Jacobi: strictly worse as β→0

--- a/tests/test_fem_ams_gradient.py
+++ b/tests/test_fem_ams_gradient.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 
 import jno
-from jno.utils.solver.ams import discrete_gradient
+from jno.utils.solver.ams import discrete_gradient, nodal_vector_interpolation
 
 _HAS_SCIPY = importlib.util.find_spec("scipy") is not None
 inner = jno.np.inner
@@ -30,8 +30,10 @@ def _x64():
         jax.config.update("jax_enable_x64", prev)
 
 
-def _curlcurl(mesh_size, beta):
-    """Assembled dense curl-curl (+ β·mass) N1E operator and its discrete gradient G."""
+def _assemble(mesh_size, beta):
+    """Assembled dense curl-curl (+ β·mass) N1E operator and the stashed edge topology. Meshes are kept
+    coarse enough that the assembly fits the (small, 8 GB) dev GPU — this is a numpy/scipy structure
+    test, so a refinement *contrast* is all it needs, not a fine mesh."""
     d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
@@ -39,10 +41,8 @@ def _curlcurl(mesh_size, beta):
     ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
     cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
     term = inner(cu, cv) if beta == 0 else inner(cu, cv) + beta * inner(ui, vi)
-    fem = jno.fem([term])
-    A = np.asarray(fem.operator[0])  # small mesh → assembled dense
-    G = discrete_gradient(d._fem_nonnodal_topology)
-    return A, np.asarray(G.todense())
+    A = np.asarray(jno.fem([term]).operator[0])  # small mesh → assembled dense
+    return A, d._fem_nonnodal_topology
 
 
 def test_discrete_gradient_lies_in_curl_curl_kernel():
@@ -50,9 +50,24 @@ def test_discrete_gradient_lies_in_curl_curl_kernel():
 
     A few flipped edge signs would leave ``K·G`` small-but-nonzero — the iteration test below would
     still pass, so this exact identity is the real regression guard on the sign convention."""
-    K, G = _curlcurl(0.3, beta=0)
+    K, topo = _assemble(0.3, beta=0)
+    G = np.asarray(discrete_gradient(topo).todense())
     rel = np.linalg.norm(K @ G) / np.linalg.norm(K)
     assert rel < 1e-9, f"‖K·G‖/‖K‖ = {rel:.2e} — G is not in the curl-curl kernel (edge signs?)"
+
+
+def test_pi_reproduces_constant_vector_fields():
+    """Π reproduces constant vector fields and ties back to G at machine precision:
+    ``Π_α · 1 = G · coords[:, α]`` (both equal the edge vector component ``t_e[α]``). This is the
+    Π-side counterpart of the de Rham guard — a scale or sign slip in Π would pass the iteration
+    margins below but fail this exact identity."""
+    _, topo = _assemble(0.3, beta=0)
+    G = np.asarray(discrete_gradient(topo).todense())
+    Pis = [np.asarray(P.todense()) for P in nodal_vector_interpolation(topo)]
+    coords = np.asarray(topo["vertex_points"])
+    ones = np.ones(int(topo["n_verts"]))
+    for a in range(3):
+        assert np.max(np.abs(Pis[a] @ ones - G @ coords[:, a])) < 1e-12
 
 
 @pytest.mark.skipif(not _HAS_SCIPY, reason="needs scipy.sparse.linalg for the CG iteration count")
@@ -64,9 +79,10 @@ def test_gradient_correction_collapses_and_is_beta_independent():
     import scipy.sparse.linalg as spla
 
     def counts(mesh_size, beta):
-        A, G = _curlcurl(mesh_size, beta)
+        A, topo = _assemble(mesh_size, beta)
         n = A.shape[0]
-        Asp, Gsp = sp.csr_matrix(A), sp.csr_matrix(G)
+        Asp = sp.csr_matrix(A)
+        Gsp = sp.csr_matrix(np.asarray(discrete_gradient(topo).todense()))
         b = np.random.default_rng(0).standard_normal(n)
         dinv = 1.0 / np.diag(A)
         aux_pinv = np.linalg.pinv((Gsp.T @ Asp @ Gsp).toarray())  # (GᵀAG)⁺; const null-space is harmless
@@ -93,3 +109,58 @@ def test_gradient_correction_collapses_and_is_beta_independent():
     assert ams_hi * 4 < jac_hi and ams_lo * 4 < jac_lo  # correction collapses the count (≥4×)
     assert ams_lo < 1.5 * ams_hi  # AMS-lite: ~flat in β (the auxiliary correction absorbs it)
     assert jac_lo > 1.3 * jac_hi  # Jacobi: strictly worse as β→0
+
+
+@pytest.mark.skipif(not _HAS_SCIPY, reason="needs scipy.sparse.linalg for the CG iteration count")
+def test_pi_correction_gives_h_independence_and_matches_lu():
+    """M2: adding the Π (vector-nodal) correction makes full AMS ``h-independent`` — its CG count stays
+    flat under refinement, where the gradient-only AMS-lite keeps growing. Aux solves are exact (pinv),
+    so this probes the *structure*, not the (M5) AMG backend; the converged solve also matches the
+    direct LU, confirming the additive applier is wired correctly."""
+    import scipy.sparse as sp
+    import scipy.sparse.linalg as spla
+
+    def measure(mesh_size, beta=1e-4):
+        A, topo = _assemble(mesh_size, beta)
+        n = A.shape[0]
+        Asp = sp.csr_matrix(A)
+        Gsp = sp.csr_matrix(np.asarray(discrete_gradient(topo).todense()))
+        Pis = [sp.csr_matrix(np.asarray(P.todense())) for P in nodal_vector_interpolation(topo)]
+        b = np.random.default_rng(0).standard_normal(n)
+        dinv = 1.0 / np.diag(A)
+        g_aux = np.linalg.pinv((Gsp.T @ Asp @ Gsp).toarray())
+        p_aux = [np.linalg.pinv((P.T @ Asp @ P).toarray()) for P in Pis]
+
+        def lite(r):
+            return dinv * r + Gsp @ (g_aux @ (Gsp.T @ r))
+
+        def full(r):
+            x = lite(r)
+            for P, Pv in zip(Pis, p_aux):
+                x = x + P @ (Pv @ (P.T @ r))
+            return x
+
+        def cg_iters(matvec, rtol=1e-8):
+            k = [0]
+            x, _ = spla.cg(
+                Asp,
+                b,
+                M=spla.LinearOperator((n, n), matvec=matvec),
+                rtol=rtol,
+                maxiter=3000,
+                callback=lambda _x: k.__setitem__(0, k[0] + 1),
+            )
+            return k[0], x
+
+        it_lite, _ = cg_iters(lite)
+        it_full, x_full = cg_iters(full, rtol=1e-10)
+        res = np.linalg.norm(Asp @ x_full - b) / np.linalg.norm(b)  # the residual CG actually drives
+        return it_lite, it_full, res
+
+    lite_c, full_c, res_c = measure(0.4)
+    lite_f, full_f, res_f = measure(0.22)  # ~3× the DOFs (kept GPU-safe)
+
+    assert full_f < 1.5 * full_c  # Π buys h-independence: full-AMS count ~flat under refinement
+    assert lite_f > lite_c  # the gradient-only AMS-lite is NOT h-independent (it grows)
+    assert full_f < 0.6 * lite_f  # and full AMS sits well below AMS-lite at the fine mesh
+    assert res_c < 1e-8 and res_f < 1e-8  # the AMS-preconditioned CG converges (correct applier)

--- a/tests/test_fem_ams_gradient.py
+++ b/tests/test_fem_ams_gradient.py
@@ -34,7 +34,7 @@ def _assemble(mesh_size, beta):
     """Assembled dense curl-curl (+ β·mass) N1E operator and the stashed edge topology. Meshes are kept
     coarse enough that the assembly fits the (small, 8 GB) dev GPU — this is a numpy/scipy structure
     test, so a refinement *contrast* is all it needs, not a fine mesh."""
-    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]

--- a/tests/test_fem_ams_gradient.py
+++ b/tests/test_fem_ams_gradient.py
@@ -41,7 +41,8 @@ def _assemble(mesh_size, beta):
     ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
     cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
     term = inner(cu, cv) if beta == 0 else inner(cu, cv) + beta * inner(ui, vi)
-    A = np.asarray(jno.fem([term]).operator[0])  # small mesh → assembled dense
+    A_raw = jno.fem([term]).operator[0]  # RT/N1E/P0 assemble sparse: .operator[0] is a BCOO (not dense)
+    A = np.asarray(A_raw.todense() if hasattr(A_raw, "todense") else A_raw)
     return A, d._fem_nonnodal_topology
 
 

--- a/tests/test_fem_eigs.py
+++ b/tests/test_fem_eigs.py
@@ -1,0 +1,84 @@
+"""``jno.solve.eigs`` / ``FEM.eigs`` — generalized symmetric eigensolver ``K x = λ M x`` (V1a: dense).
+
+Oracle is the all-Neumann box Laplacian, whose spectrum ``λ = π²(n₁²+n₂²)`` is analytic and *degenerate*
+((1,0)/(0,1), (2,0)/(0,2)) — so it stresses the block/degeneracy handling. Guards: the spectrum, the
+M-orthonormality invariant ``XᵀMX=I``, and a differentiable (simple) eigenvalue vs finite differences.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+import jno
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _laplacian(mesh_size):
+    """Stiffness fem K = ∫∇u·∇v and the mass form [u v] on the unit square (all-Neumann)."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, v = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    return jno.fem([ui.x * vi.x + ui.y * vi.y]), [ui * vi]
+
+
+def _dense(A):
+    return np.asarray(A.todense() if hasattr(A, "todense") else A)
+
+
+def test_eigs_box_laplacian_spectrum_with_degeneracies():
+    """The six lowest generalized eigenvalues match π²[0,1,1,2,4,4] and the degenerate pairs coincide."""
+    K, mass = _laplacian(0.045)
+    lam, X = K.eigs(mass=mass, k=6)
+    lam = np.asarray(lam)
+    analytic = np.pi**2 * np.array([0.0, 1, 1, 2, 4, 4])
+    assert np.allclose(lam, analytic, rtol=0.06, atol=0.3)  # P1 over-estimates slightly; loose gate
+    assert abs(lam[1] - lam[2]) < 1e-2 * lam[2]  # (1,0)/(0,1) degeneracy
+    assert abs(lam[4] - lam[5]) < 1e-2 * lam[5]  # (2,0)/(0,2) degeneracy
+
+
+def test_eigs_eigenvectors_are_m_orthonormal():
+    """Eigenvectors are M-orthonormal: XᵀMX = I (the invariant every eigensolver variant must hold)."""
+    K, mass = _laplacian(0.06)
+    lam, X = K.eigs(mass=mass, k=6)
+    M = _dense(jno.fem(mass).operator[0])
+    assert np.max(np.abs(np.asarray(X).T @ M @ np.asarray(X) - np.eye(6))) < 1e-9
+
+
+def test_eigs_eigenvalue_is_differentiable():
+    """∂λ/∂θ flows through the solve. Scaling K→sK scales every eigenvalue (λ = s·λ₀), so for a simple
+    eigenvalue ∂λ/∂s = λ₀; the autodiff gradient matches both finite differences and that analytic value."""
+    K, mass = _laplacian(0.07)
+    K0 = jnp.asarray(_dense(K.operator[0]))
+    M = jnp.asarray(_dense(jno.fem(mass).operator[0]))
+    solver = jno.solve.eigs(k=6)
+
+    def lam_simple(s):
+        lam, _ = solver(s * K0, M)
+        return lam[3]  # the (1,1) mode ~2π² — simple (non-degenerate)
+
+    val = float(lam_simple(1.0))
+    g = float(jax.grad(lam_simple)(1.0))
+    fd = float((lam_simple(1.0 + 1e-6) - lam_simple(1.0 - 1e-6)) / 2e-6)
+    assert abs(g - fd) / abs(fd) < 1e-4  # matches finite differences
+    assert abs(g - val) / val < 1e-5  # and the analytic d(sλ)/ds = λ
+
+
+def test_eigs_standard_problem_and_largest():
+    """``M=None`` is the standard problem ``Kx=λx``; ``which='largest'`` returns them in descending order."""
+    K, _ = _laplacian(0.12)
+    lam, X = jno.solve.eigs(k=3, which="largest")(K.operator[0])
+    lam = np.asarray(lam)
+    assert np.all(np.diff(lam) <= 1e-9)  # descending
+    assert lam.shape == (3,) and X.shape[1] == 3

--- a/tests/test_fem_matfun.py
+++ b/tests/test_fem_matfun.py
@@ -162,6 +162,28 @@ def test_diagonal_gradient_matches_trace():
     assert abs(g - float(jnp.trace(dense))) / float(jnp.trace(dense)) < 0.05
 
 
+def test_lstsq_rectangular_and_damped():
+    """LSMR least-squares for a rectangular ``A``: overdetermined matches ``np.linalg.lstsq``; ``damp``
+    reproduces the Tikhonov normal equations ``(AᵀA + damp²I)x = Aᵀb``; and it differentiates in ``b``."""
+    rng = np.random.default_rng(3)
+    m, n = 120, 60
+    A = jnp.asarray(rng.standard_normal((m, n)))
+    b = jnp.asarray(rng.standard_normal(m))
+
+    # LSMR is iterative (atol=btol=1e-6) so the gate is its convergence floor, not machine precision
+    x = jno.solve.lstsq(A, b, atol=1e-10, btol=1e-10)
+    xr = jnp.asarray(np.linalg.lstsq(np.asarray(A), np.asarray(b), rcond=None)[0])
+    assert float(jnp.linalg.norm(x - xr) / jnp.linalg.norm(xr)) < 1e-5
+
+    damp = 2.0
+    xd = jno.solve.lstsq(A, b, damp=damp, atol=1e-10, btol=1e-10)
+    xo = jnp.linalg.solve(A.T @ A + damp**2 * jnp.eye(n), A.T @ b)
+    assert float(jnp.linalg.norm(xd - xo) / jnp.linalg.norm(xo)) < 1e-5
+
+    gb = jax.grad(lambda bb: jnp.sum(jno.solve.lstsq(A, bb) ** 2))(b)
+    assert bool(jnp.isfinite(gb).all())
+
+
 @pytest.mark.skipif(_HAS_MATFREE, reason="matfree installed; this checks the missing-dependency message")
 def test_missing_matfree_message():
     _op, dense = _spd_fem()

--- a/tests/test_fem_matfun.py
+++ b/tests/test_fem_matfun.py
@@ -103,6 +103,44 @@ def test_logdet_trains_a_parameter():
     assert abs(float(theta) - 2.0) < 0.05  # recovered the scale by training through logdet
 
 
+def _advection_fem():
+    """A **non-symmetric** advection–diffusion FEM operator ``b·∇u + (∇u,∇v)`` and its dense form."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.16)
+    u, v = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    A = jno.fem([5.0 * ui.x * vi + ui.x * vi.x + ui.y * vi.y]).operator[0]  # convection ⇒ A ≠ Aᵀ
+    dense = jnp.asarray(A.todense() if hasattr(A, "todense") else A)
+    return LinearOperator(A), dense
+
+
+_CPU = jax.devices("cpu")[0]  # jax.scipy.linalg.schur (the non-symmetric path) is CPU-only
+
+
+def test_applyfun_nonsymmetric_forward_is_exact():
+    """``symmetric=False`` (Arnoldi) computes ``exp(A)·v`` for a non-symmetric advection–diffusion ``A``,
+    forward-exact — matching the dense matrix exponential. CPU-only (Schur)."""
+    _op, dense = _advection_fem()
+    w = jnp.asarray(np.random.default_rng(0).standard_normal(dense.shape[0]))
+    with jax.default_device(_CPU):
+        fv = jno.solve.applyfun(dense, w, fun=lambda z: jnp.exp(-0.05 * z), order=40, symmetric=False)
+        true = jax.scipy.linalg.expm(-0.05 * dense) @ w
+    assert float(jnp.linalg.norm(fv - true) / jnp.linalg.norm(true)) < 1e-8
+
+
+def test_applyfun_nonsymmetric_gradient_is_blocked_loudly():
+    """The non-symmetric path is forward-only: differentiating it raises (JAX has no Schur derivative),
+    per the house rule against a silently-non-differentiable path dressed up as differentiable."""
+    _op, dense = _advection_fem()
+    w = jnp.asarray(np.random.default_rng(0).standard_normal(dense.shape[0]))
+
+    def loss(s):
+        return jnp.sum(jno.solve.applyfun(s * dense, w, fun=lambda z: jnp.exp(-0.05 * z), symmetric=False) ** 2)
+
+    with jax.default_device(_CPU), pytest.raises(NotImplementedError):
+        jax.grad(loss)(1.0)
+
+
 def test_diagonal_matches_dense():
     """``diagonal`` estimates the per-DOF diagonal field — of ``A`` and (the key use) of ``A⁻¹``, the
     pointwise variance map. Stochastic, so the whole-field error is loose."""

--- a/tests/test_fem_matfun.py
+++ b/tests/test_fem_matfun.py
@@ -103,6 +103,27 @@ def test_logdet_trains_a_parameter():
     assert abs(float(theta) - 2.0) < 0.05  # recovered the scale by training through logdet
 
 
+def test_diagonal_matches_dense():
+    """``diagonal`` estimates the per-DOF diagonal field — of ``A`` and (the key use) of ``A⁻¹``, the
+    pointwise variance map. Stochastic, so the whole-field error is loose."""
+    op, dense = _spd_fem()
+    d0 = jno.solve.diagonal(op, samples=4000, key=jax.random.PRNGKey(0))
+    true0 = jnp.diagonal(dense)
+    assert float(jnp.linalg.norm(d0 - true0) / jnp.linalg.norm(true0)) < 0.1
+    # diag(A⁻¹) (the variance map) is a much higher-variance estimand — loose gate, honestly stochastic
+    di = jno.solve.diagonal(op, fun=lambda z: 1.0 / z, samples=6000, order=30, key=jax.random.PRNGKey(1))
+    truei = jnp.diagonal(jnp.linalg.inv(dense))
+    assert float(jnp.linalg.norm(di - truei) / jnp.linalg.norm(truei)) < 0.2
+
+
+def test_diagonal_gradient_matches_trace():
+    """``∂/∂s Σ diag(sA) = Σ diag(A) = tr A`` — autodiff flows through the diagonal estimator."""
+    _op, dense = _spd_fem()
+    key = jax.random.PRNGKey(0)
+    g = float(jax.grad(lambda s: jnp.sum(jno.solve.diagonal(s * dense, samples=2000, key=key)))(1.0))
+    assert abs(g - float(jnp.trace(dense))) / float(jnp.trace(dense)) < 0.05
+
+
 @pytest.mark.skipif(_HAS_MATFREE, reason="matfree installed; this checks the missing-dependency message")
 def test_missing_matfree_message():
     _op, dense = _spd_fem()

--- a/tests/test_fem_matfun.py
+++ b/tests/test_fem_matfun.py
@@ -1,0 +1,110 @@
+"""``jno.solve.{logdet, trace, applyfun}`` — matrix-free, differentiable matrix functions (via matfree).
+
+``logdet`` / ``trace`` are stochastic (Hutchinson + Lanczos quadrature) so gates are loose; ``applyfun``
+(``f(A)·v`` by Lanczos) is deterministic and essentially exact for the exponential. The last test trains
+a parameter *through* ``logdet`` — the Bayesian-evidence workflow the layer exists for.
+"""
+
+import importlib.util
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+import jno
+from jno.utils.solver.solver_api import LinearOperator
+
+_HAS_MATFREE = importlib.util.find_spec("matfree") is not None
+pytestmark = pytest.mark.skipif(not _HAS_MATFREE, reason="requires the optional 'matfree' package")
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _spd_fem():
+    """An SPD FEM operator (mass + stiffness) and its dense form."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.09)
+    u, v = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    A = jno.fem([ui * vi + ui.x * vi.x + ui.y * vi.y]).operator[0]
+    dense = jnp.asarray(A.todense() if hasattr(A, "todense") else A)
+    return LinearOperator(A), dense
+
+
+def test_logdet_matches_dense():
+    op, dense = _spd_fem()
+    est = float(jno.solve.logdet(op, samples=500, order=30, key=jax.random.PRNGKey(0)))
+    true = float(jnp.linalg.slogdet(dense)[1])
+    assert abs(est - true) / abs(true) < 0.02  # stochastic estimate
+
+
+def test_trace_and_trace_of_inverse():
+    op, dense = _spd_fem()
+    tr = float(jno.solve.trace(op, samples=800, key=jax.random.PRNGKey(0)))
+    assert abs(tr - float(jnp.trace(dense))) / float(jnp.trace(dense)) < 0.03
+    tri = float(jno.solve.trace(op, fun=lambda z: 1.0 / z, samples=800, order=30, key=jax.random.PRNGKey(1)))
+    assert abs(tri - float(jnp.trace(jnp.linalg.inv(dense)))) / float(jnp.trace(jnp.linalg.inv(dense))) < 0.05
+
+
+def test_applyfun_matrix_exponential_is_exact():
+    op, dense = _spd_fem()
+    w = jnp.asarray(np.random.default_rng(0).standard_normal(dense.shape[0]))
+    fv = jno.solve.applyfun(op, w, fun=lambda z: jnp.exp(-0.1 * z), order=35)
+    true = jax.scipy.linalg.expm(-0.1 * dense) @ w
+    assert float(jnp.linalg.norm(fv - true) / jnp.linalg.norm(true)) < 1e-8
+
+
+def test_logdet_gradient_matches_analytic():
+    """∂/∂s log det(sA) = n/s (=n at s=1) — the eigenvalue-scaling identity; autodiff flows through."""
+    _op, dense = _spd_fem()
+    n = dense.shape[0]
+    key = jax.random.PRNGKey(0)
+
+    def ld(s):
+        return jno.solve.logdet(s * dense, samples=400, order=30, key=key)
+
+    g = float(jax.grad(ld)(1.0))
+    assert abs(g - n) / n < 0.02
+
+
+@pytest.mark.slow
+def test_logdet_trains_a_parameter():
+    """Train a scale ``θ`` by matching ``logdet(θ·A)`` to a target — the differentiable-evidence loop.
+    With a fixed key the estimator satisfies ``logdet(θA) = logdet(A) + n·log θ`` *exactly* (same probes),
+    so the recovered optimum is θ*=2, and reaching it proves the gradient of ``logdet`` drives training."""
+    _op, dense = _spd_fem()
+    n = dense.shape[0]
+    key = jax.random.PRNGKey(0)
+    cfg = dict(samples=300, order=30, key=key)
+    target = jno.solve.logdet(dense, **cfg) + n * jnp.log(2.0)  # ⇒ θ* = 2
+
+    import optax
+
+    def loss(theta):
+        return (jno.solve.logdet(theta * dense, **cfg) - target) ** 2
+
+    theta = jnp.array(1.0)
+    opt = optax.adam(0.05)
+    state = opt.init(theta)
+    grad = jax.jit(jax.grad(loss))
+    for _ in range(200):
+        updates, state = opt.update(grad(theta), state)
+        theta = optax.apply_updates(theta, updates)
+    assert abs(float(theta) - 2.0) < 0.05  # recovered the scale by training through logdet
+
+
+@pytest.mark.skipif(_HAS_MATFREE, reason="matfree installed; this checks the missing-dependency message")
+def test_missing_matfree_message():
+    _op, dense = _spd_fem()
+    with pytest.raises(ImportError, match="matfree"):
+        jno.solve.logdet(dense)

--- a/tests/test_fem_matfun.py
+++ b/tests/test_fem_matfun.py
@@ -114,31 +114,33 @@ def _advection_fem():
     return LinearOperator(A), dense
 
 
-_CPU = jax.devices("cpu")[0]  # jax.scipy.linalg.schur (the non-symmetric path) is CPU-only
-
-
 def test_applyfun_nonsymmetric_forward_is_exact():
-    """``symmetric=False`` (Arnoldi) computes ``exp(A)·v`` for a non-symmetric advection–diffusion ``A``,
-    forward-exact — matching the dense matrix exponential. CPU-only (Schur)."""
+    """``symmetric=False`` (Arnoldi + eig) computes ``f(A)·v`` for a non-symmetric advection–diffusion ``A``,
+    forward-exact — the matrix exponential and a resolvent both match their dense references (GPU-capable)."""
     _op, dense = _advection_fem()
     w = jnp.asarray(np.random.default_rng(0).standard_normal(dense.shape[0]))
-    with jax.default_device(_CPU):
-        fv = jno.solve.applyfun(dense, w, fun=lambda z: jnp.exp(-0.05 * z), order=40, symmetric=False)
-        true = jax.scipy.linalg.expm(-0.05 * dense) @ w
+    fv = jno.solve.applyfun(dense, w, fun=lambda z: jnp.exp(-0.05 * z), order=40, symmetric=False)
+    true = jax.scipy.linalg.expm(-0.05 * dense) @ w
     assert float(jnp.linalg.norm(fv - true) / jnp.linalg.norm(true)) < 1e-8
 
+    fr = jno.solve.applyfun(dense, w, fun=lambda z: 1.0 / (3.0 + z), order=40, symmetric=False)
+    truer = jnp.linalg.solve(3.0 * jnp.eye(dense.shape[0]) + dense, w)
+    assert float(jnp.linalg.norm(fr - truer) / jnp.linalg.norm(truer)) < 1e-8
 
-def test_applyfun_nonsymmetric_gradient_is_blocked_loudly():
-    """The non-symmetric path is forward-only: differentiating it raises (JAX has no Schur derivative),
-    per the house rule against a silently-non-differentiable path dressed up as differentiable."""
+
+def test_applyfun_nonsymmetric_is_differentiable():
+    """The non-symmetric path is **differentiable** for a general holomorphic ``fun`` — the Daleckii–Krein
+    JVP supplies the matrix-function derivative analytically (no differentiating through ``eig``), so
+    ``jax.grad`` flows and matches central finite differences to machine precision."""
     _op, dense = _advection_fem()
     w = jnp.asarray(np.random.default_rng(0).standard_normal(dense.shape[0]))
 
     def loss(s):
-        return jnp.sum(jno.solve.applyfun(s * dense, w, fun=lambda z: jnp.exp(-0.05 * z), symmetric=False) ** 2)
+        return jnp.sum(jno.solve.applyfun(s * dense, w, fun=lambda z: jnp.exp(-0.05 * z), order=40, symmetric=False) ** 2)
 
-    with jax.default_device(_CPU), pytest.raises(NotImplementedError):
-        jax.grad(loss)(1.0)
+    g = float(jax.grad(loss)(1.0))
+    fd = float((loss(1.0 + 1e-6) - loss(1.0 - 1e-6)) / 2e-6)
+    assert abs(g - fd) / abs(fd) < 1e-5
 
 
 def test_diagonal_matches_dense():

--- a/tests/test_fem_nonnodal_sparse_assembly.py
+++ b/tests/test_fem_nonnodal_sparse_assembly.py
@@ -1,0 +1,95 @@
+"""Sparse per-element assembly on the non-nodal (RT/N1E/P0) path.
+
+The steady-linear matrix for edge/cell-DOF families is assembled one element at a time — ``jacfwd``
+of each cell's element residual w.r.t. its LOCAL dofs, scattered into a BCOO — instead of a single
+global ``jacfwd(full_residual)`` that materialises an ``O(n_edges × n_cells)`` tangent and overflows
+the 2³¹ XLA element limit past ~10⁴ edges. This mirrors the native (Lagrange) assembler
+``fem_native._make_jacobian``.
+
+These tests pin both properties the refactor must guarantee:
+  1. the assembled operator is genuinely sparse (BCOO), and entry-for-entry correct (symmetric-PD
+     coercive H(curl) operator, and the exact curl-curl bilinear value);
+  2. a problem far past the old dense-``jacfwd`` ceiling assembles and solves (scale regression).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygmsh", reason="pygmsh required for 3D cube meshing")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+
+inner = jno.np.inner
+_dense = lambda A: np.asarray(jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A))  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _n1e_cube(mesh_size):
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    xi, yi, zi = c[0], c[1], c[2]
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    cu, cv = u.vector.curl(xi, yi, zi), v.vector.curl(xi, yi, zi)
+    return d, (xi, yi, zi), (ui, vi), (cu, cv)
+
+
+def test_steady_n1e_operator_is_bcoo_sparse():
+    """The steady-linear N1E matrix must be a BCOO — proof the per-element sparse path (not the dense
+    global ``jacfwd``) is taken. A dense ``ndarray`` here would mean the O(n²) path is still live."""
+    _, _, (ui, vi), (cu, cv) = _n1e_cube(0.5)
+    fem = jno.fem([inner(cu, cv) + inner(ui, vi)])
+    A_raw = fem.operator[0]  # raw assembled operator (fem.A densifies for convenience; .operator does not)
+    assert hasattr(A_raw, "indices") and hasattr(A_raw, "todense"), f"expected a BCOO operator, got {type(A_raw).__name__}"
+
+
+def test_sparse_assembly_is_symmetric_pd():
+    """Entry-for-entry correctness: the coercive H(curl) operator ``∫ u·v + ∫ curl u·curl v`` assembled
+    per-element is symmetric positive-definite, exactly as the (previously dense-assembled) form was."""
+    _, _, (ui, vi), (cu, cv) = _n1e_cube(0.5)
+    A = _dense(jno.fem([inner(ui, vi) + inner(cu, cv)]).A)
+    np.testing.assert_allclose(A, A.T, atol=1e-12)
+    assert float(np.linalg.eigvalsh(A).min()) > 0.0
+
+
+def test_sparse_curl_curl_exact_bilinear():
+    """Orientation + assembly together: projecting a field with constant ``curl u* = (0,0,1)`` and
+    evaluating the pure curl-curl form ``uᵀ K u`` reproduces ``∫|curl u*|² = vol(unit cube) = 1`` — now
+    through the sparse scatter (global tet-edge signs must survive the per-element assembly)."""
+    _, (xi, yi, zi), (ui, vi), (cu, cv) = _n1e_cube(0.5)
+    M = _dense(jno.fem([inner(ui, vi)]).A)
+    b = np.asarray(jnp.asarray(jno.fem([inner(ui, vi) - (-0.5 * yi * vi[0] + 0.5 * xi * vi[1] + 0.0 * vi[2])]).b))
+    u_dof = np.linalg.solve(M, b.reshape(-1))
+    K = _dense(jno.fem([inner(cu, cv)]).A)
+    np.testing.assert_allclose(float(u_dof @ K @ u_dof), 1.0, atol=1e-9)
+
+
+@pytest.mark.slow
+def test_sparse_assembly_scales_past_dense_ceiling():
+    """Scale regression: assemble+solve a complex N1E system with ~2×10⁴ edges — well past the old dense
+    ``jacfwd`` ceiling (its ``O(n_edges × n_cells)`` tangent overflows the 2³¹ element limit near ~10⁴
+    edges). Must return a finite, genuinely complex field. This is the acceptance test for the refactor."""
+    d, (xi, yi, zi), (ui, vi), (cu, cv) = _n1e_cube(0.08)
+    # complex coercive eddy-like operator: curl-curl + i·mass, forced by a real source (so the solution is
+    # genuinely complex). Coercive → no BC needed to be nonsingular. (.A raises for a complex form — it is
+    # stored as two real legs — so read the size from the solution.)
+    fvec = jno.np.vector(1.0 + 0.0 * xi, 0.0 * yi, 0.0 * zi)
+    fem = jno.fem([inner(cu, cv) + 1j * inner(ui, vi) - inner(fvec, vi)])
+    sol = np.asarray(jnp.asarray(fem.solve())).reshape(-1)
+    # ~1.2×10⁴ edges over ~10⁴ cells: the old dense-jacfwd tangent (n_edges × n_cells × 24 ≈ 3×10⁹ elements)
+    # exceeds the 2³¹ XLA limit, so this problem was unassemblable before the per-element refactor.
+    assert sol.size > 10000, f"mesh too coarse to exercise the scale regime: {sol.size} edges"
+    assert np.all(np.isfinite(sol))
+    assert np.iscomplexobj(sol) and np.max(np.abs(sol.imag)) > 0.0

--- a/tests/test_fem_nonnodal_sparse_assembly.py
+++ b/tests/test_fem_nonnodal_sparse_assembly.py
@@ -37,7 +37,7 @@ def _x64():
 
 
 def _n1e_cube(mesh_size):
-    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -1,0 +1,99 @@
+"""``jno.precond.ams()`` — the H(curl) auxiliary-space Maxwell preconditioner, through ``fem.solve``.
+
+M4a: the spec is exercised on the REAL curl-curl+β·mass system via the ordinary steady-linear path
+(no complex-solve changes yet). It must reproduce the direct solve and converge in the handful of
+iterations M1/M2 established — where the gradient near-null-space makes an un-preconditioned CG crawl.
+"""
+
+import contextlib
+
+import jax
+import jax.experimental.sparse as jsparse
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import jno
+
+inner, vec = jno.np.inner, jno.np.vector
+# The lu auxiliary runs on CPU (jax-spsolve/cuSolver is flaky on GPU — the same reason the complex
+# eddy path is CPU-pinned); the GPU-native aux is a multigrid inner solver (M5). Pin the solves.
+_CPU = next(iter(jax.devices("cpu")), None)
+_ON_CPU = jax.default_device(_CPU) if _CPU else contextlib.nullcontext()
+
+
+def _solve(fem, **kw):
+    with _ON_CPU:
+        return np.asarray(jnp.asarray(fem.solve(**kw))).reshape(-1)
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _curlcurl_source(mesh_size, beta):
+    """A driven real curl-curl (+ β·mass) N1E problem: inner(curl u, curl v) + β⟨u,v⟩ − ⟨Js, v⟩."""
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    x, y, z = c[0], c[1], c[2]
+    ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
+    cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
+    Js = vec(0.0 * x, 0.0 * y, 1.0 + 0.0 * z)
+    term = inner(cu, cv) + beta * inner(ui, vi) - inner(Js, vi)
+    return jno.fem([term])
+
+
+def test_ams_matches_direct_solve_through_fem_solve():
+    """fem.solve(linear=cg, precond=ams()) reproduces the sparse-direct solve — the spec is wired
+    end-to-end (prepare builds G/Π from the mesh, materialize assembles the nodal aux, CG converges)."""
+    fem = _curlcurl_source(0.3, beta=1e-4)
+    x_lu = _solve(fem, linear=jno.solve.lu())
+    x_ams = _solve(fem, linear=jno.solve.cg(tol=1e-9, maxiter=400), precond=jno.precond.ams())
+    assert np.linalg.norm(x_ams - x_lu) / np.linalg.norm(x_lu) < 1e-7
+
+
+def test_ams_converges_in_a_small_iteration_budget():
+    """The whole point: AMS collapses the count. It reaches tol in a budget (60) far below the
+    hundreds an un-preconditioned/Jacobi CG needs on this gradient-dominated (β→small) operator."""
+    fem = _curlcurl_source(0.3, beta=1e-5)
+    x_lu = _solve(fem, linear=jno.solve.lu())
+    x_ams = _solve(fem, linear=jno.solve.cg(tol=1e-7, maxiter=60), precond=jno.precond.ams())
+    assert np.linalg.norm(x_ams - x_lu) / np.linalg.norm(x_lu) < 1e-5  # converged within the budget
+    with pytest.raises(Exception):  # Jacobi cannot, in the same budget — the null-space is undamped
+        _solve(fem, linear=jno.solve.cg(tol=1e-7, maxiter=60), precond=jno.precond.jacobi())
+
+
+def test_ams_custom_aux_solver():
+    """The auxiliary nodal solves are a pluggable ``jno.solve`` inner solver (default lu()); an
+    iterative inner solver works too — the hook M5 swaps a multigrid solver into."""
+    fem = _curlcurl_source(0.3, beta=1e-4)
+    x_lu = _solve(fem, linear=jno.solve.lu())
+    spec = jno.precond.ams(aux=jno.solve.cg(tol=1e-10, maxiter=500))
+    x = _solve(fem, linear=jno.solve.cg(tol=1e-9, maxiter=400), precond=spec)
+    assert np.linalg.norm(x - x_lu) / np.linalg.norm(x_lu) < 1e-6
+
+
+def test_ams_requires_a_gauge_on_pure_curl_curl():
+    """A bare curl-curl has GᵀAG ≡ 0 (curl∘grad = 0) — no coercivity on the gradient space. The spec
+    must refuse with actionable guidance rather than silently forming a singular auxiliary solve."""
+    fem = _curlcurl_source(0.3, beta=0.0)
+    with pytest.raises(ValueError, match="curl-curl"):
+        _solve(fem, linear=jno.solve.cg(maxiter=50), precond=jno.precond.ams())
+
+
+def test_ams_needs_the_owning_fem():
+    """Materialised on a bare operator (no ctx.fem → no edge topology) it errors clearly, since G/Π
+    are mesh objects, not recoverable from the matrix alone."""
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext
+
+    n = 6
+    op = LinearOperator(jsparse.BCOO.fromdense(jnp.eye(n)))
+    with pytest.raises(TypeError, match="owning FEM"):
+        jno.precond.ams().materialize(PrecondContext(op, None))

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -128,6 +128,34 @@ def test_ams_requires_a_gauge_on_pure_curl_curl():
         _solve(fem, linear=jno.solve.cg(maxiter=50), precond=jno.precond.ams())
 
 
+def test_ams_build_makes_the_solve_differentiable():
+    """The eager ``.build(fem)`` hook runs the host aux-assembly ONCE outside the trace and freezes it,
+    so an AMS-preconditioned solve runs — and **differentiates** — under a trace. The gradient flows by
+    implicit differentiation through the traced operator (the frozen preconditioner only accelerates);
+    it matches finite differences and the analytic ``d/ds ‖(sA)⁻¹b‖² = -2‖A⁻¹b‖²`` at ``s=1``."""
+    import jax.experimental.sparse as jsp
+
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext, materialize_precond
+
+    fem = _curlcurl_source(0.3, beta=1e-4)
+    A0 = fem.operator[0]
+    A0b = A0 if hasattr(A0, "indices") else jsp.BCOO.fromdense(jnp.asarray(A0))
+    b = jnp.asarray(fem.operator[1]).reshape(-1)
+    spec = jno.precond.ams().build(fem)  # eager host setup → frozen auxiliaries
+
+    def loss(s):  # the operator s·A is traced in s → materialize must not host-assemble
+        op = LinearOperator(jsp.BCOO((A0b.data * s, A0b.indices), shape=A0b.shape))
+        M = materialize_precond(spec, PrecondContext(op, fem))
+        return jnp.sum(jno.solve.fgmres(tol=1e-10, restart=100, maxiter=600)(op, b, M=M) ** 2)
+
+    with _ON_CPU:
+        val = float(loss(1.0))
+        g = float(jax.grad(loss)(1.0))
+        fd = float((loss(1.0 + 1e-5) - loss(1.0 - 1e-5)) / 2e-5)
+    assert abs(g - fd) / abs(fd) < 1e-3  # matches finite differences
+    assert abs(g - (-2.0 * val)) / abs(2.0 * val) < 1e-3  # and the analytic -2‖A⁻¹b‖²
+
+
 def test_ams_needs_the_owning_fem():
     """Materialised on a bare operator (no ctx.fem → no edge topology) it errors clearly, since G/Π
     are mesh objects, not recoverable from the matrix alone."""

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -78,6 +78,31 @@ def test_ams_complex_eddy_matches_sparse_lu():
     assert np.linalg.norm(x_ams - x_lu) / np.linalg.norm(x_lu) < 1e-8
 
 
+def test_ams_complex_eddy_extreme_scale_matches_lu():
+    """Regression for the extreme-magnitude Krylov breakdown. The *physical* eddy operator has huge
+    absolute coefficients (ν ~ 1/μ₀ ~ 1e6, jωσ ~ jω·σ_cu ~ 1e12), and jax GMRES's Arnoldi breaks down
+    on it — it returns ~0 (relative residual 1.0) *regardless of preconditioner* — unless the system is
+    normalized to O(1) first. The slot path auto-scales the operator+RHS by a concrete scalar (solution-
+    invariant), so a realistic-scale eddy solve reproduces the sparse-direct result. Every other test
+    here uses O(1) coefficients, so they miss this; without the normalization x_ams would be ~0 and the
+    solve would raise the residual-check error."""
+    mu0 = 4 * np.pi * 1e-7
+    nu, sigma, omega = 1.0 / mu0, 5.8e7, 2 * np.pi * 1e4  # ν~8e5, jωσ~3.6e12  ⇒  |A| ~ 1e12
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    x, y, z = c[0], c[1], c[2]
+    ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
+    cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
+    sig = jno.np.where(x > 0.5, sigma, 0.0)  # conductor half; ε-gauge mass floor everywhere
+    Js = vec(0.0 * x, 0.0 * x, jno.np.where(x > 0.5, 1.0, 0.0))
+    fem = jno.fem([nu * inner(cu, cv) + 1j * omega * (sig + sigma * 1e-3) * inner(ui, vi) - inner(Js, vi)])
+    x_lu = _solve(fem)
+    x_ams = _solve(fem, linear=jno.solve.gmres(tol=1e-8, restart=200, maxiter=20), precond=jno.precond.ams())
+    assert x_ams.dtype == np.complex128
+    assert np.linalg.norm(x_ams - x_lu) / np.linalg.norm(x_lu) < 1e-7
+
+
 def test_ams_matches_direct_solve_through_fem_solve():
     """fem.solve(linear=cg, precond=ams()) reproduces the sparse-direct solve — the spec is wired
     end-to-end (prepare builds G/Π from the mesh, materialize assembles the nodal aux, CG converges)."""

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -68,7 +68,9 @@ def _complex_eddy(mesh_size, freq, eps):
 def test_ams_complex_eddy_matches_sparse_lu():
     """M4b: the complex eddy operator solved by complex GMRES + AMS (through the new complex-direct
     wiring — sparse ``A_r + i·A_i``, never the dense 2n block) matches the sparse-direct solve. This is
-    the σ=0-in-air ε-gauge regime, complex-symmetric ⇒ GMRES (not CG)."""
+    the σ=0-in-air ε-gauge regime, complex-symmetric ⇒ GMRES (not CG). Also the CI guard for the M5b
+    complex→real auxiliary reformulation: the default ``lu`` aux here runs through it (factor-jω
+    gradient + real 2n-block Π), so a passing solve confirms the reformulation is exact."""
     fem = _complex_eddy(0.3, freq=1e6, eps=1e-3)
     x_lu = _solve(fem)  # default: complex sparse-LU on the real-equivalent block
     x_ams = _solve(fem, linear=jno.solve.gmres(tol=1e-8, restart=120, maxiter=600), precond=jno.precond.ams())

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -156,6 +156,27 @@ def test_ams_build_makes_the_solve_differentiable():
     assert abs(g - (-2.0 * val)) / abs(2.0 * val) < 1e-3  # and the analytic -2‖A⁻¹b‖²
 
 
+def test_ams_reference_build_preconditions_a_parametric_solve():
+    """Parametric-inverse (design-loop) use: the operator ``A(θ)`` is traced, so freeze the AMS
+    auxiliaries once from a **concrete reference** at ``θ₀`` — ``jno.precond.ams().build(fem0)`` — and
+    reuse that spec for the parametric solve. The parametric node evaluates to the forward solution (so
+    the frozen preconditioner solved it correctly); it is a trace node, so ``∂/∂θ`` flows through it."""
+    spec = jno.precond.ams().build(_curlcurl_source(0.35, beta=1e-3))  # concrete reference
+    assert spec._frozen is not None
+
+    beta = jno.np.parameter((1,), key=jax.random.PRNGKey(0), name="beta_ams")
+    beta.initialize(jax.nn.initializers.constant(1e-3))
+    beta.dtype(jnp.float64)
+    fem_p = _curlcurl_source(0.35, beta)  # β is now a jno.np.parameter → parametric FemLinearSystem
+
+    with _ON_CPU:
+        node = fem_p.solve(linear=jno.solve.fgmres(tol=1e-9, restart=80, maxiter=400), precond=spec)
+        assert not isinstance(node, jax.Array), "a parametric solve must be a differentiable trace node"
+        u_ref = np.asarray(_curlcurl_source(0.35, 1e-3).solve(linear=jno.solve.lu())).reshape(-1)
+        u = np.asarray(jno.core([(node - jnp.asarray(u_ref)).mae], domain=None).eval([node])).reshape(-1)
+    assert np.linalg.norm(u - u_ref) / np.linalg.norm(u_ref) < 1e-6
+
+
 def test_ams_needs_the_owning_fem():
     """Materialised on a bare operator (no ctx.fem → no edge topology) it errors clearly, since G/Π
     are mesh objects, not recoverable from the matrix alone."""

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -106,6 +106,18 @@ def test_ams_custom_aux_solver():
     assert np.linalg.norm(x - x_lu) / np.linalg.norm(x_lu) < 1e-6
 
 
+def test_ams_inexact_aux_pairs_with_flexible_outer():
+    """M5 mechanism: an *inexact/iterative* auxiliary solver (here a loose CG — a stand-in for a
+    multigrid ``aux`` such as jaxamg/AmgX) is a **variable** preconditioner, so it must be driven by a
+    **flexible** outer solver (fgmres). This is the exact path the scalable GPU AMG aux runs through;
+    the real jaxamg aux is verified separately (it needs a GPU + the AmgX stack)."""
+    fem = _curlcurl_source(0.3, beta=1e-4)
+    x_lu = _solve(fem, linear=jno.solve.lu())
+    inexact_aux = jno.solve.cg(tol=1e-3, maxiter=80)  # solved loosely → M varies iteration to iteration
+    x = _solve(fem, linear=jno.solve.fgmres(tol=1e-7, restart=80, maxiter=400), precond=jno.precond.ams(aux=inexact_aux))
+    assert np.linalg.norm(x - x_lu) / np.linalg.norm(x_lu) < 1e-5
+
+
 def test_ams_requires_a_gauge_on_pure_curl_curl():
     """A bare curl-curl has GᵀAG ≡ 0 (curl∘grad = 0) — no coercivity on the gradient space. The spec
     must refuse with actionable guidance rather than silently forming a singular auxiliary solve."""

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -103,6 +103,31 @@ def test_ams_complex_eddy_extreme_scale_matches_lu():
     assert np.linalg.norm(x_ams - x_lu) / np.linalg.norm(x_lu) < 1e-7
 
 
+def test_non_native_precond_complex_extreme_scale_does_not_break_down():
+    """A non-complex-native precond (jacobi) on a complex problem solves the real-equivalent 2n block.
+    That block must be handed to the slot solver as a SPARSE BCOO so the composed solver's extreme-scale
+    normalization fires — otherwise the mass-dominated eddy block (|A| ~ 1e12) breaks the Krylov Arnoldi
+    and the solve returns ~0 (relative residual 1.0 → raises). Jacobi is a weak preconditioner for the
+    indefinite eddy block, so it does not reach tight accuracy (that is what AMS is for), but the solve
+    now *converges to a real answer* instead of breaking down. Regression for the sparse-2n-block route."""
+    mu0 = 4 * np.pi * 1e-7
+    nu, sigma, omega = 1.0 / mu0, 5.8e7, 2 * np.pi * 1e4  # |A| ~ 1e12
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    x, y, z = c[0], c[1], c[2]
+    ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
+    cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
+    sig = jno.np.where(x > 0.5, sigma, 0.0)
+    Js = vec(0.0 * x, 0.0 * x, jno.np.where(x > 0.5, 1.0, 0.0))
+    fem = jno.fem([nu * inner(cu, cv) + 1j * omega * (sig + sigma * 1e-3) * inner(ui, vi) - inner(Js, vi)])
+    x_lu = _solve(fem)
+    # Without the fix this raises (residual 1.0). With it, jacobi iterates to a real (if loose) solution.
+    x_jac = _solve(fem, linear=jno.solve.gmres(tol=1e-8, restart=300, maxiter=40), precond=jno.precond.jacobi())
+    assert np.all(np.isfinite(x_jac))
+    assert np.linalg.norm(x_jac - x_lu) / np.linalg.norm(x_lu) < 0.1  # real solution, not the x≈0 breakdown
+
+
 def test_ams_matches_direct_solve_through_fem_solve():
     """fem.solve(linear=cg, precond=ams()) reproduces the sparse-direct solve — the spec is wired
     end-to-end (prepare builds G/Π from the mesh, materialize assembles the nodal aux, CG converges)."""

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -50,6 +50,32 @@ def _curlcurl_source(mesh_size, beta):
     return jno.fem([term])
 
 
+def _complex_eddy(mesh_size, freq, eps):
+    """A complex eddy operator νK + jω(σ+ε)M with σ nonzero only on a sub-region (copper analog) and a
+    small ε mass floor everywhere (the σ=0-in-air ε-gauge), plus a source in the conductor."""
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    x, y, z = c[0], c[1], c[2]
+    ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
+    cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
+    sig = jno.np.where(x > 0.5, 1.0, 0.0)
+    Js = vec(0.0 * x, 0.0 * x, sig)
+    omega = 2 * np.pi * freq
+    return jno.fem([inner(cu, cv) + 1j * omega * (sig + eps) * inner(ui, vi) - inner(Js, vi)])
+
+
+def test_ams_complex_eddy_matches_sparse_lu():
+    """M4b: the complex eddy operator solved by complex GMRES + AMS (through the new complex-direct
+    wiring — sparse ``A_r + i·A_i``, never the dense 2n block) matches the sparse-direct solve. This is
+    the σ=0-in-air ε-gauge regime, complex-symmetric ⇒ GMRES (not CG)."""
+    fem = _complex_eddy(0.3, freq=1e6, eps=1e-3)
+    x_lu = _solve(fem)  # default: complex sparse-LU on the real-equivalent block
+    x_ams = _solve(fem, linear=jno.solve.gmres(tol=1e-8, restart=120, maxiter=600), precond=jno.precond.ams())
+    assert x_ams.dtype == np.complex128
+    assert np.linalg.norm(x_ams - x_lu) / np.linalg.norm(x_lu) < 1e-8
+
+
 def test_ams_matches_direct_solve_through_fem_solve():
     """fem.solve(linear=cg, precond=ams()) reproduces the sparse-direct solve — the spec is wired
     end-to-end (prepare builds G/Π from the mesh, materialize assembles the nodal aux, CG converges)."""

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -39,7 +39,7 @@ def _x64():
 
 def _curlcurl_source(mesh_size, beta):
     """A driven real curl-curl (+ β·mass) N1E problem: inner(curl u, curl v) + β⟨u,v⟩ − ⟨Js, v⟩."""
-    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -53,7 +53,7 @@ def _curlcurl_source(mesh_size, beta):
 def _complex_eddy(mesh_size, freq, eps):
     """A complex eddy operator νK + jω(σ+ε)M with σ nonzero only on a sub-region (copper analog) and a
     small ε mass floor everywhere (the σ=0-in-air ε-gauge), plus a source in the conductor."""
-    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]

--- a/tests/test_fem_solver_amg_jaxamg.py
+++ b/tests/test_fem_solver_amg_jaxamg.py
@@ -1,0 +1,84 @@
+"""`jno.solve.amg()` — the optional GPU AMG solver slot backed by jaxamg (NVIDIA AmgX).
+
+jaxamg needs a prebuilt AmgX / CUDA / MPI stack, so the end-to-end solve is skipped where it (or a GPU)
+is unavailable; the jNO-side plumbing (slot construction, direct-solver contract, matrix-free rejection,
+optional-dependency error) is always tested.
+"""
+
+import importlib.util
+
+import jax
+import jax.experimental.sparse as jsparse
+import jax.numpy as jnp
+import pytest
+
+import jno
+from jno.utils.solver.solver_api import LinearOperator
+
+_HAS_JAXAMG = importlib.util.find_spec("jaxamg") is not None
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _spd_operator(n=8):
+    dense = jnp.diag(2.0 * jnp.ones(n)) + jnp.diag(-1.0 * jnp.ones(n - 1), 1) + jnp.diag(-1.0 * jnp.ones(n - 1), -1)
+    return LinearOperator(jsparse.BCOO.fromdense(dense)), dense
+
+
+def test_amg_slot_constructs():
+    s = jno.solve.amg()
+    assert s.name == "amg" and s.direct is True  # self-contained AMG solve, owns its preconditioner
+    assert "amg" in jno.solve.__all__
+
+
+def test_amg_is_a_direct_slot_rejecting_precond():
+    """A direct solver takes no outer preconditioner — the contract is enforced before any jaxamg import."""
+    op, _ = _spd_operator()
+    with pytest.raises(ValueError, match="direct"):
+        jno.solve.amg()(op, jnp.ones(op.shape[0]), M=lambda v: v)
+
+
+def test_amg_rejects_matrix_free_operator():
+    """No assembled matrix → clear error (jaxamg needs the sparse matrix); checked before the import."""
+    n = 6
+    op = LinearOperator.from_matvec(lambda v: 2.0 * v, shape=(n, n))
+    with pytest.raises(ValueError, match="matrix-free"):
+        jno.solve.amg()(op, jnp.ones(n))
+
+
+@pytest.mark.skipif(_HAS_JAXAMG, reason="jaxamg installed; this checks the missing-dependency message")
+def test_amg_missing_dependency_message():
+    op, _ = _spd_operator()
+    with pytest.raises(ImportError, match="jaxamg"):
+        jno.solve.amg()(op, jnp.ones(op.shape[0]))
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not _HAS_JAXAMG, reason="requires jaxamg + AmgX + CUDA")
+def test_amg_matches_direct_on_poisson():
+    """End-to-end: an SPD (1-D Poisson) system solved by jno.solve.amg() matches the sparse-direct LU."""
+    op, dense = _spd_operator(64)
+    b = jnp.ones(op.shape[0])
+    x_ref = jnp.linalg.solve(dense, b)
+    x_amg = jno.solve.amg(tol=1e-10)(op, b)
+    assert jnp.max(jnp.abs(x_amg - x_ref)) < 1e-6
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not _HAS_JAXAMG, reason="requires jaxamg + AmgX + CUDA")
+def test_amg_composes_as_preconditioner():
+    """`jno.precond.inner(jno.solve.amg(...))` uses the AMG solve as M⁻¹ inside an outer Krylov."""
+    op, dense = _spd_operator(64)
+    b = jnp.ones(op.shape[0])
+    x_ref = jnp.linalg.solve(dense, b)
+    solve = jno.solve.cg(tol=1e-10)
+    x = solve(op, b, M=jno.precond.inner(jno.solve.amg(maxiter=1, krylov=None)))
+    assert jnp.max(jnp.abs(x - x_ref)) < 1e-6

--- a/tests/test_fem_solver_amg_jaxamg.py
+++ b/tests/test_fem_solver_amg_jaxamg.py
@@ -82,3 +82,44 @@ def test_amg_composes_as_preconditioner():
     solve = jno.solve.cg(tol=1e-10)
     x = solve(op, b, M=jno.precond.inner(jno.solve.amg(maxiter=1, krylov=None)))
     assert jnp.max(jnp.abs(x - x_ref)) < 1e-6
+
+
+# ── jno.precond.jaxamg() — the GPU AMG preconditioner (build-once/apply-many via make_preconditioner) ──
+
+
+def test_jaxamg_precond_constructs_and_is_cacheable():
+    p = jno.precond.jaxamg()
+    assert "jaxamg" in jno.precond.__all__
+    assert type(p.cached()).__name__ == "_Cached"  # inherits _Spec → fluent .cached() for free
+
+
+def test_jaxamg_precond_rejects_matrix_free():
+    from jno.utils.solver.solver_api import PrecondContext
+
+    n = 6
+    op = LinearOperator.from_matvec(lambda v: 2.0 * v, shape=(n, n))
+    with pytest.raises(ValueError, match="matrix-free"):
+        jno.precond.jaxamg().materialize(PrecondContext(op, None))
+
+
+@pytest.mark.skipif(_HAS_JAXAMG, reason="jaxamg installed; this checks the missing-dependency message")
+def test_jaxamg_precond_missing_dependency_message():
+    from jno.utils.solver.solver_api import PrecondContext
+
+    op, _ = _spd_operator()
+    with pytest.raises(ImportError, match="jaxamg"):
+        jno.precond.jaxamg().materialize(PrecondContext(op, None))
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not _HAS_JAXAMG, reason="requires jaxamg + AmgX + CUDA")
+def test_jaxamg_precond_solves_poisson():
+    """AMG-preconditioned CG (with the cached jaxamg preconditioner) matches the direct solve."""
+    from jno.utils.solver.solver_api import PrecondContext, materialize_precond
+
+    op, dense = _spd_operator(64)
+    b = jnp.ones(op.shape[0])
+    x_ref = jnp.linalg.solve(dense, b)
+    M = materialize_precond(jno.precond.jaxamg().cached(), PrecondContext(op, None))
+    x = jno.solve.cg(tol=1e-10)(op, b, M=M)
+    assert jnp.max(jnp.abs(x - x_ref)) < 1e-6

--- a/tests/test_fem_solver_precond_cached.py
+++ b/tests/test_fem_solver_precond_cached.py
@@ -123,6 +123,29 @@ def test_cached_is_idempotent():
     assert c.cached() is c  # .cached() on an already-cached spec is a no-op
 
 
+def test_amg_no_longer_self_caches_but_cached_does(monkeypatch):
+    """Unification: `jno.precond.amg()` rebuilds the hierarchy each solve (no silent cross-solve
+    cache); `.cached()` is the explicit build-once mechanism. Verified without pyamg by counting the
+    (monkeypatched) hierarchy build."""
+    import jno.utils.solver.amg as amgmod
+
+    builds = []
+    monkeypatch.setattr(amgmod, "build_hierarchy", lambda A, **kw: builds.append(1) or "LEVELS")
+    monkeypatch.setattr(amgmod, "vcycle_apply", lambda levels, r: r)  # identity apply
+    ctx = PrecondContext(_op()[0], None)
+
+    bare = jno.precond.amg()
+    materialize_precond(bare, ctx)
+    materialize_precond(bare, ctx)
+    assert len(builds) == 2  # rebuilt each solve — no implicit self-cache
+
+    builds.clear()
+    wrapped = jno.precond.amg().cached()
+    materialize_precond(wrapped, ctx)
+    materialize_precond(wrapped, ctx)
+    assert len(builds) == 1  # .cached() builds once, reuses
+
+
 def test_cached_forwards_prepare_hook():
     class _WithPrepare:
         def __init__(self):

--- a/tests/test_fem_solver_precond_cached.py
+++ b/tests/test_fem_solver_precond_cached.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 import pytest
 
 import jno
+from jno.precond import _Spec  # base that grants the fluent .cached() (user specs can inherit it too)
 from jno.utils.solver.solver_api import (
     LinearOperator,
     PrecondApplier,
@@ -30,7 +31,7 @@ def _op(n=6):
     return LinearOperator(jsparse.BCOO.fromdense(dense)), dense
 
 
-class _Counting:
+class _Counting(_Spec):
     """A minimal spec that counts how many times its (notional) setup is built."""
 
     def __init__(self):
@@ -92,6 +93,34 @@ def test_cached_matches_uncached_solve():
     x_cached = solve(op, b, M=materialize_precond(jno.precond.cached(jno.precond.jacobi()), ctx))
     assert jnp.max(jnp.abs(x_cached - x_ref)) < 1e-8
     assert jnp.max(jnp.abs(x_cached - x_bare)) < 1e-10
+
+
+def test_fluent_cached_on_every_spec():
+    """Every jno.precond.* spec has a fluent .cached() equivalent to cached(spec)."""
+    for spec in (jno.precond.jacobi(), jno.precond.amg(), jno.precond.form([]), jno.precond.chebyshev()):
+        wrapped = spec.cached()
+        assert type(wrapped).__name__ == "_Cached" and wrapped.spec is spec
+
+
+def test_fluent_cached_builds_once():
+    inner = _Counting()
+    c = inner.cached()  # fluent form
+    materialize_precond(c, PrecondContext(_op()[0], None))
+    materialize_precond(c, PrecondContext(_op()[0], None))
+    assert inner.n == 1
+
+
+def test_fluent_cached_passes_refresh():
+    inner = _Counting()
+    c = inner.cached(refresh=True)
+    materialize_precond(c, PrecondContext(_op(6)[0], None))
+    materialize_precond(c, PrecondContext(_op(8)[0], None))
+    assert inner.n == 2  # refresh=True rebuilt on the structure change
+
+
+def test_cached_is_idempotent():
+    c = jno.precond.amg().cached()
+    assert c.cached() is c  # .cached() on an already-cached spec is a no-op
 
 
 def test_cached_forwards_prepare_hook():

--- a/tests/test_fem_solver_precond_cached.py
+++ b/tests/test_fem_solver_precond_cached.py
@@ -1,0 +1,110 @@
+"""`jno.precond.cached(spec)` — memoise any preconditioner's setup across solves (backend-agnostic)."""
+
+import jax
+import jax.experimental.sparse as jsparse
+import jax.numpy as jnp
+import pytest
+
+import jno
+from jno.utils.solver.solver_api import (
+    LinearOperator,
+    PrecondApplier,
+    PrecondContext,
+    materialize_precond,
+    prepare_precond,
+)
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _op(n=6):
+    dense = jnp.diag(2.0 * jnp.ones(n)) + jnp.diag(-1.0 * jnp.ones(n - 1), 1) + jnp.diag(-1.0 * jnp.ones(n - 1), -1)
+    return LinearOperator(jsparse.BCOO.fromdense(dense)), dense
+
+
+class _Counting:
+    """A minimal spec that counts how many times its (notional) setup is built."""
+
+    def __init__(self):
+        self.n = 0
+
+    def materialize(self, ctx):
+        self.n += 1
+        d = ctx.diag()
+        inv = 1.0 / jnp.where(jnp.abs(d) > 1e-30, d, 1.0)
+        return PrecondApplier(lambda v: inv * v)
+
+
+def test_cached_builds_once_and_reuses_applier():
+    inner = _Counting()
+    c = jno.precond.cached(inner)
+    op, _ = _op()
+    m1 = materialize_precond(c, PrecondContext(op, None))
+    m2 = materialize_precond(c, PrecondContext(op, None))
+    assert inner.n == 1  # setup built exactly once across two solves
+    assert m1 is m2  # same applier object reused
+
+
+def test_cached_frozen_reuses_even_when_operator_changes():
+    inner = _Counting()
+    c = jno.precond.cached(inner)  # refresh=False (frozen)
+    materialize_precond(c, PrecondContext(_op(6)[0], None))
+    materialize_precond(c, PrecondContext(_op(8)[0], None))  # different operator, still reuses
+    assert inner.n == 1
+
+
+def test_cached_refresh_rebuilds_on_structure_change():
+    inner = _Counting()
+    c = jno.precond.cached(inner, refresh=True)
+    materialize_precond(c, PrecondContext(_op(6)[0], None))
+    materialize_precond(c, PrecondContext(_op(8)[0], None))  # shape/nnz changed → rebuild
+    assert inner.n == 2
+
+
+def test_cached_custom_key():
+    inner = _Counting()
+    c = jno.precond.cached(inner, refresh=lambda ctx: ctx.A.shape[0])  # key on size
+    materialize_precond(c, PrecondContext(_op(6)[0], None))
+    materialize_precond(c, PrecondContext(_op(6)[0], None))  # same size → reuse
+    materialize_precond(c, PrecondContext(_op(8)[0], None))  # new size → rebuild
+    assert inner.n == 2
+
+
+def test_cached_matches_uncached_solve():
+    """The cached preconditioner produces the same converged solution as the bare one.
+
+    (Calling a solver directly takes a materialised applier as ``M``; ``fem.solve(precond=...)``
+    does that materialisation from the spec internally.)"""
+    op, dense = _op(48)
+    b = jnp.ones(op.shape[0])
+    ctx = PrecondContext(op, None)
+    x_ref = jnp.linalg.solve(dense, b)
+    solve = jno.solve.cg(tol=1e-12)
+    x_bare = solve(op, b, M=materialize_precond(jno.precond.jacobi(), ctx))
+    x_cached = solve(op, b, M=materialize_precond(jno.precond.cached(jno.precond.jacobi()), ctx))
+    assert jnp.max(jnp.abs(x_cached - x_ref)) < 1e-8
+    assert jnp.max(jnp.abs(x_cached - x_bare)) < 1e-10
+
+
+def test_cached_forwards_prepare_hook():
+    class _WithPrepare:
+        def __init__(self):
+            self.prepared = False
+
+        def prepare(self, fem):
+            self.prepared = True
+
+        def materialize(self, ctx):
+            return PrecondApplier(lambda v: v)
+
+    inner = _WithPrepare()
+    prepare_precond(jno.precond.cached(inner), fem=object())  # prepare_precond no-ops on fem=None
+    assert inner.prepared  # the eager build hook is forwarded to the wrapped spec

--- a/tests/test_fem_solver_transient.py
+++ b/tests/test_fem_solver_transient.py
@@ -66,15 +66,20 @@ def test_linear_transient_slots_match_default():
         assert np.abs(sol - ref).max() < 1e-8, f"{name} trajectory deviates from the default"
 
 
-def test_linear_transient_amg_built_once_on_step_operator():
+def test_linear_transient_amg_built_once_on_step_operator(monkeypatch):
     pytest.importorskip("pyamg", reason="pyamg required for the AMG setup (optional dep)")
+    import jno.utils.solver.amg as amgmod
+
     fem = _heat(mesh_size=0.1)
     ref = np.asarray(fem.solve().fn())
-    spec = jno.precond.amg()
-    sol = np.asarray(fem.solve(linear=jno.solve.cg(tol=1e-10), precond=spec).fn())
+    builds = []
+    orig = amgmod.build_hierarchy
+    monkeypatch.setattr(amgmod, "build_hierarchy", lambda A, **kw: (builds.append(1), orig(A, **kw))[1])
+    sol = np.asarray(fem.solve(linear=jno.solve.cg(tol=1e-10), precond=jno.precond.amg()).fn())
     assert np.abs(sol - ref).max() < 1e-8
-    # the hierarchy was set up eagerly (constant step operator M + theta*dt*A), before the scan
-    assert spec._levels is not None
+    # the hierarchy is set up ONCE for the whole run (constant step operator M + θ·dt·A), before the scan —
+    # not per step (amg() no longer self-caches; the transient compose materialises it once up front)
+    assert len(builds) == 1
 
 
 def test_nonlinear_transient_slots_match_default():

--- a/tests/test_fem_time_schemes.py
+++ b/tests/test_fem_time_schemes.py
@@ -41,6 +41,18 @@ def _heat(nsteps, T=0.03, h=0.11):
     return jno.fem([ui.t * vi + ui.x * vi.x + ui.y * vi.y, u(xb, yb) - 0.0, u(ci[0], ci[1]) - ic])
 
 
+def _advection_diffusion(nsteps, T=0.02, h=0.14, beta=6.0):
+    """Transient **advection–diffusion** — the convection term ``β·∂ₓu`` makes ``A`` non-symmetric."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=h, time=(0.0, T, nsteps))
+    u, v = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    ic = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    return jno.fem([ui.t * vi + beta * ui.x * vi + ui.x * vi.x + ui.y * vi.y, u(xb, yb) - 0.0, u(ci[0], ci[1]) - ic])
+
+
 def _final(fem, **kw):
     return np.asarray(fem.solve(**kw).fn())[-1]
 
@@ -125,6 +137,40 @@ def test_m_inner_product_lanczos_matches_dense_and_differentiates():
     g = float(jax.grad(loss)(1.0))
     fd = float((loss(1.0 + 1e-5) - loss(1.0 - 1e-5)) / 2e-5)
     assert abs(g - fd) / abs(fd) < 1e-3  # gradient flows through the matrix-free Lanczos
+
+
+@pytest.mark.skipif(not _HAS_MATFREE, reason="jno.solve.exponential needs the optional 'matfree' package")
+def test_exponential_nonsymmetric_advection_diffusion():
+    """``symmetric=False`` advances a **non-symmetric** advection–diffusion operator with an Arnoldi + Padé
+    exponential: exact in time (step-independent) and closer to the time-converged reference than backward
+    Euler. The symmetric path is *invalid* here (it assumes ``A = Aᵀ``), so it must be visibly worse."""
+    ns = jno.solve.exponential(symmetric=False, order=40)
+    e3 = _final(_advection_diffusion(3), time=ns)
+    e9 = _final(_advection_diffusion(9), time=ns)
+    assert np.linalg.norm(e3 - e9) / np.linalg.norm(e9) < 1e-5  # exact in time
+
+    ref = _final(_advection_diffusion(300))  # fine backward-Euler reference
+    exp_err = np.linalg.norm(_final(_advection_diffusion(4), time=ns) - ref) / np.linalg.norm(ref)
+    be_err = np.linalg.norm(_final(_advection_diffusion(4)) - ref) / np.linalg.norm(ref)
+    sym_err = np.linalg.norm(_final(_advection_diffusion(4), time=jno.solve.exponential(order=40)) - ref) / np.linalg.norm(
+        ref
+    )
+    assert exp_err < be_err  # exact-in-time beats backward Euler at coarse steps
+    assert sym_err > 3 * exp_err  # the symmetric path is wrong on a non-symmetric operator
+
+
+@pytest.mark.skipif(not _HAS_MATFREE, reason="jno.solve.exponential needs the optional 'matfree' package")
+def test_exponential_nonsymmetric_is_differentiable():
+    """A gradient flows through the non-symmetric (Arnoldi + Padé) exponential integrator — the whole point:
+    differentiable transport for inverse problems. ``∂/∂β`` of the final-state energy matches central FD."""
+    ns = jno.solve.exponential(symmetric=False, order=40)
+
+    def loss(beta):
+        return jnp.sum(jnp.asarray(_advection_diffusion(3, beta=beta).solve(time=ns).fn())[-1] ** 2)
+
+    g = float(jax.grad(loss)(6.0))
+    fd = (float(loss(6.0 + 1e-4)) - float(loss(6.0 - 1e-4))) / 2e-4
+    assert abs(g - fd) / abs(fd) < 1e-4
 
 
 def test_time_scheme_rejects_a_steady_problem():

--- a/tests/test_fem_time_schemes.py
+++ b/tests/test_fem_time_schemes.py
@@ -75,6 +75,20 @@ def test_exponential_beats_backward_euler():
     assert exp_err < 0.5 * be_err  # exact-in-time wins at coarse steps
 
 
+@pytest.mark.skipif(not _HAS_MATFREE, reason="jno.solve.exponential needs the optional 'matfree' package")
+def test_exponential_consistent_mass_is_more_accurate():
+    """``mass='consistent'`` (Cholesky-factored M, no lumping error) is closer to the time-converged
+    reference than ``mass='lumped'`` — and is still exact in time (step-independent)."""
+    ref = _final(_heat(400))
+    lump = np.linalg.norm(_final(_heat(4), time=jno.solve.exponential(mass="lumped")) - ref) / np.linalg.norm(ref)
+    cons = np.linalg.norm(_final(_heat(4), time=jno.solve.exponential(mass="consistent")) - ref) / np.linalg.norm(ref)
+    assert cons < lump  # consistent mass removes the lumping error
+
+    c4 = _final(_heat(4), time=jno.solve.exponential(mass="consistent"))
+    c8 = _final(_heat(8), time=jno.solve.exponential(mass="consistent"))
+    assert np.linalg.norm(c4 - c8) / np.linalg.norm(c8) < 1e-6  # still exact in time
+
+
 def test_time_scheme_rejects_a_steady_problem():
     """``time=`` selects a TIME integrator, so it is an error on a non-transient problem."""
     d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.2)

--- a/tests/test_fem_time_schemes.py
+++ b/tests/test_fem_time_schemes.py
@@ -203,6 +203,25 @@ def test_transient_with_source_converges_to_manufactured_solution():
             assert np.linalg.norm(got - exact) / np.linalg.norm(exact) < 5e-3, (time_varying, scheme)
 
 
+@pytest.mark.skipif(not _HAS_MATFREE, reason="jno.solve.exponential needs the optional 'matfree' package")
+def test_exponential_rejects_time_varying_forcing():
+    """The exponential integrator is exact-in-time only for an autonomous system with a TIME-INDEPENDENT
+    source. A time-varying forcing would be silently frozen at t0 (an 83%-wrong solution), so it must fail
+    loud and point to the θ-scheme instead."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.12, time=(0.0, 0.3, 6))
+    u, v = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    ss = jno.np.sin(PI * xi) * jno.np.sin(PI * yi)
+    fem = jno.fem(
+        [ui.t * vi + ui.x * vi.x + ui.y * vi.y - ss * (1.0 + 2.0 * PI**2 * ti) * vi, u(xb, yb) - 0.0, u(ci[0], ci[1]) - 0.0]
+    )
+    with pytest.raises(NotImplementedError, match="time-INDEPENDENT|autonomous|time-varying"):
+        fem.solve(time=jno.solve.exponential(order=40)).fn()
+
+
 def test_time_scheme_rejects_a_steady_problem():
     """``time=`` selects a TIME integrator, so it is an error on a non-transient problem."""
     d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.2)

--- a/tests/test_fem_time_schemes.py
+++ b/tests/test_fem_time_schemes.py
@@ -1,0 +1,86 @@
+"""Time-integration schemes via ``fem.solve(time=...)`` — ``jno.solve.theta`` and ``jno.solve.exponential``.
+
+Oracle is transient heat with a fundamental-mode IC (``sin πx sin πy``), which decays as ``e^{-2π²t}``.
+The defining property of the exponential integrator is that it is **exact in time**: its answer is
+independent of the number of steps, where backward-Euler's is not — and it beats backward-Euler at a
+fixed (coarse) step count. The θ-scheme test checks the override (θ=1 ≡ default, θ=½ differs, both valid).
+"""
+
+import importlib.util
+
+import jax
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+import jno
+
+_HAS_MATFREE = importlib.util.find_spec("matfree") is not None
+PI = np.pi
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _heat(nsteps, T=0.03, h=0.11):
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=h, time=(0.0, T, nsteps))
+    u, v = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    ic = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    return jno.fem([ui.t * vi + ui.x * vi.x + ui.y * vi.y, u(xb, yb) - 0.0, u(ci[0], ci[1]) - ic])
+
+
+def _final(fem, **kw):
+    return np.asarray(fem.solve(**kw).fn())[-1]
+
+
+def test_theta_override():
+    """θ=1 reproduces the default (backward-Euler); θ=½ (Crank–Nicolson) gives a different, valid answer."""
+    default = _final(_heat(6))
+    be = _final(_heat(6), time=jno.solve.theta(1.0))
+    cn = _final(_heat(6), time=jno.solve.theta(0.5))
+    assert np.allclose(be, default, atol=1e-10)  # θ=1 ≡ the assembly default
+    assert not np.allclose(cn, default, atol=1e-4)  # θ=½ is a genuinely different scheme
+    assert np.isfinite(cn).all()
+
+
+@pytest.mark.skipif(not _HAS_MATFREE, reason="jno.solve.exponential needs the optional 'matfree' package")
+def test_exponential_is_exact_in_time():
+    """The exponential integrator is *exact in time*: its answer does not depend on the step count, where
+    backward-Euler's does. exp(2 steps) ≈ exp(8 steps); BE(2) is far from BE(8)."""
+    e2 = _final(_heat(2), time=jno.solve.exponential(order=40))
+    e8 = _final(_heat(8), time=jno.solve.exponential(order=40))
+    assert np.linalg.norm(e2 - e8) / np.linalg.norm(e8) < 1e-5  # step-independent ⇒ exact in time
+
+    b2, b8 = _final(_heat(2)), _final(_heat(8))
+    assert np.linalg.norm(b2 - b8) / np.linalg.norm(b8) > 5e-2  # backward-Euler depends strongly on the step
+
+
+@pytest.mark.skipif(not _HAS_MATFREE, reason="jno.solve.exponential needs the optional 'matfree' package")
+def test_exponential_beats_backward_euler():
+    """At a fixed coarse step count the exponential integrator is much closer to the time-converged answer."""
+    ref = _final(_heat(400))  # time-converged reference
+    exp_err = np.linalg.norm(_final(_heat(4), time=jno.solve.exponential(order=40)) - ref) / np.linalg.norm(ref)
+    be_err = np.linalg.norm(_final(_heat(4)) - ref) / np.linalg.norm(ref)
+    assert exp_err < 0.5 * be_err  # exact-in-time wins at coarse steps
+
+
+def test_time_scheme_rejects_a_steady_problem():
+    """``time=`` selects a TIME integrator, so it is an error on a non-transient problem."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.2)
+    u, v = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi])
+    with pytest.raises(ValueError, match="transient"):
+        fem.solve(time=jno.solve.theta(0.5))

--- a/tests/test_fem_time_schemes.py
+++ b/tests/test_fem_time_schemes.py
@@ -173,6 +173,36 @@ def test_exponential_nonsymmetric_is_differentiable():
     assert abs(g - fd) / abs(fd) < 1e-4
 
 
+def test_transient_with_source_converges_to_manufactured_solution():
+    """A transient heat problem **with a source term** must converge to the exact manufactured solution.
+
+    Regression: the per-step linear solve must be preconditioned. The composed default was a *bare*
+    ``bicgstab()`` (no preconditioner) that silently under-converged each step — invisible on homogeneous
+    decay (the warm-start already sits near the answer) but ~30% wrong on any forced/growing solution.
+    Constant source ``f=SS`` ⇒ ``u=SS·(1−e^{−2π²T})/(2π²)``; time-varying ``f=SS(1+2π²t)`` ⇒ ``u=SS·t``."""
+    T = 0.3
+
+    def build(time_varying):
+        d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.06, time=(0.0, T, 60))
+        u, v = d.fem_symbols()
+        xi, yi, ti = d.variable("interior", split=True)
+        xb, yb, _ = d.variable("boundary", split=True)
+        ci = d.variable("initial", split=True)
+        ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+        ss = jno.np.sin(PI * xi) * jno.np.sin(PI * yi)
+        f = ss * (1.0 + 2.0 * PI**2 * ti) if time_varying else ss
+        return jno.fem([ui.t * vi + ui.x * vi.x + ui.y * vi.y - f * vi, u(xb, yb) - 0.0, u(ci[0], ci[1]) - 0.0])
+
+    for time_varying in (False, True):
+        fem = build(time_varying)
+        pts = np.asarray(fem.points)
+        ss = np.sin(PI * pts[:, 0]) * np.sin(PI * pts[:, 1])
+        exact = ss * T if time_varying else ss * (1.0 - np.exp(-2.0 * PI**2 * T)) / (2.0 * PI**2)
+        for scheme in (None, jno.solve.theta(0.5), jno.solve.theta(1.0)):
+            got = _final(fem) if scheme is None else _final(fem, time=scheme)
+            assert np.linalg.norm(got - exact) / np.linalg.norm(exact) < 5e-3, (time_varying, scheme)
+
+
 def test_time_scheme_rejects_a_steady_problem():
     """``time=`` selects a TIME integrator, so it is an error on a non-transient problem."""
     d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.2)

--- a/tests/test_fem_time_schemes.py
+++ b/tests/test_fem_time_schemes.py
@@ -9,6 +9,7 @@ fixed (coarse) step count. The θ-scheme test checks the override (θ=1 ≡ defa
 import importlib.util
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 from shapely.geometry import box
@@ -75,18 +76,55 @@ def test_exponential_beats_backward_euler():
     assert exp_err < 0.5 * be_err  # exact-in-time wins at coarse steps
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not _HAS_MATFREE, reason="jno.solve.exponential needs the optional 'matfree' package")
 def test_exponential_consistent_mass_is_more_accurate():
-    """``mass='consistent'`` (Cholesky-factored M, no lumping error) is closer to the time-converged
-    reference than ``mass='lumped'`` — and is still exact in time (step-independent)."""
-    ref = _final(_heat(400))
-    lump = np.linalg.norm(_final(_heat(4), time=jno.solve.exponential(mass="lumped")) - ref) / np.linalg.norm(ref)
-    cons = np.linalg.norm(_final(_heat(4), time=jno.solve.exponential(mass="consistent")) - ref) / np.linalg.norm(ref)
+    """``mass='consistent'`` (full M, no lumping error, matrix-free M-inner-product Lanczos) is closer to
+    the time-converged reference than ``mass='lumped'`` — and is still exact in time (step-independent)."""
+    h = 0.16  # coarse: the consistent path runs a CG M-solve per Lanczos step
+    ref = _final(_heat(300, h=h))
+    lump = np.linalg.norm(_final(_heat(4, h=h), time=jno.solve.exponential(mass="lumped")) - ref) / np.linalg.norm(ref)
+    cons = np.linalg.norm(
+        _final(_heat(4, h=h), time=jno.solve.exponential(mass="consistent", order=30)) - ref
+    ) / np.linalg.norm(ref)
     assert cons < lump  # consistent mass removes the lumping error
 
-    c4 = _final(_heat(4), time=jno.solve.exponential(mass="consistent"))
-    c8 = _final(_heat(8), time=jno.solve.exponential(mass="consistent"))
-    assert np.linalg.norm(c4 - c8) / np.linalg.norm(c8) < 1e-6  # still exact in time
+    c4 = _final(_heat(4, h=h), time=jno.solve.exponential(mass="consistent", order=30))
+    c8 = _final(_heat(8, h=h), time=jno.solve.exponential(mass="consistent", order=30))
+    assert np.linalg.norm(c4 - c8) / np.linalg.norm(c8) < 1e-5  # still exact in time
+
+
+def test_m_inner_product_lanczos_matches_dense_and_differentiates():
+    """The matrix-free M-inner-product Lanczos (the consistent-mass engine) computes ``f(M⁻¹A)·v``
+    exactly and is differentiable — pure JAX, no host factorization, so consistent mass is scalable
+    *and* autodiff-friendly (unlike a dense Cholesky with a concrete interior extraction)."""
+    from jno.utils.solver.mass import m_inner_funm
+
+    rng = np.random.default_rng(0)
+    n = 50
+    Bm = rng.standard_normal((n, n))
+    M = jnp.asarray(Bm @ Bm.T + n * np.eye(n))
+    Ba = rng.standard_normal((n, n))
+    A = jnp.asarray(Ba @ Ba.T + np.eye(n))
+    Minv = jnp.linalg.inv(M)
+    L = Minv @ A
+    m_inner = lambda a, b: a @ (M @ b)
+    ones = jnp.ones(n)
+    e0 = ones / jnp.sqrt(m_inner(ones, ones))
+    v = jnp.asarray(rng.standard_normal(n))
+    t = 0.05
+
+    fv = m_inner_funm(lambda x: Minv @ (A @ x), m_inner, e0, v, lambda lam: jnp.exp(-t * lam), order=40)
+    true = jax.scipy.linalg.expm(-t * L) @ v
+    assert float(jnp.linalg.norm(fv - true) / jnp.linalg.norm(true)) < 1e-8  # exact vs dense expm
+
+    def loss(scale):
+        fw = m_inner_funm(lambda x: scale * (Minv @ (A @ x)), m_inner, e0, v, lambda lam: jnp.exp(-t * lam), order=40)
+        return jnp.sum(fw**2)
+
+    g = float(jax.grad(loss)(1.0))
+    fd = float((loss(1.0 + 1e-5) - loss(1.0 - 1e-5)) / 2e-5)
+    assert abs(g - fd) / abs(fd) < 1e-3  # gradient flows through the matrix-free Lanczos
 
 
 def test_time_scheme_rejects_a_steady_problem():

--- a/tests/test_n1e_reconstruction_3d.py
+++ b/tests/test_n1e_reconstruction_3d.py
@@ -36,7 +36,7 @@ def _project_and_reconstruct(mesh_size):
     from jno.utils.solver.fem_nonnodal import n1e_field_at_tet_centroids
     from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
 
-    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -77,7 +77,7 @@ def test_reconstruction_is_complex_linear():
     from jno.utils.solver.fem_nonnodal import n1e_field_at_tet_centroids
     from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
 
-    d = jno.domain(constructor=jno.domain.cube(mesh_size=0.5))
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]

--- a/tests/test_n1e_reconstruction_3d.py
+++ b/tests/test_n1e_reconstruction_3d.py
@@ -1,0 +1,92 @@
+"""Reconstruct a 3-D Nédélec (H(curl)) field and its curl at tet centroids.
+
+``n1e_field_at_tet_centroids`` reads a solved N1E edge-DOF vector back as a physical vector field at
+each tet centroid — the tetrahedral counterpart of ``n1e_field_at_centroids`` (triangles). It is how a
+magnetic-vector-potential solve is post-processed into ``A`` and ``B = curl A`` for plotting/quantities.
+
+Validated against a field that lies exactly in the lowest-order N1E space: ``u* = (-y/2, x/2, 0)``,
+which has constant ``curl u* = (0, 0, 1)``. Projecting ``u*`` to edge DOFs and reconstructing must
+recover both the value (pointwise, since ``u*`` is affine and in the space) and the constant curl.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pygmsh", reason="pygmsh required for 3D cube meshing")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+import jno  # noqa: E402
+
+inner = jno.np.inner
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _project_and_reconstruct(mesh_size):
+    from jno.utils.solver.fem_nonnodal import n1e_field_at_tet_centroids
+    from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
+
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=mesh_size))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    x, y, z = c[0], c[1], c[2]
+    ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
+    ustar = jno.np.vector(-0.5 * y, 0.5 * x, 0.0 * z)  # curl = (0, 0, 1)
+
+    M = np.asarray(jnp.asarray(jno.fem([inner(ui, vi)]).operator[0].todense()))
+    b = np.asarray(jnp.asarray(jno.fem([inner(ui, vi) - inner(ustar, vi)]).b)).reshape(-1)
+    A = jnp.asarray(np.linalg.solve(M, b))  # L²-projection of u* onto the N1E space
+
+    pts = np.asarray(d.mesh.points)
+    cells = np.asarray(d.mesh.cells_dict["tetra"])
+    top = build_edge_topology(cells, BASIX_TET_EDGES)
+    val, crl = n1e_field_at_tet_centroids(pts, cells, top, A, curl=True)
+    cent = pts[cells].mean(axis=1)
+    exact = np.stack([-0.5 * cent[:, 1], 0.5 * cent[:, 0], 0.0 * cent[:, 2]], axis=1)
+    return np.asarray(val), np.asarray(crl), exact
+
+
+def test_tet_value_reconstruction_is_exact_for_affine_field():
+    """``u*`` is affine and lies in the lowest-order N1E space, so its projection is itself and the
+    reconstructed centroid values match ``u*(centroid)`` to solver tolerance."""
+    val, _, exact = _project_and_reconstruct(0.34)
+    np.testing.assert_allclose(val, exact, atol=1e-6)
+
+
+def test_tet_curl_reconstruction_recovers_constant_curl():
+    """The curl recovered from the antisymmetric parts of the physical gradient equals the analytic
+    constant ``curl u* = (0, 0, 1)`` at every centroid — validating the edge-orientation signs and the
+    covariant push-forward together (this is the ``B = curl A`` post-processing path)."""
+    _, crl, _ = _project_and_reconstruct(0.34)
+    np.testing.assert_allclose(crl, np.tile([0.0, 0.0, 1.0], (crl.shape[0], 1)), atol=1e-5)
+
+
+def test_reconstruction_is_complex_linear():
+    """A complex edge vector reconstructs to a complex field (the map is linear), so eddy-current
+    ``A = A_r + i A_i`` post-processes in one call."""
+    from jno.utils.solver.fem_nonnodal import n1e_field_at_tet_centroids
+    from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
+
+    d = jno.domain(constructor=jno.domain.cube(mesh_size=0.5))
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
+    c = d.variable("interior", split=True)
+    x, y, z = c[0], c[1], c[2]
+    ui, vi = u.bind(x=x, y=y, z=z), v.bind(x=x, y=y, z=z)
+    ustar = jno.np.vector(-0.5 * y, 0.5 * x, 0.0 * z)
+    M = np.asarray(jnp.asarray(jno.fem([inner(ui, vi)]).operator[0].todense()))
+    b = np.asarray(jnp.asarray(jno.fem([inner(ui, vi) - inner(ustar, vi)]).b)).reshape(-1)
+    A = jnp.asarray(np.linalg.solve(M, b)) * (1.0 + 2.0j)  # scale into the complex plane
+    pts, cells = np.asarray(d.mesh.points), np.asarray(d.mesh.cells_dict["tetra"])
+    top = build_edge_topology(cells, BASIX_TET_EDGES)
+    val = np.asarray(n1e_field_at_tet_centroids(pts, cells, top, A))
+    assert np.iscomplexobj(val) and np.max(np.abs(val.imag)) > 0.0


### PR DESCRIPTION
## Summary

Makes jNO's **complex H(curl) / Nédélec (N1E) curl-curl eddy-current solves GPU-scalable**, replacing the CPU-pinned sparse-direct path with a sparse, matrix-free **AMS-preconditioned** iterative solve, and bundles the supporting matrix-free solver stack.

### Preconditioners (`jno.precond`)
- **`ams()`** — auxiliary-space Maxwell preconditioner for H(curl) curl-curl systems (Hiptmair–Xu 2007 / Kolev–Vassilevski 2009): discrete-gradient `G` + vector-nodal `Π` corrections on cheap nodal auxiliaries → near mesh-independent convergence. Pluggable `aux=` solver (exact `lu`, or a GPU AMG). **Complex** operators solved directly & sparsely (real-reformulated auxiliaries so a real-only AMG aux works). Differentiable via a frozen-aux `.build()` hook.
- **`jaxamg()` / `jno.solve.amg()`** — optional GPU AMG (NVIDIA AmgX via `jaxamg`).
- **`cached()`** + fluent `.cached()` — memoise any preconditioner's setup across solves.

### Solvers (`jno.solve`)
- Matrix functions — `logdet` / `trace` / `applyfun` (matrix-free, differentiable; symmetric & non-symmetric).
- `eigs` — differentiable generalized eigensolver (Kx=λMx).
- `lstsq` (LSMR), `diagonal` (matrix-free diag / diag-inverse).
- Exponential integrator + θ-schemes for `fem.solve(time=...)`; consistent-mass via matrix-free M-inner-product Lanczos.

### FEM
- **Complex-direct iterative solve** — threads linear/precond slots onto the sparse complex operator `A_r + jA_i` (never densified).
- **Sparse per-element N1E/RT/P0 assembly** — drops the O(n²) dense `jacfwd` (scales 7k→60k+ edges).
- **3-D N1E field/curl reconstruction** at tet centroids.

## Compatibility with #88
No merge conflict — the two branches touch disjoint code (their `jno/_fem.py` hunks do not overlap). The one shared touchpoint — #88 dropping `jno.domain.cube` — is pre-handled here: the AMS/N1E tests build their cube domains via `jno.Shape.box(0,0,0,1,1,1,size=…).domain()`, so this branch is compatible in **either** merge order.

## Testing
New tests cover AMS gradient/Π structure + go/no-go, AMS precond (real & complex), sparse N1E assembly, N1E reconstruction, generalized eigensolver, matrix functions, time schemes, and cached preconditioners. Format + lint clean; affected suites verified locally.