### PR TITLE
Docstring wording, and an explicit input path for the reanalysis example

### DIFF
--- a/docs/fem.md
+++ b/docs/fem.md
@@ -655,7 +655,7 @@ written exactly as they are on a simplex mesh.
 **Why bother.** Linear triangles and tetrahedra are stiff: they lock in near-incompressible
 elasticity and are poor in bending, which is why mechanics codes are built on hexahedra. A
 quadrilateral grid is also the mesh the topology-optimisation literature is written on, and for
-layered geometry (a metasurface stack, a planar transformer, a PCB) a structured hex mesh is both
+layered geometry (a thin-film stack, a wound magnetic component, a PCB) a structured hex mesh is both
 better conditioned and far cheaper per node than tetrahedra.
 
 **Why 3-D is structured-only.** gmsh cannot hexahedral-mesh general geometry. Measured here,

--- a/docs/tutorial_examples/08_fem_and_varpinns/reanalysis.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/reanalysis.py
@@ -30,8 +30,7 @@ import jno  # noqa: E402
 inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
 
 p = argparse.ArgumentParser()
-BASE = "/tmp/claude-1000/-home-fleef-Work-projects-voithos/a8003704-902f-43f1-840f-06dc9c329d5c/scratchpad/"
-p.add_argument("--design", default=BASE + "fine_perim_deform_p0_patch_cont.npz")
+p.add_argument("--design", required=True, help="path to the .npz design field to re-analyse")
 p.add_argument("--h-fine", type=float, default=0.5, help="reanalysis mesh size")
 p.add_argument("--threshold", type=float, default=0.5)
 args = p.parse_args()

--- a/tests/test_fem_fieldsplit.py
+++ b/tests/test_fem_fieldsplit.py
@@ -60,7 +60,7 @@ def _stokes(mesh_size=0.3):
 # solution-dependent precond.form — the Picard-lagged Schur weight
 # --------------------------------------------------------------------------------------
 def test_solution_dependent_form_solves_and_matches():
-    """The pikimam spelling: a form whose coefficient is computed FROM the solution. It refreshes
+    """A form whose coefficient is computed FROM the solution. It refreshes
     from the outer iterate and the preconditioned solve must land on the plain solve's answer —
     a preconditioner changes speed, never the solution."""
     fem, ui, vi = _nonlinear_diffusion()
@@ -134,7 +134,7 @@ def test_diagonal_sub_block_is_assembled_sparse():
 
 
 def test_stokes_triangular_with_amg_velocity_block():
-    """The full pikimam-shaped recipe on a saddle system: triangular fieldsplit, multigrid on the
+    """The full rigid-plastic-flow recipe on a saddle system: triangular fieldsplit, multigrid on the
     velocity sub-block, weighted pressure mass as the Schur approximation."""
     pytest.importorskip("pyamg", reason="pyamg required for the hybrid AMG spec")
     fem, u, p, pp, qq, mu = _stokes()

--- a/tests/test_polygon_domain_build_mesh.py
+++ b/tests/test_polygon_domain_build_mesh.py
@@ -398,7 +398,7 @@ def test_build_mesh_interface_is_conforming_across_internal_interface():
 
     Furnace-faithful setup: a ``wall`` slab whose left edge x=2 is a single
     segment (2,0)-(2,3); a ``block`` touching that edge over z in [1,2]; and
-    ``Air`` built as the scene-box minus everything (as cg_furnace does). Air's
+    ``Air`` built as the scene-box minus everything. Air's
     boundary along x=2 is then split into (2,0)-(2,1) and (2,2)-(2,3) with
     vertices (2,1)/(2,2) that the wall's single edge lacks. Those vertices sit
     on an *internal* interface, so ``_collect_source_edge_endpoints`` (which


### PR DESCRIPTION
Prose tidy-up in two tests and one docs section, plus one argument default.

The fieldsplit tests and the polygon-domain test named particular components where the reader needs
the general case; they now describe the recipe or scene they actually exercise — a solution-dependent
coefficient, a triangular fieldsplit with multigrid on the velocity block and a weighted
pressure-mass Schur, a scene-box-minus-everything air region. Likewise the hex motivation in
`docs/fem.md` lists the *kind* of layered geometry that benefits from a structured hex mesh.

The reanalysis example took its design field from a hardcoded absolute default that resolved on one
machine only, so it could not run as written. `--design` is now `required=True`, which is what it
effectively already was.

No behaviour change beyond that argument: 5 lines of prose and one default.

Verified: `ruff format --check` and `ruff check` clean (372 files); the two touched test files pass
(32 tests).
