### PR TITLE
Tier 1 + 2 competitiveness: rebuild, AMG, fieldsplit, one-sided contact, runtime Dirichlet parameters

### DIFF
--- a/benchmarks/amg_scaling.py
+++ b/benchmarks/amg_scaling.py
@@ -1,0 +1,127 @@
+"""Does AMG cash in the iteration win the roofline memo promised — and through WHICH front door?
+
+The GPU roofline analysis found SpMV at ~69% of bandwidth: the backend is not the lever, the
+ITERATION COUNT is (Jacobi-Krylov grows ~sqrt(n) on elliptic operators, multigrid stays ~flat).
+jNO has three AMG front doors with very different overhead profiles, so this measures all three:
+
+* ``precond.amg()``            — pyamg setup on host, pure-JAX V-cycle per application (no
+                                 per-application host crossing; compiles into the solve).
+* ``solve.amg()``              — direct AmgX solve: ONE host/handle crossing per SOLVE, and AmgX's
+                                 structure-keyed warm resetup makes repeats ~10x cheaper (measured).
+* ``precond.jaxamg()``         — AmgX per APPLICATION: measured ~11 ms fixed handle overhead per
+                                 call, so it only pays where iterations x savings exceed that.
+                                 (Kept out of the wall-clock table for that measured reason.)
+
+Two tables: iterations-to-tol (host PCG, float64, counting — machine-independent) and wall-clock
+repeat solve (second call timed; the first carries compilation — fair_bench convention).
+
+Run: JAX_PLATFORMS=cuda,cpu pixi run python benchmarks/amg_scaling.py
+"""
+
+import json
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import jno
+
+
+def build_poisson_3d(size):
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    u, v = d.fem_symbols()
+    xi, yi, zi, _ = d.variable("interior", split=True)
+    xb, yb, zb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - 3.0 * vi, u(xb, yb, zb) - 0.0])
+    return fem
+
+
+def to_csr(A_raw, n):
+    import scipy.sparse as sp
+
+    if hasattr(A_raw, "indices"):
+        idx = np.asarray(A_raw.indices)
+        return sp.csr_matrix((np.asarray(A_raw.data, dtype=np.float64), (idx[:, 0], idx[:, 1])), shape=(n, n))
+    return sp.csr_matrix(np.asarray(A_raw, dtype=np.float64))
+
+
+def pcg_iterations(A_sp, b, M_apply, tol=1e-8, maxiter=20000):
+    """Preconditioned CG on the host, counting iterations — the measurement jax.scipy hides."""
+    x = np.zeros_like(b)
+    r = b - A_sp @ x
+    z = M_apply(r)
+    p = z.copy()
+    rz = float(r @ z)
+    bnorm = float(np.linalg.norm(b))
+    for it in range(1, maxiter + 1):
+        Ap = A_sp @ p
+        alpha = rz / float(p @ Ap)
+        x += alpha * p
+        r -= alpha * Ap
+        if np.linalg.norm(r) <= tol * bnorm:
+            return it
+        z = M_apply(r)
+        rz_new = float(r @ z)
+        p = z + (rz_new / rz) * p
+        rz = rz_new
+    return maxiter
+
+
+def timed_repeat(fn, warmup=2):
+    # TWO warmups, not one: a cached AMG spec is eager on call 0 (builds the hierarchy), becomes
+    # traceable, and call 1 pays the jit compile -- the steady state a repeated workflow sees starts
+    # at call 2. Timing call 1 measured the COMPILE and misread the compiled path as eager.
+    for _ in range(warmup):
+        fn()
+    t0 = time.perf_counter()
+    out = fn()
+    jax.block_until_ready(out)
+    return time.perf_counter() - t0
+
+
+def main():
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext
+
+    rows = []
+    for size in (0.10, 0.07, 0.05, 0.04, 0.035):
+        fem = build_poisson_3d(size)
+        b = np.asarray(fem.b, dtype=np.float64)
+        n = b.shape[0]
+        A_sp = to_csr(fem.A, n)
+
+        # -- iterations to 1e-8 with the V-CYCLE jNO actually ships (pyamg-hybrid applier) --------
+        diag = A_sp.diagonal()
+        it_jac = pcg_iterations(A_sp, b, lambda r: r / diag)
+        spec = jno.precond.amg()
+        applier = spec.materialize(
+            PrecondContext(
+                LinearOperator(
+                    fem.A if hasattr(fem.A, "indices") else jnp.asarray(np.asarray(A_sp.todense(), dtype=np.float32))
+                )
+            )
+        )
+        it_amg = pcg_iterations(A_sp, b, lambda r: np.asarray(applier(jnp.asarray(r, dtype=jnp.float32)), dtype=np.float64))
+
+        # -- wall-clock repeat solve through the three front doors ------------------------------
+        t_def = timed_repeat(lambda: fem.solve())
+        amg_pre = jno.precond.amg().cached()
+        t_pyamg = timed_repeat(lambda: fem.solve(linear=jno.solve.cg(tol=1e-8), precond=amg_pre))
+        t_amgx = timed_repeat(lambda: fem.solve(linear=jno.solve.amg()))
+
+        row = dict(n=n, it_jacobi=it_jac, it_amg=it_amg, t_default=t_def, t_pyamg_cg=t_pyamg, t_amgx_direct=t_amgx)
+        rows.append(row)
+        print(
+            f"n={n:7d}  iters: jacobi {it_jac:5d}  amg-vcycle {it_amg:3d} ({it_jac / max(it_amg, 1):5.1f}x)   "
+            f"solve#2: default {t_def * 1e3:7.1f} ms  amg-cg {t_pyamg * 1e3:7.1f} ms  amgx-direct {t_amgx * 1e3:7.1f} ms"
+        )
+        del fem, A_sp
+
+    with open("benchmarks/amg_scaling.json", "w") as f:
+        json.dump(rows, f, indent=1)
+    print("\njacobi iterations grow ~sqrt(n), the V-cycle stays ~flat; wrote benchmarks/amg_scaling.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -424,17 +424,40 @@ For a bonded (tied) interface use the two-sided penalty `p = -c*g` instead of th
 and stiffening `c` converges to the tie: two bonded unit blocks squeezed by 0.02 reproduce the single-bar
 answer `uy(y=1) = -0.01` to 1.5e-05 at `c = 1e6`.
 
+**One-sided (separating, Signorini) contact works** with the `max(0, -c*g)` spelling above, and the
+earlier "the kink stalls Newton" note was re-measured and re-classified: the stall was a **float32
+residual floor** (~2e-5 on the reference stack), not active-set cycling — `jax.linearize` through
+`max` selects the active branch, which *is* the semismooth Jacobian, and under x64 the identical
+iteration meets `rtol=1e-8` at residual 4e-10, superlinearly. Practical guidance: set tolerances the
+precision can reach (`newton(line_search=True, rtol=1e-6, atol=1e-6)` in float32; anything tighter
+wants x64), press converges to the bonded answer like `1/c`, and release separates exactly — no
+adhesion, measured `max|u| < 1e-9` on the far body.
+
+To remove the penalty's `O(1/c)` penetration error, add the **augmented-Lagrangian** multiplier — a
+scalar *surface state* on the secondary face riding the existing `evolves` + `tau=` march machinery,
+no new API:
+
+```python
+lam, _ = d.fem_symbols(value_shape=())            # the multiplier, per face quadrature point
+p = jno.np.maximum(0.0, lam.i(-1) + c*(-g))       # AL pressure
+fem = jno.fem([..., p * inner(n, phi_s, 1), lam.evolves(p), *bcs])   # tau march = Uzawa updates
+```
+
+Measured on the reference stack at the *same* `c = 1e3`: penalty error 3.4e-3, AL error **1.1e-5**
+after 8 updates, falling monotonically. Differentiable through *closed* contact: `jax.grad` of a
+response w.r.t. a load or (parametric-Dirichlet) grip displacement runs through the driver's
+`custom_root` on the branch-selected operator and FD-checks; at contact *onset* the derivative is a
+subgradient (the `max` kink).
+
 > **Scope.** Small sliding — the pairing is frozen at build time, so a configuration that slides must be
 > rebuilt per load step. Differentiable in the DOF values but **not** in the mesh coordinates (the
 > projection weights are host-computed). Frictionless: no tangential traction, so a body held *only* by
 > contact is free to slide and its system is singular — constrain the tangential direction independently.
-> The gap is non-local (it reads DOFs on the other body's cells), so the tangent is matrix-free;
-> `newton(direct=True)` is refused. **One-sided contact does not yet converge to tight tolerances**: the
-> `max(0, ·)` kink is non-smooth and the residual stalls around 1e-2 with a line search, against a 1e-8
-> target. The bonded two-sided path is smooth and converges. Signorini contact is the same kind of
-> object as [`u.bounds(lo, hi)`](#inequalities--uboundslo-hi) — a complementarity condition rather than
-> a penalty — so that machinery is the natural route for it, but the reformulation has **not** been
-> done and the penalty path above is what exists today.
+> The **assembled tangent now carries the gap's nonlocal blocks** — `(s,m)` from `jacfwd` w.r.t. the
+> gathered main values chained through the frozen mortar weights, plus the reaction rows' `(m,s)` and
+> `(m,m)` — verified against the matrix-free JVP on random probes in both the active and separated
+> branches, so `newton(direct=True)` + `lu`/cuDSS works with contact (the pattern is static; inactive
+> contact contributes zeros in the data, which keeps the sparsity-keyed factorization caches valid).
 
 ---
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -2047,24 +2047,29 @@ solve slower, so compare **build + solve**, and remember jNO assembles *once* wh
 assembler pays again on every Newton iteration.
 
 Most of a cold build is **XLA compilation**, and the cost is fixed per problem *structure* rather than
-per DOF — a 15x larger mesh still compiles about the same number of programs. That makes it worth
-caching across processes, which is **opt-in**:
+per DOF — a 15x larger mesh still compiles about the same number of programs. Two caches attack it,
+both **on by default**:
 
-```python
-dire = jno.setup(__file__, compile_cache=True)     # or, per project, in .jno.toml:
-                                                   #   [jno]
-                                                   #   compile_cache = true
-```
+**Across processes** — the persistent XLA cache (`~/.cache/jno/xla`), enabled at `import jno`:
 
 | 3-D Poisson, 27,833 nodes | first build | repeat build |
 |---|---|---|
-| default (no cache) | 4.75 s | 2.48 s |
-| `compile_cache=True` | **2.22 s** | **1.51 s** |
+| no cache | 4.75 s | 2.48 s |
+| persistent cache (default) | **2.22 s** | **1.51 s** |
 
-**Off by default on purpose**, for two reasons: a library should not write to your disk uninvited, and
-the run that *populates* the cache is **slower** than having none at all — so a single cold run is a
-straight loss. Turn it on for anything you run more than once: a sweep, an optimisation loop, a test
-suite, or simply re-running a script after an edit.
+The very first run on a machine is *slower* (populating the cache costs more than not having one);
+it pays back from the second process onward, which is jNO's normal life — sweeps, optimisation
+loops, test suites, re-running a script after an edit. Opt out with `JNO_COMPILE_CACHE=0`,
+`jno.setup(__file__, compile_cache=False)`, or per project in `.jno.toml`: `[jno] compile_cache =
+false`.
+
+**Within a process** — rebuilding an *identical* problem (same mesh content, same terms) reuses the
+already-compiled assembly kernels outright, keyed on content rather than object identity, so a
+rebuild costs meshing plus host prep and **no XLA work at all** (measured: 1.94 s → 0.28 s on 3-D
+Poisson at 29k nodes). Anything that changes the operator — a different mesh, a different
+coefficient — recompiles exactly the kernels that bake it. Structure that a tokenizer cannot key by
+value simply never caches (a safe miss); the coverage is measurable, not guessed
+(`jno.utils.solver.fem_utils._ELEM_MAP_STATS`).
 
 ---
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -1258,7 +1258,15 @@ preconditioner never changes the converged solution, only the speed, so specs ne
   solve). Iterative inner ⇒ flexible outer (`fgmres`).
 * `jno.precond.form([...terms], inner=…)` — **preconditioners as weak forms**: assemble an auxiliary
   operator from ordinary traced terms and invert it as `M⁻¹` (weighted mass matrices, shifted-Laplacian
-  Helmholtz twins, low-order proxies — written in the PDE's language).
+  Helmholtz twins, low-order proxies — written in the PDE's language). Pass a **callable**
+  `form(lambda sol: [...terms...])` for a **solution-dependent** auxiliary — a `(1/μ(u))`-weighted
+  Schur mass whose weight is computed from the current solution. It is re-assembled once per outer
+  solve from that solve's entry iterate (warm start / previous march step) — the **Picard-lagged
+  preconditioner** (Elman, Silvester & Wathen 2014, §9.2): the coefficient trails the solution by one
+  outer solve, which changes convergence *speed* only, never the answer. Eager by necessity — every
+  Newton loop is a `lax.while_loop`, so the per-step iterate is a tracer no host assembly can see; a
+  fully traced solve that never supplies a concrete iterate gets a loud `NotImplementedError`, not a
+  garbage preconditioner.
 * `jno.precond.block_diag((field, spec), …)` / `jno.precond.triangular((field, spec), …)` — per-field
   composition over `fem.blocks`. `triangular` is the standard saddle-point shape: last block solved
   first, substituted back through the assembled off-diagonal matvecs.
@@ -1268,6 +1276,16 @@ preconditioner never changes the converged solution, only the speed, so specs ne
   `jit`/`vmap`-native and exactly linear, so it preconditions `cg`/`minres` too. Mesh-independent
   convergence ⇒ *the* choice for large elliptic blocks. Inside traced/parametric solves, pre-build
   eagerly: `spec = jno.precond.amg(); spec.build(fem.A)`. Without pyamg, `amg` raises a clear install hint.
+* `jno.precond.jaxamg(symmetric=…)` — GPU AMG via NVIDIA **AmgX** as the `M⁻¹` application (setup and
+  apply both on the device). `symmetric=False` builds a second hierarchy on `Aᵀ` so the adjoint
+  (reverse-mode) solve of a non-symmetric operator is preconditioned too. Measured caveat: each AmgX
+  application carries ~11 ms of fixed handle overhead, so it pays only where the iteration savings
+  exceed it — for most problems prefer `precond.amg()` (whose V-cycle compiles into the solve) or
+  `linear=jno.solve.amg()` (ONE AmgX crossing per solve, with warm structure-keyed re-setup measured
+  ~10x cheaper on repeats). `benchmarks/amg_scaling.py` holds the numbers.
+* `.cached(refresh=…)` on any spec — reuse an expensive setup across solves: `False` frozen, `True`
+  rebuild on shape/sparsity change, an **int k** to rebuild every k-th materialization (the cadence
+  for a march whose operator values drift step by step), or a `ctx -> key` callable.
 
 The flagship pattern — Taylor–Hood **Stokes** by FGMRES with an inexact velocity block solve and the
 viscosity-weighted pressure-mass Schur approximation (Elman, Silvester & Wathen, 2014, §9.2):
@@ -1299,6 +1317,23 @@ its symmetry/definiteness); the converged solution is identical to full Newton's
 marker, `picard(damping=…)` is exactly damped Newton (`jno.solve.newton(damping=…)`). Caveat for inverse
 problems: implicit differentiation then also uses the lagged Jacobian — drop `lag` when exact parameter
 gradients matter more than per-step solvability.
+
+**What did the solver do? — `fem.stats`.** After any `fem.solve()`, `fem.stats` reports what happened
+without changing the solve's return: `mode`, `dofs`, `wall_s` (dispatch time — JAX is async; block on
+the result for compute time), the `linear`/`precond` slot reprs, `nonlinear` (driver, final residual
+norm against its bound, converged flag, and the step count where the driver runs its forward loop
+eagerly — `newton_direct` reports steps; the drivers whose loop lives inside `custom_root` report
+`None`), and `amgx_cache` occupancy when jaxamg served the solve. Populated on eager paths; a solve
+wrapped whole in `jit`/`vmap`/`grad` records the slots but no residuals — the same concrete-only
+self-disabling as the convergence guards.
+
+```python
+sol = fem.solve(nonlinear=jno.solve.newton(direct=True), linear=jno.solve.lu(backend="host"))
+fem.stats
+# {'mode': 'nonlinear', 'dofs': 44, 'wall_s': 0.31, 'linear': 'jno.solve.lu-host(...)',
+#  'precond': None, 'nonlinear': {'driver': 'newton_direct', 'residual': 1.6e-07,
+#                                 'bound': 1.7e-06, 'steps': 3, 'converged': True}}
+```
 
 **Alternate minimization — `jno.solve.staggered([u, d])`.** Some coupled energies are **non-convex in
 the fields jointly but convex in each separately**. A monolithic Newton then has no descent guarantee

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -2135,8 +2135,14 @@ unaffected. Full detail is inline in the sections above.
 - **Reduced-order (`basis=`) solves** cover steady and **first-order transient** (linear and
   nonlinear). Second-order-in-time (`u_tt`), complex, and periodic-tied problems refuse, each with its
   own reason. Nonlinear reduces, but without hyper-reduction that is a memory win, not a speed one.
-- **No runtime Dirichlet parameters** — a trainable parameter may sit in the operator (stiffness) but
-  not in an essential/Dirichlet boundary *value*.
+- **Runtime Dirichlet parameters** work on the steady linear, steady nonlinear, and linear transient
+  paths: a trainable `jno.np.parameter` may sit in an essential value (`u(top) - g`, or scaling a
+  coordinate profile `u(top) - g*sin(pi*x)`), and the boundary value is recovered from data like any
+  other parameter — `∂b/∂g` flows through the symmetric elimination (linear), and `∂/∂g` through the
+  solve's / each step's `custom_root` (nonlinear / transient). NOT supported, refused loudly: a value
+  that is **both** parametric and t/τ-dependent (`u(top) - g*tau` — train the amplitude through a
+  Neumann/body term instead). A FIELD-sized optimizer-less parameter stays the nodal data-field value
+  (a neighbour's field in a DD solve), gathered per node.
 - **Affine parameter lowering expects a single, direct factor** — one trainable scalar per additive
   term (`nu * grad(u)·grad(phi)`), not nested or buried in a nonlinear expression.
 - **Enclosure radiation is a composition, not an auto-detected term** — it is 2D / axisymmetric and

--- a/docs/inverse-problems.md
+++ b/docs/inverse-problems.md
@@ -218,3 +218,27 @@ rel_l2_u = float(jnp.linalg.norm(_u - _u_obs) / (jnp.linalg.norm(_u_obs) + 1e-8)
 print(f"u  rel-L2 error : {rel_l2_u:.3e}")           # should be < 10 %
 print(f"k  min / mean   : {_k.min():.3f} / {_k.mean():.3f}")  # k > 0 from exp; mean ≈ 1.0
 ```
+
+## Recovering a boundary value — runtime Dirichlet parameters
+
+An essential (Dirichlet) boundary *value* can itself be the unknown: a grip displacement, an inlet
+temperature, a prescribed potential you only observe indirectly. Put a `jno.np.parameter` in the
+essential term and train it like any other parameter — the held boundary value stays a traced JAX
+scalar, so the gradient flows through the symmetric elimination (steady linear) or the solve's
+`custom_root` (nonlinear, and each step of a linear transient march):
+
+```python
+g = jno.np.parameter((1,), name="g")
+g.initialize(jax.nn.initializers.constant(1.0))
+
+fem  = jno.fem([ui.x*vi.x + ui.y*vi.y - f*vi, u(xb, yb) - g])   # g is the unknown boundary value
+crux = jno.core([(fem.solve() - u_obs).mse])                     # u_obs generated at g* = 2.5
+g.optimizer(optax.adam(1e-1))
+crux.solve(300)                                                  # recovers g = 2.5 exactly
+```
+
+The parameter may scale a spatial profile (`u(xb, yb) - g*jno.np.sin(jno.np.pi*xb)`) and may appear
+in the operator and the boundary value simultaneously. Scope and refusals: steady linear, steady
+nonlinear, and linear transient; a value that is both parametric **and** t/τ-dependent
+(`u(top) - g*tau`) refuses loudly — drive a trainable ramp through a Neumann/body term instead.
+See `tests/test_fem_dirichlet_parameters.py` for the recovery oracles on all three paths.

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -62,6 +62,8 @@ from .utils import Logger
 from .utils import init_default_logger as logger
 from .utils.adaptive import LearningRateSchedule, WeightSchedule, callbacks, sampler
 from .utils.config import (
+    _auto_compile_cache,
+    disable_compile_cache,
     enable_compile_cache,
     get_config,
     get_config_path,
@@ -146,6 +148,7 @@ __all__ = [
     "iree",
     "save",
     "load",
+    "disable_compile_cache",
     "enable_compile_cache",
     "setup",
     "wandb_finish",
@@ -184,3 +187,8 @@ __all__ = [
     "NamedMatrixViewWithPartials",
     "NamedVoigtViewWithPartials",
 ]
+
+# Persistent XLA compilation cache, ON by default (opt out: JNO_COMPILE_CACHE=0, `[jno]
+# compile_cache = false`, or jno.setup(compile_cache=False)). Measured 2.1x-4.3x on warm builds;
+# see `jno.utils.config.enable_compile_cache` for the numbers and the first-run populate cost.
+_auto_compile_cache()

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -379,7 +379,14 @@ def _lower_gauge_pin(pin: GaugePin) -> Any:
     # Single leading underscore (not "__...__"): the pin node is a genuine single-vertex boundary
     # region that `_region_and_support` must SEE, so its tag must not match the reserved
     # double-underscore filter that hides internal/temporal tags from region detection.
-    tag = f"_gauge_pin_{field.field_key}"
+    #
+    # Keyed on the field NAME, not `field_key`: the key is a process-global counter, so the tag came
+    # out `_gauge_pin_3` on one build and `_gauge_pin_7` on the next -- the one string that kept two
+    # otherwise-identical problems from sharing their compiled assembly kernels (the rebuild cache
+    # keys on content). The name is deterministic, and just as unique where uniqueness matters:
+    # trial names are distinct within a problem, and the per-domain cache WANTS two problems pinning
+    # the same-named field on the same domain to share the pin region.
+    tag = f"_gauge_pin_{getattr(field, 'name', None) or field.field_key}"
     cache = domain.__dict__.setdefault("_gauge_pin_coords", {})
     if tag not in cache:
         pts = _np.asarray(domain.mesh.points)[:, :dim]

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -1249,6 +1249,21 @@ class FEM:
             return None
         return [slice(int(off[i]), int(off[i + 1])) for i in range(len(off) - 1)]
 
+    @property
+    def stats(self) -> "dict | None":
+        """What the last :meth:`solve` did — observability without changing the solve's return.
+
+        ``None`` before any solve. Afterwards a dict with ``mode``, ``dofs``, ``wall_s`` (dispatch
+        time of the solve call — JAX is async; block on the result for compute time), the ``linear``
+        and ``precond`` slot reprs, ``nonlinear`` (driver name, final residual norm against its
+        bound, step count where the driver runs its loop eagerly — ``newton_direct`` reports steps,
+        the traced-loop drivers report ``None``), and ``amgx_cache`` (AmgX solver-cache occupancy)
+        when jaxamg served the solve. Populated on eager paths; a solve wrapped whole in
+        ``jit``/``vmap``/``grad`` records the slots but no residuals — the same concrete-only
+        self-disabling as the convergence guards.
+        """
+        return getattr(self, "_stats", None)
+
     def block_index(self, field) -> int:
         """Resolve a trial symbol (or plain index) to its position in :attr:`blocks` /
         :attr:`offsets` — the field order is first appearance in the ``jno.fem`` constraints."""
@@ -1452,11 +1467,41 @@ class FEM:
                 result._fem_ref = self
             return result
 
+        def _run_with_stats():
+            import sys as _sys
+            import time as _time
+
+            from .utils.solver.newton_krylov import LAST_NEWTON_STATS
+
+            LAST_NEWTON_STATS.clear()
+            t0 = _time.perf_counter()
+            result = _run()
+            self._stats = {
+                "mode": self._mode,
+                "dofs": self.dofs,
+                # Dispatch time of the solve CALL: JAX is async, so for a compiled eager solve this
+                # includes compute only if something blocked; block on the result for compute time.
+                "wall_s": _time.perf_counter() - t0,
+                "linear": repr(linear) if linear is not None else "default",
+                "precond": repr(precond) if precond is not None else None,
+                # Written by the drivers' eager convergence check; empty under jit/vmap/grad, where
+                # the check self-disables -- the same silence the guard itself has.
+                "nonlinear": dict(LAST_NEWTON_STATS) or None,
+            }
+            if "jaxamg" in _sys.modules:  # AmgX solver-cache summary, only if jaxamg is in play
+                try:
+                    info = _sys.modules["jaxamg"].get_solver_cache_info()
+                    gpu = info.get("single_gpu", {})
+                    self._stats["amgx_cache"] = {"size": gpu.get("size"), "capacity": gpu.get("capacity")}
+                except Exception:  # noqa: BLE001 -- observability must never fail a solve
+                    pass
+            return result
+
         if not profile:  # profile=True: run the (eager) solve inside a JAX Perfetto trace + print a summary
-            return _run()
+            return _run_with_stats()
         from .utils.profiling import profile_solve
 
-        return profile_solve(_run, label=f"fem profile · {self.dofs} DOFs · {self._mode}", warm=(adapt is None))
+        return profile_solve(_run_with_stats, label=f"fem profile · {self.dofs} DOFs · {self._mode}", warm=(adapt is None))
 
     #: relative residual of the FULL system above which a ``basis=`` solve is refused. Not a tuning
     #: knob: at this size the basis does not span the solution at all (a modelling error), rather than

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -5321,7 +5321,19 @@ def _assemble_second_order_time(
     # Dirichlet from the native assembler (it stashes them): constant (dof, value) pairs → the held
     # value rides the affine bias; time-varying entries (dofs, g(x,t) node, coords) → the displacement
     # rows carry u[d]=g(x_d,t) and the velocity rows the compatible v[d]=ġ(x_d,t), written per step.
-    assemble_fem_native(domain, stiff_raw, boundary_terms, dirichlet_raw, [], vec=_vec_asm, quad_degree=quad_degree)
+    assemble_fem_native(
+        domain,
+        stiff_raw,
+        boundary_terms,
+        dirichlet_raw,
+        [],
+        vec=_vec_asm,
+        quad_degree=quad_degree,
+        # This block consumes the time-varying Dirichlet stash ITSELF (u[d]=g(x_d,t), v[d]=ġ per
+        # step, just below) -- without the flag the assembler's fail-loud fallthrough guard fires on
+        # this legitimate consumer.
+        tv_dirichlet_external=True,
+    )
     pairs = list(getattr(domain, "_fem_native_dirichlet_pairs", []) or [])
     rows = jnp.asarray([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
     g = jnp.asarray([p[1] for p in pairs], dtype=dtype) if pairs else jnp.zeros((0,), dtype=dtype)

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -79,10 +79,11 @@ class _Spec:
     key = None
     complex_ok = False  # conservative: a consumer reformulates unless the spec says it takes complex
 
-    def cached(self, *, refresh: bool = False):
+    def cached(self, *, refresh=False):
         """Wrap this preconditioner so its setup is built **once** and reused across solves — the
         fluent form of :func:`cached`. E.g. ``jno.precond.amg().cached()``. ``refresh`` controls
-        invalidation (``False`` frozen, ``True`` on shape/sparsity change, or a ``ctx -> key`` callable)."""
+        invalidation (``False`` frozen, ``True`` on shape/sparsity change, an ``int k`` to rebuild
+        every k-th materialization, or a ``ctx -> key`` callable)."""
         return _Cached(self, refresh)
 
     def __eq__(self, other):
@@ -259,20 +260,54 @@ class _Form(_Spec):
     """Spec assembling an auxiliary weak form as the preconditioner operator; see :func:`form`."""
 
     def __init__(self, terms, inner_solver, quad_degree):
-        self.terms = list(terms)
+        # A CALLABLE is the solution-dependent variant: ``fn(sol) -> term list``, re-assembled from
+        # the current outer iterate (see :meth:`refresh_from`). A plain list stays what it was: one
+        # parameter-independent assembly, cached forever.
+        self._terms_fn = terms if callable(terms) and not isinstance(terms, (list, tuple)) else None
+        self.terms = None if self._terms_fn is not None else list(terms)
         self.inner = inner_solver
         self.quad_degree = quad_degree
-        self._op = None  # assembled once; the auxiliary operator is parameter-independent
+        self._op = None  # assembled once (static terms); rebuilt per refresh (callable terms)
 
     def prepare(self, fem):
         """Eager one-time assembly (called at compose time, OUTSIDE any trace — assembling a
-        fresh ``jno.fem`` inside the Newton/Picard ``while_loop`` entangles with loop tracers)."""
-        if self._op is None:
+        fresh ``jno.fem`` inside the Newton/Picard ``while_loop`` entangles with loop tracers).
+        The callable variant skips this: it has no terms until a concrete iterate arrives."""
+        if self._op is None and self._terms_fn is None:
             from .utils.solver.solver_api import PrecondContext as _Ctx
 
             self._op = _Ctx(None, fem).assemble(self.terms, quad_degree=self.quad_degree)
 
+    def refresh_from(self, sol, fem):
+        """Re-assemble the auxiliary operator from the CONCRETE outer iterate ``sol``.
+
+        Called by the composed nonlinear solve once per invocation, with the solve's entry iterate
+        (the warm start / previous march step) — the **Picard-lagged preconditioner**: the
+        coefficient trails the solution by one outer solve, which changes convergence *speed* only,
+        never the answer (Elman, Silvester & Wathen, *Finite Elements and Fast Iterative Solvers*,
+        2nd ed., OUP 2014, §9.2 uses exactly this lag for the viscosity-weighted Schur mass).
+
+        Eager by necessity: every Newton driver's loop is a ``lax.while_loop``, so the per-step
+        iterate is a tracer and no host assembly can see it. The lag is therefore not a shortcut but
+        the only place a solution-dependent auxiliary CAN be assembled."""
+        if self._terms_fn is None:
+            return
+        import numpy as _np
+
+        from .utils.solver.solver_api import PrecondContext as _Ctx
+
+        self.terms = list(self._terms_fn(_np.asarray(sol).reshape(-1)))
+        self._op = _Ctx(None, fem).assemble(self.terms, quad_degree=self.quad_degree)
+
     def materialize(self, ctx: PrecondContext):
+        if self._op is None and self._terms_fn is not None:
+            raise NotImplementedError(
+                "jno.precond.form(<callable>): this solution-dependent auxiliary was never assembled "
+                "-- no concrete iterate reached it. It refreshes from the outer solve's entry iterate "
+                "on the composed nonlinear path (fem.solve(nonlinear=..., precond=...)); a fully "
+                "traced context (jit/vmap over the whole solve, a lax.scan march) never has one. "
+                "Run the solve eagerly, or use a static form([...]) with a frozen coefficient."
+            )
         if self._op is None:
             self._op = ctx.assemble(self.terms, quad_degree=self.quad_degree)
         op = self._op
@@ -286,7 +321,8 @@ class _Form(_Spec):
         return PrecondApplier(lambda v: solver(op, v), lambda v: solver(op.T, v))
 
     def __repr__(self):
-        return f"jno.precond.form(<{len(self.terms)} terms>, inner={self.inner})"
+        what = "<solution-dependent>" if self._terms_fn is not None else f"<{len(self.terms)} terms>"
+        return f"jno.precond.form({what}, inner={self.inner})"
 
 
 def form(terms, *, inner=None, quad_degree: int = 2) -> _Form:
@@ -1019,8 +1055,11 @@ def ams(*, aux=None) -> _AMS:
 class _JaxAMG(_Spec):
     """Spec for the GPU AMG preconditioner via jaxamg (NVIDIA AmgX); see :func:`jaxamg`."""
 
-    def __init__(self, config):
+    complex_ok = False  # AmgX is real-only -- a complex operator must take the 2n real-equivalent path
+
+    def __init__(self, config, symmetric=True):
         self.config = config
+        self.symmetric = bool(symmetric)
 
     def materialize(self, ctx: PrecondContext):
         from .solve import _require_jaxamg  # reuse the lazy import + install-requirements error
@@ -1034,13 +1073,23 @@ class _JaxAMG(_Spec):
         jax_amg = _require_jaxamg()
         cfg = dict(self.config) if self.config is not None else {"solver": "AMG"}
         apply = jax_amg.make_preconditioner(A, config=cfg)  # build-once M⁻¹ apply (single AMG cycle)
-        return PrecondApplier(lambda v: apply(v))
+        if self.symmetric:
+            return PrecondApplier(lambda v: apply(v))  # .T reuses the applier -- right for SPD
+        # The reverse pass of a differentiable solve preconditions A^T and needs M^T (see
+        # PrecondApplier): an AMG hierarchy is not structurally transposable, so build a SECOND
+        # hierarchy on the transposed matrix. Costs one extra setup; without it the adjoint Krylov
+        # solve of a non-symmetric operator runs effectively unpreconditioned.
+        import jax.experimental.sparse as _js
+
+        At = _js.BCOO((jnp.asarray(A.data), jnp.asarray(A.indices)[:, ::-1]), shape=(A.shape[1], A.shape[0]))
+        apply_t = jax_amg.make_preconditioner(At, config=cfg)
+        return PrecondApplier(lambda v: apply(v), lambda v: apply_t(v))
 
     def __repr__(self):
-        return "jno.precond.jaxamg()"
+        return f"jno.precond.jaxamg(symmetric={self.symmetric})"
 
 
-def jaxamg(*, config: "dict | None" = None) -> _JaxAMG:
+def jaxamg(*, config: "dict | None" = None, symmetric: bool = True) -> _JaxAMG:
     """GPU AMG **preconditioner** via jaxamg (NVIDIA AmgX wrapped as a JAX primitive) — the
     on-device counterpart of :func:`amg`, and the natural smoother for large elliptic blocks or the
     auxiliary nodal solves of an H(curl) AMS preconditioner on the GPU.
@@ -1054,9 +1103,16 @@ def jaxamg(*, config: "dict | None" = None) -> _JaxAMG:
     ``config`` is a full AmgX-format dict (default ``{"solver": "AMG"}``). Needs an **assembled**
     operator. Optional dependency — jaxamg (AmgX 2.5+, CUDA 12+, mpi4py/mpi4jax) is imported lazily.
 
-    Reference: Liu, Fan & Wang, arXiv:2606.09001 (2026), wrapping NVIDIA AmgX (Naumov et al., 2015).
+    ``symmetric=False`` builds a **second hierarchy on** ``A^T`` so the adjoint (reverse-mode) solve
+    is preconditioned too — an AMG hierarchy is not structurally transposable, and without this the
+    reverse pass of a differentiable non-symmetric solve runs effectively unpreconditioned (see
+    ``PrecondApplier``). Leave the default for SPD operators, where one hierarchy serves both
+    directions. Real-valued operators only — AmgX has no complex mode.
+
+    Reference: Liu, Fan & Wang, arXiv:2606.09001 (2026), wrapping NVIDIA AmgX (Naumov et al.,
+    *SIAM J. Sci. Comput.* 37(5), 2015).
     """
-    return _JaxAMG(config)
+    return _JaxAMG(config, symmetric)
 
 
 _MISS = object()  # sentinel so the first materialize always builds
@@ -1067,9 +1123,12 @@ class _Cached(_Spec):
 
     def __init__(self, spec, refresh):
         self.spec = spec
-        self.refresh = refresh  # False → frozen | True → rebuild on sparsity change | callable ctx→key
+        # False → frozen | True → rebuild on sparsity change | int k → rebuild every k-th
+        # materialization | callable ctx→key
+        self.refresh = refresh
         self._applier = None
         self._key = _MISS
+        self._count = 0  # materializations since construction, for the int-k policy
 
     @property
     def traceable(self):
@@ -1094,7 +1153,7 @@ class _Cached(_Spec):
         ``id`` cannot be recycled while this spec is alive."""
         return (type(self), id(self._applier)) if self.traceable else None
 
-    def cached(self, *, refresh: bool = False):
+    def cached(self, *, refresh=False):
         return self  # already cached — .cached() is idempotent (no double-wrapping)
 
     def prepare(self, fem):  # forward the eager (out-of-trace) build hook, if the inner spec has one
@@ -1105,13 +1164,22 @@ class _Cached(_Spec):
     def _key_of(self, ctx):
         if self.refresh is False:
             return "frozen"
+        if isinstance(self.refresh, bool):  # True → key on the operator's shape + sparsity size
+            A = ctx.A
+            return (A.shape, int(A.bcoo.nse)) if A.bcoo is not None else (A.shape,)
+        if isinstance(self.refresh, int):
+            # Every k-th materialization: the operator's values drift step by step (a Newton loop, a
+            # transient march driving one solve per step), so the hierarchy is rebuilt on a cadence
+            # rather than frozen forever or rebuilt every time. In between, the stale setup is a
+            # legitimate preconditioner: speed degrades gracefully, correctness never.
+            return self._count // max(1, int(self.refresh))
         if callable(self.refresh):
             return self.refresh(ctx)
-        A = ctx.A  # refresh=True → key on the operator's shape + sparsity size
-        return (A.shape, int(A.bcoo.nse)) if A.bcoo is not None else (A.shape,)
+        raise TypeError(f"cached(refresh=...): expected bool, int, or callable, got {type(self.refresh).__name__}")
 
     def materialize(self, ctx: PrecondContext):
         key = self._key_of(ctx)
+        self._count += 1
         if self._applier is None or key != self._key:
             self._applier = materialize_precond(self.spec, ctx)  # build the wrapped preconditioner once
             self._key = key
@@ -1121,7 +1189,7 @@ class _Cached(_Spec):
         return f"jno.precond.cached({self.spec!r}, refresh={self.refresh}, built={self._applier is not None})"
 
 
-def cached(spec, *, refresh: bool = False):
+def cached(spec, *, refresh=False):
     """Memoise any preconditioner's setup so it is built **once** and reused across solves — the
     plug-and-play way to amortise an expensive setup (a multigrid hierarchy, an assembled auxiliary
     operator, a jaxamg/AmgX coloring) over a frequency sweep, a Newton loop, or an inverse-problem
@@ -1132,8 +1200,9 @@ def cached(spec, *, refresh: bool = False):
     reuses it forever — the standard frozen-preconditioner trade (a preconditioner only changes
     convergence *speed*, never the solution, so reusing a slightly-stale setup is always correct and
     usually cheap). ``refresh=True`` rebuilds when the operator's shape/sparsity changes (values may
-    still drift under the frozen setup); pass a callable ``ctx -> hashable`` for a custom invalidation
-    key. The wrapped spec's eager ``prepare(fem)`` hook (if any) is forwarded, so it composes with the
+    still drift under the frozen setup); an ``int k`` rebuilds every k-th materialization — the
+    cadence policy for a Newton loop or transient march whose operator values drift step by step;
+    pass a callable ``ctx -> hashable`` for a custom invalidation key. The wrapped spec's eager ``prepare(fem)`` hook (if any) is forwarded, so it composes with the
     ``jit``/``vmap``/parametric-inverse build-eagerly requirement unchanged.
 
     Reuse the SAME ``cached(...)`` object across the solves you want to share the setup::

--- a/jno/utils/config.py
+++ b/jno/utils/config.py
@@ -247,9 +247,11 @@ def enable_compile_cache(directory: str | None = None) -> str:
     -- the same Stokes assembly measured **9.43 s cold, 2.20 s warm (4.3x)** on a second process,
     for 187 entries and 7.2 MB.
 
-    Off by default because a library should not write to a user's disk uninvited; this is the
-    opt-in, also reachable as ``jno.setup(__file__, compile_cache=True)`` or, per project,
-    ``[jno] compile_cache = true`` in ``.jno.toml``.
+    **ON by default** since the warm-cache build was measured at 2.1x (and 4.3x on Stokes): jNO's
+    audience re-runs scripts, sweeps and test suites, where the cache pays back from the second
+    process onward. Opt out with ``JNO_COMPILE_CACHE=0``, ``[jno] compile_cache = false`` in
+    ``.jno.toml``, or ``jno.setup(__file__, compile_cache=False)`` — see
+    :func:`_auto_compile_cache` / :func:`disable_compile_cache`.
 
     **The first run is SLOWER, sometimes much slower** -- writing the entries is not free. A 75k-node
     3-D Poisson build measured 7.45 s with no cache, 18.30 s on the run that populates one, and
@@ -278,6 +280,40 @@ def enable_compile_cache(directory: str | None = None) -> str:
     jax.config.update("jax_compilation_cache_dir", path)
     jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
     return path
+
+
+def disable_compile_cache() -> None:
+    """Turn the persistent compilation cache back off (it is on by default) — the programmatic twin
+    of ``JNO_COMPILE_CACHE=0`` / ``[jno] compile_cache = false``."""
+    import jax
+
+    jax.config.update("jax_compilation_cache_dir", None)
+    jax.config.update("jax_persistent_cache_min_compile_time_secs", 1.0)
+
+
+def _auto_compile_cache() -> None:
+    """Enable the persistent XLA cache at ``import jno`` unless the user opted out.
+
+    Precedence: ``JNO_COMPILE_CACHE`` env (0/false/off/no disables; a path enables *there*), then
+    ``[jno] compile_cache`` in the TOML config (``false`` disables, a string names the directory),
+    then on. An unwritable cache directory must never break ``import jno`` — the failure is logged
+    and the session simply runs uncached, exactly as before the default flipped."""
+    env = os.getenv("JNO_COMPILE_CACHE")
+    if env is not None:
+        if env.strip().lower() in ("0", "false", "off", "no"):
+            return
+        directory = env if os.sep in env or env.startswith("~") else None
+    else:
+        opt = get_config().get("jno", {}).get("compile_cache", True)
+        if opt is False:
+            return
+        directory = opt if isinstance(opt, str) else None
+    try:
+        enable_compile_cache(directory)
+    except Exception as e:  # noqa: BLE001 — an uncached session beats a broken import
+        import logging
+
+        logging.getLogger("jno").debug(f"persistent compile cache not enabled: {e}")
 
 
 def setup(
@@ -392,9 +428,13 @@ def setup(
     # over the historical defaults already in ad_mode.py.
     apply_ad_mode_defaults(diff_type, hessian_type)
 
-    # --- Optional persistent XLA compilation cache (explicit kwarg wins over TOML) ---
-    cache_opt = get_config().get("jno", {}).get("compile_cache", False) if compile_cache is None else compile_cache
-    if cache_opt:
+    # --- Persistent XLA compilation cache: ON by default (enabled at import); an explicit kwarg
+    # wins over TOML, and False here actively disables what the import turned on. ---
+    cache_opt = get_config().get("jno", {}).get("compile_cache", True) if compile_cache is None else compile_cache
+    if cache_opt is False:
+        disable_compile_cache()
+        _logger_mod._default_logger.info("XLA compilation cache disabled")
+    elif cache_opt:
         cache_dir = enable_compile_cache(cache_opt if isinstance(cache_opt, str) else None)
         _logger_mod._default_logger.info(f"XLA compilation cache enabled at {cache_dir}")
 

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -1528,7 +1528,8 @@ def assemble_fem_native(
         Done GLOBALLY, outside the per-face vmap, because the main nodes live on the other body's
         cells -- they are not in the secondary face's parent-cell DOF slice. A plain weighted gather, so
         ``jax.linearize`` (the default JFNK path) picks up the main coupling in the tangent exactly,
-        with no assembled Jacobian block needed.
+        with no assembled Jacobian block needed. (The ASSEMBLED tangent builds its own explicit
+        nonlocal blocks from these same tables -- see the gap emission in `_make_jacobian`.)
         """
         tb = _gap_tables[key]
         fidx, vt = tb["field"], vecs[tb["field"]]
@@ -1917,30 +1918,6 @@ def assemble_fem_native(
 
         return residual
 
-    def _gap_refuses_assembled_tangent(bterms):
-        """A contact gap is NON-LOCAL: it reads DOFs on the main body's cells, not the secondary face's
-        parent cell. The assembled path builds each element block by ``jacfwd`` w.r.t. that element's
-        own DOFs and emits columns ``cell_all_dofs[pcells]``, so it would silently drop the whole
-        secondary-main coupling -- a tangent that looks fine and just makes Newton crawl.
-
-        Emitting a second block with main columns is possible (``_emit`` takes arbitrary indices) but
-        costs another element-matrix buffer for every surface term, and the DEFAULT path never needs
-        it: contact is nonlinear, so ``newton_krylov`` takes matrix-free JVPs through
-        ``jax.linearize`` of the residual, which picks up the main coupling exactly. So the block is
-        not built at all, and this path refuses rather than being quietly wrong.
-
-        Raised on USE, not on construction -- ``_make_jacobian`` is called unconditionally at build
-        time even for problems that will only ever take the matrix-free route.
-        """
-        if _gap_tables and bterms:
-            raise NotImplementedError(
-                "jno.fem: a contact gap (u.gap) needs the matrix-free tangent -- its dependence on the "
-                "main body's DOFs cannot be expressed in this assembled per-element Jacobian, and "
-                "silently dropping it would degrade Newton with no error. Contact is nonlinear, so the "
-                "default fem.solve() already takes the matrix-free path; drop "
-                "`nonlinear=jno.solve.newton(direct=True)` if you set it."
-            )
-
     def _make_jacobian(terms, bterms=None):
         """Build the dense Jacobian ``J(u_flat) -> (total, total)`` by *per-element* forward-mode AD.
 
@@ -1962,6 +1939,66 @@ def assemble_fem_native(
         # static `nse` under jit, and inferring one requires concrete indices it does not have inside
         # the trace. This mirrors `fem_nonnodal._make_sparse_assembler`, which already hoists its
         # `_vol_idx` the same way. Order must match the append order in `jacobian` exactly.
+        def _gap_key_of(region):
+            """The (single) gap key whose SECONDARY face is this region, or ``None``."""
+            ks = [k for k in _gap_tables if _gap_tables[k]["secondary"] == region]
+            return ks[0] if ks else None
+
+        _gap_static_cache: Dict[Any, Any] = {}
+
+        def _gap_static(region, face_ids, btfi):
+            """Concrete index/weight geometry of a region's gap blocks — computed ONCE from the frozen
+            pairing tables and shared by the pattern hoist and the traced assembly, so the two cannot
+            drift. The three nonlocal blocks, flat index arrays in emission order:
+
+            * ``(s,m)``: secondary test rows x main columns (one column per (q, mortar-node, comp));
+            * ``(m,s)``: reaction rows (main dofs, one per (q, mortar-node, comp)) x parent-local cols;
+            * ``(m,m)``: reaction rows x main columns.
+            """
+            k = _gap_key_of(region)
+            cache_key = (region, int(btfi))
+            hit = _gap_static_cache.get(cache_key)
+            if hit is not None:
+                return hit
+            tb = _gap_tables[k]
+            fidx_m, vt = tb["field"], vecs[tb["field"]]
+            fids_np = np.asarray(face_ids, dtype=np.int64)
+            ids_f = np.asarray(tb["ids_full"])[fids_np]  # (n_face, n_q, K)
+            w_f = jnp.asarray(np.asarray(tb["w_full"])[fids_np])  # (n_face, n_q, K)
+            n_face, n_q, K = ids_f.shape
+            pc = np.asarray(parent_j)[fids_np]
+            rows_test = np.asarray(cdofs[btfi])[pc]  # (n_face, n_test)
+            n_test = rows_test.shape[1]
+            dof_m = (np.asarray(offs[fidx_m]) + ids_f[..., None] * vt + np.arange(vt)).astype(np.int64)
+            nqKv = n_q * K * vt
+            dof_m_flat = dof_m.reshape(n_face, nqKv)
+            cols_parent = np.asarray(cell_all_dofs)[pc]  # (n_face, n_local_all)
+            n_local = cols_parent.shape[1]
+            sh_sm = (n_face, n_test, n_q, K, vt)
+            rows_sm = np.broadcast_to(rows_test[:, :, None, None, None], sh_sm).reshape(-1)
+            cols_sm = np.broadcast_to(dof_m[:, None, :, :, :], sh_sm).reshape(-1)
+            sh_ms = (n_face, nqKv, n_local)
+            rows_ms = np.broadcast_to(dof_m_flat[:, :, None], sh_ms).reshape(-1)
+            cols_ms = np.broadcast_to(cols_parent[:, None, :], sh_ms).reshape(-1)
+            sh_mm = (n_face, nqKv, nqKv)
+            rows_mm = np.broadcast_to(dof_m_flat[:, :, None], sh_mm).reshape(-1)
+            cols_mm = np.broadcast_to(dof_m_flat[:, None, :], sh_mm).reshape(-1)
+            out = {
+                "rows_sm": jnp.asarray(rows_sm, dtype=jnp.int32),
+                "cols_sm": jnp.asarray(cols_sm, dtype=jnp.int32),
+                "rows_ms": jnp.asarray(rows_ms, dtype=jnp.int32),
+                "cols_ms": jnp.asarray(cols_ms, dtype=jnp.int32),
+                "rows_mm": jnp.asarray(rows_mm, dtype=jnp.int32),
+                "cols_mm": jnp.asarray(cols_mm, dtype=jnp.int32),
+                "w_f": w_f,
+                "n_q": n_q,
+                "K": K,
+                "vt": vt,
+                "key": k,
+            }
+            _gap_static_cache[cache_key] = out
+            return out
+
         _idx_rows, _idx_cols = [], []
         for _coeff_s, _tfi_s, _rn_s in typed_with_masks:
             _sh = (n_cells, int(cdofs[_tfi_s].shape[1]), int(cell_all_dofs.shape[1]))
@@ -1974,6 +2011,19 @@ def assemble_fem_native(
                 _sh = (int(_pc.shape[0]), int(cdofs[_btfi_s].shape[1]), int(cell_all_dofs.shape[1]))
                 _idx_rows.append(jnp.broadcast_to(cdofs[_btfi_s][_pc][:, :, None], _sh).reshape(-1))
                 _idx_cols.append(jnp.broadcast_to(_fcols[:, None, :], _sh).reshape(-1))
+                # The gap's nonlocal blocks, in the SAME append order the traced assembly emits
+                # them: (s,m) always when the region carries a gap; (m,s) and (m,m) when this term
+                # also drives the main-side reaction. The indices come from the frozen pairing
+                # tables, so the pattern stays static; inactive contact contributes zeros in DATA.
+                if _gap_key_of(_region_s) is not None:
+                    _gs = _gap_static(_region_s, _face_ids_s, _btfi_s)
+                    _idx_rows.append(_gs["rows_sm"])
+                    _idx_cols.append(_gs["cols_sm"])
+                    if _gaps_in(_bcoeff_s, _region_s):
+                        _idx_rows.append(_gs["rows_ms"])
+                        _idx_cols.append(_gs["cols_ms"])
+                        _idx_rows.append(_gs["rows_mm"])
+                        _idx_cols.append(_gs["cols_mm"])
         _blk_sizes = [int(r.shape[0]) for r in _idx_rows]  # per-term flat lengths, in append order
         _idx_static = (
             jnp.stack([jnp.concatenate(_idx_rows).astype(jnp.int32), jnp.concatenate(_idx_cols).astype(jnp.int32)], axis=1)
@@ -1986,7 +2036,6 @@ def assemble_fem_native(
             _idx_static, _plan = None, None  # fall back to the uncompressed (still correct) path
 
         def jacobian(u_flat, t=0.0, args=None):
-            _gap_refuses_assembled_tangent(bterms)  # non-local gap -> matrix-free tangent only
             # Assemble into COO triplets and build a BCOO -- never materialises the dense (total, total)
             # matrix (O(nnz), GPU-able at large N). Each per-element block is element-sized; duplicate
             # (i, j) triplets from neighbouring cells are summed by BCOO on matvec / todense, so the
@@ -2034,21 +2083,34 @@ def assemble_fem_native(
                 )
 
             normals_dyn = _surface_normals(pts_dyn)  # differentiable facet normals under coordinate motion
+            # Main-side values for every contact gap -- the residual's own gather, reused so the
+            # assembled tangent linearizes the SAME function the residual evaluates.
+            gap_um_j = {k: _gap_gather(u_flat, k) for k in _gap_tables}
             for region, face_ids, btyped in surface_work:
                 fids = jnp.asarray(face_ids, dtype=jnp.int32)
                 pcells = parent_j[fids]
                 lv = u_flat[cell_all_dofs[pcells]]  # (n_face, n_local_all)
                 fcols = cell_all_dofs[pcells]  # (n_face, n_local_all)
+                gslice = _gap_slices(region, fids, gap_um_j)  # {key: (g0, u_m)} or None
                 for bcoeff, btfi in btyped:
 
-                    def _kef(fi, la, _e=bcoeff, _t=btfi, _r=region, _p=pts_dyn, _n=normals_dyn):
-                        return jax.jacfwd(lambda v: _surf_elem_res(fi, v, _e, _t, _r, t, args, _p, _n))(la)
+                    def _kef(fi, la, gp=None, _e=bcoeff, _t=btfi, _r=region, _p=pts_dyn, _n=normals_dyn):
+                        # gaps PACKED: the local block then carries d(traction)/du_s THROUGH the gap,
+                        # exactly as `jax.linearize` of the residual would.
+                        return jax.jacfwd(lambda v: _surf_elem_res(fi, v, _e, _t, _r, t, args, _p, _n, gp))(la)
 
-                    Kef = _elem_map(  # (n_face, n_test_btfi, n_local_all)
-                        _kef,
-                        (fids, lv),
-                        _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], cell_all_dofs.shape[1]),
-                    )
+                    if gslice:
+                        Kef = _elem_map(
+                            _kef,
+                            (fids, lv, gslice),
+                            _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], cell_all_dofs.shape[1]),
+                        )
+                    else:
+                        Kef = _elem_map(  # (n_face, n_test_btfi, n_local_all)
+                            _kef,
+                            (fids, lv),
+                            _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], cell_all_dofs.shape[1]),
+                        )
                     _emit(
                         Kef.reshape(-1),
                         lambda _K=Kef, _t=btfi, _p=pcells: jnp.broadcast_to(cdofs[_t][_p][:, :, None], _K.shape).reshape(
@@ -2056,6 +2118,68 @@ def assemble_fem_native(
                         ),
                         lambda _K=Kef, _f=fcols: jnp.broadcast_to(_f[:, None, :], _K.shape).reshape(-1),
                     )
+
+                    if gslice:
+                        # ---- the gap's NONLOCAL blocks (same append order as the pattern hoist) ----
+                        gs = _gap_static(region, face_ids, btfi)
+                        n_q, vt, gk = gs["n_q"], gs["vt"], gs["key"]
+                        w_f = gs["w_f"]
+                        g0_sl, um_sl = gslice[gk]
+
+                        # (s,m): jacfwd of the SAME face residual w.r.t. the gathered main values,
+                        # chained through the frozen mortar weights to global main columns.
+                        def _kem(fi, la, g0f, umf, _e=bcoeff, _t=btfi, _r=region, _p=pts_dyn, _n=normals_dyn, _k=gk):
+                            return jax.jacfwd(
+                                lambda um: _surf_elem_res(fi, la, _e, _t, _r, t, args, _p, _n, {_k: (g0f, um)})
+                            )(umf)
+
+                        Kem = _elem_map(  # (n_face, n_test, n_q, vt)
+                            _kem,
+                            (fids, lv, g0_sl, um_sl),
+                            _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], n_q * vt),
+                        )
+                        d_sm = jnp.einsum("frqv,fqk->frqkv", Kem.reshape(Kem.shape[0], Kem.shape[1], n_q, vt), w_f)
+                        _emit(d_sm.reshape(-1), lambda _g=gs: _g["rows_sm"], lambda _g=gs: _g["cols_sm"])
+
+                        if _gaps_in(bcoeff, region):
+                            # Reaction-row tangent: tau (the per-QP weighted traction via the identity
+                            # test-table substitution -- the residual's own trick) linearized w.r.t.
+                            # the parent-local dofs (m,s) and the gathered main values (m,m), scattered
+                            # through the same -w weights the residual's reaction uses.
+                            def _tau(fi, la, g0f, umf, _e=bcoeff, _t=btfi, _r=region, _k=gk):
+                                out = _surf_elem_res(
+                                    fi,
+                                    la,
+                                    _e,
+                                    _t,
+                                    _r,
+                                    t,
+                                    args,
+                                    pts_dyn,
+                                    normals_dyn,
+                                    {_k: (g0f, umf)},
+                                    test_vals=jnp.eye(n_q, dtype=lv.dtype),
+                                )
+                                return jnp.asarray(out).reshape(n_q, vt)
+
+                            n_local_all = int(cell_all_dofs.shape[1])
+                            Dls = _elem_map(
+                                lambda fi, la, g0f, umf: jax.jacfwd(lambda v: _tau(fi, v, g0f, umf))(la),
+                                (fids, lv, g0_sl, um_sl),
+                                _cell_chunk(int(fids.shape[0]), n_q * vt, n_local_all),
+                            )
+                            Dum = _elem_map(
+                                lambda fi, la, g0f, umf: jax.jacfwd(lambda um: _tau(fi, la, g0f, um))(umf),
+                                (fids, lv, g0_sl, um_sl),
+                                _cell_chunk(int(fids.shape[0]), n_q * vt, n_q * vt),
+                            )
+                            n_face = int(fids.shape[0])
+                            # (m,s): K[dof(f,q,K,v), parent_local] -= w[f,q,K] * dtau[f,q,v,local]
+                            d_ms = -jnp.einsum("fqk,fqvl->fqkvl", w_f, Dls.reshape(n_face, n_q, vt, n_local_all))
+                            _emit(d_ms.reshape(-1), lambda _g=gs: _g["rows_ms"], lambda _g=gs: _g["cols_ms"])
+                            # (m,m): K[dof(q,K,v), dof(q2,K2,v2)] -= w[f,q,K] dtau[q,v,q2,v2] w[f,q2,K2]
+                            d_mm = -jnp.einsum("fqk,fqvpw,fpl->fqkvplw", w_f, Dum.reshape(n_face, n_q, vt, n_q, vt), w_f)
+                            _emit(d_mm.reshape(-1), lambda _g=gs: _g["rows_mm"], lambda _g=gs: _g["cols_mm"])
 
             if _plan is not None:
                 if _acc[0] is None:  # no terms -> empty operator

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -887,7 +887,7 @@ def assemble_fem_native(
     # runtime args in ``_dirichlet_pairs_at`` so ``∂b/∂weights`` flows through the solve.
     from ..._fem import _bare as _bare_node
     from ..._fem import _essential_spec as _essential_spec_node
-    from ...trace import ModelWeights
+    from ...trace import ModelCall, ModelWeights
     from .parametric_helpers import _is_neural_coefficient, _neural_coefficient_name
 
     _dir_net_models: Dict[str, Any] = {}
@@ -895,6 +895,61 @@ def assemble_fem_native(
         _vn = _bare_node(_vnode) if _vnode is not None else None
         if _vn is not None and _is_neural_coefficient(_vn):
             _dir_net_models[_neural_coefficient_name(_vn)] = _vn.model
+    # A trainable ``jno.np.parameter`` in an ESSENTIAL value -- ``u(top) - g``, or ``u(top) -
+    # g*profile(x)``. Exactly the coord-params pattern above: it rides ``runtime_parameter_exprs``
+    # (crux discovers it, its value arrives in ``args``) but stays OUT of ``runtime_parameter_tags``
+    # -- it is not a term coefficient, and ``_runtime_vals`` must not pack it per cell. The rows are
+    # recorded so ``_dirichlet_pairs_at`` re-forms the lift from args (``∂b/∂g`` flows through the
+    # symmetric elimination, the same contract the net-valued branch documents) and
+    # ``_build_dirichlet_pairs`` skips them instead of freezing the stored value behind ``float(g)``.
+    #
+    # The one exclusion: an optimizer-less FIELD-sized parameter stays the nodal DATA-field value the
+    # branch in ``_build_dirichlet_pairs`` gathers per node (a neighbour's field in a DD solve). A
+    # SCALAR optimizer-less parameter is runtime-parametric here -- the old path crashed on it
+    # (IndexError gathering a length-1 value by node id) rather than meaning anything.
+    _dir_param_exprs: Dict[str, Any] = {}
+    _dir_param_rows: set = set()
+    for _i, (_fk, _rg, _comp, _val, _vnode) in enumerate(dirichlet_raw):
+        _vn = _bare_node(_vnode) if _vnode is not None else None
+        if _vn is None or _is_neural_coefficient(_vn):
+            continue
+        if (
+            isinstance(_vn, ModelCall)
+            and getattr(_vn.model, "_is_parameter", False)
+            and getattr(_vn.model, "_opt_fn", None) is None
+            and np.asarray(_vn.model.module.value).size > 1
+        ):
+            continue  # nodal data field -- the per-node gather branch owns it
+        _found: Dict[str, Any] = {}
+        _collect_runtime_parameter_exprs(_vnode, _found)
+        if _found:
+            from ..._fem import _is_temporal_value_node as _is_tv
+
+            if _is_tv(_vnode):
+                # `u(top) - g * tau`: the value is BOTH parametric and time/τ-dependent. The parametric
+                # branch would hold it constant in τ (silently un-ramping the load); the temporal branch
+                # would freeze the parameter at its stored value (silently un-training it). Neither is
+                # right, so refuse until the two held-value mechanisms compose.
+                raise NotImplementedError(
+                    f"jno.fem: the essential value on {_rg!r} is BOTH runtime-parametric "
+                    f"({sorted(_found)}) and time/τ-dependent. A trainable parameter in a t/τ-varying "
+                    "essential value is not supported yet -- train the amplitude through a Neumann/body "
+                    "term written as a function of τ, or fix one of the two."
+                )
+            _dir_param_exprs.update(_found)
+            _dir_param_rows.add(_i)
+    if _dir_param_exprs:
+        _param_and_neural_exprs = {**_param_and_neural_exprs, **_dir_param_exprs}
+
+    def _dir_static_args() -> Dict[str, Any]:
+        """Stored-value args for every args-dependent Dirichlet slot (net modules + parameter values) --
+        what the static placeholders and dof-layout probes evaluate at, in place of runtime args."""
+        return {n: m.module for n, m in _dir_net_models.items()} | {
+            n: jnp.asarray(nd.model.module.value) for n, nd in _dir_param_exprs.items()
+        }
+
+    #: any Dirichlet condition whose held value must be (re-)formed from runtime ``args``.
+    _dir_args_dependent = bool(_dir_net_models) or bool(_dir_param_rows)
     # A net-valued INITIAL condition ``u(initial) - net(x)`` (a trainable starting state, recovered from a
     # trajectory): its weights join the runtime slots the same way, and the initial state is (re-)formed
     # from the runtime args in ``_state0_at`` so ``∂traj/∂weights`` flows through the IC.
@@ -2182,10 +2237,12 @@ def assemble_fem_native(
 
         pairs: List[Tuple[int, float]] = []
         tv_stash: List[Tuple[Any, Any, Any]] = []  # (dofs, value_node, coords) for time-varying g(x,t)
-        for field_key, region, comp, value, value_node in dirichlet_raw:
+        for _row_i, (field_key, region, comp, value, value_node) in enumerate(dirichlet_raw):
             fidx = field_index.get(field_key)
             if fidx is None:
                 continue
+            if _row_i in _dir_param_rows:
+                continue  # args-dependent value: (re-)formed per args in _dirichlet_pairs_at, never frozen here
             # Time-varying Dirichlet g(x,t): no constant pair — stash (dofs, value_node, coords) so a
             # transient caller (e.g. the second-order augmented block) writes g(x_d, t) each step.
             if value_node is not None and _is_temporal_value_node(value_node):
@@ -2255,12 +2312,36 @@ def assemble_fem_native(
         coordinates, so the value stays a differentiable JAX scalar and ``∂b/∂weights`` flows through the
         symmetric elimination. Non-net conditions reuse the concrete ``_build_dirichlet_pairs`` values."""
         a = args or {}
-        pairs = list(_build_dirichlet_pairs())  # concrete (non-net) conditions
-        for field_key, region, comp, value, value_node in dirichlet_raw:
+        pairs = list(_build_dirichlet_pairs())  # concrete (non-net, non-parametric) conditions
+        for _row_i, (field_key, region, comp, value, value_node) in enumerate(dirichlet_raw):
             fidx = field_index.get(field_key)
             if fidx is None:
                 continue
             _vn = _bare_node(value_node) if value_node is not None else None
+            if _row_i in _dir_param_rows:
+                # A trainable parameter in the value (`u(top) - g`, `u(top) - g*profile(x)`): evaluate
+                # the value NODE at the boundary nodes with the args-substituted parameter, so the held
+                # value stays a traced JAX scalar and ∂b/∂g (steady) / ∂step/∂g (transient) flows --
+                # the same contract as the net branch below. `_eval_value_node_at(params=...)` is the
+                # existing parametric-coefficient evaluator; no bespoke walker.
+                from ..._fem import _eval_value_node_at as _eval_at
+
+                vt = vecs[fidx]
+                pts_all = np.asarray(pts_f_all[fidx])
+                node_ids = list(_boundary_node_ids(fidx, region))
+                pts = pts_all[np.asarray(node_ids, dtype=np.int64)] if node_ids else np.zeros((0, dim))
+                raw = jnp.asarray(_eval_at(value_node, jnp.asarray(pts), params=a)).reshape(-1)
+                # Constant vs spatial profile: a constant returns the same shape for ANY batch (the
+                # static-path trick) -- one extra single-point evaluation decides, shapes are static.
+                one = jnp.asarray(_eval_at(value_node, jnp.asarray(pts[:1]), params=a)).reshape(-1)
+                if raw.shape == one.shape or not node_ids:
+                    gvals = jnp.broadcast_to(raw.reshape(-1)[:1], (len(node_ids),))
+                else:
+                    gvals = raw.reshape(len(node_ids), -1)[:, 0]
+                for i, nid in enumerate(node_ids):
+                    for c in range(vt) if comp is None else [int(comp)]:
+                        pairs.append((offs[fidx] + nid * vt + c, gvals[i]))
+                continue
             if _vn is None or not _is_neural_coefficient(_vn):
                 continue
             vt = vecs[fidx]
@@ -2472,19 +2553,19 @@ def assemble_fem_native(
                     "form is not wired yet (state0_fn threads only the linear stepper). Use a linear "
                     "transient form (a net IC threads there)."
                 )
-            if _dir_net_models and _nonlinear_mass:
+            if _dir_args_dependent and _nonlinear_mass:
                 raise NotImplementedError(
                     "jno.fem: a net-valued Dirichlet with a state-dependent (nonlinear) mass c(u)·u_t on a "
                     "transient form is not supported (the mass residual holds a static Dirichlet dof set). "
                     "Use a linear/parametric mass."
                 )
 
-            if _dir_net_models:
-                # net-valued Dirichlet u(∂Ω) - net(x): the held value is re-formed from the net weights each
+            if _dir_args_dependent:
+                # net- or parameter-valued Dirichlet: the held value is re-formed from the args each
                 # Newton residual (mirrors the nonlinear STEADY path ``res_p``); the dof set is static, only
-                # the held values ride the weights, and ``∂/∂weights`` flows through the step's custom_root.
+                # the held values ride the args, and ``∂/∂args`` flows through the step's custom_root.
                 _tnpd = jnp.asarray(
-                    [p[0] for p in _dirichlet_pairs_at({n: m.module for n, m in _dir_net_models.items()})],
+                    [p[0] for p in _dirichlet_pairs_at(_dir_static_args())],
                     dtype=jnp.int32,
                 )
 
@@ -2541,8 +2622,8 @@ def assemble_fem_native(
         # falls to the static branch, where A and M are built once with ``args=None`` and
         # ``_apply_coord_params`` short-circuits -- so ``block.step(..., args={coord: X})`` silently ignores
         # X and ``du/dX`` is exactly ZERO. That is a wrong gradient with no symptom, not a missing feature.
-        if runtime_parameter_tags or neural_param_names or _dir_net_models or _ic_net_models or _coord_specs:
-            if _dir_net_models:
+        if runtime_parameter_tags or neural_param_names or _dir_args_dependent or _ic_net_models or _coord_specs:
+            if _dir_args_dependent:
                 if getattr(domain, "_fem_native_dirichlet_tv", None):
                     raise NotImplementedError(
                         "jno.fem: a net-valued Dirichlet combined with a time-varying g(x, t) Dirichlet on a "
@@ -2551,7 +2632,7 @@ def assemble_fem_native(
                     )
                 # const + net Dirichlet dofs (static boundary-node layout); held values re-formed from args.
                 _dd = jnp.asarray(
-                    [p[0] for p in _dirichlet_pairs_at({n: m.module for n, m in _dir_net_models.items()})],
+                    [p[0] for p in _dirichlet_pairs_at(_dir_static_args())],
                     dtype=jnp.int32,
                 )
 
@@ -2568,8 +2649,8 @@ def assemble_fem_native(
                 A = spatial_jac(zeros, t, args)
                 return A if _d is None else bcoo_set_dirichlet_rows(A, _d)
 
-            if _dir_net_models:
-                c_bias = zeros  # every held value (const + net) rides the forcing
+            if _dir_args_dependent:
+                c_bias = zeros  # every held value (const + net + parameter) rides the forcing
 
                 def forcing_vector_fn(t, args=None, _mask=free_mask, _d=_dd):
                     f = _mask * (-spatial_res(zeros, t, args))
@@ -2700,7 +2781,7 @@ def assemble_fem_native(
     if (
         runtime_parameter_tags
         or neural_param_names
-        or _dir_net_models
+        or _dir_args_dependent
         or history_specs
         or surface_history_specs
         or _coord_specs
@@ -2711,13 +2792,13 @@ def assemble_fem_native(
             # ``t`` carries the pseudo-time (load) coordinate τ for the history march — the load written
             # as a function of τ in the weak form varies through it. Defaults to 0.0, so the ordinary
             # (non-marching) parametric/inverse call sites are unchanged.
-            if _dir_net_models:
-                # net-valued Dirichlet u(∂Ω) - net(x): the held value is a differentiable function of the
-                # net weights (delivered on args), so the row-replacement value is re-evaluated from args
-                # each residual call (mirrors the linear parametric path's ``_dirichlet_pairs_at``). The
-                # dof set is static (boundary-node layout); only the held values ride the weights.
+            if _dir_args_dependent:
+                # net- or parameter-valued Dirichlet: the held value is a differentiable function of the
+                # args (net weights or a trainable boundary value), so the row-replacement value is
+                # re-evaluated from args each residual call (mirrors the linear parametric path's
+                # ``_dirichlet_pairs_at``). The dof set is static; only the held values ride the args.
                 _npd = jnp.asarray(
-                    [p[0] for p in _dirichlet_pairs_at({n: m.module for n, m in _dir_net_models.items()})],
+                    [p[0] for p in _dirichlet_pairs_at(_dir_static_args())],
                     dtype=jnp.int32,
                 )
 
@@ -2805,17 +2886,20 @@ def assemble_fem_native(
         def _assemble_at(args):
             A = jacobian(zeros, 0.0, args)
             b = -residual(zeros, 0.0, args)
-            # a net-valued Dirichlet re-forms the lift from args each call; otherwise the static pairs.
-            pairs = _dirichlet_pairs_at(args) if _dir_net_models else dirichlet_pairs
+            # a net- or parameter-valued Dirichlet re-forms the lift from args each call; else static.
+            pairs = _dirichlet_pairs_at(args) if (_dir_net_models or _dir_param_rows) else dirichlet_pairs
             if pairs:
                 A, b = _apply_dirichlet_symmetric(A, b, pairs)
             return A, b
 
-        # Static placeholder for .A/.b: scalar params at 0, networks (coefficient + Dirichlet) at stored weights.
+        # Static placeholder for .A/.b: scalar params at 0, networks (coefficient + Dirichlet) at stored
+        # weights, Dirichlet-value parameters at their STORED value (like the nets: `fem.b` then reflects
+        # the initialized boundary value rather than an arbitrary zero condition).
         a0, b0 = _assemble_at(
             {n: 0.0 for n in runtime_parameter_tags}
             | {n: _neural_models[n].module for n in neural_param_names}
             | {n: m.module for n, m in _dir_net_models.items()}
+            | {n: jnp.asarray(nd.model.module.value) for n, nd in _dir_param_exprs.items()}
         )
         op = FemLinearSystem(
             a0,

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -2306,13 +2306,23 @@ def assemble_fem_native(
         domain._fem_native_dirichlet_tv = tv_stash
         return pairs
 
+    _static_dirichlet_cache: Dict[str, Any] = {}
+
     def _dirichlet_pairs_at(args):
         """Dirichlet ``(dof, value)`` pairs with the net-valued profiles evaluated from the runtime
         ``args`` (an unknown BC ``u(region) - net(x)``): the net is called on the region's boundary-node
         coordinates, so the value stays a differentiable JAX scalar and ``∂b/∂weights`` flows through the
         symmetric elimination. Non-net conditions reuse the concrete ``_build_dirichlet_pairs`` values."""
         a = args or {}
-        pairs = list(_build_dirichlet_pairs())  # concrete (non-net, non-parametric) conditions
+        # The concrete (non-net, non-parametric) pairs are ARG-INDEPENDENT, and rebuilding them here
+        # is not just wasted work: this runs inside the traced Newton residual (`_np_hold(args)`),
+        # where the host-side tag resolution in `_build_dirichlet_pairs` can meet traced state a
+        # contact assembly stashed (measured: TracerArrayConversionError from the tag location fn on
+        # a gap-carrying form). Built ONCE, on the first call -- which is always the eager dof-layout
+        # probe `_dirichlet_pairs_at(_dir_static_args())`, outside any trace.
+        if "pairs" not in _static_dirichlet_cache:
+            _static_dirichlet_cache["pairs"] = _build_dirichlet_pairs()
+        pairs = list(_static_dirichlet_cache["pairs"])
         for _row_i, (field_key, region, comp, value, value_node) in enumerate(dirichlet_raw):
             fidx = field_index.get(field_key)
             if fidx is None:
@@ -2324,12 +2334,23 @@ def assemble_fem_native(
                 # value stays a traced JAX scalar and ∂b/∂g (steady) / ∂step/∂g (transient) flows --
                 # the same contract as the net branch below. `_eval_value_node_at(params=...)` is the
                 # existing parametric-coefficient evaluator; no bespoke walker.
+                #
+                # The node LAYOUT is static per (field, region) and memoized from the first (eager)
+                # call: this body re-runs inside the traced Newton residual, where the host tag
+                # resolution behind `_boundary_node_ids` can meet traced state (measured on a
+                # gap-carrying form: TracerArrayConversionError out of the tag location fn).
                 from ..._fem import _eval_value_node_at as _eval_at
 
                 vt = vecs[fidx]
-                pts_all = np.asarray(pts_f_all[fidx])
-                node_ids = list(_boundary_node_ids(fidx, region))
-                pts = pts_all[np.asarray(node_ids, dtype=np.int64)] if node_ids else np.zeros((0, dim))
+                _lk = ("layout", fidx, region)
+                if _lk not in _static_dirichlet_cache:
+                    pts_all = np.asarray(pts_f_all[fidx])
+                    nid_list = list(_boundary_node_ids(fidx, region))
+                    _static_dirichlet_cache[_lk] = (
+                        nid_list,
+                        pts_all[np.asarray(nid_list, dtype=np.int64)] if nid_list else np.zeros((0, dim)),
+                    )
+                node_ids, pts = _static_dirichlet_cache[_lk]
                 raw = jnp.asarray(_eval_at(value_node, jnp.asarray(pts), params=a)).reshape(-1)
                 # Constant vs spatial profile: a constant returns the same shape for ANY batch (the
                 # static-path trick) -- one extra single-point evaluation decides, shapes are static.

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -569,6 +569,7 @@ def assemble_fem_native(
     quad_degree: int,
     evolution: Optional[Dict[Any, Any]] = None,
     bounded: bool = False,
+    tv_dirichlet_external: bool = False,
 ) -> Tuple[Any, str]:
     """Assemble a Lagrange FEM system into ``(op, mode, offs)`` for :class:`FEM`.
 
@@ -3060,7 +3061,12 @@ def assemble_fem_native(
 
     # A τ/t-dependent essential value that no branch above threaded would be silently DROPPED here --
     # the constraint disappears and the solve returns a plausible-looking wrong answer. Fail instead.
-    if _tv_dirichlet:
+    # EXCEPT when the caller declared it consumes the tv stash itself (`tv_dirichlet_external=True`):
+    # the second-order u_tt block calls this assembler for the spatial operator and the Dirichlet
+    # stashes, then writes g(x_d, t) and the compatible ġ(x_d, t) onto its augmented [u, v] system per
+    # step -- a legitimate consumer this guard was firing on (found by the pre-push suite: two wave
+    # oracles that pass on origin/main NotImplementedError'd from the guard's own commit onward).
+    if _tv_dirichlet and not tv_dirichlet_external:
         raise NotImplementedError(
             "jno.fem: a time/τ-dependent essential value (e.g. `u(top) - delta*tau`) is threaded on the "
             "steady residual path -- the load-path march and the runtime-parametric solve -- and by the "

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -3403,6 +3403,289 @@ _PLAN_CACHE: "OrderedDict[tuple, tuple]" = OrderedDict()
 _PLAN_CACHE_MAX = 4
 
 
+#: Content digests of baked array leaves, keyed by object id. Each entry PINS the array it was
+#: computed from -- numpy arrays are not weakref-able, and pinning is what keeps the id in the key
+#: from being recycled onto a different array while the entry is live (the same pattern
+#: ``_ELEM_MAP_CACHE`` documents for its baked leaves). Bounded: an entry is one array pin + a small
+#: digest tuple, and one build touches ~20 array leaves.
+_LEAF_DIGEST_CACHE: "OrderedDict[int, tuple]" = OrderedDict()
+_LEAF_DIGEST_CACHE_MAX = 4096
+
+#: The CONTENT-keyed twin of ``_ELEM_MAP_CACHE`` -- same values (``(jitted, pins)`` tuples), keyed on
+#: what the compilation depends on *by value* rather than by object identity. This is what makes a
+#: REBUILD of an identical problem (fresh mesh arrays, fresh closures, identical content) reuse the
+#: compiled programs instead of paying trace + XLA compile again: measured on 3-D Poisson at 10k
+#: nodes, the 8 recompiles were 1.25 s of a 1.56 s warm rebuild.
+_ELEM_MAP_CONTENT: "OrderedDict[tuple, tuple]" = OrderedDict()
+_ELEM_MAP_CONTENT_MAX = 128
+
+#: Diagnostics for tests and for finding out WHY a rebuild failed to hit: hit/miss counters plus a
+#: per-type tally of the leaves that defeated content keying (``content_bail``).
+_ELEM_MAP_STATS: Dict[str, Any] = {"id_hits": 0, "content_hits": 0, "misses": 0, "content_bail": {}}
+
+
+def _array_digest(leaf):
+    """Content identity of a baked array leaf, memoized by object id (arrays are immutable).
+
+    Includes dtype, shape and -- for JAX arrays -- ``weak_type`` and the sharding string, because each
+    of those changes the program a jit would bake, not just the numbers in it. ``np.asarray`` on a
+    device array is a host transfer; it happens once per array object (the memo), at build time, and
+    only on the rebuild-miss path -- never per solve."""
+    key = id(leaf)
+    hit = _LEAF_DIGEST_CACHE.get(key)
+    if hit is not None and hit[0] is leaf:
+        _LEAF_DIGEST_CACHE.move_to_end(key)
+        return hit[1]
+    if isinstance(leaf, jax.core.Tracer):
+        return None
+    extra = ()
+    if isinstance(leaf, jax.Array):
+        extra = (bool(getattr(leaf, "weak_type", False)), str(getattr(leaf, "sharding", "")))
+    arr = np.ascontiguousarray(np.asarray(leaf))
+    digest = (
+        "arr",
+        arr.dtype.str,
+        arr.shape,
+        extra,
+        _hashlib.blake2b(memoryview(arr).cast("B"), digest_size=16).digest(),
+    )
+    _LEAF_DIGEST_CACHE[key] = (leaf, digest)
+    while len(_LEAF_DIGEST_CACHE) > _LEAF_DIGEST_CACHE_MAX:
+        _LEAF_DIGEST_CACHE.popitem(last=False)
+    return digest
+
+
+def _callable_token(fn, seen):
+    """Content token of a plain Python function: its code object plus the recursive tokens of its
+    closure -- ``_fn_content_key`` without the treedef packaging. Bound methods and builtins hash by
+    their qualified name (their behaviour is version-stable within a process)."""
+    import types as _types
+
+    if isinstance(fn, _types.FunctionType):
+        sub = _fn_content_key(fn, None, seen)
+        return None if sub is None else ("fn",) + sub
+    qual = getattr(fn, "__qualname__", None) or getattr(fn, "__name__", None)
+    mod = getattr(fn, "__module__", None)
+    if qual and mod:
+        return ("callable", mod, qual)
+    return None
+
+
+def _expr_digest(node, seen=None):
+    """Structural content digest of a traced expression -- the coefficient trees the element
+    functions bake in. **Allow-list, strict**: a node type this walker does not positively know how
+    to fingerprint returns ``None``, which disables content keying for that closure (safe: a miss
+    costs a recompile, a wrong hit would be a wrong operator). The bail is tallied by type in
+    ``_ELEM_MAP_STATS["content_bail"]`` so coverage gaps are measurable, not guessed.
+
+    Deliberately EXCLUDED from every token: per-build counters (``op_id``, ``frozen_id``,
+    ``layer_id``) -- they differ across rebuilds without changing the compiled program, and any node
+    whose counter DOES key runtime lookups (``FrozenField``'s gather table, ``ModelCall``) is not on
+    the allow-list at all."""
+    from ...trace import RegionMask as _RM
+    from ...trace import TagMask as _TM
+
+    if seen is None:
+        seen = set()
+    if id(node) in seen:
+        return None  # a true back-edge (ancestor on the CURRENT path); a DAG is fine -- see below
+    seen.add(id(node))
+
+    def _val(v):
+        if isinstance(v, (np.ndarray, jax.Array)):
+            return _array_digest(v)
+        if isinstance(v, (bool, int, float, complex, str, bytes, type(None), np.integer, np.floating)):
+            return ("v", type(v).__name__, v)
+        if isinstance(v, (tuple, list)):
+            parts = tuple(_val(x) for x in v)
+            return None if any(p is None for p in parts) else ("seq", parts)
+        return None
+
+    t = type(node).__name__
+    if isinstance(node, Literal) or isinstance(node, Constant):
+        head = _val(node.value)
+    elif isinstance(node, _RM):
+        head = ("region", node.region)
+    elif isinstance(node, _TM):
+        head = ("tag", node.tag)
+    elif isinstance(node, Variable):
+        head = _val((node.tag, tuple(np.atleast_1d(node.dim).tolist()), getattr(node, "axis", "spatial")))
+    elif isinstance(node, (TrialFunction, TestFunction)):
+        head = _val(
+            (
+                getattr(node, "name", ""),
+                tuple(getattr(node, "value_shape", ()) or ()),
+                int(getattr(node, "order", 1)),
+                str(getattr(node, "space", "Lagrange")),
+            )
+        )
+    elif isinstance(node, (Jacobian, Hessian)):
+        head = ("d", str(getattr(node, "scheme", "")))
+    elif isinstance(node, BinaryOp):
+        head = ("op", node.op)
+    elif isinstance(node, FunctionCall):
+        fn_tok = _callable_token(node.fn, seen)
+        kw = _val(tuple(sorted((node.kwargs or {}).items()))) if getattr(node, "kwargs", None) else ()
+        if fn_tok is None or kw is None:
+            fn_tok = None
+        head = None if fn_tok is None else ("call", node._name, fn_tok, getattr(node, "reduces_axis", None), kw)
+    else:
+        head = None
+    if head is None:
+        _ELEM_MAP_STATS["content_bail"][t] = _ELEM_MAP_STATS["content_bail"].get(t, 0) + 1
+        return None
+    child_digests = []
+    from .solver_helper import iter_children
+
+    for child in iter_children(node) or ():
+        d = _expr_digest(child, seen)
+        if d is None:
+            return None
+        child_digests.append(d)
+    # PATH-based guard, not visited-based: an expression is a DAG (`ui` appears once per term but is
+    # ONE object), so a shared node must digest normally on every path -- only a genuine cycle, where
+    # a node is its own ancestor, is refused. Hence the discard on exit.
+    seen.discard(id(node))
+    return (t, head, tuple(child_digests))
+
+
+def _leaf_content_token(leaf, seen):
+    """Content token of ONE baked closure leaf, or ``None`` when this leaf cannot be keyed by value.
+
+    The probe over a real build's element functions found exactly these kinds: arrays, plain scalars,
+    coefficient expression trees, nested functions, empty sets, an empty ``NeuralSlots``, and the
+    owning ``domain``. Everything else bails -- tallied, so the next kind to support is measured."""
+    import types as _types
+
+    from ...trace import Placeholder as _Ph
+
+    if isinstance(leaf, (np.ndarray, jax.Array)):
+        return _array_digest(leaf)
+    if isinstance(leaf, (bool, int, float, complex, str, bytes, type(None), np.integer, np.floating, np.bool_)):
+        return ("v", type(leaf).__name__, leaf)
+    if isinstance(leaf, (set, frozenset)):
+        try:
+            return ("set", frozenset(leaf))
+        except TypeError:
+            return None
+    if isinstance(leaf, _types.FunctionType):
+        sub = _fn_content_key(leaf, None, seen)
+        return None if sub is None else ("fn",) + sub
+    if isinstance(leaf, _Ph):
+        d = _expr_digest(leaf)
+        return None if d is None else ("expr", d)
+    tname = type(leaf).__name__
+    if tname == "domain" and type(leaf).__module__.startswith("jno."):
+        return _domain_content_token(leaf)
+    if tname == "NeuralSlots" and not getattr(leaf, "models", None):
+        return ("neural", tuple(getattr(leaf, "all_names", ())), tuple(getattr(leaf, "param_names", ())))
+    _ELEM_MAP_STATS["content_bail"][tname] = _ELEM_MAP_STATS["content_bail"].get(tname, 0) + 1
+    return None
+
+
+def _domain_content_token(d):
+    """Mesh-content identity of a ``jno.domain``: dimension, point and cell digests, and the tag
+    names. Memoized on the instance (a domain's mesh is fixed after build; adaptivity REPLACES the
+    domain object). Everything an element function reads from the domain at trace time is either
+    covered here or reaches the closure as a separately-digested array (masks, facet ids, context
+    tensors), so identical tokens imply identical compiled programs."""
+    cached = d.__dict__.get("_elem_map_content_token")
+    if cached is not None:
+        return cached
+    try:
+        mesh = d.mesh
+        parts = [("dim", int(d.dimension)), _array_digest(np.asarray(mesh.points))]
+        for name in sorted(mesh.cells_dict):
+            parts.append((name, _array_digest(np.asarray(mesh.cells_dict[name]))))
+        parts.append(("tags", tuple(sorted(map(str, getattr(d, "avaiable_mesh_tags", ()) or ())))))
+        token = ("domain", tuple(parts))
+    except Exception:  # noqa: BLE001 -- no mesh (point cloud), exotic state: just do not key it
+        return None
+    d.__dict__["_elem_map_content_token"] = token
+    return token
+
+
+def _structure_token(obj, seen, renumber):
+    """Canonical content token of one baked value -- container structure INCLUDED, walked by hand
+    rather than through ``tree_flatten``, for one reason: **integer dict keys are per-build counters**.
+
+    The assembler's closures carry tables keyed by ``field_key`` (= ``op_id``, a process-global
+    counter), so two builds of the identical problem capture ``{1: ...}`` and ``{3: ...}`` -- same
+    structure, different key -- and a treedef-based key can never match across builds. Those keys are
+    pure within-problem lookup indices: the compiled program depends on WHICH entry a trace-time
+    lookup resolved to, never on the integer's value. So they are alpha-renumbered by first
+    appearance (De Bruijn-style), and an int LEAF equal to a renumbered key is renumbered with it (it
+    is the same field key stored as a value, e.g. ``fields[i]['field_key']``). A literal int that
+    merely collides with a field key makes the maps diverge and the lookup MISS -- the safe
+    direction; a false hit would need two different programs with identical canonical forms, which
+    the consistent renumbering excludes.
+
+    String dict keys and everything else compare by value. Unknown container/leaf types fall through
+    to :func:`_leaf_content_token`, whose bail disables keying for the whole closure."""
+    if isinstance(obj, dict):
+        # NUMERIC sort for int keys, in both the renumber assignment and the item order: counters
+        # increase monotonically per build, so numeric order preserves the cross-build semantic
+        # correspondence (1<->3, 10<->12), where a repr sort would flip it ("12" < "3").
+        def _is_int(k):
+            return isinstance(k, (int, np.integer)) and not isinstance(k, bool)
+
+        for k in sorted(k for k in obj if _is_int(k)):
+            renumber.setdefault(int(k), len(renumber))
+        # A field key also travels as a VALUE under its own name (``fields[i]['field_key']``), where
+        # no int dict key ever introduces it. The entry name identifies the semantics, so it joins
+        # the same renumbering -- consistently with any table keyed by the same counter.
+        for k in sorted(obj, key=lambda k: (0, int(k)) if _is_int(k) else (1, repr(k))):
+            if k == "field_key" and _is_int(obj[k]):
+                renumber.setdefault(int(obj[k]), len(renumber))
+        items = []
+        for k in sorted(obj, key=lambda k: (0, int(k)) if _is_int(k) else (1, repr(k))):
+            kk = ("#", renumber[int(k)]) if _is_int(k) else k
+            if k == "field_key" and _is_int(obj[k]):
+                # Renumbered HERE, at the semantically-identified site -- never as a bare int leaf,
+                # where a literal 1 colliding with field_key=1 would be renumbered in one build and
+                # not the other, guaranteeing a miss for the commonest small-int literals.
+                v = ("#", renumber[int(obj[k])])
+            else:
+                v = _structure_token(obj[k], seen, renumber)
+            if v is None:
+                return None
+            items.append((kk, v))
+        return ("dict", tuple(items))
+    if isinstance(obj, (list, tuple)):
+        parts = tuple(_structure_token(x, seen, renumber) for x in obj)
+        return None if any(p is None for p in parts) else (type(obj).__name__, parts)
+    import types as _types
+
+    if isinstance(obj, _types.FunctionType):
+        sub = _fn_content_key(obj, None, seen, renumber)
+        return None if sub is None else ("fn",) + sub
+    return _leaf_content_token(obj, seen)
+
+
+def _fn_content_key(fn, chunk, seen=None, renumber=None):
+    """The CONTENT twin of :func:`_bake_fingerprint`: everything a jit of ``fn`` would bake, keyed by
+    value -- recursing through nested functions (fresh objects per build, identical code and captures
+    across rebuilds), containers walked canonically (see :func:`_structure_token`). ``None`` disables
+    content keying for this call; the reason is tallied in ``_ELEM_MAP_STATS['content_bail']``."""
+    if seen is None:
+        seen = set()
+    if renumber is None:
+        renumber = {}
+    if id(fn) in seen:
+        _ELEM_MAP_STATS["content_bail"]["<recursive-fn>"] = _ELEM_MAP_STATS["content_bail"].get("<recursive-fn>", 0) + 1
+        return None
+    seen.add(id(fn))
+    try:
+        captured = tuple(c.cell_contents for c in (fn.__closure__ or ()))
+    except ValueError:
+        _ELEM_MAP_STATS["content_bail"]["<unfilled-cell>"] = _ELEM_MAP_STATS["content_bail"].get("<unfilled-cell>", 0) + 1
+        return None
+    tok = _structure_token((captured, fn.__defaults__ or ()), seen, renumber)
+    if tok is None:
+        return None
+    return (fn.__code__, tok, chunk)
+
+
 def _bake_fingerprint(fn, chunk):
     """Identity of everything a ``jit`` of ``fn`` would BAKE IN: its code object, and the *leaves* of
     its closure cells and default arguments.
@@ -3480,11 +3763,35 @@ def elem_map(fn, xs, chunk):
     key, pins = fp
     hit = _ELEM_MAP_CACHE.get(key)
     if hit is None:
-        hit = (jax.jit(run), pins)
+        # Identity miss. Before compiling, try the CONTENT key: a rebuild of an identical problem
+        # bakes fresh objects with identical values, and identical values compile to the identical
+        # program. On a hit the id key is inserted as an ALIAS, so every subsequent call from this
+        # build fast-paths without touching a digest again. A ``None`` content key (a leaf the
+        # tokenizer cannot key by value) falls through to compile -- a miss is safe, a wrong hit
+        # would be a wrong operator.
+        ckey = _fn_content_key(fn, chunk)
+        if ckey is not None:
+            hit = _ELEM_MAP_CONTENT.get(ckey)
+        if hit is not None:
+            _ELEM_MAP_STATS["content_hits"] += 1
+            _ELEM_MAP_CONTENT.move_to_end(ckey)
+            # Share the COMPILED program but pin THIS call's leaves: the id key contains this build's
+            # object ids, and the entry's pins are what stop those ids from being recycled onto
+            # different objects after a GC -- the invariant the id fast path rests on. Pinning the
+            # old build's leaves instead would leave the new ids unguarded.
+            hit = (hit[0], pins)
+        else:
+            _ELEM_MAP_STATS["misses"] += 1
+            hit = (jax.jit(run), pins)
+            if ckey is not None:
+                _ELEM_MAP_CONTENT[ckey] = hit
+                while len(_ELEM_MAP_CONTENT) > _ELEM_MAP_CONTENT_MAX:
+                    _ELEM_MAP_CONTENT.popitem(last=False)
         _ELEM_MAP_CACHE[key] = hit
         if len(_ELEM_MAP_CACHE) > _ELEM_MAP_CACHE_MAX:
             _ELEM_MAP_CACHE.popitem(last=False)
     else:
+        _ELEM_MAP_STATS["id_hits"] += 1
         _ELEM_MAP_CACHE.move_to_end(key)
     return hit[0](*arrays)
 

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -3764,7 +3764,24 @@ def elem_map(fn, xs, chunk):
         return jax.jit(run)(*arrays)
 
     key, pins = fp
+
+    # Cache entries are ``(jit_fn, pins, baked)``: ``pins`` guard THIS call's ids against recycling,
+    # ``baked`` are the leaves of the build that COMPILED the function -- the arrays actually
+    # captured in its closure. The two differ exactly for content-hit ALIASES, and the distinction
+    # is what makes the donated-buffer check below possible.
+    def _baked_dead(entry):
+        return entry[2] is not entry[1] and any(
+            isinstance(_l, jax.Array) and _l.is_deleted() for _l in jax.tree_util.tree_leaves(entry[2])
+        )
+
     hit = _ELEM_MAP_CACHE.get(key)
+    if hit is not None and _baked_dead(hit):
+        # An id-keyed ALIAS whose original baked device buffers were DONATED and deleted since (a
+        # training loop's optimizer step donates the old parameter buffer). Executing the shared
+        # compilation reads a corpse: measured "Array has been deleted with shape=float64[1]" out of
+        # a kernel shared across tests. Recompile with this build's live leaves.
+        _ELEM_MAP_CACHE.pop(key, None)
+        hit = None
     if hit is None:
         # Identity miss. Before compiling, try the CONTENT key: a rebuild of an identical problem
         # bakes fresh objects with identical values, and identical values compile to the identical
@@ -3773,19 +3790,30 @@ def elem_map(fn, xs, chunk):
         # tokenizer cannot key by value) falls through to compile -- a miss is safe, a wrong hit
         # would be a wrong operator.
         ckey = _fn_content_key(fn, chunk)
+        chit = None
         if ckey is not None:
-            hit = _ELEM_MAP_CONTENT.get(ckey)
-        if hit is not None:
+            chit = _ELEM_MAP_CONTENT.get(ckey)
+            if chit is not None and any(
+                isinstance(_l, jax.Array) and _l.is_deleted() for _l in jax.tree_util.tree_leaves(chit[2])
+            ):
+                # Same corpse check for the content table (its entries keep the ORIGINAL build's
+                # leaves as ``baked``, which are exactly the compiled closure's buffers).
+                del _ELEM_MAP_CONTENT[ckey]
+                _ELEM_MAP_STATS["content_bail"]["<deleted-buffer>"] = (
+                    _ELEM_MAP_STATS["content_bail"].get("<deleted-buffer>", 0) + 1
+                )
+                chit = None
+        if chit is not None:
             _ELEM_MAP_STATS["content_hits"] += 1
             _ELEM_MAP_CONTENT.move_to_end(ckey)
             # Share the COMPILED program but pin THIS call's leaves: the id key contains this build's
             # object ids, and the entry's pins are what stop those ids from being recycled onto
-            # different objects after a GC -- the invariant the id fast path rests on. Pinning the
-            # old build's leaves instead would leave the new ids unguarded.
-            hit = (hit[0], pins)
+            # different objects after a GC. ``baked`` stays the ORIGINAL build's leaves -- the
+            # closure's actual buffers -- so the liveness checks above test the right arrays.
+            hit = (chit[0], pins, chit[2])
         else:
             _ELEM_MAP_STATS["misses"] += 1
-            hit = (jax.jit(run), pins)
+            hit = (jax.jit(run), pins, pins)
             if ckey is not None:
                 _ELEM_MAP_CONTENT[ckey] = hit
                 while len(_ELEM_MAP_CONTENT) > _ELEM_MAP_CONTENT_MAX:

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -3575,7 +3575,10 @@ def _leaf_content_token(leaf, seen):
         d = _expr_digest(leaf)
         return None if d is None else ("expr", d)
     tname = type(leaf).__name__
-    if tname == "domain" and type(leaf).__module__.startswith("jno."):
+    # MRO walk, not a name match on the leaf class: ``PolygonDomain(domain)`` and any other subclass
+    # must token the same way -- matching only the base name made every shapely-built domain bail,
+    # which the tally surfaced as ``{'PolygonDomain': 12}`` on the first multifield rebuild measured.
+    if any(c.__name__ == "domain" and c.__module__.startswith("jno.") for c in type(leaf).__mro__):
         return _domain_content_token(leaf)
     if tname == "NeuralSlots" and not getattr(leaf, "models", None):
         return ("neural", tuple(getattr(leaf, "all_names", ())), tuple(getattr(leaf, "param_names", ())))

--- a/jno/utils/solver/newton_krylov.py
+++ b/jno/utils/solver/newton_krylov.py
@@ -29,7 +29,15 @@ __all__ = ["newton_krylov", "newton_direct", "staggered_newton", "bicgstab"]
 _EPS = 1e-300
 
 
-def _convergence_check(f0, u0, u, *, rtol, atol, max_steps, who):
+#: Last eager nonlinear solve's outcome, written by ``_convergence_check`` and read by
+#: ``fem.solve`` into ``fem.stats``. A module-level slot rather than a return-value change on
+#: purpose: the drivers' ``(residual_fn, u0) -> u`` contract has many callers, and observability
+#: must not alter it. Under jit/vmap/grad the check self-disables (concrete-only, as documented
+#: below) and this slot simply keeps its previous content -- the same silence the guard itself has.
+LAST_NEWTON_STATS: dict = {}
+
+
+def _convergence_check(f0, u0, u, *, rtol, atol, max_steps, who, steps=None):
     """Raise (eagerly) if the Newton loop returned on its STEP CAP rather than on the tolerance.
 
     Both drivers below iterate a ``jax.lax.while_loop`` whose condition is
@@ -47,6 +55,14 @@ def _convergence_check(f0, u0, u, *, rtol, atol, max_steps, who):
         return u
     rn = float(jnp.linalg.norm(f0(u)))
     bound = atol + rtol * float(jnp.linalg.norm(f0(u0)))
+    LAST_NEWTON_STATS.clear()
+    LAST_NEWTON_STATS.update(
+        driver=who,
+        residual=rn,
+        bound=bound,
+        steps=None if steps is None or isinstance(steps, jax.core.Tracer) else int(steps),
+        converged=bool(math.isfinite(rn) and rn <= bound),
+    )
     if not math.isfinite(rn) or rn > bound:
         raise RuntimeError(
             f"{who} did not converge in max_steps={max_steps}: residual norm {rn:.3e} against the "
@@ -372,11 +388,11 @@ def newton_direct(
             u = u + alpha * delta
             return u, f0(u), k + 1
 
-        u, _r, _k = jax.lax.while_loop(cond, body, (x0, f0(x0), 0))
-        return u
+        u, _r, k = jax.lax.while_loop(cond, body, (x0, f0(x0), 0))
+        return u, k
 
-    root = _forward(u0)  # un-differentiated forward solve; custom_root below supplies the gradient
-    _convergence_check(f0, u0, root, rtol=rtol, atol=atol, max_steps=max_steps, who="newton_direct")
+    root, _steps = _forward(u0)  # un-differentiated forward solve; custom_root supplies the gradient
+    _convergence_check(f0, u0, root, rtol=rtol, atol=atol, max_steps=max_steps, who="newton_direct", steps=_steps)
 
     def _tangent(g, y):  # solve J_root x = y (and Jᵀ on the reverse pass) DIRECTLY at the converged root
         J = jacobian_fn(root)

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -457,6 +457,21 @@ def materialize_precond(spec: Any, ctx: PrecondContext) -> Callable:
     )
 
 
+def _iter_specs(spec):
+    """Every spec in a (possibly nested) preconditioner tree, duck-typed: ``.spec`` is a wrapper
+    (``cached``), ``.pairs`` a block preconditioner's ``(field, spec)`` list. Used to reach hooks
+    like ``refresh_from`` wherever they sit -- a solution-dependent Schur form typically lives one
+    level down, inside ``triangular``'s pressure pair."""
+    if spec is None:
+        return
+    yield spec
+    inner = getattr(spec, "spec", None)
+    if inner is not None:
+        yield from _iter_specs(inner)
+    for pair in getattr(spec, "pairs", None) or ():
+        yield from _iter_specs(pair[1])
+
+
 def prepare_precond(spec: Any, fem: Any) -> None:
     """Run a spec's eager preparation (optional ``spec.prepare(fem)``) once, at compose time.
 
@@ -810,6 +825,17 @@ def compose_nonlinear_solve_fn(nonlinear, linear, precond, fem=None) -> Callable
             return solver(op, rhs, M=M)
 
     def _composed(residual_fn, u0, *, jacobian=None, project=None):
+        # Solution-dependent preconditioner refresh -- the Picard lag. Every Newton driver's loop is
+        # a ``lax.while_loop``, so the per-step iterate is a tracer no host assembly can see; the
+        # solve's ENTRY iterate (warm start / previous march step) is the one concrete solution a
+        # solution-dependent auxiliary form can be assembled from, and it is refreshed here, once
+        # per composed invocation. A fully traced caller passes a tracer and skips the refresh --
+        # the spec then raises its own loud error at materialization if it was never assembled.
+        if precond is not None and fem is not None and not isinstance(u0, jax.core.Tracer):
+            for s in _iter_specs(precond):
+                hook = getattr(s, "refresh_from", None)
+                if hook is not None:
+                    hook(u0, fem)
         return nonlinear(residual_fn, u0, linear_solve=inner, jacobian=jacobian, project=project)
 
     # A direct (assembled-Jacobian) Newton needs the step Jacobian threaded in; flag it so the caller

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,21 +183,41 @@ def _restore_cache_dir():
         jax.config.update("jax_compilation_cache_dir", prev)
 
 
-def test_setup_leaves_the_compile_cache_off_by_default(tmp_path, monkeypatch, _restore_cache_dir):
-    """jNO must not write to a user's disk unless asked. Also guards the cold-run case: populating
-    the cache is SLOWER than not having one, so on-by-default would penalise a single run."""
+def test_setup_turns_the_compile_cache_on_by_default(tmp_path, monkeypatch, _restore_cache_dir):
+    """The default FLIPPED (2026-08-15): the warm-cache build measured 2.1x (4.3x on Stokes) and
+    jNO's normal life is the repeated run, so the persistent cache is ON unless opted out —
+    `JNO_COMPILE_CACHE=0`, `[jno] compile_cache = false`, or `setup(compile_cache=False)`. This test
+    used to pin the opposite ('must not write to a user's disk unless asked'); the populate-cost
+    caveat it guarded is now documented in `enable_compile_cache` and docs/fem.md instead."""
     import jax
 
     import jno
 
-    monkeypatch.chdir(tmp_path)  # no .jno.toml here, so nothing can opt in behind the test's back
+    monkeypatch.chdir(tmp_path)  # no .jno.toml here, so nothing can opt OUT behind the test's back
+    monkeypatch.delenv("JNO_COMPILE_CACHE", raising=False)
     cfg_module._CONFIG = None
     jax.config.update("jax_compilation_cache_dir", None)
     try:
         jno.setup(str(tmp_path / "script.py"), name="cache_default")
-        assert _cache_dir() is None, "the compile cache must stay opt-in"
+        assert _cache_dir() is not None, "the compile cache is ON by default since the 08-15 flip"
     finally:
         cfg_module._CONFIG = None
+
+
+def test_setup_compile_cache_false_disables_the_default(tmp_path, monkeypatch, _restore_cache_dir):
+    """The explicit opt-out must actively disable what the import-time default turned on."""
+    import jax
+
+    import jno
+
+    monkeypatch.chdir(tmp_path)
+    cfg_module._CONFIG = None
+    try:
+        jno.setup(str(tmp_path / "script.py"), name="cache_off", compile_cache=False)
+        assert _cache_dir() is None, "setup(compile_cache=False) must disable the cache"
+    finally:
+        cfg_module._CONFIG = None
+        jax.config.update("jax_persistent_cache_min_compile_time_secs", 1.0)
 
 
 def test_compile_cache_true_turns_it_on(tmp_path, _restore_cache_dir):

--- a/tests/test_fem_contact_gap.py
+++ b/tests/test_fem_contact_gap.py
@@ -421,3 +421,193 @@ def test_the_documented_contact_sign_engages_instead_of_finding_the_free_root():
     # (the max() kink chatters -- see item 2 in plans/contact-main-reaction.md), so the position is
     # not yet trustworthy enough to gate on. That the base is loaded at all is the sign question, and
     # it is the half that inverts.
+
+
+# ---------------------------------------------------------------------------
+# ONE-SIDED (separating, Signorini) contact -- the max(0,.) case, measured.
+#
+# The old note here deferred one-sided contact as "a solver question: the max() kink chatters". The
+# measurement that closed it: the chatter was a FLOAT32 RESIDUAL FLOOR (~1.6e-5 on the pressed
+# stack, line search or not), not active-set cycling -- under x64 the same iteration converges to
+# 3.6e-10 at rtol=1e-8. `jax.linearize` through `max` selects the active branch, which IS the
+# semismooth Jacobian (the same argument `u.bounds` documents), so the solver was never the problem;
+# the tolerance expectation was. These tests pin the physics at honest float32 tolerances and the
+# x64 discriminator that proves the iteration superlinear.
+# ---------------------------------------------------------------------------
+
+
+def _one_sided(c, squeeze, *, rtol=1e-6):
+    """The pressed stack with the ONE-SIDED penalty `max(0, -c*g)`; squeeze>0 lifts the platen."""
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    d = _stacked_blocks()
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    terms = [LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2)]
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    terms.append(jno.np.maximum(0.0, -c * g) * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1))
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    terms += [u(xb, yb)[0] - 0.0, u(xb, yb)[1] - 0.0, u(xt, yt)[0] - 0.0, u(xt, yt)[1] - squeeze]
+    fem = jno.fem(terms)
+    sol = np.asarray(fem.solve(nonlinear=jno.solve.newton(line_search=True, rtol=rtol, atol=rtol))).reshape(-1, 2)
+    return d, sol, np.asarray(d.tag_indices[secondary]).reshape(-1), np.asarray(d.tag_indices[main]).reshape(-1)
+
+
+def test_one_sided_press_converges_to_the_bonded_oracle_like_one_over_c():
+    """Under compression the closed one-sided contact must agree with the bonded interface: the
+    uniform-bar oracle has uy(y=1) = -0.01, approached as the penalty stiffens."""
+    errs = {}
+    for c in (1e3, 1e4, 1e5):
+        _d, sol, _s, main = _one_sided(c, -0.02)
+        errs[c] = abs(sol[main, 1].mean() - (-0.01))
+    assert errs[1e3] > errs[1e4] > errs[1e5], f"not converging to the bonded limit: {errs}"
+    assert errs[1e5] < 3e-4, f"closed one-sided contact should sit near the bonded answer: {errs[1e5]:.2e}"
+
+
+def test_one_sided_release_separates_without_adhesion():
+    """THE defining physics: lift the platen and the traction must be exactly zero -- the main body
+    undisturbed, the cap carried up rigidly, no tension transmitted across the open gap."""
+    d, sol, secondary, main = _one_sided(1e4, +0.02)
+    base = np.asarray(d.built_mesh.points)[:, 1] < 0.999
+    assert np.abs(sol[base]).max() < 1e-9, (
+        f"the open gap transmitted load: base max|u| = {np.abs(sol[base]).max():.3e} -- adhesion where there must be none"
+    )
+    assert sol[secondary, 1].mean() > 0.01, "the cap must move up with the platen once free"
+
+
+def test_one_sided_zero_load_is_the_unconstrained_solve():
+    """Extreme: no squeeze at all -- the contact term must contribute nothing anywhere."""
+    _d, sol, _s, _m = _one_sided(1e4, 0.0)
+    assert np.abs(sol).max() < 1e-9
+
+
+def test_one_sided_complementarity_via_the_interface_jump():
+    """p.g = 0, observed through displacements: pressed, the interface jump is O(1/c) (contact
+    active, gap ~ 0); released, the jump is the full opening with zero transmitted force (gap open,
+    traction 0). The two regimes may never mix."""
+    _d, press, s_ids, m_ids = _one_sided(1e5, -0.02)
+    jump_pressed = abs(press[s_ids, 1].mean() - press[m_ids, 1].mean())
+    assert jump_pressed < 5e-4, f"pressed: the gap must be ~closed, jump {jump_pressed:.2e}"
+    d, rel, s_ids, m_ids = _one_sided(1e5, +0.02)
+    jump_open = rel[s_ids, 1].mean() - rel[m_ids, 1].mean()
+    assert jump_open > 0.015, f"released: the gap must be OPEN by ~the lift, got {jump_open:.2e}"
+
+
+def test_one_sided_tight_tolerance_is_a_float32_floor_not_a_solver_stall():
+    """The discriminator that re-classified the recorded 'max() kink stalls Newton': under x64 the
+    SAME iteration meets rtol=1e-8 (measured residual 3.6e-10) -- superlinear semismooth Newton,
+    exactly as the `u.bounds` machinery argues. The float32 failure at 1e-8 is a precision floor."""
+    import jax as _jax
+
+    prev = _jax.config.jax_enable_x64
+    _jax.config.update("jax_enable_x64", True)
+    try:
+        _d, sol, _s, main = _one_sided(1e4, -0.02, rtol=1e-8)
+        assert abs(sol[main, 1].mean() - (-0.01)) < 1e-3
+    finally:
+        _jax.config.update("jax_enable_x64", prev)
+
+
+def test_gradient_through_closed_one_sided_contact_fd_checks():
+    """Differentiability through the ACTIVE contact: the platen displacement is a runtime Dirichlet
+    PARAMETER, and d(mean base uy)/d(squeeze) flows through custom_root across the max() branch
+    selection. FD-checked; away from onset the subgradient is the gradient."""
+    import jax as _jax
+
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    d = _stacked_blocks()
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    sq = jno.np.parameter((1,), name="sq", key=_jax.random.PRNGKey(0))
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    fem = jno.fem(
+        [
+            LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2),
+            jno.np.maximum(0.0, -1e4 * g) * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1),
+            u(xb, yb)[0] - 0.0,
+            u(xb, yb)[1] - 0.0,
+            u(xt, yt)[0] - 0.0,
+            u(xt, yt)[1] - sq,
+        ]
+    )
+    base_ids = np.asarray(d.tag_indices[main]).reshape(-1)
+
+    import jax.numpy as jnp
+
+    op = fem.operator  # FemResidualOperator: residual(u, args, t) with the held value re-formed per call
+    ndofs = int(fem.dofs)
+    drv = jno.solve.newton(line_search=True, rtol=1e-6, atol=1e-6)
+
+    def out(sqv):
+        r = lambda w: jnp.asarray(op.residual(w, {"sq": jnp.asarray(sqv).reshape(-1)})).reshape(-1)  # noqa: E731
+        w = drv(r, jnp.zeros(ndofs))
+        return w.reshape(-1, 2)[base_ids, 1].mean()
+
+    grad = float(_jax.grad(out)(jnp.asarray(-0.02)))
+    fd = float((out(jnp.asarray(-0.022)) - out(jnp.asarray(-0.020))) / (-0.002))
+    # jax.grad runs through the driver's custom_root on the branch-selected (semismooth) operator;
+    # in the closed regime the response is smooth in the platen displacement and the two must agree.
+    assert 0.1 < fd < 1.0, f"FD slope {fd:.3f} outside the physical (0,1) load-share range"
+    assert abs(grad - fd) < 0.05 * abs(fd), f"gradient through closed one-sided contact: jax.grad {grad:.4f} vs FD {fd:.4f}"
+
+
+def test_augmented_lagrangian_beats_the_penalty_error_at_the_same_c():
+    """AL exactness. The pure penalty carries an O(1/c) penetration error by construction; the
+    Uzawa multiplier update `lam.evolves(max(0, lam.i(-1) - c*g))` absorbs it, so at the SAME
+    c the marched AL answer must land far closer to the bonded oracle. Measured while writing
+    this test: penalty err 3.4e-3 at c=1e3; AL err 1.1e-5 after 8 updates -- monotone geometric
+    convergence (-0.00663 -> -0.00886 -> ... -> -0.00999). The multiplier is an ordinary scalar
+    SURFACE state on the secondary face: the machinery is `evolves` + the tau march, no new API."""
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    c, nsteps = 1e3, 8
+    d = jno.Shape.regions(
+        base=jno.Shape.rect(0, 0, 1, 1, size=0.22),
+        cap=jno.Shape.rect(0, 1, 1, 2, size=0.09),
+        conforming=False,
+    ).domain(tau=(0.0, 1.0, nsteps))
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    lam, _ = d.fem_symbols(value_shape=())  # the AL multiplier: a scalar surface state
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    p = jno.np.maximum(0.0, lam.i(-1) + c * (-g))
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    fem = jno.fem(
+        [
+            LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2),
+            p * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1),
+            lam.evolves(p),
+            u(xb, yb)[0] - 0.0,
+            u(xb, yb)[1] - 0.0,
+            u(xt, yt)[0] - 0.0,
+            u(xt, yt)[1] - (-0.02),
+        ]
+    )
+    # atol above the measured float32 residual floor (~1.7e-5): the march guard re-checks each step.
+    traj = np.asarray(fem.solve(nonlinear=jno.solve.newton(line_search=True, rtol=1e-5, atol=3e-5)))
+    m = np.asarray(d.tag_indices[main]).reshape(-1)
+    uys = [traj[k].reshape(-1, 2)[m, 1].mean() for k in range(traj.shape[0])]
+    errs = [abs(v - (-0.01)) for v in uys]
+    assert errs[0] > 2e-3, "step 0 is the pure-penalty answer and must carry the 1/c error"
+    assert all(e2 <= e1 * 1.05 for e1, e2 in zip(errs, errs[1:])), f"AL error must fall monotonically: {errs}"
+    assert errs[-1] < 1e-4, f"AL must beat the penalty error by orders of magnitude: final err {errs[-1]:.2e}"

--- a/tests/test_fem_contact_gap.py
+++ b/tests/test_fem_contact_gap.py
@@ -152,7 +152,8 @@ def test_a_penalty_on_the_gap_closes_the_interface_like_one_over_c():
     """The end-to-end gate, and the one that proves the gap is *live*: penalising it must drive the
     interface jump to zero like 1/c. That can only happen if the gap measures the real jump AND the
     tangent carries the main-side coupling — the matrix-free path picks the latter up through
-    `jax.linearize` of the residual, which is why no assembled Jacobian block is built."""
+    `jax.linearize` of the residual; the assembled path builds the explicit nonlocal blocks
+    (gated by `test_assembled_gap_tangent_matches_the_matrix_free_jvp`)."""
     free, _ = _vector_poisson(None)
     jumps = {c: _vector_poisson(c)[0] for c in (1e2, 1e3, 1e4, 1e5)}
 
@@ -163,9 +164,15 @@ def test_a_penalty_on_the_gap_closes_the_interface_like_one_over_c():
     assert jumps[1e5] < 1e-3 * free
 
 
-def test_the_assembled_tangent_refuses_a_gap():
-    """A gap is non-local, and the per-element Jacobian emits parent-cell columns only, so it would
-    silently drop the secondary–main coupling. It must refuse rather than return a degraded tangent."""
+def test_assembled_gap_tangent_matches_the_matrix_free_jvp():
+    """The assembled tangent now carries the gap's NONLOCAL blocks -- (s,m) from jacfwd w.r.t. the
+    gathered main values chained through the frozen mortar weights, and the reaction rows' (m,s) and
+    (m,m). The matrix-free JVP (jax.linearize of the residual) is exact by construction, so the two
+    must agree on random probe vectors, in both the ACTIVE (pressed) and INACTIVE (separated)
+    branches of a one-sided max(0,.) traction."""
+    import jax as _jax
+    import jax.numpy as jnp
+
     d = _two_body_domain()
     u, v = d.fem_symbols(value_shape=(3,))
     secondary, main = _sides(d)
@@ -177,16 +184,68 @@ def test_the_assembled_tangent_refuses_a_gap():
     g = u.gap(secondary, main, domain=d)
     terms = [
         jno.np.inner(gu, gv, n_contract=2) - 1.0 * v.bind(x=ci[0], y=ci[1], z=ci[2])[2],
-        g * jno.np.inner(n, v.bind(x=sb[0], y=sb[1], z=sb[2]), n_contract=1),
+        jno.np.maximum(0.0, -1e3 * g) * jno.np.inner(n, v.bind(x=sb[0], y=sb[1], z=sb[2]), n_contract=1),
     ]
     bb = d.variable("boundary", split=True)
     terms += [u(bb[0], bb[1], bb[2])[i] - 0.0 for i in range(3)]
     fem = jno.fem(terms, element_type="TET4")
-    with pytest.raises(NotImplementedError, match="matrix-free tangent"):
-        fem.jacobian(np.zeros(fem.n_dofs) if hasattr(fem, "n_dofs") else np.zeros(1))
+    op = fem.operator
+    ndofs = int(fem.dofs)
+    key = _jax.random.PRNGKey(0)
+
+    for state_scale, label in ((-1e-3, "active (pressed)"), (+1e-3, "inactive (separated)")):
+        # a z-displacement state that closes / opens the gap uniformly
+        u0 = jnp.zeros(ndofs).reshape(-1, 3).at[:, 2].set(state_scale).reshape(-1)
+        r = lambda w: jnp.asarray(op.residual(w)).reshape(-1)  # noqa: E731
+        J = op.jacobian(u0)
+        _r0, jvp = _jax.linearize(r, u0)
+        for i in range(3):
+            probe = _jax.random.normal(_jax.random.fold_in(key, i), (ndofs,))
+            a = np.asarray(J @ probe)
+            b = np.asarray(jvp(probe))
+            scale = max(np.abs(b).max(), 1e-8)
+            assert np.abs(a - b).max() < 5e-4 * scale, (
+                f"{label}: assembled J and matrix-free JVP disagree "
+                f"(max diff {np.abs(a - b).max():.3e} vs scale {scale:.3e})"
+            )
+
+
+def test_direct_newton_one_sided_matches_matrix_free():
+    """`newton(direct=True)` + host LU over a one-sided contact -- the path that refused before --
+    must land on the matrix-free answer."""
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    d = _stacked_blocks()
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    terms = [
+        LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2),
+        jno.np.maximum(0.0, -1e4 * g) * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1),
+        u(xb, yb)[0] - 0.0,
+        u(xb, yb)[1] - 0.0,
+        u(xt, yt)[0] - 0.0,
+        u(xt, yt)[1] - (-0.02),
+    ]
+    mf = np.asarray(jno.fem(terms).solve(nonlinear=jno.solve.newton(line_search=True, rtol=1e-6, atol=1e-6))).reshape(-1, 2)
+    dr = np.asarray(
+        jno.fem(terms).solve(
+            nonlinear=jno.solve.newton(direct=True, line_search=True, rtol=1e-6, atol=1e-6),
+            linear=jno.solve.lu(backend="host"),
+        )
+    ).reshape(-1, 2)
+    assert np.abs(mf - dr).max() < 5e-5, f"direct vs matrix-free one-sided contact: {np.abs(mf - dr).max():.2e}"
 
 
 # ---------------------------------------------------------------------------
+# The reaction on the main body# ---------------------------------------------------------------------------
 # The reaction on the main body -- Newton's third law across the interface.
 #
 # The interface traction is written on the secondary face only, so the main's share has to be added by

--- a/tests/test_fem_dirichlet_parameters.py
+++ b/tests/test_fem_dirichlet_parameters.py
@@ -1,0 +1,241 @@
+"""Runtime Dirichlet parameters — a trainable ``jno.np.parameter`` in an ESSENTIAL value.
+
+The documented limitation was "a trainable parameter may sit in the operator (stiffness) but not in
+an essential/Dirichlet boundary *value*" — and the reality was worse: a scalar parameter without an
+optimizer CRASHED (IndexError, gathered as a per-node data field), and with one it was silently
+frozen at its stored value behind ``float(g)``.
+
+Now a parameter in a Dirichlet value rides the exact plumbing the net-valued Dirichlet built:
+collected into ``runtime_parameter_exprs`` (crux discovers it; it stays OUT of the per-cell
+``runtime_parameter_tags``, like trainable mesh coordinates), and the held value is re-formed from
+``args`` by ``_dirichlet_pairs_at`` — a traced JAX scalar, so ``∂b/∂g`` flows through the symmetric
+elimination (steady linear), ``∂/∂g`` through the solve's ``custom_root`` (steady nonlinear), and
+the adjoint through each step's ``custom_root`` (linear transient).
+"""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+import pytest
+
+import jno
+
+
+def _poisson_pieces(size=0.3, time=None):
+    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain(**({"time": time} if time else {}))
+    u, v = d.fem_symbols()
+    if time:
+        xi, yi, ti = d.variable("interior", split=True)
+        ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    else:
+        xi, yi, _ = d.variable("interior", split=True)
+        ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    xb, yb, _ = d.variable("boundary", split=True)
+    return d, u, v, ui, vi, (xb, yb)
+
+
+def _param(name, value, key=0):
+    g = jno.np.parameter((1,), name=name, key=jax.random.PRNGKey(key))
+    g.initialize(jax.nn.initializers.constant(value))
+    return g
+
+
+def _dense(A):
+    return np.asarray(A.todense() if hasattr(A, "todense") else A)
+
+
+def _solve_at(fem, args):
+    A, b = fem.operator.evaluate(args)
+    return np.linalg.solve(_dense(A), np.asarray(b))
+
+
+# --------------------------------------------------------------------------------------
+# steady linear: b(args), oracle agreement, differentiability
+# --------------------------------------------------------------------------------------
+def test_a_dirichlet_parameter_makes_the_problem_parametric():
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    assert fem.operator.is_parametric
+    b1 = np.asarray(fem.operator.evaluate({"g": np.asarray([1.0])})[1])
+    b2 = np.asarray(fem.operator.evaluate({"g": np.asarray([5.0])})[1])
+    assert not np.allclose(b1, b2), "b must ride the boundary value"
+
+
+@pytest.mark.parametrize("gval", [0.0, -3.0, 1e3])
+def test_solution_matches_the_constant_dirichlet_oracle(gval):
+    """Zero, negative and large per the house rule — each must equal the hand-written constant BC."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    oracle = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - gval])
+    got = _solve_at(fem, {"g": np.asarray([gval])})
+    ref = np.asarray(oracle.solve())
+    scale = max(1.0, abs(gval))
+    np.testing.assert_allclose(got, ref, rtol=1e-4, atol=1e-5 * scale)
+
+
+def test_gradient_through_the_linear_solve_fd_checks():
+    import jax.numpy as jnp
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    op = fem.operator
+
+    def loss(gv):
+        A, b = op.evaluate({"g": gv})
+        return jnp.sum(jnp.linalg.solve(A.todense() if hasattr(A, "todense") else A, b))
+
+    gr = float(jax.grad(loss)(jnp.asarray([2.0]))[0])
+    fd = float((loss(jnp.asarray([2.0 + 1e-3])) - loss(jnp.asarray([2.0 - 1e-3]))) / 2e-3)
+    assert abs(gr - fd) < 1e-2 * abs(fd), f"grad {gr} vs FD {fd}"
+
+
+def test_spatial_profile_times_parameter():
+    """`u(top) - g*sin(pi x)`: the parameter scales a coordinate profile — evaluated per boundary
+    node with the args-substituted parameter, not collapsed to a constant."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g * jno.np.sin(jno.np.pi * xb)])
+    oracle = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - 3.0 * jno.np.sin(jno.np.pi * xb)])
+    got = _solve_at(fem, {"g": np.asarray([3.0])})
+    np.testing.assert_allclose(got, np.asarray(oracle.solve()), rtol=1e-4, atol=1e-5)
+
+
+def test_one_parameter_in_operator_and_dirichlet_value():
+    """The coupling case naive affine lowering cannot express: k scales the stiffness AND is the
+    boundary value. The re-assembly route must handle both sites from one args entry."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    k = _param("k", 1.0, key=1)
+    fem = jno.fem([k * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - k])
+    oracle = jno.fem([2.0 * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - 2.0])
+    got = _solve_at(fem, {"k": np.asarray([2.0])})
+    np.testing.assert_allclose(got, np.asarray(oracle.solve()), rtol=1e-4, atol=1e-5)
+
+
+def test_fem_b_placeholder_reflects_the_stored_value():
+    """`fem.b` (the static placeholder) evaluates the Dirichlet parameter at its STORED value at
+    build time — like the net branch uses stored weights. NB `parameter.initialize` is lazy (applied
+    at crux compile), so the build-time stored value is whatever the module holds then."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 2.0)
+    stored = np.asarray(g.model.module.value)  # lazy initialize: this is what build sees
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    b_stored = np.asarray(fem.b)
+    b_at_stored = np.asarray(fem.operator.evaluate({"g": stored})[1])
+    np.testing.assert_allclose(b_stored, b_at_stored, rtol=1e-6, atol=1e-7)
+
+
+def test_scalar_parameter_without_optimizer_no_longer_crashes():
+    """The old path gathered a length-1 value by boundary-node id -> IndexError. A scalar
+    optimizer-less parameter is now runtime-parametric like any other."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.5)  # no .optimizer(...) attached
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    got = _solve_at(fem, {"g": np.asarray([1.5])})
+    assert np.all(np.isfinite(got))
+
+
+# --------------------------------------------------------------------------------------
+# the acceptance tests: recover a boundary value from data, all three paths
+# --------------------------------------------------------------------------------------
+def test_recover_boundary_value_steady_linear():
+    import optax
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    truth = np.asarray(jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - 2.5]).solve())
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    crux = jno.core([(fem.solve() - truth).mse], domain=d)
+    g.optimizer(optax.adam(1e-1))
+    crux.solve(300)
+    rec = float(np.asarray(crux.eval([g])).reshape(-1)[0])
+    assert abs(rec - 2.5) / 2.5 < 0.01, f"recovered {rec}, want 2.5"
+
+
+def test_recover_boundary_value_steady_nonlinear():
+    import optax
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    truth = np.asarray(
+        jno.fem([(1.0 + ui * ui) * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - 1.5]).solve(
+            nonlinear=jno.solve.newton(rtol=1e-6, atol=1e-6)
+        )
+    )
+    g = _param("g", 0.5)
+    fem = jno.fem([(1.0 + ui * ui) * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - g])
+    crux = jno.core([(fem.solve() - truth).mse], domain=d)
+    g.optimizer(optax.adam(1e-1))
+    crux.solve(300)
+    rec = float(np.asarray(crux.eval([g])).reshape(-1)[0])
+    assert abs(rec - 1.5) / 1.5 < 0.01, f"recovered {rec}, want 1.5"
+
+
+def test_recover_boundary_value_linear_transient():
+    """A time-constant but TRAINABLE inlet value, recovered from the trajectory — the adjoint runs
+    through every step's custom_root."""
+    import optax
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces(size=0.35, time=(0.0, 0.5, 26))
+    ci = d.variable("initial", split=True)
+
+    def build(gval):
+        return jno.fem([ui.t * vi + ui.x * vi.x + ui.y * vi.y, u(xb, yb) - gval, u(ci[0], ci[1]) - 0.0])
+
+    truth = np.asarray(build(2.5).solve().fn())
+    g = _param("g", 1.0)
+    fem = build(g)
+    crux = jno.core([(fem.solve() - truth).mse], domain=d)
+    g.optimizer(optax.adam(2e-1))
+    crux.solve(150)
+    rec = float(np.asarray(crux.eval([g])).reshape(-1)[0])
+    assert abs(rec - 2.5) / 2.5 < 0.01, f"recovered {rec}, want 2.5"
+
+
+# --------------------------------------------------------------------------------------
+# breadth: vector per-component; the data-field branch must still work
+# --------------------------------------------------------------------------------------
+def test_vector_field_per_component_parametric_value():
+    d = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+    u, v = d.fem_symbols(value_shape=(2,))
+    inner, grad = jno.np.inner, jno.np.grad
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    g = _param("g", 1.0)
+    fem = jno.fem([inner(gu, gv, n_contract=2), u(xb, yb)[0] - g, u(xb, yb)[1] - 0.0])
+    oracle = jno.fem([inner(gu, gv, n_contract=2), u(xb, yb)[0] - 4.0, u(xb, yb)[1] - 0.0])
+    got = _solve_at(fem, {"g": np.asarray([4.0])})
+    np.testing.assert_allclose(got, np.asarray(oracle.solve()), rtol=1e-4, atol=1e-4)
+
+
+def test_parametric_times_temporal_value_refuses_loudly():
+    """`u(top) - g*tau`: the parametric branch would un-ramp the load, the temporal branch would
+    un-train the parameter — both silently wrong, so the combination must refuse at build."""
+    d = jno.Shape.rect(0, 0, 0.5, 1, size=0.3).domain(tau=(0.0, 1.0, 4))
+    u, v = d.fem_symbols(value_shape=(2,))
+    inner, grad = jno.np.inner, jno.np.grad
+    xi, yi, _ = d.variable("interior", split=True)
+    ct = d.variable("top", where=lambda x, y: y > 1 - 1e-9, split=True)
+    cb = d.variable("bottom", where=lambda x, y: y < 1e-9, split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    g = _param("g", 0.01)
+    with pytest.raises(NotImplementedError, match="BOTH runtime-parametric"):
+        jno.fem([inner(gu, gv, n_contract=2), u(*ct[:2])[1] - g * ct[-1], u(*cb[:2])[0] - 0.0, u(*cb[:2])[1] - 0.0])
+
+
+def test_field_sized_optimizerless_parameter_is_still_a_data_field():
+    """The nodal data-field branch (a neighbour's field in a DD solve) must be untouched: a
+    FIELD-sized optimizer-less parameter gathers per node, concretely, exactly as before."""
+    import equinox as eqx
+    import jax.numpy as jnp
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    n = int(np.asarray(d.mesh.points).shape[0])
+    vals = np.linspace(0.0, 1.0, n)
+    gfield = jno.np.parameter((n,), name="gfield")
+    gfield.model.module = eqx.tree_at(lambda m: m.value, gfield.model.module, jnp.asarray(vals))
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - gfield])
+    assert np.all(np.isfinite(np.asarray(fem.b)))

--- a/tests/test_fem_fieldsplit.py
+++ b/tests/test_fem_fieldsplit.py
@@ -1,0 +1,214 @@
+"""Fieldsplit completion — the three gaps that stalled the rigid-plastic rolling model.
+
+That project needed (1) a Schur-complement approximation whose weight depends on the SOLUTION
+(``(1/mu(u))``-weighted pressure mass), (2) a real (sparse) AMG on a velocity sub-block, and (3) any
+visibility into what the solver did. ``precond.form`` assembled once and was parameter-independent,
+``ctx.sub`` handed sub-blocks back dense-or-matvec, and nothing reported anything.
+
+Now: ``form(<callable>)`` re-assembles from the outer iterate (the Picard-lagged preconditioner —
+Elman, Silvester & Wathen, *Finite Elements and Fast Iterative Solvers*, 2nd ed., §9.2), diagonal
+sub-blocks come back as assembled BCOO, and ``fem.stats`` reports the drivers' outcome.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import jno
+
+
+def _nonlinear_diffusion(size=0.2):
+    """-div((1+u^2) grad u) = f — the smallest problem with a genuinely solution-dependent operator."""
+    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    u, v = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    fem = jno.fem([(1.0 + ui * ui) * (ui.x * vi.x + ui.y * vi.y) - 5.0 * vi, u(xb, yb) - 0.0])
+    return fem, ui, vi
+
+
+def _stokes(mesh_size=0.3):
+    """Taylor-Hood Poiseuille channel — the saddle system block preconditioners exist for."""
+    pytest.importorskip("shapely", reason="shapely required for the box domain")
+    from shapely.geometry import box
+
+    inner_, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+    G, mu, H, Lx = 1.0, 1.0, 1.0, 4.0
+    u_profile = lambda y: (G / (2 * mu)) * y * (H - y)
+    d = jno.domain(box(0.0, 0.0, Lx, H), mesh_size=mesh_size)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
+    p, q = d.fem_symbols(names=("p", "q"), order=1)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    pp, qq = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+    fem = jno.fem(
+        [
+            mu * inner_(gu, gv, n_contract=2) - pp * trace(gv),
+            -qq * trace(gu),
+            u(xb, yb)[0] - u_profile(yb),
+            u(xb, yb)[1] - 0.0,
+            p.pin(),
+        ]
+    )
+    return fem, u, p, pp, qq, mu
+
+
+# --------------------------------------------------------------------------------------
+# solution-dependent precond.form — the Picard-lagged Schur weight
+# --------------------------------------------------------------------------------------
+def test_solution_dependent_form_solves_and_matches():
+    """The pikimam spelling: a form whose coefficient is computed FROM the solution. It refreshes
+    from the outer iterate and the preconditioned solve must land on the plain solve's answer —
+    a preconditioner changes speed, never the solution."""
+    fem, ui, vi = _nonlinear_diffusion()
+    ref = fem.solve(nonlinear=jno.solve.newton(direct=True, rtol=1e-6, atol=1e-6), linear=jno.solve.lu(backend="host"))
+
+    M = jno.precond.form(
+        lambda sol: [(1.0 + float(np.mean(np.asarray(sol) ** 2))) * ui * vi],
+        inner=jno.solve.lu(backend="host"),
+    )
+    got = fem.solve(nonlinear=jno.solve.newton(rtol=1e-6, atol=1e-6), linear=jno.solve.fgmres(tol=1e-8), precond=M)
+    np.testing.assert_allclose(np.asarray(got), np.asarray(ref), rtol=1e-3, atol=1e-4)
+    assert M.terms is not None, "the callable form was never refreshed from the iterate"
+
+
+def test_solution_dependent_form_refreshes_per_solve():
+    """Two solves = two refreshes, each from that solve's entry iterate (the lag is per OUTER solve)."""
+    fem, ui, vi = _nonlinear_diffusion()
+    seen = []
+
+    def terms_fn(sol):
+        seen.append(float(np.linalg.norm(sol)))
+        return [(1.0 + float(np.mean(sol**2))) * ui * vi]
+
+    M = jno.precond.form(terms_fn, inner=jno.solve.lu(backend="host"))
+    kw = dict(nonlinear=jno.solve.newton(rtol=1e-6, atol=1e-6), linear=jno.solve.fgmres(tol=1e-8), precond=M)
+    s1 = fem.solve(**kw)
+    fem.solve(x0=s1, **kw)
+    assert len(seen) == 2, f"expected one refresh per solve, saw {len(seen)}"
+    assert seen[0] != seen[1], "the second refresh should see the first solve's answer as its iterate"
+
+
+def test_solution_dependent_form_never_assembled_raises_loudly():
+    """No concrete iterate -> the spec must refuse at materialization, naming the path — not
+    silently precondition with garbage."""
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext
+
+    fem, ui, vi = _nonlinear_diffusion()
+    M = jno.precond.form(lambda sol: [ui * vi])
+    with pytest.raises(NotImplementedError, match="never assembled"):
+        M.materialize(PrecondContext(LinearOperator.from_matvec(lambda v: v, shape=(4, 4)), fem))
+
+
+def test_static_form_is_unchanged():
+    """The list form keeps its one-time parameter-independent assembly — no behavior change."""
+    fem, ui, vi = _nonlinear_diffusion()
+    M = jno.precond.form([ui * vi], inner=jno.solve.lu(backend="host"))
+    ref = fem.solve(nonlinear=jno.solve.newton(direct=True, rtol=1e-6, atol=1e-6), linear=jno.solve.lu(backend="host"))
+    got = fem.solve(nonlinear=jno.solve.newton(rtol=1e-6, atol=1e-6), linear=jno.solve.fgmres(tol=1e-8), precond=M)
+    np.testing.assert_allclose(np.asarray(got), np.asarray(ref), rtol=1e-3, atol=1e-4)
+
+
+# --------------------------------------------------------------------------------------
+# sparse sub-blocks — AMG on the velocity block of a saddle system
+# --------------------------------------------------------------------------------------
+def test_diagonal_sub_block_is_assembled_sparse():
+    """`ctx.sub(i, i)` must hand back an assembled sub-operator (`.bcoo` or dense), not a
+    matvec-only view — that is what lets `inner(lu)` / `amg` run on a velocity block at all."""
+    from jno.utils.solver.solver_api import PrecondContext
+
+    fem, u, p, *_ = _stokes()
+    _ = np.asarray(fem.b)
+    from jno.utils.solver.solver_api import LinearOperator
+
+    ctx = PrecondContext(LinearOperator(fem.A), fem)
+    sub = ctx.sub(fem.block_index(u))
+    assert sub.bcoo is not None or sub.dense() is not None
+    nu = fem.blocks[fem.block_index(u)]
+    assert sub.shape == (nu.stop - nu.start, nu.stop - nu.start)
+    # and it is the REAL block: its diagonal equals the parent's slice
+    np.testing.assert_allclose(np.asarray(sub.diag()), np.asarray(LinearOperator(fem.A).diag()[nu]), rtol=1e-6, atol=1e-7)
+
+
+def test_stokes_triangular_with_amg_velocity_block():
+    """The full pikimam-shaped recipe on a saddle system: triangular fieldsplit, multigrid on the
+    velocity sub-block, weighted pressure mass as the Schur approximation."""
+    pytest.importorskip("pyamg", reason="pyamg required for the hybrid AMG spec")
+    fem, u, p, pp, qq, mu = _stokes()
+    # The DEFAULT (Jacobi-BiCGStab) is exactly what fails on an indefinite saddle -- that is why
+    # fieldsplit exists. The oracle is a direct solve.
+    ref = fem.solve(linear=jno.solve.lu(backend="host"))
+
+    tri = jno.precond.triangular(
+        (u, jno.precond.amg()),
+        (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.lu(backend="host"))),
+    )
+    got = fem.solve(linear=jno.solve.fgmres(tol=1e-9), precond=tri)
+    # float32 Krylov floor: measured rel err 6.3e-4 against the direct solve at these settings.
+    err = np.linalg.norm(np.asarray(got) - np.asarray(ref)) / np.linalg.norm(np.asarray(ref))
+    assert err < 5e-3, f"fieldsplit solve drifted from the direct oracle: rel err {err:.2e}"
+    assert fem.stats is not None and "triangular" in str(fem.stats["precond"])
+
+
+# --------------------------------------------------------------------------------------
+# fem.stats — observability
+# --------------------------------------------------------------------------------------
+def test_stats_reports_the_newton_outcome():
+    fem, *_ = _nonlinear_diffusion()
+    fem.solve(nonlinear=jno.solve.newton(direct=True, rtol=1e-6, atol=1e-6), linear=jno.solve.lu(backend="host"))
+    st = fem.stats
+    assert st["mode"] == "nonlinear" and st["dofs"] > 0
+    nl = st["nonlinear"]
+    assert nl["driver"] == "newton_direct" and nl["converged"] and nl["steps"] >= 1
+    assert nl["residual"] <= nl["bound"]
+
+
+def test_stats_none_before_any_solve():
+    fem, *_ = _nonlinear_diffusion()
+    assert fem.stats is None
+
+
+def test_stats_records_the_slots():
+    fem, u, p, pp, qq, mu = _stokes(mesh_size=0.4)
+    fem.solve(
+        linear=jno.solve.fgmres(tol=1e-9),
+        precond=jno.precond.block_diag(
+            (u, jno.precond.inner(jno.solve.cg(tol=1e-4))),
+            (p, jno.precond.form([(1.0 / mu) * pp * qq], inner=jno.solve.lu(backend="host"))),
+        ),
+    )
+    st = fem.stats
+    assert "fgmres" in st["linear"] and "block_diag" in st["precond"]
+
+
+# --------------------------------------------------------------------------------------
+# refresh cadence on cached specs
+# --------------------------------------------------------------------------------------
+def test_cached_refresh_int_rebuilds_on_cadence():
+    """`cached(spec, refresh=k)`: reuse within the window, rebuild on the k-th materialization."""
+    import jax.numpy as jnp
+
+    from jno.precond import PrecondContext, cached, jacobi
+    from jno.utils.solver.solver_api import LinearOperator
+
+    op = LinearOperator.from_matvec(lambda v: v, diag_fn=lambda: jnp.ones(4), shape=(4, 4))
+    ctx = PrecondContext(op)
+    c = cached(jacobi(), refresh=2)
+    a1, a2, a3, a4, a5 = (c.materialize(ctx) for _ in range(5))
+    assert a1 is a2, "within the k-window the applier must be reused"
+    assert a3 is not a2, "the k-th materialization must rebuild"
+    assert a3 is a4 and a5 is not a4
+
+
+def test_cached_refresh_rejects_nonsense():
+    from jno.precond import cached, jacobi
+
+    c = cached(jacobi(), refresh="often")
+    from jno.precond import PrecondContext
+    from jno.utils.solver.solver_api import LinearOperator
+
+    with pytest.raises(TypeError, match="expected bool, int, or callable"):
+        c.materialize(PrecondContext(LinearOperator.from_matvec(lambda v: v, shape=(2, 2))))

--- a/tests/test_fem_rebuild_cache.py
+++ b/tests/test_fem_rebuild_cache.py
@@ -1,0 +1,150 @@
+"""Rebuilding an identical problem must not recompile — the content-keyed twin of the elem_map cache.
+
+``elem_map``'s jit cache keys the baked closure leaves by object identity, so a REBUILD (fresh mesh
+arrays, fresh closures, identical content) missed every entry and paid trace + XLA compile again:
+measured 1.25 s of a 1.56 s warm rebuild on 3-D Poisson. The content-keyed fallback
+(`_fn_content_key`) makes the rebuild reuse the compiled programs; these tests pin the three
+properties that make that safe:
+
+1. an identical rebuild HITS (and its results are identical),
+2. anything that changes the operator MISSES (a different mesh, a different coefficient),
+3. the keying never lies: a hit's solution equals the from-scratch solution bit-for-bit in structure
+   and to float tolerance in values.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import jno
+from jno.utils.solver.fem_utils import _ELEM_MAP_STATS
+
+
+def _snap():
+    return dict(_ELEM_MAP_STATS, content_bail=dict(_ELEM_MAP_STATS["content_bail"]))
+
+
+def _delta(before):
+    return {
+        "content_hits": _ELEM_MAP_STATS["content_hits"] - before["content_hits"],
+        "misses": _ELEM_MAP_STATS["misses"] - before["misses"],
+        "id_hits": _ELEM_MAP_STATS["id_hits"] - before["id_hits"],
+    }
+
+
+def _poisson2d(size=0.28, k=1.0, f=1.0):
+    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    u, v = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    fem = jno.fem([k * (ui.x * vi.x + ui.y * vi.y) - f * vi, u(xb, yb) - 0.0])
+    _ = np.asarray(fem.b)  # force assembly
+    return fem
+
+
+def test_identical_rebuild_hits_and_matches():
+    """THE property: same problem, fresh objects -> compiled programs reused, results identical."""
+    fem1 = _poisson2d()
+    before = _snap()
+    fem2 = _poisson2d()
+    d = _delta(before)
+    assert d["content_hits"] > 0, f"identical rebuild produced no content hits: {d}"
+    assert d["misses"] == 0, f"identical rebuild recompiled {d['misses']} kernels: {d}"
+    np.testing.assert_allclose(np.asarray(fem1.b), np.asarray(fem2.b), rtol=1e-6, atol=1e-7)
+    np.testing.assert_allclose(np.asarray(fem1.solve()), np.asarray(fem2.solve()), rtol=1e-5, atol=1e-6)
+
+
+def test_a_different_mesh_misses():
+    """Staleness guard: geometry is baked into the kernels, so a different mesh must recompile —
+    shape-keying would silently hand one mesh's coordinates to another."""
+    _poisson2d(size=0.28)
+    before = _snap()
+    _poisson2d(size=0.22)  # different mesh -> different baked arrays
+    d = _delta(before)
+    assert d["misses"] > 0, f"a DIFFERENT mesh reused compiled kernels: {d}"
+
+
+def test_a_different_coefficient_misses_and_differs():
+    """A changed material must both recompile the kernels that bake it and change the answer."""
+    fem1 = _poisson2d(k=1.0)
+    before = _snap()
+    fem3 = _poisson2d(k=7.0)
+    d = _delta(before)
+    assert d["misses"] > 0, f"a different coefficient reused every kernel: {d}"
+    assert not np.allclose(np.asarray(fem1.solve()), np.asarray(fem3.solve()), atol=1e-6)
+
+
+def test_zero_and_negative_coefficients_key_distinctly():
+    """Extremes: 0.0 and -1.0 are distinct problems, not cache aliases of 1.0."""
+    sols = {}
+    for k in (1.0, -1.0):
+        sols[k] = np.asarray(_poisson2d(k=k, f=1.0).solve())
+    assert not np.allclose(sols[1.0], sols[-1.0], atol=1e-6)
+
+
+def test_3d_rebuild_hits():
+    def build():
+        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.35).domain()
+        u, v = d.fem_symbols()
+        xi, yi, zi, _ = d.variable("interior", split=True)
+        xb, yb, zb, _ = d.variable("boundary", split=True)
+        ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+        fem = jno.fem([ui.x * vi.x + ui.y * vi.y + ui.z * vi.z - 1.0 * vi, u(xb, yb, zb) - 0.0])
+        _ = np.asarray(fem.b)
+        return fem
+
+    f1 = build()
+    before = _snap()
+    f2 = build()
+    d = _delta(before)
+    assert d["misses"] == 0 and d["content_hits"] > 0, f"3-D rebuild recompiled: {d}"
+    np.testing.assert_allclose(np.asarray(f1.solve()), np.asarray(f2.solve()), rtol=1e-5, atol=1e-6)
+
+
+def test_parametric_rebuild_hits_and_solves_per_args():
+    """A runtime parameter in the terms: the rebuild reuses kernels, and args still steer the solve
+    (the compiled program must not have frozen the parameter's value)."""
+    import jax
+
+    def build():
+        d = jno.Shape.rect(0, 0, 1, 1, size=0.28).domain()
+        u, v = d.fem_symbols()
+        xi, yi, _ = d.variable("interior", split=True)
+        xb, yb, _ = d.variable("boundary", split=True)
+        ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+        k = jno.np.parameter((1,), name="kk", key=jax.random.PRNGKey(0))
+        k.initialize(jax.nn.initializers.constant(1.0))
+        fem = jno.fem([k * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - 0.0])
+        return fem
+
+    f1 = build()
+    A1, b1v = f1.operator.evaluate({"kk": np.asarray([1.0])})
+    a = np.linalg.solve(np.asarray(A1.todense() if hasattr(A1, "todense") else A1), np.asarray(b1v))
+    before = _snap()
+    f2 = build()
+    A2, b2v = f2.operator.evaluate({"kk": np.asarray([1.0])})
+    b1 = np.linalg.solve(np.asarray(A2.todense() if hasattr(A2, "todense") else A2), np.asarray(b2v))
+    A3, b3v = f2.operator.evaluate({"kk": np.asarray([4.0])})
+    b2 = np.linalg.solve(np.asarray(A3.todense() if hasattr(A3, "todense") else A3), np.asarray(b3v))
+    d = _delta(before)
+    np.testing.assert_allclose(a, b1, rtol=1e-5, atol=1e-6)
+    assert not np.allclose(b1, b2, atol=1e-6), "args stopped steering the operator after a cache hit"
+    assert d["misses"] == 0 or d["content_hits"] > 0, f"parametric rebuild shared nothing: {d}"
+
+
+def test_bail_is_observable_not_silent():
+    """The tokenizer's coverage is MEASURED: whatever it cannot key lands in the bail tally, so a
+    problem class that never caches is a visible number, not a mystery slowdown."""
+    assert isinstance(_ELEM_MAP_STATS["content_bail"], dict)
+
+
+def test_compile_cache_is_on_by_default_with_optouts():
+    import jax
+
+    # import jno already ran _auto_compile_cache in this process
+    assert jax.config.jax_compilation_cache_dir, "persistent compile cache should be ON by default"
+    jno.disable_compile_cache()
+    assert jax.config.jax_compilation_cache_dir is None
+    jno.enable_compile_cache()  # restore for the rest of the session

--- a/tests/test_fem_rebuild_cache.py
+++ b/tests/test_fem_rebuild_cache.py
@@ -134,6 +134,45 @@ def test_parametric_rebuild_hits_and_solves_per_args():
     assert d["misses"] == 0 or d["content_hits"] > 0, f"parametric rebuild shared nothing: {d}"
 
 
+def test_multifield_rebuild_hits():
+    """Taylor-Hood Stokes with a pressure pin — the case that exposed two per-build counters leaking
+    into content keys (`field_key` dict keys, and `p.pin()`'s counter-suffixed tag name). A
+    PolygonDomain (shapely-built) also exercises the domain-token MRO walk."""
+    pytest.importorskip("shapely", reason="shapely required for the box domain")
+    from shapely.geometry import box
+
+    def build():
+        inner_, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+        d = jno.domain(box(0.0, 0.0, 4.0, 1.0), mesh_size=0.35)
+        u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
+        p, q = d.fem_symbols(names=("p", "q"), order=1)
+        xi, yi, _ = d.variable("interior", split=True)
+        xb, yb, _ = d.variable("boundary", split=True)
+        gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+        pp, qq = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+        fem = jno.fem(
+            [
+                1.0 * inner_(gu, gv, n_contract=2) - pp * trace(gv),
+                -qq * trace(gu),
+                u(xb, yb)[0] - yb * (1 - yb),
+                u(xb, yb)[1] - 0.0,
+                p.pin(),
+            ]
+        )
+        _ = np.asarray(fem.b)
+        return fem
+
+    f1 = build()
+    before = _snap()
+    f2 = build()
+    d = _delta(before)
+    assert d["misses"] == 0 and d["content_hits"] > 0, f"multifield rebuild recompiled: {d}"
+    s1 = np.asarray(f1.solve(linear=jno.solve.lu(backend="host")))
+    s2 = np.asarray(f2.solve(linear=jno.solve.lu(backend="host")))
+    # float32 direct solve on a saddle: independent builds measured ~1e-5 apart even pre-cache.
+    assert np.linalg.norm(s1 - s2) / np.linalg.norm(s1) < 1e-3
+
+
 def test_bail_is_observable_not_silent():
     """The tokenizer's coverage is MEASURED: whatever it cannot key lands in the bail tally, so a
     problem class that never caches is a visible number, not a mystery slowdown."""


### PR DESCRIPTION
## What

The Tier-1 and Tier-2 competitiveness work, consolidated into one PR after #105's squash-merge (the stack was rebased onto the squashed main — every commit here is content-identical to the suite-verified originals, and #107's content is included since it was merged into this branch). 11 commits.

### Zero-recompile rebuild (the P0)
Warm rebuild of an identical problem was 1.94 s vs JAX-FEM's 0.022 s — 8 XLA recompiles because `elem_map`'s jit cache keyed baked closure leaves by object identity. A content-keyed twin behind the untouched id fast path fixes it: arrays by blake2b digest, nested functions recursively, expression trees by a strict allow-list walker, the domain by a mesh-content token; per-build counters alpha-renumbered at semantically identified sites. Untokenizable structure bails to a safe miss, tallied. **Measured** (fair_bench, 29,353 nodes): cold build 4.24 → 1.97 s (persistent XLA cache now ON by default, opt-outs kept), warm rebuild 1.94 → 0.93 s with the XLA share at zero, repeat solve unchanged at 7 ms. Includes the donated-buffer liveness fix the pre-push suite caught (a shared kernel could hold a deleted array after a training loop's donation).

### AMG maturity
`jaxamg(symmetric=False)` transpose hierarchy for adjoint solves; `.cached(refresh=k)` cadence; measured front-door guidance in `docs/fem.md` + `benchmarks/amg_scaling.py`: iterations Jacobi 52→100 (~√n) vs V-cycle flat 10–16; `jaxamg.solve`'s default already warm-resetups (0.024 vs 0.212 s); its `reuse_setup=True` is measured wrong across value changes and deliberately not exposed; AmgX-as-M carries ~11 ms/application overhead.

### Fieldsplit completion
`precond.form(<callable>)` — a solution-dependent Schur weight, re-assembled per outer solve from the entry iterate (Picard-lagged, ESW §9.2; loud refusal in traced contexts). `fem.stats` observability. Acceptance: Taylor–Hood Stokes with triangular fieldsplit + AMG on the sparse velocity sub-block + weighted pressure mass at rel err 6.3e-4 where the default Jacobi-BiCGStab NaNs.

### Runtime Dirichlet parameters
A trainable parameter in an essential value (previously: crash without an optimizer, silent freeze with one). Crux recovers boundary values on steady linear (0.00%, gradient FD-checked), steady nonlinear (<1%), and a 26-step transient march (0.01%, adjoint through every step). Spatial profiles and operator+value shared parameters work; parametric×temporal values refuse loudly (#103).

### One-sided (Signorini) contact
The recorded "max(0,·) kink stalls Newton" re-measured: a float32 residual floor, not active-set cycling (x64 converges superlinearly to 4e-10). Press → bonded oracle like 1/c; release → exact separation; **AL exactness** via a surface state + τ march (err 1.1e-5 vs penalty 3.4e-3 at the same c); `jax.grad` through closed contact FD-checks against a parametric-Dirichlet grip. The **assembled tangent now carries the gap's nonlocal blocks** — `newton(direct=True)` + LU/cuDSS works with contact, gated by assembled-J ≡ matrix-free-JVP agreement in both branches.

## Related issues
Found and filed during this work: #99, #100, #101, #102, #103, #104 — none are regressions of this PR.

## Verification
Full per-file suite (206 files) green except `test_symbol_positional_time::test_third_positional_coord_still_binds_z_in_3d`, which fails identically on `origin/main` and predates all of this. The rebase onto the squashed #105 is content-identical to the verified heads (`git diff old new` empty on both tiers).