### PR TITLE
feat(fem): state-dependent (nonlinear) transient mass c(u)·u_t

### DIFF
--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1665,6 +1665,12 @@ class FEM:
         # the nonlinear-transient route carries the mass as a callable (the ``.M`` attribute is
         # unset); evaluate it once at t0 -- the mass is constant in the standard ``u_t * v`` form.
         M = self._op.M
+        if M is None and getattr(self._op, "mass_residual", None) is not None:
+            raise AttributeError(
+                "FEM has a STATE-DEPENDENT (nonlinear) mass ``c(u)·u_t``: there is no single mass matrix "
+                "(the mass M(u) varies with the solution). Its per-step action is assembled inside the "
+                "solve; use ``fem.solve()`` to march it, not ``fem.M``."
+            )
         if M is None:
             M = self._op.mass(self.t0, {})
         return _as_dense(M)

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -3526,6 +3526,34 @@ class LoadPathField(FrozenField):
         return f"LoadPathField(source_key={self.field_key}, steps={self.n_steps}, nnode={self.values.shape[0]})"
 
 
+class PrevStateField(FrozenField):
+    """The PREVIOUS transient-step nodal values of a field, delivered each backward-Euler step through
+    the load-path channel (``args["__loadpath__"]``) by the transient stepper — which already carries the
+    prior solution.
+
+    Assembler-synthesized (never user-constructed) when a transient mass term's coefficient depends on the
+    unknown, i.e. a **state-dependent mass** ``c(u)·u_t·v``. Such a term is reformulated to
+    ``c(u)·(u − u_prev)·v`` with ``u_prev`` this field; the ordinary ``_make_residual`` / ``_make_jacobian``
+    then assemble the exact backward-Euler mass action ``M(u)(u−u_prev)`` and its exact ``∂/∂u`` (both the
+    ``M`` block and the ``∫c′(u)(u−u_prev)·v`` coefficient-coupling block) — the ``1/dt`` factor is applied
+    by the stepper. Because it is a :class:`FrozenField` it stays invisible to unknown-detection, so the
+    reformulated term's nonlinearity in the true unknown ``u`` is detected correctly. Scalar or vector
+    Lagrange fields (it carries the source field's own key/basis, so a vector velocity ``ρ(φ)·u_vec_t``
+    resolves the field's own P1/P2 vector basis — the load-path gather delivers its ``(n_nodes, vec)`` slice).
+    """
+
+    def __init__(self, source):
+        import jax.numpy as _jnp
+
+        # values are a placeholder: the real per-step nodal slice is delivered on args["__loadpath__"]
+        # (this field is registered in the assembler's load-path connectivity, not the compile-time gather).
+        super().__init__(source, _jnp.zeros(1))
+        self.name = f"prev[{getattr(source, 'name', 'u')}]"
+
+    def __repr__(self):
+        return f"PrevStateField(source_key={self.field_key})"
+
+
 def load_path_fields_in(expr):
     """The distinct :class:`LoadPathField` nodes in ``expr`` (by identity, first-seen order)."""
     return [f for f in frozen_fields_in(expr) if isinstance(f, LoadPathField)]

--- a/jno/utils/solver/backend_blocks.py
+++ b/jno/utils/solver/backend_blocks.py
@@ -124,6 +124,14 @@ class SemidiscreteTimeBlock:
     mass: Optional[Callable] = None
     residual: Optional[Callable] = None
     nonlinear_runtime: Dict[str, Any] = field(default_factory=dict)
+    # STATE-DEPENDENT (nonlinear) MASS. When a transient mass term's coefficient depends on the unknown
+    # (``c(u)·u_t·v``) the mass cannot be a fixed matrix. It is carried instead as the backward-Euler mass
+    # *residual* ``mass_residual(u, t, args) = ∫ c(u)·(u − u_prev)·v`` (its ``1/dt`` applied by the step)
+    # and its exact Jacobian ``mass_residual_jac(u, t, args)``; the previous step's nodal values ``u_prev``
+    # are delivered by :meth:`step` on ``args["__loadpath__"]`` per the ``prev_state_slices`` metadata.
+    # Backward Euler only (θ=1) — a state-dependent mass makes a θ≠1 half-step ill-defined.
+    mass_residual: Optional[Callable] = None
+    mass_residual_jac: Optional[Callable] = None
 
     state0: Any = None
     initial_conditions: Any = None
@@ -194,8 +202,13 @@ class SemidiscreteTimeBlock:
         callables are populated. The represented system is:
 
             mass(t) u_dot + residual(u, t) = 0
+
+        A **state-dependent mass** block (``mass_residual`` set) is also nonlinear even if the fixed
+        ``mass`` matrix path is unused — the mass action lives in the residual there.
         """
-        return self.mass is not None and self.residual is not None
+        return (self.mass is not None and self.residual is not None) or (
+            self.mass_residual is not None and self.residual is not None
+        )
 
     def step(self, u, t, dt, args=None, theta=None, *, linear_solve=None, nonlinear_solve=None):
         """Advance the semidiscrete state by one implicit step: ``u(t) -> u(t + dt)``.
@@ -240,6 +253,48 @@ class SemidiscreteTimeBlock:
             # existing first-order behaviour; a second-order (u_tt) block sets θ=½ (trapezoidal /
             # Newmark average-acceleration) so an undamped nonlinear wave is not spuriously damped.
             thn = theta if theta is not None else (float(self.metadata.get("theta", 1.0)) if self.metadata else 1.0)
+
+            # STATE-DEPENDENT MASS: the backward-Euler mass action lives in ``mass_residual(y⁺)`` (its
+            # coefficient c(y⁺) cannot be a fixed matrix), so the step residual is
+            #     G(y⁺) = mass_residual(y⁺; u_prev=y)/dt + R(y⁺)
+            # Newton on G is exact (both matrix-free — jax linearizes through c(y⁺) and (y⁺−y) — and
+            # sparse-direct, which adds mass_residual_jac(y⁺)/dt to R's Jacobian). Backward Euler only.
+            if self.mass_residual is not None:
+                if abs(thn - 1.0) > 1e-12:
+                    raise ValueError(
+                        "jno.fem: a state-dependent (nonlinear) transient mass `c(u)·u_t` supports only "
+                        f"backward Euler (theta=1), not theta={thn:g}. A θ≠1 half-step needs the mass at the "
+                        "half-state, which is ill-defined for a coefficient that depends on the unknown. "
+                        "Drop `jno.solve.theta(...)` (use the default) for a nonlinear mass."
+                    )
+                # Deliver the previous state y as each prev-field's nodal slice on the load-path channel.
+                # A vector field's DOFs are node-major interleaved (node·vec + comp), so reshape its slice to
+                # (n_nodes, vec); a scalar field stays 1-D. The assembler's load-path gather handles either.
+                _lp = dict((args or {}).get("__loadpath__", {}) or {})
+                _uprev = jnp.asarray(u, dtype).reshape(-1)
+                for _fid, _s0, _s1, _vec in self.metadata.get("prev_state_slices", []):
+                    _slice = _uprev[_s0:_s1]
+                    _lp[_fid] = _slice if _vec == 1 else _slice.reshape(-1, _vec)
+                _ap = {**(args or {}), "__loadpath__": _lp}
+
+                def G(wn):
+                    m = jnp.asarray(self.mass_residual(wn, t_next, _ap), dtype).reshape(-1) / dt
+                    return m + jnp.asarray(self.residual(wn, t_next, args), dtype).reshape(-1)
+
+                if nonlinear_solve is not None:
+                    if getattr(nonlinear_solve, "wants_jacobian", False) and self.mass_residual_jac is not None:
+                        from .solver_api import _add_step_operator
+
+                        def jac_step(wn):
+                            # J = J_spatial(wn) + (1/dt)·J_mass(wn); both assembled BCOO (exact ∂M/∂u).
+                            return _add_step_operator(
+                                self.jacobian(wn, t_next, args), self.mass_residual_jac(wn, t_next, _ap), 1.0 / dt
+                            )
+
+                        return nonlinear_solve(G, u, jacobian=jac_step)
+                    return nonlinear_solve(G, u)
+                return newton_krylov(G, u)
+
             M_t = _operand(self.mass(t_next, args))
             r_now = (1.0 - thn) * jnp.asarray(self.residual(u, t, args), dtype).reshape(-1) if thn < 1.0 else None
 

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -853,7 +853,13 @@ def assemble_fem_native(
         fz = dict(loc.get("frozen_fields", {}))
         for _fid, _conn in _path_conn.items():
             if _fid in pbuf:
-                fz[_fid] = jnp.asarray(pbuf[_fid]).reshape(-1)[_conn[c]].reshape(_conn.shape[1], 1)
+                _arr = jnp.asarray(pbuf[_fid])
+                # scalar field: (n_nodes,) -> per-cell (n_local, 1); vector field (prev-state mass):
+                # (n_nodes, vec) -> per-cell (n_local, vec). The kernel interpolation handles either.
+                if _arr.ndim <= 1:
+                    fz[_fid] = _arr.reshape(-1)[_conn[c]].reshape(_conn.shape[1], 1)
+                else:
+                    fz[_fid] = _arr[_conn[c]]
         loc["frozen_fields"] = fz
 
     def _split_cell_local(local_vals):
@@ -1474,7 +1480,11 @@ def assemble_fem_native(
             )
         from ..._fem import _bare, _essential_spec, _eval_value_node_at, _field_key_of
         from .backend_blocks import SemidiscreteTimeBlock
-        from .time_route import _infer_time_window, _strip_temporal_trial_derivative
+        from .time_route import (
+            _infer_time_window,
+            _replace_temporal_with_backward_euler,
+            _strip_temporal_trial_derivative,
+        )
 
         sub_signed = [
             _apply_sign(domain, sign, sub) for bare in volume_terms for sign, sub in _split_additive_terms(domain, bare)
@@ -1551,6 +1561,50 @@ def assemble_fem_native(
         d_dofs = jnp.asarray([p[0] for p in dirichlet_pairs], dtype=jnp.int32) if dirichlet_pairs else None
         d_vals = jnp.asarray([p[1] for p in dirichlet_pairs], dtype=zeros.dtype) if dirichlet_pairs else None
 
+        # ---- STATE-DEPENDENT (nonlinear) MASS: ``c(u)·u_t`` with a coefficient depending on the unknown.
+        # The fixed ``M = _mass_jac(zeros)`` freezes ``c`` at ``u=0`` (silently wrong; see jno-fem-hard-limits).
+        # Reformulate each temporal term to backward-Euler *residual* form ``c(u)·(u − u_prev)·v`` — with
+        # ``u_prev`` the previous step's nodal values delivered per step on the load-path channel — so the
+        # ordinary residual/Jacobian assembly captures the exact mass action ``M(u)(u−u_prev)`` AND its exact
+        # ``∂/∂u`` (both the ``M`` block and the ``∫c′(u)(u−u_prev)·v`` coefficient coupling). The ``1/dt``
+        # factor is applied by the stepper. Backward Euler (θ=1) only; scalar fields only (load-path is scalar).
+        _nonlinear_mass = (not _parametric_mass) and any(
+            _is_obviously_nonlinear_in_unknown(domain, mt) for mt in mass_terms
+        )
+        prev_state_slices: List[Tuple[int, int, int, int]] = []  # (frozen_id, dof_start, dof_stop, n_components)
+        mass_res_bc = mass_jac_bc = None
+        if _nonlinear_mass:
+            from ...trace import PrevStateField as _PrevStateField
+
+            _prev_by_field: Dict[Any, Any] = {}
+
+            def _prev_for(trial, _cache=_prev_by_field):
+                fkey = trial.field_key
+                pf = _cache.get(fkey)
+                if pf is None:
+                    fidx = field_index[fkey]
+                    pf = _PrevStateField(trial)
+                    _cache[fkey] = pf
+                    # The prev-state field carries the source field's OWN key/basis, so it resolves the field's
+                    # own shape data (P1 or P2, scalar or vector) — no P1 aliasing (unlike a load-path field).
+                    _path_conn[pf.frozen_id] = cells_f_j[fidx]  # the field's own vertex connectivity
+                    # (frozen_id, dof-slice into the flat state, n_components) — the step delivers this slice
+                    # reshaped to (n_nodes, vec) on the load-path channel each backward-Euler step.
+                    prev_state_slices.append((int(pf.frozen_id), int(offs[fidx]), int(offs[fidx + 1]), int(vecs[fidx])))
+                return pf
+
+            temporal_be = [_replace_temporal_with_backward_euler(t, _prev_for) for t in temporal]
+            _mass_res_raw = _make_residual(temporal_be)  # ∫ c(u)·(u − u_prev)·v  (volume only; mass has no boundary)
+            _mass_jac_raw = _make_jacobian(temporal_be)
+
+            def mass_res_bc(u, t, args=None, _d=d_dofs, _f=_mass_res_raw):
+                R = jnp.asarray(_f(jnp.asarray(u), t, args)).reshape(-1)
+                return R if _d is None else R.at[_d].set(0.0)  # a constrained DOF carries no mass equation
+
+            def mass_jac_bc(u, t, args=None, _d=d_dofs, _f=_mass_jac_raw):
+                J = _f(jnp.asarray(u), t, args)
+                return J if _d is None else bcoo_zero_rows(J, _d)
+
         # Parametric mass ``mass_fn(t, args)`` (unknown density net(x)*u_t): re-assemble M from args each
         # step with the Dirichlet rows/cols zeroed (a constrained DOF carries no time derivative). ``None``
         # keeps the static ``M_bc`` for a non-parametric mass.
@@ -1558,7 +1612,9 @@ def assemble_fem_native(
             Mt = _mass_jac(zeros, t, args)
             return Mt if _d is None else bcoo_zero_rows_cols(Mt, _d)
 
-        nonlinear = any(_is_obviously_nonlinear_in_unknown(domain, t) for t in spatial)
+        # A mass-only nonlinearity (state-dependent mass) also requires the nonlinear step path, even when
+        # every spatial term is linear — the mass action lives in the residual there (``mass_residual``).
+        nonlinear = _nonlinear_mass or any(_is_obviously_nonlinear_in_unknown(domain, t) for t in spatial)
         if nonlinear:
             # Row-replacement Dirichlet (constant g), threaded through the runtime time t AND the
             # runtime args so a time-dependent / parametric spatial coefficient is re-evaluated each step.
@@ -1573,10 +1629,16 @@ def assemble_fem_native(
             M_bc = M if d_dofs is None else bcoo_zero_rows_cols(M, d_dofs)
             return (
                 SemidiscreteTimeBlock(
-                    mass=_mass_cb if _parametric_mass else (lambda t, args=None, _M=M_bc: _M),
+                    # A state-dependent mass carries no fixed matrix; the mass action is in mass_residual.
+                    mass=None
+                    if _nonlinear_mass
+                    else (_mass_cb if _parametric_mass else (lambda t, args=None, _M=M_bc: _M)),
+                    mass_residual=mass_res_bc,
+                    mass_residual_jac=mass_jac_bc,
                     residual=res_bc,
                     jacobian=jac_bc,
                     runtime_parameter_exprs=dict(_param_and_neural_exprs),
+                    metadata={"prev_state_slices": prev_state_slices} if _nonlinear_mass else {},
                     **common,
                 ),
                 "transient",

--- a/jno/utils/solver/time_route.py
+++ b/jno/utils/solver/time_route.py
@@ -119,3 +119,63 @@ def _strip_temporal_trial_derivative(node: Any) -> Any:
         )
 
     return node
+
+
+def _replace_temporal_with_backward_euler(node: Any, prev_for) -> Any:
+    """Replace ``d/dt(TrialFunction)`` with ``(TrialFunction − u_prev)`` — the backward-Euler
+    discretization of a transient term used when the mass coefficient depends on the unknown
+    (state-dependent mass). ``prev_for(trial) -> PrevStateField`` supplies the field's previous-step
+    frozen values.
+
+    A term ``c(u)·u_t·v`` becomes ``c(u)·(u − u_prev)·v``; assembling its residual/Jacobian gives the
+    exact mass action ``M(u)(u − u_prev)`` and its exact ``∂/∂u`` (both ``M`` and the coefficient
+    coupling). The ``1/dt`` factor is applied by the stepper, NOT here — so the produced term is
+    independent of the (runtime) step size. Mirrors :func:`_strip_temporal_trial_derivative`'s traversal.
+    """
+    if _is_temporal_jacobian_of_trial(node):
+        trial = node.target
+        return trial - prev_for(trial)  # (u − u_prev); trace BinaryOp via Placeholder.__sub__
+
+    if isinstance(node, BinaryOp):
+        return BinaryOp(
+            node.op,
+            _replace_temporal_with_backward_euler(node.left, prev_for),
+            _replace_temporal_with_backward_euler(node.right, prev_for),
+        )
+
+    if isinstance(node, FunctionCall):
+        new_args = [
+            _replace_temporal_with_backward_euler(a, prev_for) if isinstance(a, Placeholder) else a for a in node.args
+        ]
+        if hasattr(node, "copy_with_args"):
+            return node.copy_with_args(new_args)
+        return FunctionCall(
+            node.fn,
+            new_args,
+            name=getattr(node, "_name", None),
+            reduces_axis=getattr(node, "reduces_axis", None),
+            kwargs=getattr(node, "kwargs", None),
+        )
+
+    if isinstance(node, Jacobian):
+        return Jacobian(
+            _replace_temporal_with_backward_euler(node.target, prev_for),
+            [
+                _replace_temporal_with_backward_euler(v, prev_for) if isinstance(v, Placeholder) else v
+                for v in node.variables
+            ],
+            node.scheme,
+        )
+
+    if isinstance(node, Hessian):
+        return Hessian(
+            _replace_temporal_with_backward_euler(node.target, prev_for),
+            [
+                _replace_temporal_with_backward_euler(v, prev_for) if isinstance(v, Placeholder) else v
+                for v in node.variables
+            ],
+            node.scheme,
+            trace=node.trace,
+        )
+
+    return node

--- a/tests/test_fem_nonlinear_mass.py
+++ b/tests/test_fem_nonlinear_mass.py
@@ -1,0 +1,215 @@
+"""State-dependent (nonlinear) transient mass:  ``c(u)·u_t = κΔu + f``.
+
+The transient mass term may carry a coefficient that depends on the *unknown* — e.g. an
+apparent heat capacity ``c(u)=1+u``, or a phase-dependent density ``ρ(φ)`` on ``∂_t u`` in a
+coupled system.  The semidiscrete residual is then ``M(u) u̇ + K u = f`` with a genuinely
+state-dependent mass, and its exact step Jacobian gains the ``∂M/∂u`` coupling term.
+
+Oracle: the **method of manufactured solutions**.  On the unit square with homogeneous Dirichlet,
+
+    u*(x, y, t) = g(t)·φ(x, y),   g(t) = 1 + A t,   φ = sin(πx) sin(πy)   (≡ 0 on ∂Ω)
+
+is fed into ``c(u) u_t = κΔu + f`` with ``c(u)=1+u`` by supplying the required forcing
+``f = c(u*) u*_t − κΔu*`` (hand-derived below).  If the mass coefficient is honored at the
+current state the solve reproduces u*; if it is frozen at ``u=0`` (c≡1, plain heat) the
+trajectory is wrong by an O(1) amount — c(u*) ranges over [1, 2.2] here.
+
+Regression pin: on the pre-feature assembler this FAILS (the mass is assembled once at zeros,
+so ``c(u)·u_t`` silently reduces to ``u_t``); see jno-fem-hard-limits #1.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely", reason="shapely required for the box domain")
+from shapely.geometry import box  # noqa: E402
+
+import jno  # noqa: E402
+
+PI = np.pi
+A, KAPPA, T_END, NT = 0.5, 0.05, 0.4, 41  # capacity slope, diffusivity, horizon, steps (dt=0.01)
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _phi(x, y):
+    return jnp.sin(PI * x) * jnp.sin(PI * y)
+
+
+def _u_star(x, y, t):
+    return (1.0 + A * t) * _phi(x, y)
+
+
+def _f_src(x, y, t):
+    # c(u*) u*_t − κΔu*,  with c(u)=1+u, Δφ = −2π²φ, u*_t = A·φ, u* = g·φ, g = 1+At
+    phi = _phi(x, y)
+    g = 1.0 + A * t
+    return (1.0 + g * phi) * (A * phi) + 2.0 * PI**2 * KAPPA * g * phi
+
+
+def _build():
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.05, time=(0.0, T_END, NT))
+    u, v = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    xi0, yi0, _ = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    # c(u)=1+u on the time term; the whole point is that c is read at the current state.
+    weak = (1.0 + ui) * ui.t * vi + KAPPA * (ui.x * vi.x + ui.y * vi.y) - jno.fn(_f_src, [xi, yi, ti]) * vi
+    ic = jno.fn(lambda x, y: _phi(x, y), [xi0, yi0])
+    fem = jno.fem([weak, u(xb, yb) - 0.0, u(xi0, yi0) - ic])
+    return d, fem
+
+
+def _rel_err(d, sol):
+    pts = np.asarray(d.mesh.points)[:, :2]
+    exact = np.asarray(jax.vmap(lambda p: _u_star(p[0], p[1], T_END))(jnp.asarray(pts)))
+    got = np.asarray(sol)
+    got = got[-1] if got.ndim == 2 else got  # transient .fn() is (n_times, n_nodes); take t=T_END
+    return np.linalg.norm(got.reshape(-1) - exact) / max(np.linalg.norm(exact), 1e-12)
+
+
+def test_nonlinear_mass_matches_manufactured_solution():
+    """The state-dependent capacity c(u)=1+u is honored: default solve reproduces u*."""
+    d, fem = _build()
+    err = _rel_err(d, fem.solve().fn())
+    assert err < 0.05, f"nonlinear-mass trajectory did not reproduce u*: rel L2 = {err:.3f}"
+
+
+def test_nonlinear_mass_direct_newton_matches_default():
+    """The sparse-direct step Newton (exact assembled ∂M/∂u tangent) matches the matrix-free path."""
+    d, fem = _build()
+    err = _rel_err(d, fem.solve(nonlinear=jno.solve.newton(direct=True)).fn())
+    assert err < 0.05, f"direct-Newton nonlinear-mass trajectory wrong: rel L2 = {err:.3f}"
+
+
+def test_nonlinear_mass_theta_half_raises():
+    """A state-dependent mass is backward-Euler only; Crank–Nicolson must fail loud, not silently wrong."""
+    _, fem = _build()
+    with pytest.raises((ValueError, Exception), match="backward Euler|theta"):
+        fem.solve(time=jno.solve.theta(0.5)).fn()
+
+
+# --- coupled cross-coefficient: mass of field `a` depends on another field `b` (the ∂M/∂b coupling that a
+#     phase-field ρ(φ)·u_t needs). One-way manufactured pair a*(1+At)φ, b*(1+Bt)φ, φ=sin πx sin πy. ---
+B = 0.7
+
+
+def _build_coupled():
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.05, time=(0.0, T_END, NT))
+    a, pa = d.fem_symbols(names=("a", "pa"))
+    b, pb = d.fem_symbols(names=("b", "pb"))
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    xi0, yi0, _ = d.variable("initial", split=True)
+    ai, pai = a.bind(x=xi, y=yi, t=ti), pa.bind(x=xi, y=yi, t=ti)
+    bi, pbi = b.bind(x=xi, y=yi, t=ti), pb.bind(x=xi, y=yi, t=ti)
+
+    def f_a(x, y, t):
+        phi = _phi(x, y)
+        return (1.0 + (1.0 + B * t) * phi) * (A * phi) + 2.0 * PI**2 * KAPPA * (1.0 + A * t) * phi
+
+    def f_b(x, y, t):
+        phi = _phi(x, y)
+        return B * phi + 2.0 * PI**2 * KAPPA * (1.0 + B * t) * phi
+
+    # mass of `a` carries the state-dependent coefficient (1 + b); `b`'s mass is plain.
+    a_eq = (1.0 + bi) * ai.t * pai + KAPPA * (ai.x * pai.x + ai.y * pai.y) - jno.fn(f_a, [xi, yi, ti]) * pai
+    b_eq = bi.t * pbi + KAPPA * (bi.x * pbi.x + bi.y * pbi.y) - jno.fn(f_b, [xi, yi, ti]) * pbi
+    ic = jno.fn(lambda x, y: _phi(x, y), [xi0, yi0])
+    fem = jno.fem([a_eq, b_eq, a(xb, yb) - 0.0, b(xb, yb) - 0.0, a(xi0, yi0) - ic, b(xi0, yi0) - ic])
+    return d, fem
+
+
+def test_nonlinear_mass_cross_field_coupling():
+    """Mass coefficient of `a` depends on field `b`: the exact ∂M/∂b coupling reproduces both fields."""
+    d, fem = _build_coupled()
+    traj = np.asarray(fem.solve().fn())  # (n_times, 2*n_nodes) — fields concatenated
+    pts = np.asarray(d.mesh.points)[:, :2]
+    n = pts.shape[0]
+    a_exact = np.asarray(jax.vmap(lambda p: _u_star(p[0], p[1], T_END))(jnp.asarray(pts)))
+    b_exact = np.asarray(jax.vmap(lambda p: (1.0 + B * T_END) * _phi(p[0], p[1]))(jnp.asarray(pts)))
+    final = traj[-1].reshape(-1)
+    a_got, b_got = final[:n], final[n : 2 * n]
+    ea = np.linalg.norm(a_got - a_exact) / np.linalg.norm(a_exact)
+    eb = np.linalg.norm(b_got - b_exact) / np.linalg.norm(b_exact)
+    # 8% = the backward-Euler + P1 discretization floor at this dt/mesh (matches the moving-boundary MMS
+    # threshold): note the LINEAR-mass field `b` sits at the same ~6%, so the state-dependent mass of `a`
+    # (and its ∂M/∂b coupling) is exact — a wrong coupling would make `a` diverge from `b`, not track it.
+    assert ea < 0.08 and eb < 0.08, f"cross-coupled nonlinear mass wrong: rel L2 a={ea:.3f}, b={eb:.3f}"
+
+
+def test_nonlinear_mass_vector_field():
+    """State-dependent mass on a VECTOR field (CHNS velocity shape): c(w)=1+w₀ on the vector u_t term.
+    Manufactured w* = (1+At)(φ, φ); both components must be reproduced. Exercises the (n_nodes, vec)
+    previous-state delivery and the field's own vector basis (no P1 aliasing)."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=0.06, time=(0.0, T_END, NT))
+    w, v = d.fem_symbols(value_shape=(2,), names=("w", "v"))
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    xi0, yi0, _ = d.variable("initial", split=True)
+    wi, vi = w.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+
+    def f_src(x, y, t):  # same forcing for both components (c(w*)=1+(1+At)φ, w*_i,t = Aφ)
+        phi = _phi(x, y)
+        return (1.0 + (1.0 + A * t) * phi) * (A * phi) + 2.0 * PI**2 * KAPPA * (1.0 + A * t) * phi
+
+    f = jno.fn(f_src, [xi, yi, ti])
+    mass = (1.0 + wi[0]) * (wi.t[0] * vi[0] + wi.t[1] * vi[1])  # coefficient depends on component 0
+    diff = KAPPA * (wi.x[0] * vi.x[0] + wi.y[0] * vi.y[0] + wi.x[1] * vi.x[1] + wi.y[1] * vi.y[1])
+    weak = mass + diff - f * (vi[0] + vi[1])
+    ic = jno.fn(lambda x, y: _phi(x, y), [xi0, yi0])
+    fem = jno.fem([weak, w(xb, yb) - 0.0, w(xi0, yi0)[0] - ic, w(xi0, yi0)[1] - ic])
+
+    final = np.asarray(fem.solve().fn())[-1].reshape(-1)  # node-major interleaved (node·2 + comp)
+    pts = np.asarray(d.mesh.points)[:, :2]
+    exact = np.asarray(jax.vmap(lambda p: _u_star(p[0], p[1], T_END))(jnp.asarray(pts)))
+    e0 = np.linalg.norm(final[0::2] - exact) / np.linalg.norm(exact)
+    e1 = np.linalg.norm(final[1::2] - exact) / np.linalg.norm(exact)
+    assert e0 < 0.08 and e1 < 0.08, f"vector nonlinear-mass wrong: rel L2 comp0={e0:.3f}, comp1={e1:.3f}"
+
+
+def _heat_nlmass(coeff, mesh_size=0.25, time=(0.0, 0.2, 11)):
+    """Transient heat whose u_t coefficient is 1 + coeff·u (state-dependent mass), sine-bump IC."""
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size, time=time)
+    u, v = d.fem_symbols()
+    xi, yi, ti = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ci = d.variable("initial", split=True)
+    ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    ic = jno.np.sin(PI * ci[0]) * jno.np.sin(PI * ci[1])
+    weak = (1.0 + coeff * ui) * ui.t * vi + KAPPA * (ui.x * vi.x + ui.y * vi.y)
+    return jno.fem([weak, u(xb, yb) - 0.0, u(ci[0], ci[1]) - ic])
+
+
+def test_nonlinear_mass_inverse_adjoint():
+    """Reverse-mode adjoint flows through the state-dependent mass: recover a coefficient parameter
+    (α in c(u)=1+α·u on the u_t term) from an observed trajectory. Guards jNO differentiability (rule #3):
+    the per-step Newton's ``custom_root`` and the mass reassembly must be transposable end-to-end."""
+    import optax
+
+    u_obs = jnp.asarray(_heat_nlmass(1.0).solve().fn())  # α_true = 1
+
+    alpha = jno.np.parameter((1,), key=jax.random.PRNGKey(0), name="alpha_mass")
+    alpha.initialize(jax.nn.initializers.constant(2.5))
+    alpha.dtype(jnp.float64)
+    alpha.optimizer(optax.adam(5e-2))
+
+    node = _heat_nlmass(alpha).solve()
+    dummy = jno.domain.from_array({"_": np.zeros((1, 1))})
+    crux = jno.core([(node - u_obs).mse], domain=dummy)
+    crux.solve(150)
+    a = float(np.asarray(crux.eval([alpha])).reshape(-1)[0])
+    assert abs(a - 1.0) < 0.1, f"mass-coefficient α not recovered through the nonlinear-mass adjoint: {a}"


### PR DESCRIPTION
## What

A transient mass term whose coefficient depends on the unknown — an apparent capacity `c(u)·u_t`, or a phase-dependent density `ρ(φ)·u_vec_t` in a coupled system — is now honored exactly. Previously it was **silently frozen**: the semidiscrete mass was assembled once at `u=0`, and a mass-only nonlinearity was misclassified linear (`transient block is linear`), so e.g. an apparent-capacity latent-heat form or a variable-density Navier–Stokes mass changed the answer by nothing.

## How

Each temporal term is reformulated to backward-Euler **residual** form `c(u)·(u − u_prev)·v`, with `u_prev` the previous step's nodal values delivered per step through the existing frozen-field / load-path channel (`args["__loadpath__"]`) — which the transient stepper already carries — and the `1/dt` applied by the stepper. The ordinary `_make_residual` / `_make_jacobian` then assemble the exact mass action `M(u)(u − u_prev)` **and** its exact `∂/∂u`: both the `M` block and the `∫ c′(u)(u − u_prev)·v` coefficient-coupling block, matrix-free (Newton–Krylov) and sparse-direct alike.

A clean state-dependent mass *matrix* cannot be assembled for the self-coefficient case (evaluating the mass Jacobian off `u=0` is contaminated by the coefficient derivative) — which is precisely why the mass is carried as a residual, not a matrix.

Internals:
- `PrevStateField(FrozenField)` — assembler-synthesized (no public API); rides the load-path interpolation, scalar or vector.
- `_replace_temporal_with_backward_euler` in `time_route.py` — sibling of `_strip_temporal_trial_derivative`.
- `SemidiscreteTimeBlock.mass_residual` / `mass_residual_jac`; the step delivers `u_prev` and applies `1/dt`.
- Vector fields: the load-path gather delivers the field's `(n_nodes, vec)` slice; the kernel interpolation was already vector-capable.

## Scope / limits

- **Backward Euler (θ=1) only** — a state-dependent mass makes a θ≠1 half-step ill-defined; θ≠1 raises a clear error rather than silently doing something wrong.
- Scalar and vector Lagrange fields.
- No public API change — you just write `c(u)·u.t·v` in the weak form and it works. `fem.M` on such a problem raises (there is no single mass matrix).

## Tests

`tests/test_fem_nonlinear_mass.py` — MMS oracles: scalar match (matrix-free), direct-Newton exact tangent, cross-field coupling `∂M/∂b`, the θ=½ guard, a reverse-mode inverse adjoint (recovers a mass-coefficient parameter → differentiable), and a vector velocity field. No regressions across the transient / native / load-path / moving-boundary suites.