### PR TITLE
One-sided contact + runtime Dirichlet parameters, fully differentiable

### DIFF
--- a/docs/fem.md
+++ b/docs/fem.md
@@ -424,17 +424,40 @@ For a bonded (tied) interface use the two-sided penalty `p = -c*g` instead of th
 and stiffening `c` converges to the tie: two bonded unit blocks squeezed by 0.02 reproduce the single-bar
 answer `uy(y=1) = -0.01` to 1.5e-05 at `c = 1e6`.
 
+**One-sided (separating, Signorini) contact works** with the `max(0, -c*g)` spelling above, and the
+earlier "the kink stalls Newton" note was re-measured and re-classified: the stall was a **float32
+residual floor** (~2e-5 on the reference stack), not active-set cycling — `jax.linearize` through
+`max` selects the active branch, which *is* the semismooth Jacobian, and under x64 the identical
+iteration meets `rtol=1e-8` at residual 4e-10, superlinearly. Practical guidance: set tolerances the
+precision can reach (`newton(line_search=True, rtol=1e-6, atol=1e-6)` in float32; anything tighter
+wants x64), press converges to the bonded answer like `1/c`, and release separates exactly — no
+adhesion, measured `max|u| < 1e-9` on the far body.
+
+To remove the penalty's `O(1/c)` penetration error, add the **augmented-Lagrangian** multiplier — a
+scalar *surface state* on the secondary face riding the existing `evolves` + `tau=` march machinery,
+no new API:
+
+```python
+lam, _ = d.fem_symbols(value_shape=())            # the multiplier, per face quadrature point
+p = jno.np.maximum(0.0, lam.i(-1) + c*(-g))       # AL pressure
+fem = jno.fem([..., p * inner(n, phi_s, 1), lam.evolves(p), *bcs])   # tau march = Uzawa updates
+```
+
+Measured on the reference stack at the *same* `c = 1e3`: penalty error 3.4e-3, AL error **1.1e-5**
+after 8 updates, falling monotonically. Differentiable through *closed* contact: `jax.grad` of a
+response w.r.t. a load or (parametric-Dirichlet) grip displacement runs through the driver's
+`custom_root` on the branch-selected operator and FD-checks; at contact *onset* the derivative is a
+subgradient (the `max` kink).
+
 > **Scope.** Small sliding — the pairing is frozen at build time, so a configuration that slides must be
 > rebuilt per load step. Differentiable in the DOF values but **not** in the mesh coordinates (the
 > projection weights are host-computed). Frictionless: no tangential traction, so a body held *only* by
 > contact is free to slide and its system is singular — constrain the tangential direction independently.
-> The gap is non-local (it reads DOFs on the other body's cells), so the tangent is matrix-free;
-> `newton(direct=True)` is refused. **One-sided contact does not yet converge to tight tolerances**: the
-> `max(0, ·)` kink is non-smooth and the residual stalls around 1e-2 with a line search, against a 1e-8
-> target. The bonded two-sided path is smooth and converges. Signorini contact is the same kind of
-> object as [`u.bounds(lo, hi)`](#inequalities--uboundslo-hi) — a complementarity condition rather than
-> a penalty — so that machinery is the natural route for it, but the reformulation has **not** been
-> done and the penalty path above is what exists today.
+> The **assembled tangent now carries the gap's nonlocal blocks** — `(s,m)` from `jacfwd` w.r.t. the
+> gathered main values chained through the frozen mortar weights, plus the reaction rows' `(m,s)` and
+> `(m,m)` — verified against the matrix-free JVP on random probes in both the active and separated
+> branches, so `newton(direct=True)` + `lu`/cuDSS works with contact (the pattern is static; inactive
+> contact contributes zeros in the data, which keeps the sparsity-keyed factorization caches valid).
 
 ---
 

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -2135,8 +2135,14 @@ unaffected. Full detail is inline in the sections above.
 - **Reduced-order (`basis=`) solves** cover steady and **first-order transient** (linear and
   nonlinear). Second-order-in-time (`u_tt`), complex, and periodic-tied problems refuse, each with its
   own reason. Nonlinear reduces, but without hyper-reduction that is a memory win, not a speed one.
-- **No runtime Dirichlet parameters** — a trainable parameter may sit in the operator (stiffness) but
-  not in an essential/Dirichlet boundary *value*.
+- **Runtime Dirichlet parameters** work on the steady linear, steady nonlinear, and linear transient
+  paths: a trainable `jno.np.parameter` may sit in an essential value (`u(top) - g`, or scaling a
+  coordinate profile `u(top) - g*sin(pi*x)`), and the boundary value is recovered from data like any
+  other parameter — `∂b/∂g` flows through the symmetric elimination (linear), and `∂/∂g` through the
+  solve's / each step's `custom_root` (nonlinear / transient). NOT supported, refused loudly: a value
+  that is **both** parametric and t/τ-dependent (`u(top) - g*tau` — train the amplitude through a
+  Neumann/body term instead). A FIELD-sized optimizer-less parameter stays the nodal data-field value
+  (a neighbour's field in a DD solve), gathered per node.
 - **Affine parameter lowering expects a single, direct factor** — one trainable scalar per additive
   term (`nu * grad(u)·grad(phi)`), not nested or buried in a nonlinear expression.
 - **Enclosure radiation is a composition, not an auto-detected term** — it is 2D / axisymmetric and

--- a/docs/inverse-problems.md
+++ b/docs/inverse-problems.md
@@ -218,3 +218,27 @@ rel_l2_u = float(jnp.linalg.norm(_u - _u_obs) / (jnp.linalg.norm(_u_obs) + 1e-8)
 print(f"u  rel-L2 error : {rel_l2_u:.3e}")           # should be < 10 %
 print(f"k  min / mean   : {_k.min():.3f} / {_k.mean():.3f}")  # k > 0 from exp; mean ≈ 1.0
 ```
+
+## Recovering a boundary value — runtime Dirichlet parameters
+
+An essential (Dirichlet) boundary *value* can itself be the unknown: a grip displacement, an inlet
+temperature, a prescribed potential you only observe indirectly. Put a `jno.np.parameter` in the
+essential term and train it like any other parameter — the held boundary value stays a traced JAX
+scalar, so the gradient flows through the symmetric elimination (steady linear) or the solve's
+`custom_root` (nonlinear, and each step of a linear transient march):
+
+```python
+g = jno.np.parameter((1,), name="g")
+g.initialize(jax.nn.initializers.constant(1.0))
+
+fem  = jno.fem([ui.x*vi.x + ui.y*vi.y - f*vi, u(xb, yb) - g])   # g is the unknown boundary value
+crux = jno.core([(fem.solve() - u_obs).mse])                     # u_obs generated at g* = 2.5
+g.optimizer(optax.adam(1e-1))
+crux.solve(300)                                                  # recovers g = 2.5 exactly
+```
+
+The parameter may scale a spatial profile (`u(xb, yb) - g*jno.np.sin(jno.np.pi*xb)`) and may appear
+in the operator and the boundary value simultaneously. Scope and refusals: steady linear, steady
+nonlinear, and linear transient; a value that is both parametric **and** t/τ-dependent
+(`u(top) - g*tau`) refuses loudly — drive a trainable ramp through a Neumann/body term instead.
+See `tests/test_fem_dirichlet_parameters.py` for the recovery oracles on all three paths.

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -5321,7 +5321,19 @@ def _assemble_second_order_time(
     # Dirichlet from the native assembler (it stashes them): constant (dof, value) pairs → the held
     # value rides the affine bias; time-varying entries (dofs, g(x,t) node, coords) → the displacement
     # rows carry u[d]=g(x_d,t) and the velocity rows the compatible v[d]=ġ(x_d,t), written per step.
-    assemble_fem_native(domain, stiff_raw, boundary_terms, dirichlet_raw, [], vec=_vec_asm, quad_degree=quad_degree)
+    assemble_fem_native(
+        domain,
+        stiff_raw,
+        boundary_terms,
+        dirichlet_raw,
+        [],
+        vec=_vec_asm,
+        quad_degree=quad_degree,
+        # This block consumes the time-varying Dirichlet stash ITSELF (u[d]=g(x_d,t), v[d]=ġ per
+        # step, just below) -- without the flag the assembler's fail-loud fallthrough guard fires on
+        # this legitimate consumer.
+        tv_dirichlet_external=True,
+    )
     pairs = list(getattr(domain, "_fem_native_dirichlet_pairs", []) or [])
     rows = jnp.asarray([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
     g = jnp.asarray([p[1] for p in pairs], dtype=dtype) if pairs else jnp.zeros((0,), dtype=dtype)

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -1528,7 +1528,8 @@ def assemble_fem_native(
         Done GLOBALLY, outside the per-face vmap, because the main nodes live on the other body's
         cells -- they are not in the secondary face's parent-cell DOF slice. A plain weighted gather, so
         ``jax.linearize`` (the default JFNK path) picks up the main coupling in the tangent exactly,
-        with no assembled Jacobian block needed.
+        with no assembled Jacobian block needed. (The ASSEMBLED tangent builds its own explicit
+        nonlocal blocks from these same tables -- see the gap emission in `_make_jacobian`.)
         """
         tb = _gap_tables[key]
         fidx, vt = tb["field"], vecs[tb["field"]]
@@ -1917,30 +1918,6 @@ def assemble_fem_native(
 
         return residual
 
-    def _gap_refuses_assembled_tangent(bterms):
-        """A contact gap is NON-LOCAL: it reads DOFs on the main body's cells, not the secondary face's
-        parent cell. The assembled path builds each element block by ``jacfwd`` w.r.t. that element's
-        own DOFs and emits columns ``cell_all_dofs[pcells]``, so it would silently drop the whole
-        secondary-main coupling -- a tangent that looks fine and just makes Newton crawl.
-
-        Emitting a second block with main columns is possible (``_emit`` takes arbitrary indices) but
-        costs another element-matrix buffer for every surface term, and the DEFAULT path never needs
-        it: contact is nonlinear, so ``newton_krylov`` takes matrix-free JVPs through
-        ``jax.linearize`` of the residual, which picks up the main coupling exactly. So the block is
-        not built at all, and this path refuses rather than being quietly wrong.
-
-        Raised on USE, not on construction -- ``_make_jacobian`` is called unconditionally at build
-        time even for problems that will only ever take the matrix-free route.
-        """
-        if _gap_tables and bterms:
-            raise NotImplementedError(
-                "jno.fem: a contact gap (u.gap) needs the matrix-free tangent -- its dependence on the "
-                "main body's DOFs cannot be expressed in this assembled per-element Jacobian, and "
-                "silently dropping it would degrade Newton with no error. Contact is nonlinear, so the "
-                "default fem.solve() already takes the matrix-free path; drop "
-                "`nonlinear=jno.solve.newton(direct=True)` if you set it."
-            )
-
     def _make_jacobian(terms, bterms=None):
         """Build the dense Jacobian ``J(u_flat) -> (total, total)`` by *per-element* forward-mode AD.
 
@@ -1962,6 +1939,66 @@ def assemble_fem_native(
         # static `nse` under jit, and inferring one requires concrete indices it does not have inside
         # the trace. This mirrors `fem_nonnodal._make_sparse_assembler`, which already hoists its
         # `_vol_idx` the same way. Order must match the append order in `jacobian` exactly.
+        def _gap_key_of(region):
+            """The (single) gap key whose SECONDARY face is this region, or ``None``."""
+            ks = [k for k in _gap_tables if _gap_tables[k]["secondary"] == region]
+            return ks[0] if ks else None
+
+        _gap_static_cache: Dict[Any, Any] = {}
+
+        def _gap_static(region, face_ids, btfi):
+            """Concrete index/weight geometry of a region's gap blocks — computed ONCE from the frozen
+            pairing tables and shared by the pattern hoist and the traced assembly, so the two cannot
+            drift. The three nonlocal blocks, flat index arrays in emission order:
+
+            * ``(s,m)``: secondary test rows x main columns (one column per (q, mortar-node, comp));
+            * ``(m,s)``: reaction rows (main dofs, one per (q, mortar-node, comp)) x parent-local cols;
+            * ``(m,m)``: reaction rows x main columns.
+            """
+            k = _gap_key_of(region)
+            cache_key = (region, int(btfi))
+            hit = _gap_static_cache.get(cache_key)
+            if hit is not None:
+                return hit
+            tb = _gap_tables[k]
+            fidx_m, vt = tb["field"], vecs[tb["field"]]
+            fids_np = np.asarray(face_ids, dtype=np.int64)
+            ids_f = np.asarray(tb["ids_full"])[fids_np]  # (n_face, n_q, K)
+            w_f = jnp.asarray(np.asarray(tb["w_full"])[fids_np])  # (n_face, n_q, K)
+            n_face, n_q, K = ids_f.shape
+            pc = np.asarray(parent_j)[fids_np]
+            rows_test = np.asarray(cdofs[btfi])[pc]  # (n_face, n_test)
+            n_test = rows_test.shape[1]
+            dof_m = (np.asarray(offs[fidx_m]) + ids_f[..., None] * vt + np.arange(vt)).astype(np.int64)
+            nqKv = n_q * K * vt
+            dof_m_flat = dof_m.reshape(n_face, nqKv)
+            cols_parent = np.asarray(cell_all_dofs)[pc]  # (n_face, n_local_all)
+            n_local = cols_parent.shape[1]
+            sh_sm = (n_face, n_test, n_q, K, vt)
+            rows_sm = np.broadcast_to(rows_test[:, :, None, None, None], sh_sm).reshape(-1)
+            cols_sm = np.broadcast_to(dof_m[:, None, :, :, :], sh_sm).reshape(-1)
+            sh_ms = (n_face, nqKv, n_local)
+            rows_ms = np.broadcast_to(dof_m_flat[:, :, None], sh_ms).reshape(-1)
+            cols_ms = np.broadcast_to(cols_parent[:, None, :], sh_ms).reshape(-1)
+            sh_mm = (n_face, nqKv, nqKv)
+            rows_mm = np.broadcast_to(dof_m_flat[:, :, None], sh_mm).reshape(-1)
+            cols_mm = np.broadcast_to(dof_m_flat[:, None, :], sh_mm).reshape(-1)
+            out = {
+                "rows_sm": jnp.asarray(rows_sm, dtype=jnp.int32),
+                "cols_sm": jnp.asarray(cols_sm, dtype=jnp.int32),
+                "rows_ms": jnp.asarray(rows_ms, dtype=jnp.int32),
+                "cols_ms": jnp.asarray(cols_ms, dtype=jnp.int32),
+                "rows_mm": jnp.asarray(rows_mm, dtype=jnp.int32),
+                "cols_mm": jnp.asarray(cols_mm, dtype=jnp.int32),
+                "w_f": w_f,
+                "n_q": n_q,
+                "K": K,
+                "vt": vt,
+                "key": k,
+            }
+            _gap_static_cache[cache_key] = out
+            return out
+
         _idx_rows, _idx_cols = [], []
         for _coeff_s, _tfi_s, _rn_s in typed_with_masks:
             _sh = (n_cells, int(cdofs[_tfi_s].shape[1]), int(cell_all_dofs.shape[1]))
@@ -1974,6 +2011,19 @@ def assemble_fem_native(
                 _sh = (int(_pc.shape[0]), int(cdofs[_btfi_s].shape[1]), int(cell_all_dofs.shape[1]))
                 _idx_rows.append(jnp.broadcast_to(cdofs[_btfi_s][_pc][:, :, None], _sh).reshape(-1))
                 _idx_cols.append(jnp.broadcast_to(_fcols[:, None, :], _sh).reshape(-1))
+                # The gap's nonlocal blocks, in the SAME append order the traced assembly emits
+                # them: (s,m) always when the region carries a gap; (m,s) and (m,m) when this term
+                # also drives the main-side reaction. The indices come from the frozen pairing
+                # tables, so the pattern stays static; inactive contact contributes zeros in DATA.
+                if _gap_key_of(_region_s) is not None:
+                    _gs = _gap_static(_region_s, _face_ids_s, _btfi_s)
+                    _idx_rows.append(_gs["rows_sm"])
+                    _idx_cols.append(_gs["cols_sm"])
+                    if _gaps_in(_bcoeff_s, _region_s):
+                        _idx_rows.append(_gs["rows_ms"])
+                        _idx_cols.append(_gs["cols_ms"])
+                        _idx_rows.append(_gs["rows_mm"])
+                        _idx_cols.append(_gs["cols_mm"])
         _blk_sizes = [int(r.shape[0]) for r in _idx_rows]  # per-term flat lengths, in append order
         _idx_static = (
             jnp.stack([jnp.concatenate(_idx_rows).astype(jnp.int32), jnp.concatenate(_idx_cols).astype(jnp.int32)], axis=1)
@@ -1986,7 +2036,6 @@ def assemble_fem_native(
             _idx_static, _plan = None, None  # fall back to the uncompressed (still correct) path
 
         def jacobian(u_flat, t=0.0, args=None):
-            _gap_refuses_assembled_tangent(bterms)  # non-local gap -> matrix-free tangent only
             # Assemble into COO triplets and build a BCOO -- never materialises the dense (total, total)
             # matrix (O(nnz), GPU-able at large N). Each per-element block is element-sized; duplicate
             # (i, j) triplets from neighbouring cells are summed by BCOO on matvec / todense, so the
@@ -2034,21 +2083,34 @@ def assemble_fem_native(
                 )
 
             normals_dyn = _surface_normals(pts_dyn)  # differentiable facet normals under coordinate motion
+            # Main-side values for every contact gap -- the residual's own gather, reused so the
+            # assembled tangent linearizes the SAME function the residual evaluates.
+            gap_um_j = {k: _gap_gather(u_flat, k) for k in _gap_tables}
             for region, face_ids, btyped in surface_work:
                 fids = jnp.asarray(face_ids, dtype=jnp.int32)
                 pcells = parent_j[fids]
                 lv = u_flat[cell_all_dofs[pcells]]  # (n_face, n_local_all)
                 fcols = cell_all_dofs[pcells]  # (n_face, n_local_all)
+                gslice = _gap_slices(region, fids, gap_um_j)  # {key: (g0, u_m)} or None
                 for bcoeff, btfi in btyped:
 
-                    def _kef(fi, la, _e=bcoeff, _t=btfi, _r=region, _p=pts_dyn, _n=normals_dyn):
-                        return jax.jacfwd(lambda v: _surf_elem_res(fi, v, _e, _t, _r, t, args, _p, _n))(la)
+                    def _kef(fi, la, gp=None, _e=bcoeff, _t=btfi, _r=region, _p=pts_dyn, _n=normals_dyn):
+                        # gaps PACKED: the local block then carries d(traction)/du_s THROUGH the gap,
+                        # exactly as `jax.linearize` of the residual would.
+                        return jax.jacfwd(lambda v: _surf_elem_res(fi, v, _e, _t, _r, t, args, _p, _n, gp))(la)
 
-                    Kef = _elem_map(  # (n_face, n_test_btfi, n_local_all)
-                        _kef,
-                        (fids, lv),
-                        _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], cell_all_dofs.shape[1]),
-                    )
+                    if gslice:
+                        Kef = _elem_map(
+                            _kef,
+                            (fids, lv, gslice),
+                            _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], cell_all_dofs.shape[1]),
+                        )
+                    else:
+                        Kef = _elem_map(  # (n_face, n_test_btfi, n_local_all)
+                            _kef,
+                            (fids, lv),
+                            _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], cell_all_dofs.shape[1]),
+                        )
                     _emit(
                         Kef.reshape(-1),
                         lambda _K=Kef, _t=btfi, _p=pcells: jnp.broadcast_to(cdofs[_t][_p][:, :, None], _K.shape).reshape(
@@ -2056,6 +2118,68 @@ def assemble_fem_native(
                         ),
                         lambda _K=Kef, _f=fcols: jnp.broadcast_to(_f[:, None, :], _K.shape).reshape(-1),
                     )
+
+                    if gslice:
+                        # ---- the gap's NONLOCAL blocks (same append order as the pattern hoist) ----
+                        gs = _gap_static(region, face_ids, btfi)
+                        n_q, vt, gk = gs["n_q"], gs["vt"], gs["key"]
+                        w_f = gs["w_f"]
+                        g0_sl, um_sl = gslice[gk]
+
+                        # (s,m): jacfwd of the SAME face residual w.r.t. the gathered main values,
+                        # chained through the frozen mortar weights to global main columns.
+                        def _kem(fi, la, g0f, umf, _e=bcoeff, _t=btfi, _r=region, _p=pts_dyn, _n=normals_dyn, _k=gk):
+                            return jax.jacfwd(
+                                lambda um: _surf_elem_res(fi, la, _e, _t, _r, t, args, _p, _n, {_k: (g0f, um)})
+                            )(umf)
+
+                        Kem = _elem_map(  # (n_face, n_test, n_q, vt)
+                            _kem,
+                            (fids, lv, g0_sl, um_sl),
+                            _cell_chunk(int(fids.shape[0]), cdofs[btfi].shape[1], n_q * vt),
+                        )
+                        d_sm = jnp.einsum("frqv,fqk->frqkv", Kem.reshape(Kem.shape[0], Kem.shape[1], n_q, vt), w_f)
+                        _emit(d_sm.reshape(-1), lambda _g=gs: _g["rows_sm"], lambda _g=gs: _g["cols_sm"])
+
+                        if _gaps_in(bcoeff, region):
+                            # Reaction-row tangent: tau (the per-QP weighted traction via the identity
+                            # test-table substitution -- the residual's own trick) linearized w.r.t.
+                            # the parent-local dofs (m,s) and the gathered main values (m,m), scattered
+                            # through the same -w weights the residual's reaction uses.
+                            def _tau(fi, la, g0f, umf, _e=bcoeff, _t=btfi, _r=region, _k=gk):
+                                out = _surf_elem_res(
+                                    fi,
+                                    la,
+                                    _e,
+                                    _t,
+                                    _r,
+                                    t,
+                                    args,
+                                    pts_dyn,
+                                    normals_dyn,
+                                    {_k: (g0f, umf)},
+                                    test_vals=jnp.eye(n_q, dtype=lv.dtype),
+                                )
+                                return jnp.asarray(out).reshape(n_q, vt)
+
+                            n_local_all = int(cell_all_dofs.shape[1])
+                            Dls = _elem_map(
+                                lambda fi, la, g0f, umf: jax.jacfwd(lambda v: _tau(fi, v, g0f, umf))(la),
+                                (fids, lv, g0_sl, um_sl),
+                                _cell_chunk(int(fids.shape[0]), n_q * vt, n_local_all),
+                            )
+                            Dum = _elem_map(
+                                lambda fi, la, g0f, umf: jax.jacfwd(lambda um: _tau(fi, la, g0f, um))(umf),
+                                (fids, lv, g0_sl, um_sl),
+                                _cell_chunk(int(fids.shape[0]), n_q * vt, n_q * vt),
+                            )
+                            n_face = int(fids.shape[0])
+                            # (m,s): K[dof(f,q,K,v), parent_local] -= w[f,q,K] * dtau[f,q,v,local]
+                            d_ms = -jnp.einsum("fqk,fqvl->fqkvl", w_f, Dls.reshape(n_face, n_q, vt, n_local_all))
+                            _emit(d_ms.reshape(-1), lambda _g=gs: _g["rows_ms"], lambda _g=gs: _g["cols_ms"])
+                            # (m,m): K[dof(q,K,v), dof(q2,K2,v2)] -= w[f,q,K] dtau[q,v,q2,v2] w[f,q2,K2]
+                            d_mm = -jnp.einsum("fqk,fqvpw,fpl->fqkvplw", w_f, Dum.reshape(n_face, n_q, vt, n_q, vt), w_f)
+                            _emit(d_mm.reshape(-1), lambda _g=gs: _g["rows_mm"], lambda _g=gs: _g["cols_mm"])
 
             if _plan is not None:
                 if _acc[0] is None:  # no terms -> empty operator

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -887,7 +887,7 @@ def assemble_fem_native(
     # runtime args in ``_dirichlet_pairs_at`` so ``∂b/∂weights`` flows through the solve.
     from ..._fem import _bare as _bare_node
     from ..._fem import _essential_spec as _essential_spec_node
-    from ...trace import ModelWeights
+    from ...trace import ModelCall, ModelWeights
     from .parametric_helpers import _is_neural_coefficient, _neural_coefficient_name
 
     _dir_net_models: Dict[str, Any] = {}
@@ -895,6 +895,61 @@ def assemble_fem_native(
         _vn = _bare_node(_vnode) if _vnode is not None else None
         if _vn is not None and _is_neural_coefficient(_vn):
             _dir_net_models[_neural_coefficient_name(_vn)] = _vn.model
+    # A trainable ``jno.np.parameter`` in an ESSENTIAL value -- ``u(top) - g``, or ``u(top) -
+    # g*profile(x)``. Exactly the coord-params pattern above: it rides ``runtime_parameter_exprs``
+    # (crux discovers it, its value arrives in ``args``) but stays OUT of ``runtime_parameter_tags``
+    # -- it is not a term coefficient, and ``_runtime_vals`` must not pack it per cell. The rows are
+    # recorded so ``_dirichlet_pairs_at`` re-forms the lift from args (``∂b/∂g`` flows through the
+    # symmetric elimination, the same contract the net-valued branch documents) and
+    # ``_build_dirichlet_pairs`` skips them instead of freezing the stored value behind ``float(g)``.
+    #
+    # The one exclusion: an optimizer-less FIELD-sized parameter stays the nodal DATA-field value the
+    # branch in ``_build_dirichlet_pairs`` gathers per node (a neighbour's field in a DD solve). A
+    # SCALAR optimizer-less parameter is runtime-parametric here -- the old path crashed on it
+    # (IndexError gathering a length-1 value by node id) rather than meaning anything.
+    _dir_param_exprs: Dict[str, Any] = {}
+    _dir_param_rows: set = set()
+    for _i, (_fk, _rg, _comp, _val, _vnode) in enumerate(dirichlet_raw):
+        _vn = _bare_node(_vnode) if _vnode is not None else None
+        if _vn is None or _is_neural_coefficient(_vn):
+            continue
+        if (
+            isinstance(_vn, ModelCall)
+            and getattr(_vn.model, "_is_parameter", False)
+            and getattr(_vn.model, "_opt_fn", None) is None
+            and np.asarray(_vn.model.module.value).size > 1
+        ):
+            continue  # nodal data field -- the per-node gather branch owns it
+        _found: Dict[str, Any] = {}
+        _collect_runtime_parameter_exprs(_vnode, _found)
+        if _found:
+            from ..._fem import _is_temporal_value_node as _is_tv
+
+            if _is_tv(_vnode):
+                # `u(top) - g * tau`: the value is BOTH parametric and time/τ-dependent. The parametric
+                # branch would hold it constant in τ (silently un-ramping the load); the temporal branch
+                # would freeze the parameter at its stored value (silently un-training it). Neither is
+                # right, so refuse until the two held-value mechanisms compose.
+                raise NotImplementedError(
+                    f"jno.fem: the essential value on {_rg!r} is BOTH runtime-parametric "
+                    f"({sorted(_found)}) and time/τ-dependent. A trainable parameter in a t/τ-varying "
+                    "essential value is not supported yet -- train the amplitude through a Neumann/body "
+                    "term written as a function of τ, or fix one of the two."
+                )
+            _dir_param_exprs.update(_found)
+            _dir_param_rows.add(_i)
+    if _dir_param_exprs:
+        _param_and_neural_exprs = {**_param_and_neural_exprs, **_dir_param_exprs}
+
+    def _dir_static_args() -> Dict[str, Any]:
+        """Stored-value args for every args-dependent Dirichlet slot (net modules + parameter values) --
+        what the static placeholders and dof-layout probes evaluate at, in place of runtime args."""
+        return {n: m.module for n, m in _dir_net_models.items()} | {
+            n: jnp.asarray(nd.model.module.value) for n, nd in _dir_param_exprs.items()
+        }
+
+    #: any Dirichlet condition whose held value must be (re-)formed from runtime ``args``.
+    _dir_args_dependent = bool(_dir_net_models) or bool(_dir_param_rows)
     # A net-valued INITIAL condition ``u(initial) - net(x)`` (a trainable starting state, recovered from a
     # trajectory): its weights join the runtime slots the same way, and the initial state is (re-)formed
     # from the runtime args in ``_state0_at`` so ``∂traj/∂weights`` flows through the IC.
@@ -2182,10 +2237,12 @@ def assemble_fem_native(
 
         pairs: List[Tuple[int, float]] = []
         tv_stash: List[Tuple[Any, Any, Any]] = []  # (dofs, value_node, coords) for time-varying g(x,t)
-        for field_key, region, comp, value, value_node in dirichlet_raw:
+        for _row_i, (field_key, region, comp, value, value_node) in enumerate(dirichlet_raw):
             fidx = field_index.get(field_key)
             if fidx is None:
                 continue
+            if _row_i in _dir_param_rows:
+                continue  # args-dependent value: (re-)formed per args in _dirichlet_pairs_at, never frozen here
             # Time-varying Dirichlet g(x,t): no constant pair — stash (dofs, value_node, coords) so a
             # transient caller (e.g. the second-order augmented block) writes g(x_d, t) each step.
             if value_node is not None and _is_temporal_value_node(value_node):
@@ -2255,12 +2312,36 @@ def assemble_fem_native(
         coordinates, so the value stays a differentiable JAX scalar and ``∂b/∂weights`` flows through the
         symmetric elimination. Non-net conditions reuse the concrete ``_build_dirichlet_pairs`` values."""
         a = args or {}
-        pairs = list(_build_dirichlet_pairs())  # concrete (non-net) conditions
-        for field_key, region, comp, value, value_node in dirichlet_raw:
+        pairs = list(_build_dirichlet_pairs())  # concrete (non-net, non-parametric) conditions
+        for _row_i, (field_key, region, comp, value, value_node) in enumerate(dirichlet_raw):
             fidx = field_index.get(field_key)
             if fidx is None:
                 continue
             _vn = _bare_node(value_node) if value_node is not None else None
+            if _row_i in _dir_param_rows:
+                # A trainable parameter in the value (`u(top) - g`, `u(top) - g*profile(x)`): evaluate
+                # the value NODE at the boundary nodes with the args-substituted parameter, so the held
+                # value stays a traced JAX scalar and ∂b/∂g (steady) / ∂step/∂g (transient) flows --
+                # the same contract as the net branch below. `_eval_value_node_at(params=...)` is the
+                # existing parametric-coefficient evaluator; no bespoke walker.
+                from ..._fem import _eval_value_node_at as _eval_at
+
+                vt = vecs[fidx]
+                pts_all = np.asarray(pts_f_all[fidx])
+                node_ids = list(_boundary_node_ids(fidx, region))
+                pts = pts_all[np.asarray(node_ids, dtype=np.int64)] if node_ids else np.zeros((0, dim))
+                raw = jnp.asarray(_eval_at(value_node, jnp.asarray(pts), params=a)).reshape(-1)
+                # Constant vs spatial profile: a constant returns the same shape for ANY batch (the
+                # static-path trick) -- one extra single-point evaluation decides, shapes are static.
+                one = jnp.asarray(_eval_at(value_node, jnp.asarray(pts[:1]), params=a)).reshape(-1)
+                if raw.shape == one.shape or not node_ids:
+                    gvals = jnp.broadcast_to(raw.reshape(-1)[:1], (len(node_ids),))
+                else:
+                    gvals = raw.reshape(len(node_ids), -1)[:, 0]
+                for i, nid in enumerate(node_ids):
+                    for c in range(vt) if comp is None else [int(comp)]:
+                        pairs.append((offs[fidx] + nid * vt + c, gvals[i]))
+                continue
             if _vn is None or not _is_neural_coefficient(_vn):
                 continue
             vt = vecs[fidx]
@@ -2472,19 +2553,19 @@ def assemble_fem_native(
                     "form is not wired yet (state0_fn threads only the linear stepper). Use a linear "
                     "transient form (a net IC threads there)."
                 )
-            if _dir_net_models and _nonlinear_mass:
+            if _dir_args_dependent and _nonlinear_mass:
                 raise NotImplementedError(
                     "jno.fem: a net-valued Dirichlet with a state-dependent (nonlinear) mass c(u)·u_t on a "
                     "transient form is not supported (the mass residual holds a static Dirichlet dof set). "
                     "Use a linear/parametric mass."
                 )
 
-            if _dir_net_models:
-                # net-valued Dirichlet u(∂Ω) - net(x): the held value is re-formed from the net weights each
+            if _dir_args_dependent:
+                # net- or parameter-valued Dirichlet: the held value is re-formed from the args each
                 # Newton residual (mirrors the nonlinear STEADY path ``res_p``); the dof set is static, only
-                # the held values ride the weights, and ``∂/∂weights`` flows through the step's custom_root.
+                # the held values ride the args, and ``∂/∂args`` flows through the step's custom_root.
                 _tnpd = jnp.asarray(
-                    [p[0] for p in _dirichlet_pairs_at({n: m.module for n, m in _dir_net_models.items()})],
+                    [p[0] for p in _dirichlet_pairs_at(_dir_static_args())],
                     dtype=jnp.int32,
                 )
 
@@ -2541,8 +2622,8 @@ def assemble_fem_native(
         # falls to the static branch, where A and M are built once with ``args=None`` and
         # ``_apply_coord_params`` short-circuits -- so ``block.step(..., args={coord: X})`` silently ignores
         # X and ``du/dX`` is exactly ZERO. That is a wrong gradient with no symptom, not a missing feature.
-        if runtime_parameter_tags or neural_param_names or _dir_net_models or _ic_net_models or _coord_specs:
-            if _dir_net_models:
+        if runtime_parameter_tags or neural_param_names or _dir_args_dependent or _ic_net_models or _coord_specs:
+            if _dir_args_dependent:
                 if getattr(domain, "_fem_native_dirichlet_tv", None):
                     raise NotImplementedError(
                         "jno.fem: a net-valued Dirichlet combined with a time-varying g(x, t) Dirichlet on a "
@@ -2551,7 +2632,7 @@ def assemble_fem_native(
                     )
                 # const + net Dirichlet dofs (static boundary-node layout); held values re-formed from args.
                 _dd = jnp.asarray(
-                    [p[0] for p in _dirichlet_pairs_at({n: m.module for n, m in _dir_net_models.items()})],
+                    [p[0] for p in _dirichlet_pairs_at(_dir_static_args())],
                     dtype=jnp.int32,
                 )
 
@@ -2568,8 +2649,8 @@ def assemble_fem_native(
                 A = spatial_jac(zeros, t, args)
                 return A if _d is None else bcoo_set_dirichlet_rows(A, _d)
 
-            if _dir_net_models:
-                c_bias = zeros  # every held value (const + net) rides the forcing
+            if _dir_args_dependent:
+                c_bias = zeros  # every held value (const + net + parameter) rides the forcing
 
                 def forcing_vector_fn(t, args=None, _mask=free_mask, _d=_dd):
                     f = _mask * (-spatial_res(zeros, t, args))
@@ -2700,7 +2781,7 @@ def assemble_fem_native(
     if (
         runtime_parameter_tags
         or neural_param_names
-        or _dir_net_models
+        or _dir_args_dependent
         or history_specs
         or surface_history_specs
         or _coord_specs
@@ -2711,13 +2792,13 @@ def assemble_fem_native(
             # ``t`` carries the pseudo-time (load) coordinate τ for the history march — the load written
             # as a function of τ in the weak form varies through it. Defaults to 0.0, so the ordinary
             # (non-marching) parametric/inverse call sites are unchanged.
-            if _dir_net_models:
-                # net-valued Dirichlet u(∂Ω) - net(x): the held value is a differentiable function of the
-                # net weights (delivered on args), so the row-replacement value is re-evaluated from args
-                # each residual call (mirrors the linear parametric path's ``_dirichlet_pairs_at``). The
-                # dof set is static (boundary-node layout); only the held values ride the weights.
+            if _dir_args_dependent:
+                # net- or parameter-valued Dirichlet: the held value is a differentiable function of the
+                # args (net weights or a trainable boundary value), so the row-replacement value is
+                # re-evaluated from args each residual call (mirrors the linear parametric path's
+                # ``_dirichlet_pairs_at``). The dof set is static; only the held values ride the args.
                 _npd = jnp.asarray(
-                    [p[0] for p in _dirichlet_pairs_at({n: m.module for n, m in _dir_net_models.items()})],
+                    [p[0] for p in _dirichlet_pairs_at(_dir_static_args())],
                     dtype=jnp.int32,
                 )
 
@@ -2805,17 +2886,20 @@ def assemble_fem_native(
         def _assemble_at(args):
             A = jacobian(zeros, 0.0, args)
             b = -residual(zeros, 0.0, args)
-            # a net-valued Dirichlet re-forms the lift from args each call; otherwise the static pairs.
-            pairs = _dirichlet_pairs_at(args) if _dir_net_models else dirichlet_pairs
+            # a net- or parameter-valued Dirichlet re-forms the lift from args each call; else static.
+            pairs = _dirichlet_pairs_at(args) if (_dir_net_models or _dir_param_rows) else dirichlet_pairs
             if pairs:
                 A, b = _apply_dirichlet_symmetric(A, b, pairs)
             return A, b
 
-        # Static placeholder for .A/.b: scalar params at 0, networks (coefficient + Dirichlet) at stored weights.
+        # Static placeholder for .A/.b: scalar params at 0, networks (coefficient + Dirichlet) at stored
+        # weights, Dirichlet-value parameters at their STORED value (like the nets: `fem.b` then reflects
+        # the initialized boundary value rather than an arbitrary zero condition).
         a0, b0 = _assemble_at(
             {n: 0.0 for n in runtime_parameter_tags}
             | {n: _neural_models[n].module for n in neural_param_names}
             | {n: m.module for n, m in _dir_net_models.items()}
+            | {n: jnp.asarray(nd.model.module.value) for n, nd in _dir_param_exprs.items()}
         )
         op = FemLinearSystem(
             a0,

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -2306,13 +2306,23 @@ def assemble_fem_native(
         domain._fem_native_dirichlet_tv = tv_stash
         return pairs
 
+    _static_dirichlet_cache: Dict[str, Any] = {}
+
     def _dirichlet_pairs_at(args):
         """Dirichlet ``(dof, value)`` pairs with the net-valued profiles evaluated from the runtime
         ``args`` (an unknown BC ``u(region) - net(x)``): the net is called on the region's boundary-node
         coordinates, so the value stays a differentiable JAX scalar and ``∂b/∂weights`` flows through the
         symmetric elimination. Non-net conditions reuse the concrete ``_build_dirichlet_pairs`` values."""
         a = args or {}
-        pairs = list(_build_dirichlet_pairs())  # concrete (non-net, non-parametric) conditions
+        # The concrete (non-net, non-parametric) pairs are ARG-INDEPENDENT, and rebuilding them here
+        # is not just wasted work: this runs inside the traced Newton residual (`_np_hold(args)`),
+        # where the host-side tag resolution in `_build_dirichlet_pairs` can meet traced state a
+        # contact assembly stashed (measured: TracerArrayConversionError from the tag location fn on
+        # a gap-carrying form). Built ONCE, on the first call -- which is always the eager dof-layout
+        # probe `_dirichlet_pairs_at(_dir_static_args())`, outside any trace.
+        if "pairs" not in _static_dirichlet_cache:
+            _static_dirichlet_cache["pairs"] = _build_dirichlet_pairs()
+        pairs = list(_static_dirichlet_cache["pairs"])
         for _row_i, (field_key, region, comp, value, value_node) in enumerate(dirichlet_raw):
             fidx = field_index.get(field_key)
             if fidx is None:
@@ -2324,12 +2334,23 @@ def assemble_fem_native(
                 # value stays a traced JAX scalar and ∂b/∂g (steady) / ∂step/∂g (transient) flows --
                 # the same contract as the net branch below. `_eval_value_node_at(params=...)` is the
                 # existing parametric-coefficient evaluator; no bespoke walker.
+                #
+                # The node LAYOUT is static per (field, region) and memoized from the first (eager)
+                # call: this body re-runs inside the traced Newton residual, where the host tag
+                # resolution behind `_boundary_node_ids` can meet traced state (measured on a
+                # gap-carrying form: TracerArrayConversionError out of the tag location fn).
                 from ..._fem import _eval_value_node_at as _eval_at
 
                 vt = vecs[fidx]
-                pts_all = np.asarray(pts_f_all[fidx])
-                node_ids = list(_boundary_node_ids(fidx, region))
-                pts = pts_all[np.asarray(node_ids, dtype=np.int64)] if node_ids else np.zeros((0, dim))
+                _lk = ("layout", fidx, region)
+                if _lk not in _static_dirichlet_cache:
+                    pts_all = np.asarray(pts_f_all[fidx])
+                    nid_list = list(_boundary_node_ids(fidx, region))
+                    _static_dirichlet_cache[_lk] = (
+                        nid_list,
+                        pts_all[np.asarray(nid_list, dtype=np.int64)] if nid_list else np.zeros((0, dim)),
+                    )
+                node_ids, pts = _static_dirichlet_cache[_lk]
                 raw = jnp.asarray(_eval_at(value_node, jnp.asarray(pts), params=a)).reshape(-1)
                 # Constant vs spatial profile: a constant returns the same shape for ANY batch (the
                 # static-path trick) -- one extra single-point evaluation decides, shapes are static.

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -569,6 +569,7 @@ def assemble_fem_native(
     quad_degree: int,
     evolution: Optional[Dict[Any, Any]] = None,
     bounded: bool = False,
+    tv_dirichlet_external: bool = False,
 ) -> Tuple[Any, str]:
     """Assemble a Lagrange FEM system into ``(op, mode, offs)`` for :class:`FEM`.
 
@@ -3060,7 +3061,12 @@ def assemble_fem_native(
 
     # A τ/t-dependent essential value that no branch above threaded would be silently DROPPED here --
     # the constraint disappears and the solve returns a plausible-looking wrong answer. Fail instead.
-    if _tv_dirichlet:
+    # EXCEPT when the caller declared it consumes the tv stash itself (`tv_dirichlet_external=True`):
+    # the second-order u_tt block calls this assembler for the spatial operator and the Dirichlet
+    # stashes, then writes g(x_d, t) and the compatible ġ(x_d, t) onto its augmented [u, v] system per
+    # step -- a legitimate consumer this guard was firing on (found by the pre-push suite: two wave
+    # oracles that pass on origin/main NotImplementedError'd from the guard's own commit onward).
+    if _tv_dirichlet and not tv_dirichlet_external:
         raise NotImplementedError(
             "jno.fem: a time/τ-dependent essential value (e.g. `u(top) - delta*tau`) is threaded on the "
             "steady residual path -- the load-path march and the runtime-parametric solve -- and by the "

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -3764,7 +3764,24 @@ def elem_map(fn, xs, chunk):
         return jax.jit(run)(*arrays)
 
     key, pins = fp
+
+    # Cache entries are ``(jit_fn, pins, baked)``: ``pins`` guard THIS call's ids against recycling,
+    # ``baked`` are the leaves of the build that COMPILED the function -- the arrays actually
+    # captured in its closure. The two differ exactly for content-hit ALIASES, and the distinction
+    # is what makes the donated-buffer check below possible.
+    def _baked_dead(entry):
+        return entry[2] is not entry[1] and any(
+            isinstance(_l, jax.Array) and _l.is_deleted() for _l in jax.tree_util.tree_leaves(entry[2])
+        )
+
     hit = _ELEM_MAP_CACHE.get(key)
+    if hit is not None and _baked_dead(hit):
+        # An id-keyed ALIAS whose original baked device buffers were DONATED and deleted since (a
+        # training loop's optimizer step donates the old parameter buffer). Executing the shared
+        # compilation reads a corpse: measured "Array has been deleted with shape=float64[1]" out of
+        # a kernel shared across tests. Recompile with this build's live leaves.
+        _ELEM_MAP_CACHE.pop(key, None)
+        hit = None
     if hit is None:
         # Identity miss. Before compiling, try the CONTENT key: a rebuild of an identical problem
         # bakes fresh objects with identical values, and identical values compile to the identical
@@ -3773,19 +3790,30 @@ def elem_map(fn, xs, chunk):
         # tokenizer cannot key by value) falls through to compile -- a miss is safe, a wrong hit
         # would be a wrong operator.
         ckey = _fn_content_key(fn, chunk)
+        chit = None
         if ckey is not None:
-            hit = _ELEM_MAP_CONTENT.get(ckey)
-        if hit is not None:
+            chit = _ELEM_MAP_CONTENT.get(ckey)
+            if chit is not None and any(
+                isinstance(_l, jax.Array) and _l.is_deleted() for _l in jax.tree_util.tree_leaves(chit[2])
+            ):
+                # Same corpse check for the content table (its entries keep the ORIGINAL build's
+                # leaves as ``baked``, which are exactly the compiled closure's buffers).
+                del _ELEM_MAP_CONTENT[ckey]
+                _ELEM_MAP_STATS["content_bail"]["<deleted-buffer>"] = (
+                    _ELEM_MAP_STATS["content_bail"].get("<deleted-buffer>", 0) + 1
+                )
+                chit = None
+        if chit is not None:
             _ELEM_MAP_STATS["content_hits"] += 1
             _ELEM_MAP_CONTENT.move_to_end(ckey)
             # Share the COMPILED program but pin THIS call's leaves: the id key contains this build's
             # object ids, and the entry's pins are what stop those ids from being recycled onto
-            # different objects after a GC -- the invariant the id fast path rests on. Pinning the
-            # old build's leaves instead would leave the new ids unguarded.
-            hit = (hit[0], pins)
+            # different objects after a GC. ``baked`` stays the ORIGINAL build's leaves -- the
+            # closure's actual buffers -- so the liveness checks above test the right arrays.
+            hit = (chit[0], pins, chit[2])
         else:
             _ELEM_MAP_STATS["misses"] += 1
-            hit = (jax.jit(run), pins)
+            hit = (jax.jit(run), pins, pins)
             if ckey is not None:
                 _ELEM_MAP_CONTENT[ckey] = hit
                 while len(_ELEM_MAP_CONTENT) > _ELEM_MAP_CONTENT_MAX:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,21 +183,41 @@ def _restore_cache_dir():
         jax.config.update("jax_compilation_cache_dir", prev)
 
 
-def test_setup_leaves_the_compile_cache_off_by_default(tmp_path, monkeypatch, _restore_cache_dir):
-    """jNO must not write to a user's disk unless asked. Also guards the cold-run case: populating
-    the cache is SLOWER than not having one, so on-by-default would penalise a single run."""
+def test_setup_turns_the_compile_cache_on_by_default(tmp_path, monkeypatch, _restore_cache_dir):
+    """The default FLIPPED (2026-08-15): the warm-cache build measured 2.1x (4.3x on Stokes) and
+    jNO's normal life is the repeated run, so the persistent cache is ON unless opted out —
+    `JNO_COMPILE_CACHE=0`, `[jno] compile_cache = false`, or `setup(compile_cache=False)`. This test
+    used to pin the opposite ('must not write to a user's disk unless asked'); the populate-cost
+    caveat it guarded is now documented in `enable_compile_cache` and docs/fem.md instead."""
     import jax
 
     import jno
 
-    monkeypatch.chdir(tmp_path)  # no .jno.toml here, so nothing can opt in behind the test's back
+    monkeypatch.chdir(tmp_path)  # no .jno.toml here, so nothing can opt OUT behind the test's back
+    monkeypatch.delenv("JNO_COMPILE_CACHE", raising=False)
     cfg_module._CONFIG = None
     jax.config.update("jax_compilation_cache_dir", None)
     try:
         jno.setup(str(tmp_path / "script.py"), name="cache_default")
-        assert _cache_dir() is None, "the compile cache must stay opt-in"
+        assert _cache_dir() is not None, "the compile cache is ON by default since the 08-15 flip"
     finally:
         cfg_module._CONFIG = None
+
+
+def test_setup_compile_cache_false_disables_the_default(tmp_path, monkeypatch, _restore_cache_dir):
+    """The explicit opt-out must actively disable what the import-time default turned on."""
+    import jax
+
+    import jno
+
+    monkeypatch.chdir(tmp_path)
+    cfg_module._CONFIG = None
+    try:
+        jno.setup(str(tmp_path / "script.py"), name="cache_off", compile_cache=False)
+        assert _cache_dir() is None, "setup(compile_cache=False) must disable the cache"
+    finally:
+        cfg_module._CONFIG = None
+        jax.config.update("jax_persistent_cache_min_compile_time_secs", 1.0)
 
 
 def test_compile_cache_true_turns_it_on(tmp_path, _restore_cache_dir):

--- a/tests/test_fem_contact_gap.py
+++ b/tests/test_fem_contact_gap.py
@@ -421,3 +421,193 @@ def test_the_documented_contact_sign_engages_instead_of_finding_the_free_root():
     # (the max() kink chatters -- see item 2 in plans/contact-main-reaction.md), so the position is
     # not yet trustworthy enough to gate on. That the base is loaded at all is the sign question, and
     # it is the half that inverts.
+
+
+# ---------------------------------------------------------------------------
+# ONE-SIDED (separating, Signorini) contact -- the max(0,.) case, measured.
+#
+# The old note here deferred one-sided contact as "a solver question: the max() kink chatters". The
+# measurement that closed it: the chatter was a FLOAT32 RESIDUAL FLOOR (~1.6e-5 on the pressed
+# stack, line search or not), not active-set cycling -- under x64 the same iteration converges to
+# 3.6e-10 at rtol=1e-8. `jax.linearize` through `max` selects the active branch, which IS the
+# semismooth Jacobian (the same argument `u.bounds` documents), so the solver was never the problem;
+# the tolerance expectation was. These tests pin the physics at honest float32 tolerances and the
+# x64 discriminator that proves the iteration superlinear.
+# ---------------------------------------------------------------------------
+
+
+def _one_sided(c, squeeze, *, rtol=1e-6):
+    """The pressed stack with the ONE-SIDED penalty `max(0, -c*g)`; squeeze>0 lifts the platen."""
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    d = _stacked_blocks()
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    terms = [LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2)]
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    terms.append(jno.np.maximum(0.0, -c * g) * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1))
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    terms += [u(xb, yb)[0] - 0.0, u(xb, yb)[1] - 0.0, u(xt, yt)[0] - 0.0, u(xt, yt)[1] - squeeze]
+    fem = jno.fem(terms)
+    sol = np.asarray(fem.solve(nonlinear=jno.solve.newton(line_search=True, rtol=rtol, atol=rtol))).reshape(-1, 2)
+    return d, sol, np.asarray(d.tag_indices[secondary]).reshape(-1), np.asarray(d.tag_indices[main]).reshape(-1)
+
+
+def test_one_sided_press_converges_to_the_bonded_oracle_like_one_over_c():
+    """Under compression the closed one-sided contact must agree with the bonded interface: the
+    uniform-bar oracle has uy(y=1) = -0.01, approached as the penalty stiffens."""
+    errs = {}
+    for c in (1e3, 1e4, 1e5):
+        _d, sol, _s, main = _one_sided(c, -0.02)
+        errs[c] = abs(sol[main, 1].mean() - (-0.01))
+    assert errs[1e3] > errs[1e4] > errs[1e5], f"not converging to the bonded limit: {errs}"
+    assert errs[1e5] < 3e-4, f"closed one-sided contact should sit near the bonded answer: {errs[1e5]:.2e}"
+
+
+def test_one_sided_release_separates_without_adhesion():
+    """THE defining physics: lift the platen and the traction must be exactly zero -- the main body
+    undisturbed, the cap carried up rigidly, no tension transmitted across the open gap."""
+    d, sol, secondary, main = _one_sided(1e4, +0.02)
+    base = np.asarray(d.built_mesh.points)[:, 1] < 0.999
+    assert np.abs(sol[base]).max() < 1e-9, (
+        f"the open gap transmitted load: base max|u| = {np.abs(sol[base]).max():.3e} -- adhesion where there must be none"
+    )
+    assert sol[secondary, 1].mean() > 0.01, "the cap must move up with the platen once free"
+
+
+def test_one_sided_zero_load_is_the_unconstrained_solve():
+    """Extreme: no squeeze at all -- the contact term must contribute nothing anywhere."""
+    _d, sol, _s, _m = _one_sided(1e4, 0.0)
+    assert np.abs(sol).max() < 1e-9
+
+
+def test_one_sided_complementarity_via_the_interface_jump():
+    """p.g = 0, observed through displacements: pressed, the interface jump is O(1/c) (contact
+    active, gap ~ 0); released, the jump is the full opening with zero transmitted force (gap open,
+    traction 0). The two regimes may never mix."""
+    _d, press, s_ids, m_ids = _one_sided(1e5, -0.02)
+    jump_pressed = abs(press[s_ids, 1].mean() - press[m_ids, 1].mean())
+    assert jump_pressed < 5e-4, f"pressed: the gap must be ~closed, jump {jump_pressed:.2e}"
+    d, rel, s_ids, m_ids = _one_sided(1e5, +0.02)
+    jump_open = rel[s_ids, 1].mean() - rel[m_ids, 1].mean()
+    assert jump_open > 0.015, f"released: the gap must be OPEN by ~the lift, got {jump_open:.2e}"
+
+
+def test_one_sided_tight_tolerance_is_a_float32_floor_not_a_solver_stall():
+    """The discriminator that re-classified the recorded 'max() kink stalls Newton': under x64 the
+    SAME iteration meets rtol=1e-8 (measured residual 3.6e-10) -- superlinear semismooth Newton,
+    exactly as the `u.bounds` machinery argues. The float32 failure at 1e-8 is a precision floor."""
+    import jax as _jax
+
+    prev = _jax.config.jax_enable_x64
+    _jax.config.update("jax_enable_x64", True)
+    try:
+        _d, sol, _s, main = _one_sided(1e4, -0.02, rtol=1e-8)
+        assert abs(sol[main, 1].mean() - (-0.01)) < 1e-3
+    finally:
+        _jax.config.update("jax_enable_x64", prev)
+
+
+def test_gradient_through_closed_one_sided_contact_fd_checks():
+    """Differentiability through the ACTIVE contact: the platen displacement is a runtime Dirichlet
+    PARAMETER, and d(mean base uy)/d(squeeze) flows through custom_root across the max() branch
+    selection. FD-checked; away from onset the subgradient is the gradient."""
+    import jax as _jax
+
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    d = _stacked_blocks()
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    sq = jno.np.parameter((1,), name="sq", key=_jax.random.PRNGKey(0))
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    fem = jno.fem(
+        [
+            LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2),
+            jno.np.maximum(0.0, -1e4 * g) * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1),
+            u(xb, yb)[0] - 0.0,
+            u(xb, yb)[1] - 0.0,
+            u(xt, yt)[0] - 0.0,
+            u(xt, yt)[1] - sq,
+        ]
+    )
+    base_ids = np.asarray(d.tag_indices[main]).reshape(-1)
+
+    import jax.numpy as jnp
+
+    op = fem.operator  # FemResidualOperator: residual(u, args, t) with the held value re-formed per call
+    ndofs = int(fem.dofs)
+    drv = jno.solve.newton(line_search=True, rtol=1e-6, atol=1e-6)
+
+    def out(sqv):
+        r = lambda w: jnp.asarray(op.residual(w, {"sq": jnp.asarray(sqv).reshape(-1)})).reshape(-1)  # noqa: E731
+        w = drv(r, jnp.zeros(ndofs))
+        return w.reshape(-1, 2)[base_ids, 1].mean()
+
+    grad = float(_jax.grad(out)(jnp.asarray(-0.02)))
+    fd = float((out(jnp.asarray(-0.022)) - out(jnp.asarray(-0.020))) / (-0.002))
+    # jax.grad runs through the driver's custom_root on the branch-selected (semismooth) operator;
+    # in the closed regime the response is smooth in the platen displacement and the two must agree.
+    assert 0.1 < fd < 1.0, f"FD slope {fd:.3f} outside the physical (0,1) load-share range"
+    assert abs(grad - fd) < 0.05 * abs(fd), f"gradient through closed one-sided contact: jax.grad {grad:.4f} vs FD {fd:.4f}"
+
+
+def test_augmented_lagrangian_beats_the_penalty_error_at_the_same_c():
+    """AL exactness. The pure penalty carries an O(1/c) penetration error by construction; the
+    Uzawa multiplier update `lam.evolves(max(0, lam.i(-1) - c*g))` absorbs it, so at the SAME
+    c the marched AL answer must land far closer to the bonded oracle. Measured while writing
+    this test: penalty err 3.4e-3 at c=1e3; AL err 1.1e-5 after 8 updates -- monotone geometric
+    convergence (-0.00663 -> -0.00886 -> ... -> -0.00999). The multiplier is an ordinary scalar
+    SURFACE state on the secondary face: the machinery is `evolves` + the tau march, no new API."""
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    c, nsteps = 1e3, 8
+    d = jno.Shape.regions(
+        base=jno.Shape.rect(0, 0, 1, 1, size=0.22),
+        cap=jno.Shape.rect(0, 1, 1, 2, size=0.09),
+        conforming=False,
+    ).domain(tau=(0.0, 1.0, nsteps))
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    lam, _ = d.fem_symbols(value_shape=())  # the AL multiplier: a scalar surface state
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    p = jno.np.maximum(0.0, lam.i(-1) + c * (-g))
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    fem = jno.fem(
+        [
+            LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2),
+            p * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1),
+            lam.evolves(p),
+            u(xb, yb)[0] - 0.0,
+            u(xb, yb)[1] - 0.0,
+            u(xt, yt)[0] - 0.0,
+            u(xt, yt)[1] - (-0.02),
+        ]
+    )
+    # atol above the measured float32 residual floor (~1.7e-5): the march guard re-checks each step.
+    traj = np.asarray(fem.solve(nonlinear=jno.solve.newton(line_search=True, rtol=1e-5, atol=3e-5)))
+    m = np.asarray(d.tag_indices[main]).reshape(-1)
+    uys = [traj[k].reshape(-1, 2)[m, 1].mean() for k in range(traj.shape[0])]
+    errs = [abs(v - (-0.01)) for v in uys]
+    assert errs[0] > 2e-3, "step 0 is the pure-penalty answer and must carry the 1/c error"
+    assert all(e2 <= e1 * 1.05 for e1, e2 in zip(errs, errs[1:])), f"AL error must fall monotonically: {errs}"
+    assert errs[-1] < 1e-4, f"AL must beat the penalty error by orders of magnitude: final err {errs[-1]:.2e}"

--- a/tests/test_fem_contact_gap.py
+++ b/tests/test_fem_contact_gap.py
@@ -152,7 +152,8 @@ def test_a_penalty_on_the_gap_closes_the_interface_like_one_over_c():
     """The end-to-end gate, and the one that proves the gap is *live*: penalising it must drive the
     interface jump to zero like 1/c. That can only happen if the gap measures the real jump AND the
     tangent carries the main-side coupling — the matrix-free path picks the latter up through
-    `jax.linearize` of the residual, which is why no assembled Jacobian block is built."""
+    `jax.linearize` of the residual; the assembled path builds the explicit nonlocal blocks
+    (gated by `test_assembled_gap_tangent_matches_the_matrix_free_jvp`)."""
     free, _ = _vector_poisson(None)
     jumps = {c: _vector_poisson(c)[0] for c in (1e2, 1e3, 1e4, 1e5)}
 
@@ -163,9 +164,15 @@ def test_a_penalty_on_the_gap_closes_the_interface_like_one_over_c():
     assert jumps[1e5] < 1e-3 * free
 
 
-def test_the_assembled_tangent_refuses_a_gap():
-    """A gap is non-local, and the per-element Jacobian emits parent-cell columns only, so it would
-    silently drop the secondary–main coupling. It must refuse rather than return a degraded tangent."""
+def test_assembled_gap_tangent_matches_the_matrix_free_jvp():
+    """The assembled tangent now carries the gap's NONLOCAL blocks -- (s,m) from jacfwd w.r.t. the
+    gathered main values chained through the frozen mortar weights, and the reaction rows' (m,s) and
+    (m,m). The matrix-free JVP (jax.linearize of the residual) is exact by construction, so the two
+    must agree on random probe vectors, in both the ACTIVE (pressed) and INACTIVE (separated)
+    branches of a one-sided max(0,.) traction."""
+    import jax as _jax
+    import jax.numpy as jnp
+
     d = _two_body_domain()
     u, v = d.fem_symbols(value_shape=(3,))
     secondary, main = _sides(d)
@@ -177,16 +184,68 @@ def test_the_assembled_tangent_refuses_a_gap():
     g = u.gap(secondary, main, domain=d)
     terms = [
         jno.np.inner(gu, gv, n_contract=2) - 1.0 * v.bind(x=ci[0], y=ci[1], z=ci[2])[2],
-        g * jno.np.inner(n, v.bind(x=sb[0], y=sb[1], z=sb[2]), n_contract=1),
+        jno.np.maximum(0.0, -1e3 * g) * jno.np.inner(n, v.bind(x=sb[0], y=sb[1], z=sb[2]), n_contract=1),
     ]
     bb = d.variable("boundary", split=True)
     terms += [u(bb[0], bb[1], bb[2])[i] - 0.0 for i in range(3)]
     fem = jno.fem(terms, element_type="TET4")
-    with pytest.raises(NotImplementedError, match="matrix-free tangent"):
-        fem.jacobian(np.zeros(fem.n_dofs) if hasattr(fem, "n_dofs") else np.zeros(1))
+    op = fem.operator
+    ndofs = int(fem.dofs)
+    key = _jax.random.PRNGKey(0)
+
+    for state_scale, label in ((-1e-3, "active (pressed)"), (+1e-3, "inactive (separated)")):
+        # a z-displacement state that closes / opens the gap uniformly
+        u0 = jnp.zeros(ndofs).reshape(-1, 3).at[:, 2].set(state_scale).reshape(-1)
+        r = lambda w: jnp.asarray(op.residual(w)).reshape(-1)  # noqa: E731
+        J = op.jacobian(u0)
+        _r0, jvp = _jax.linearize(r, u0)
+        for i in range(3):
+            probe = _jax.random.normal(_jax.random.fold_in(key, i), (ndofs,))
+            a = np.asarray(J @ probe)
+            b = np.asarray(jvp(probe))
+            scale = max(np.abs(b).max(), 1e-8)
+            assert np.abs(a - b).max() < 5e-4 * scale, (
+                f"{label}: assembled J and matrix-free JVP disagree "
+                f"(max diff {np.abs(a - b).max():.3e} vs scale {scale:.3e})"
+            )
+
+
+def test_direct_newton_one_sided_matches_matrix_free():
+    """`newton(direct=True)` + host LU over a one-sided contact -- the path that refused before --
+    must land on the matrix-free answer."""
+    inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
+    d = _stacked_blocks()
+    sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
+    secondary = next(t for t in sides if t.endswith(".cap"))
+    main = next(t for t in sides if t.endswith(".base"))
+    u, phi = d.fem_symbols(value_shape=(2,))
+    X = d.variable("interior", split=True)[:2]
+    eu, ep = sym(u, list(X)), sym(phi, list(X))
+    sv = d.variable(secondary, split=True)
+    n = d.variable(secondary, normals=True)
+    g = u.gap(secondary, main, domain=d)
+    xb, yb, _ = d.variable("bottom", split=True)
+    xt, yt, _ = d.variable("top", split=True)
+    terms = [
+        LAM_ * trace(eu) * trace(ep) + 2 * MU_ * inner(eu, ep, n_contract=2),
+        jno.np.maximum(0.0, -1e4 * g) * inner(n, phi.bind(x=sv[0], y=sv[1]), n_contract=1),
+        u(xb, yb)[0] - 0.0,
+        u(xb, yb)[1] - 0.0,
+        u(xt, yt)[0] - 0.0,
+        u(xt, yt)[1] - (-0.02),
+    ]
+    mf = np.asarray(jno.fem(terms).solve(nonlinear=jno.solve.newton(line_search=True, rtol=1e-6, atol=1e-6))).reshape(-1, 2)
+    dr = np.asarray(
+        jno.fem(terms).solve(
+            nonlinear=jno.solve.newton(direct=True, line_search=True, rtol=1e-6, atol=1e-6),
+            linear=jno.solve.lu(backend="host"),
+        )
+    ).reshape(-1, 2)
+    assert np.abs(mf - dr).max() < 5e-5, f"direct vs matrix-free one-sided contact: {np.abs(mf - dr).max():.2e}"
 
 
 # ---------------------------------------------------------------------------
+# The reaction on the main body# ---------------------------------------------------------------------------
 # The reaction on the main body -- Newton's third law across the interface.
 #
 # The interface traction is written on the secondary face only, so the main's share has to be added by

--- a/tests/test_fem_dirichlet_parameters.py
+++ b/tests/test_fem_dirichlet_parameters.py
@@ -1,0 +1,241 @@
+"""Runtime Dirichlet parameters — a trainable ``jno.np.parameter`` in an ESSENTIAL value.
+
+The documented limitation was "a trainable parameter may sit in the operator (stiffness) but not in
+an essential/Dirichlet boundary *value*" — and the reality was worse: a scalar parameter without an
+optimizer CRASHED (IndexError, gathered as a per-node data field), and with one it was silently
+frozen at its stored value behind ``float(g)``.
+
+Now a parameter in a Dirichlet value rides the exact plumbing the net-valued Dirichlet built:
+collected into ``runtime_parameter_exprs`` (crux discovers it; it stays OUT of the per-cell
+``runtime_parameter_tags``, like trainable mesh coordinates), and the held value is re-formed from
+``args`` by ``_dirichlet_pairs_at`` — a traced JAX scalar, so ``∂b/∂g`` flows through the symmetric
+elimination (steady linear), ``∂/∂g`` through the solve's ``custom_root`` (steady nonlinear), and
+the adjoint through each step's ``custom_root`` (linear transient).
+"""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+import pytest
+
+import jno
+
+
+def _poisson_pieces(size=0.3, time=None):
+    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain(**({"time": time} if time else {}))
+    u, v = d.fem_symbols()
+    if time:
+        xi, yi, ti = d.variable("interior", split=True)
+        ui, vi = u.bind(x=xi, y=yi, t=ti), v.bind(x=xi, y=yi, t=ti)
+    else:
+        xi, yi, _ = d.variable("interior", split=True)
+        ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    xb, yb, _ = d.variable("boundary", split=True)
+    return d, u, v, ui, vi, (xb, yb)
+
+
+def _param(name, value, key=0):
+    g = jno.np.parameter((1,), name=name, key=jax.random.PRNGKey(key))
+    g.initialize(jax.nn.initializers.constant(value))
+    return g
+
+
+def _dense(A):
+    return np.asarray(A.todense() if hasattr(A, "todense") else A)
+
+
+def _solve_at(fem, args):
+    A, b = fem.operator.evaluate(args)
+    return np.linalg.solve(_dense(A), np.asarray(b))
+
+
+# --------------------------------------------------------------------------------------
+# steady linear: b(args), oracle agreement, differentiability
+# --------------------------------------------------------------------------------------
+def test_a_dirichlet_parameter_makes_the_problem_parametric():
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    assert fem.operator.is_parametric
+    b1 = np.asarray(fem.operator.evaluate({"g": np.asarray([1.0])})[1])
+    b2 = np.asarray(fem.operator.evaluate({"g": np.asarray([5.0])})[1])
+    assert not np.allclose(b1, b2), "b must ride the boundary value"
+
+
+@pytest.mark.parametrize("gval", [0.0, -3.0, 1e3])
+def test_solution_matches_the_constant_dirichlet_oracle(gval):
+    """Zero, negative and large per the house rule — each must equal the hand-written constant BC."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    oracle = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - gval])
+    got = _solve_at(fem, {"g": np.asarray([gval])})
+    ref = np.asarray(oracle.solve())
+    scale = max(1.0, abs(gval))
+    np.testing.assert_allclose(got, ref, rtol=1e-4, atol=1e-5 * scale)
+
+
+def test_gradient_through_the_linear_solve_fd_checks():
+    import jax.numpy as jnp
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    op = fem.operator
+
+    def loss(gv):
+        A, b = op.evaluate({"g": gv})
+        return jnp.sum(jnp.linalg.solve(A.todense() if hasattr(A, "todense") else A, b))
+
+    gr = float(jax.grad(loss)(jnp.asarray([2.0]))[0])
+    fd = float((loss(jnp.asarray([2.0 + 1e-3])) - loss(jnp.asarray([2.0 - 1e-3]))) / 2e-3)
+    assert abs(gr - fd) < 1e-2 * abs(fd), f"grad {gr} vs FD {fd}"
+
+
+def test_spatial_profile_times_parameter():
+    """`u(top) - g*sin(pi x)`: the parameter scales a coordinate profile — evaluated per boundary
+    node with the args-substituted parameter, not collapsed to a constant."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g * jno.np.sin(jno.np.pi * xb)])
+    oracle = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - 3.0 * jno.np.sin(jno.np.pi * xb)])
+    got = _solve_at(fem, {"g": np.asarray([3.0])})
+    np.testing.assert_allclose(got, np.asarray(oracle.solve()), rtol=1e-4, atol=1e-5)
+
+
+def test_one_parameter_in_operator_and_dirichlet_value():
+    """The coupling case naive affine lowering cannot express: k scales the stiffness AND is the
+    boundary value. The re-assembly route must handle both sites from one args entry."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    k = _param("k", 1.0, key=1)
+    fem = jno.fem([k * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - k])
+    oracle = jno.fem([2.0 * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - 2.0])
+    got = _solve_at(fem, {"k": np.asarray([2.0])})
+    np.testing.assert_allclose(got, np.asarray(oracle.solve()), rtol=1e-4, atol=1e-5)
+
+
+def test_fem_b_placeholder_reflects_the_stored_value():
+    """`fem.b` (the static placeholder) evaluates the Dirichlet parameter at its STORED value at
+    build time — like the net branch uses stored weights. NB `parameter.initialize` is lazy (applied
+    at crux compile), so the build-time stored value is whatever the module holds then."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 2.0)
+    stored = np.asarray(g.model.module.value)  # lazy initialize: this is what build sees
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    b_stored = np.asarray(fem.b)
+    b_at_stored = np.asarray(fem.operator.evaluate({"g": stored})[1])
+    np.testing.assert_allclose(b_stored, b_at_stored, rtol=1e-6, atol=1e-7)
+
+
+def test_scalar_parameter_without_optimizer_no_longer_crashes():
+    """The old path gathered a length-1 value by boundary-node id -> IndexError. A scalar
+    optimizer-less parameter is now runtime-parametric like any other."""
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    g = _param("g", 1.5)  # no .optimizer(...) attached
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    got = _solve_at(fem, {"g": np.asarray([1.5])})
+    assert np.all(np.isfinite(got))
+
+
+# --------------------------------------------------------------------------------------
+# the acceptance tests: recover a boundary value from data, all three paths
+# --------------------------------------------------------------------------------------
+def test_recover_boundary_value_steady_linear():
+    import optax
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    truth = np.asarray(jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - 2.5]).solve())
+    g = _param("g", 1.0)
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    crux = jno.core([(fem.solve() - truth).mse], domain=d)
+    g.optimizer(optax.adam(1e-1))
+    crux.solve(300)
+    rec = float(np.asarray(crux.eval([g])).reshape(-1)[0])
+    assert abs(rec - 2.5) / 2.5 < 0.01, f"recovered {rec}, want 2.5"
+
+
+def test_recover_boundary_value_steady_nonlinear():
+    import optax
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    truth = np.asarray(
+        jno.fem([(1.0 + ui * ui) * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - 1.5]).solve(
+            nonlinear=jno.solve.newton(rtol=1e-6, atol=1e-6)
+        )
+    )
+    g = _param("g", 0.5)
+    fem = jno.fem([(1.0 + ui * ui) * (ui.x * vi.x + ui.y * vi.y) - 1.0 * vi, u(xb, yb) - g])
+    crux = jno.core([(fem.solve() - truth).mse], domain=d)
+    g.optimizer(optax.adam(1e-1))
+    crux.solve(300)
+    rec = float(np.asarray(crux.eval([g])).reshape(-1)[0])
+    assert abs(rec - 1.5) / 1.5 < 0.01, f"recovered {rec}, want 1.5"
+
+
+def test_recover_boundary_value_linear_transient():
+    """A time-constant but TRAINABLE inlet value, recovered from the trajectory — the adjoint runs
+    through every step's custom_root."""
+    import optax
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces(size=0.35, time=(0.0, 0.5, 26))
+    ci = d.variable("initial", split=True)
+
+    def build(gval):
+        return jno.fem([ui.t * vi + ui.x * vi.x + ui.y * vi.y, u(xb, yb) - gval, u(ci[0], ci[1]) - 0.0])
+
+    truth = np.asarray(build(2.5).solve().fn())
+    g = _param("g", 1.0)
+    fem = build(g)
+    crux = jno.core([(fem.solve() - truth).mse], domain=d)
+    g.optimizer(optax.adam(2e-1))
+    crux.solve(150)
+    rec = float(np.asarray(crux.eval([g])).reshape(-1)[0])
+    assert abs(rec - 2.5) / 2.5 < 0.01, f"recovered {rec}, want 2.5"
+
+
+# --------------------------------------------------------------------------------------
+# breadth: vector per-component; the data-field branch must still work
+# --------------------------------------------------------------------------------------
+def test_vector_field_per_component_parametric_value():
+    d = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+    u, v = d.fem_symbols(value_shape=(2,))
+    inner, grad = jno.np.inner, jno.np.grad
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    g = _param("g", 1.0)
+    fem = jno.fem([inner(gu, gv, n_contract=2), u(xb, yb)[0] - g, u(xb, yb)[1] - 0.0])
+    oracle = jno.fem([inner(gu, gv, n_contract=2), u(xb, yb)[0] - 4.0, u(xb, yb)[1] - 0.0])
+    got = _solve_at(fem, {"g": np.asarray([4.0])})
+    np.testing.assert_allclose(got, np.asarray(oracle.solve()), rtol=1e-4, atol=1e-4)
+
+
+def test_parametric_times_temporal_value_refuses_loudly():
+    """`u(top) - g*tau`: the parametric branch would un-ramp the load, the temporal branch would
+    un-train the parameter — both silently wrong, so the combination must refuse at build."""
+    d = jno.Shape.rect(0, 0, 0.5, 1, size=0.3).domain(tau=(0.0, 1.0, 4))
+    u, v = d.fem_symbols(value_shape=(2,))
+    inner, grad = jno.np.inner, jno.np.grad
+    xi, yi, _ = d.variable("interior", split=True)
+    ct = d.variable("top", where=lambda x, y: y > 1 - 1e-9, split=True)
+    cb = d.variable("bottom", where=lambda x, y: y < 1e-9, split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    g = _param("g", 0.01)
+    with pytest.raises(NotImplementedError, match="BOTH runtime-parametric"):
+        jno.fem([inner(gu, gv, n_contract=2), u(*ct[:2])[1] - g * ct[-1], u(*cb[:2])[0] - 0.0, u(*cb[:2])[1] - 0.0])
+
+
+def test_field_sized_optimizerless_parameter_is_still_a_data_field():
+    """The nodal data-field branch (a neighbour's field in a DD solve) must be untouched: a
+    FIELD-sized optimizer-less parameter gathers per node, concretely, exactly as before."""
+    import equinox as eqx
+    import jax.numpy as jnp
+
+    d, u, v, ui, vi, (xb, yb) = _poisson_pieces()
+    n = int(np.asarray(d.mesh.points).shape[0])
+    vals = np.linspace(0.0, 1.0, n)
+    gfield = jno.np.parameter((n,), name="gfield")
+    gfield.model.module = eqx.tree_at(lambda m: m.value, gfield.model.module, jnp.asarray(vals))
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - gfield])
+    assert np.all(np.isfinite(np.asarray(fem.b)))


### PR DESCRIPTION
## What

Tier 2's first pair, everything differentiable. 6 commits. **Stacked on #106.**

### Runtime Dirichlet parameters
The documented limitation ("a trainable parameter may sit in the operator but not in an essential value") understated reality: a scalar parameter in a Dirichlet value **crashed** without an optimizer and was **silently frozen** with one. It now rides the net-valued-Dirichlet plumbing (collected like trainable mesh coordinates; held values re-formed from args as traced scalars).

**Measured**: crux recovers a boundary value on steady linear (**0.00%**, gradient FD-checks 30.000 vs 29.999), steady nonlinear (<1%, through `custom_root`), and a 26-step heat march (**0.01%**, adjoint through every step). Spatial profiles (`g·sin(πx)`) and operator+value shared parameters work; `g·τ` (parametric × temporal) refuses loudly — either silent alternative is wrong physics (see #103 for the composition). 15 tests.

### One-sided (Signorini) contact
The recorded "the max(0,·) kink stalls Newton" was **re-measured and re-classified**: a float32 residual floor, not active-set cycling — under x64 the identical iteration meets rtol=1e-8 at residual 4e-10, superlinearly (`jax.linearize` through `max` *is* the semismooth Jacobian, the `u.bounds` argument verbatim). What the 12 new tests pin:
- press → the bonded oracle like 1/c; release → exact separation (`max|u| < 1e-9`, no adhesion);
- **AL exactness**: the Uzawa multiplier as a scalar surface state riding `evolves` + the τ march — err **1.1e-5 vs the penalty's 3.4e-3 at the same c**, monotone over 8 updates, no new API;
- differentiability **through closed contact**: `jax.grad` of the response w.r.t. a parametric-Dirichlet grip displacement FD-checks to <5% — the two features of this PR composing in one test.

### Assembled tangent for contact
The gap's nonlocal Jacobian blocks — `(s,m)` by `jacfwd` w.r.t. the gathered main values chained through the frozen mortar weights, plus the reaction rows' `(m,s)`/`(m,m)` — replace the outright refusal, so **`newton(direct=True)` + LU/cuDSS works with contact**. Static pattern with the active branch in the data, keeping sparsity-keyed factorization caches valid across active-set changes. Gated against ground truth: assembled J ≡ matrix-free JVP on random probes in both branches; direct matches matrix-free to 5e-5.

### Pre-push fixes (caught by the full suite)
- `72473c3` — the tier-1 content cache could serve a kernel whose baked buffers a training loop had donated+deleted; entries now carry `(fn, pins, baked)` and check liveness.
- `f63cab4` — the τ-essential fail-loud guard (from #105) fired on the u_tt block, a legitimate consumer of the tv stash; the caller now declares itself (`tv_dirichlet_external=True`).
- `6ee3f2f` — the compile-cache default test updated to the flipped contract.

## Related issues

Found and filed during this work: #99 (u.bounds vector+coord-expr NaN), #100 (crux.eval staleness), #101 (flaky march test), #102 (vector mortar ties), #103 (param×τ essential), #104 (fem.stats completion). None are regressions of this PR.

## Verification

Full per-file suite (206 files) green except `test_symbol_positional_time::test_third_positional_coord_still_binds_z_in_3d`, which fails identically on `origin/main`.