### PR TITLE
A hexahedron's facet vertices are in tensor order, not perimeter order

### DIFF
--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -2632,6 +2632,45 @@ def _periodic_tie_spec(constraint: Any, domain: Any) -> Optional[Tuple[str, str,
     return (main_tag, secondary_tag, None, _field_key_of(constraint), phase)
 
 
+@functools.lru_cache(maxsize=None)
+def _facet_perimeter_order(nfv: int) -> Tuple[int, ...]:
+    """Local vertex indices putting a facet's vertices in PERIMETER (cyclic) order.
+
+    A triangular facet is already cyclic under basix's ordering, so this is the identity for it.
+    A **quadrilateral** facet is not: basix lists a hexahedron face's vertices in TENSOR order --
+    ``(0,0), (1,0), (0,1), (1,1)`` -- so walking consecutive pairs as a cycle gives
+    ``[edge, DIAGONAL, edge, DIAGONAL]`` on every one of the six faces.
+
+    Consuming that as a perimeter had two consequences, both silent: the edge walk in
+    :func:`_ref_interior_facet_dofs` covered only two of the four real edges, dropping the
+    edge-interior DOFs of the other two from the facet table; and the face-interior test took
+    ``fv[-1] - fv[0]`` -- a diagonal -- as its second in-plane basis vector. Since
+    ``_boundary_node_ids`` resolves an essential condition through that table, the dropped DOFs were
+    simply never constrained: measured at **2 of 98** boundary DOFs on an order-2 hex cube (n=2), 3
+    of 218 at n=3, always on one edge, with tetrahedra unaffected. It only surfaced when the
+    prescribed value varied normal to the two faces meeting at that edge (``g = x`` failed,
+    ``g = z``/``x*y``/const passed), which made the order-2 space look as though it reproduced
+    quadratics but not linears.
+
+    Derived from basix's own quadrilateral edge list rather than hardcoded, so it follows the
+    convention instead of restating it.
+    """
+    if nfv != 4:
+        return tuple(range(nfv))
+    import basix as _basix
+
+    from .utils.solver.fem_lagrange import basix_cell
+
+    adj: dict = {i: [] for i in range(nfv)}
+    for a, b in _basix.topology(basix_cell("quadrilateral")[0])[1]:  # the quad's REAL edges
+        adj[int(a)].append(int(b))
+        adj[int(b)].append(int(a))
+    walk = [0, adj[0][0]]
+    while len(walk) < nfv:  # follow the edge cycle, never stepping back the way we came
+        walk.append(next(v for v in adj[walk[-1]] if v != walk[-2]))
+    return tuple(walk)
+
+
 def _ref_interior_facet_dofs(
     ref_pts: np.ndarray, fv: np.ndarray, dim: int, tol: float = 1e-9, ncorner_override: int = 0
 ) -> List[int]:
@@ -2646,10 +2685,13 @@ def _ref_interior_facet_dofs(
     ncorner = int(ncorner_override) if ncorner_override else dim + 1
     cand = list(range(ncorner, len(ref_pts)))
     # The facet's own edges, walked cyclically. A 2-D facet is a single edge; a 3-D facet is a
-    # triangle (3 edges) or -- on a hexahedron -- a QUADRILATERAL (4). `fv` arrives in perimeter
-    # order, so the cycle is simply consecutive pairs.
+    # triangle (3 edges) or -- on a hexahedron -- a QUADRILATERAL (4). `fv` does NOT arrive in
+    # perimeter order for the quadrilateral (basix gives tensor order), so reorder it first; for a
+    # triangle `_facet_perimeter_order` is the identity and this is a no-op. See that function for
+    # what walking the tensor order as a cycle silently cost.
     nfv = len(fv)
-    edges = [(fv[0], fv[1])] if dim == 2 else [(fv[i], fv[(i + 1) % nfv]) for i in range(nfv)]
+    fvp = fv[list(_facet_perimeter_order(nfv))]
+    edges = [(fv[0], fv[1])] if dim == 2 else [(fvp[i], fvp[(i + 1) % nfv]) for i in range(nfv)]
     ordered: List[int] = []
     used: set = set()
     for a, b in edges:
@@ -2666,18 +2708,19 @@ def _ref_interior_facet_dofs(
             ordered.append(d)
             used.add(d)
     if dim == 3:  # face-interior nodes: on the facet plane, strictly inside it, not on one of its edges
-        a = fv[0]
+        a = fvp[0]
         # Two in-plane directions. For a triangle they are its two edges from `a`; for a quadrilateral
         # facet (perimeter order a, b, c, d) they are the two edges a->b and a->d, and the containment
         # test is the unit SQUARE rather than `s + t <= 1` -- a triangle test would reject half the
-        # face, dropping its interior node.
+        # face, dropping its interior node. Both read from the PERIMETER order: under basix's tensor
+        # order `fv[-1] - a` is the face DIAGONAL, not an in-plane edge direction at all.
         if nfv == 3:
-            M = np.stack([fv[1] - a, fv[2] - a], axis=1)  # (3, 2)
+            M = np.stack([fvp[1] - a, fvp[2] - a], axis=1)  # (3, 2)
 
             def _inside(s, t):
                 return min(s, t, 1.0 - s - t) >= -tol
         else:
-            M = np.stack([fv[1] - a, fv[-1] - a], axis=1)
+            M = np.stack([fvp[1] - a, fvp[-1] - a], axis=1)
 
             def _inside(s, t):
                 return min(s, t, 1.0 - s, 1.0 - t) >= -tol

--- a/tests/test_fem_hex_boundary_facets.py
+++ b/tests/test_fem_hex_boundary_facets.py
@@ -1,0 +1,167 @@
+"""Every boundary DOF must reach the boundary facet table — including a hexahedron's edge nodes.
+
+``_boundary_node_ids`` resolves an essential condition through the boundary FACET table, so a DOF
+missing from that table is simply never constrained. It does not raise; the solve returns a
+plausible wrong answer.
+
+Order-2 hexes did exactly that. ``_ref_interior_facet_dofs`` walked a facet's edges as *consecutive
+vertex pairs*, documented as "``fv`` arrives in perimeter order" — but basix lists a hexahedron
+face's vertices in **tensor** order, so the consecutive pairs are ``[edge, DIAGONAL, edge,
+DIAGONAL]`` on every one of the six faces. Two of the four real edges were never walked, their
+edge-interior DOFs never entered the table, and the same assumption handed the face-interior test a
+diagonal as its second in-plane basis vector.
+
+Measured before the fix: **2 of 98** boundary DOFs uncovered on an ``n=2`` hex cube, 3 of 218 at
+``n=3`` — always on one edge, tetrahedra unaffected.
+
+What made it expensive to find is that it hides. The missing constraint is invisible whenever the
+prescribed value happens to be consistent with the natural condition at that edge, so ``g = 1``,
+``z``, ``x*y`` and ``x*x - y*y`` all passed while ``g = x`` failed by 1.3e-01 — i.e. the order-2
+space appeared to reproduce *quadratics* but not *linears*, which is impossible for a real space and
+sent the diagnosis down the wrong path.
+
+The oracle here is coverage of the facet table itself, not a solution error: coverage is exact and
+mesh-independent, whereas a solution error only reveals the nodes where the missing constraint
+happened to matter.
+"""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+import pytest
+
+import jno
+from jno._fem import _boundary_facets, _facet_perimeter_order
+from jno.domain.geometries import Geometries
+
+meshio = pytest.importorskip("meshio")
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """FEM assembly is float64; these tests opt in per-test (the session default is x64-off)."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _box(cell, n, order):
+    """Build a unit-cube problem and return (dof points, assembly cells, meshio cell type)."""
+    m, _, _ = Geometries.equi_distant_box(x_range=(0, 1), y_range=(0, 1), z_range=(0, 1), nx=n, ny=n, nz=n, cell=cell)(None)
+    d = jno.domain(lambda g: (m, 3, 1.0 / n), compute_mesh_connectivity=True)
+    u, v = d.fem_symbols(names=("u", "v"), order=order)
+    c = list(d.variable("interior", split=True)[:3])
+    fem = jno.fem([jno.np.inner(jno.np.grad(u, c), jno.np.grad(v, c), n_contract=1)])
+    pts = np.asarray(fem.field_points[0])
+    cells = np.asarray(d._fem_native_assembly_cells_all[0])
+    return pts, cells, ("hexahedron" if cell == "hex" else None)
+
+
+def _on_unit_cube_boundary(pts):
+    return (np.abs(pts).min(axis=1) < 1e-9) | (np.abs(pts - 1.0).min(axis=1) < 1e-9)
+
+
+def test_perimeter_order_walks_only_real_edges():
+    """The permutation must turn a basix quad facet into a cycle of genuine edges.
+
+    Checked on the hexahedron's own reference geometry rather than restating ``(0, 1, 3, 2)``: two
+    reference vertices span a real edge exactly when they differ in ONE coordinate.
+    """
+    basix = pytest.importorskip("basix")
+    from jno.utils.solver.fem_lagrange import basix_cell
+
+    assert _facet_perimeter_order(3) == (0, 1, 2), "a triangular facet is already cyclic"
+    perm = _facet_perimeter_order(4)
+    assert sorted(perm) == [0, 1, 2, 3], "must be a permutation of the facet's vertices"
+
+    cell, tdim = basix_cell("hexahedron")
+    geo = np.asarray(basix.geometry(cell))
+    for face in basix.topology(cell)[tdim - 1]:
+        ring = [face[i] for i in perm]
+        for k in range(4):
+            a, b = geo[ring[k]], geo[ring[(k + 1) % 4]]
+            assert int(np.sum(np.abs(a - b) > 1e-12)) == 1, f"{ring} takes a diagonal, not an edge"
+        # the two in-plane basis vectors must be independent (a diagonal makes them skew)
+        o = geo[ring[0]]
+        assert np.linalg.matrix_rank(np.stack([geo[ring[1]] - o, geo[ring[-1]] - o], axis=1)) == 2
+
+
+@pytest.mark.parametrize("cell", ["hex", "tetra"])
+@pytest.mark.parametrize("n", [2, 3])
+@pytest.mark.parametrize("order", [1, 2, 3])
+def test_boundary_facet_table_covers_every_boundary_dof(cell, n, order):
+    """No DOF on the geometric boundary may be absent from the boundary facet table.
+
+    This is the direct oracle for the bug: it failed at 2/98 for ``hex, n=2, order=2`` and 3/218 at
+    ``n=3``, while every tetrahedral case passed.
+    """
+    pts, cells, ctype = _box(cell, n, order)
+    covered = np.unique(np.asarray(_boundary_facets(pts, cells, 3, order, ctype)).reshape(-1))
+    on_boundary = np.flatnonzero(_on_unit_cube_boundary(pts))
+    missed = np.setdiff1d(on_boundary, covered)
+    assert missed.size == 0, (
+        f"{missed.size} of {on_boundary.size} boundary DOFs are absent from the facet table "
+        f"({cell}, n={n}, order={order}); an essential condition on them would be silently dropped. "
+        f"First few at {[tuple(np.round(pts[k], 4)) for k in missed[:4]]}"
+    )
+
+
+def _solve_laplace_with_dirichlet(cell, n, which):
+    """Solve -Laplace(u) = 0 with u = g on the whole boundary, for a HARMONIC g of degree <= 2.
+
+    The exact solution is then g itself, so any deviation is a failure to impose the condition (or
+    to represent g), not discretisation error.
+    """
+    m, _, _ = Geometries.equi_distant_box(x_range=(0, 1), y_range=(0, 1), z_range=(0, 1), nx=n, ny=n, nz=n, cell=cell)(None)
+    d = jno.domain(lambda g: (m, 3, 1.0 / n), compute_mesh_connectivity=True)
+    u, v = d.fem_symbols(names=("u", "v"), order=2)
+    x, y, z, _ = d.variable("interior", split=True)
+    b = d.variable("boundary", split=True)
+    gs = {
+        "one": (lambda c: 0 * c[0] + 1.0, lambda P: np.ones(len(P))),
+        "x": (lambda c: c[0], lambda P: P[:, 0]),
+        "z": (lambda c: c[2], lambda P: P[:, 2]),
+        "x+2y+3z": (lambda c: c[0] + 2 * c[1] + 3 * c[2], lambda P: P[:, 0] + 2 * P[:, 1] + 3 * P[:, 2]),
+        "x*y": (lambda c: c[0] * c[1], lambda P: P[:, 0] * P[:, 1]),
+        "x*x-y*y": (lambda c: c[0] * c[0] - c[1] * c[1], lambda P: P[:, 0] ** 2 - P[:, 1] ** 2),
+    }
+    gfn, exact = gs[which]
+    fem = jno.fem(
+        [
+            jno.np.inner(jno.np.grad(u, [x, y, z]), jno.np.grad(v, [x, y, z]), n_contract=1),
+            u(b[0], b[1], b[2]) - gfn(b),
+        ]
+    )
+    sol = np.asarray(fem.solve()).reshape(-1)
+    pts = np.asarray(fem.field_points[0])
+    err = np.abs(sol[: len(pts)] - exact(pts))
+    return float(err[_on_unit_cube_boundary(pts)].max())
+
+
+@pytest.mark.parametrize("which", ["x", "x+2y+3z"])
+def test_hex_dirichlet_imposes_a_field_varying_normal_to_the_faces(which):
+    """The cases the bug actually broke: g varying normal to the two faces meeting at an edge.
+
+    Before the fix these came back at 1.3e-01 and 4.0e-01 on the Q2 edge nodes.
+    """
+    assert _solve_laplace_with_dirichlet("hex", 2, which) < 1e-7
+
+
+@pytest.mark.parametrize("which", ["one", "z", "x*y", "x*x-y*y"])
+def test_hex_dirichlet_cases_that_already_passed_still_pass(which):
+    """Guards against a 'fix' that merely moves which nodes are unconstrained.
+
+    These passed even with the broken facet table, because the missing constraint happened to agree
+    with the natural condition at that edge. They must keep passing.
+    """
+    assert _solve_laplace_with_dirichlet("hex", 2, which) < 1e-7
+
+
+@pytest.mark.parametrize("which", ["x", "x+2y+3z", "x*y"])
+def test_tetra_dirichlet_is_unaffected(which):
+    """The simplex path is deliberately untouched — its DOF ordering is a contract other code reads."""
+    assert _solve_laplace_with_dirichlet("tetra", 2, which) < 1e-7


### PR DESCRIPTION
A hexahedron's facet vertices are in **tensor** order, not perimeter order.

Stacked on #111 — this fixes a defect in the order-2 hex path that PR introduces, so it targets
that branch rather than `main`.

## The defect

`_ref_interior_facet_dofs` builds a facet's edge list by walking consecutive vertex pairs, on the
documented assumption that `fv` arrives in perimeter order:

```python
edges = [(fv[i], fv[(i + 1) % nfv]) for i in range(nfv)]   # "fv arrives in perimeter order"
```

basix lists a hexahedron face's vertices in **tensor** order, so on every one of the six faces the
consecutive pairs come out `[edge, DIAGONAL, edge, DIAGONAL]`. Two of the four real edges are never
walked, and their edge-interior DOFs never enter the boundary facet table. The same assumption hands
the face-interior containment test `fv[-1] - fv[0]` — a diagonal — as its second in-plane basis
vector.

`_boundary_node_ids` resolves an essential condition **through** that table, so the dropped DOFs were
never constrained. Nothing raised; the solve returned a finite, plausible, wrong answer.

```
hex   n=2:   98 boundary DOFs,  96 covered,  MISSED=2   (all on the edge x=y=0)
hex   n=3:  218 boundary DOFs, 215 covered,  MISSED=3
tetra n=2/3: MISSED=0 at every order
```

## Why it hid

The missing constraint is invisible whenever the prescribed value happens to agree with the natural
condition at that edge. Measured on the Q2 edge nodes:

| g | error | | g | error |
|---|---|---|---|---|
| `1` | 1.9e-08 ok | | `x` | **1.33e-01** |
| `z` | 7.1e-09 ok | | `x + y` | **2.66e-01** |
| `x*y` | 8.6e-09 ok | | `2*x` | **2.66e-01** |
| `x*x - y*y` | 1.6e-10 ok | | `x + 2y + 3z` | **3.99e-01** |

Exactly `0.133 × (coeff_x + coeff_y)`; `z` contributes nothing. Read through a solve, that looks like
an order-2 space reproducing **quadratics but not linears** — impossible for a real space, and it
sent the first diagnosis at the element rather than at two unconstrained nodes.

## The fix

Reorder a tensor-product facet's vertices to perimeter order before both uses. The permutation is
derived from `basix.topology(quadrilateral)[1]` rather than hardcoded, so it follows the convention
instead of restating it; it works out to `(0, 1, 3, 2)` and is the identity for a triangle, leaving
the simplex path byte-identical — that matters, because the simplex DOF *order* is the contract
`_periodic_facet_weights` reads.

The facet's leading vertex columns are deliberately left in basix order: consumers count them or
match by coordinate, and reordering them would put the hex-tie and hanging-node paths at risk for no
gain.

## Verified

- **0 missed** boundary DOFs across hex/tet × n=2,3 × orders 1,2,3. Order 3 was affected too.
- `g = x`: **1.33e-01 → 7.35e-12**.
- New `tests/test_fem_hex_boundary_facets.py`: 22 pass, and **6 fail with the reorder neutralised** —
  the test was checked against the bug, not just against the fix.
- 137 existing tests green: hex ties, hanging nodes, quad/hex refinement, and the quad/hex
  boundary/element/mesh/domain suites.

The new test's oracle is **coverage of the facet table**, not a solution error: coverage is exact and
mesh-independent, where a solution error only reveals the nodes at which the missing constraint
happened to matter.
