### PR TITLE
solve: a second solve() continues the first, instead of restarting the optimizer

### DIFF
--- a/jno/core.py
+++ b/jno/core.py
@@ -123,6 +123,24 @@ def _auto_gram_terms(constraints, fm) -> list:
     return gram_terms
 
 
+def _optimizer_states_match(a, b) -> bool:
+    """Whether two optax states have the same tree, leaf shapes and dtypes.
+
+    The test for "this is the same optimizer over the same parameters", and so for whether a state
+    carried over from a previous :meth:`core.solve` can be reused instead of re-initialised.
+    """
+    leaves_a, def_a = jax.tree_util.tree_flatten(a)
+    leaves_b, def_b = jax.tree_util.tree_flatten(b)
+    if def_a != def_b:
+        return False
+    for x, y in zip(leaves_a, leaves_b):
+        if getattr(x, "shape", None) != getattr(y, "shape", None):
+            return False
+        if getattr(x, "dtype", None) != getattr(y, "dtype", None):
+            return False
+    return True
+
+
 def _cpu_device():
     """Return a CPU JAX device.
 
@@ -531,6 +549,9 @@ class core:
         super().__init__()
 
         self._total_epochs = 0
+        # optax states from the last solve(). A second solve() CONTINUES the first, so these are
+        # carried over rather than re-initialised -- see the note where they are used.
+        self._opt_states: Optional[Dict[str, Any]] = None
         seed = int(get_seed())
         self.seed = seed
         self.rng = jax.random.PRNGKey(seed)
@@ -2835,6 +2856,21 @@ class core:
                 state = jno_bayesian.init_state(bayesian_handles[k], trainable[lid], _bay_init_key)
             else:
                 state = per_model_opts[k].init(trainable[lid])
+                # A second solve() CONTINUES the first. optax carries its own step count inside
+                # this state, so re-initialising it silently restarts every optax SCHEDULE --
+                # warmup, decay, join_schedules -- and a training loop that calls solve() in
+                # chunks (to checkpoint, to diagnose, to move a curriculum on) never leaves the
+                # first few steps of its schedule. Nothing warns; the run simply trains at the
+                # wrong rate. jNO's own LearningRateSchedule is already immune, because it reads
+                # the persistent ``self._total_epochs`` (see ``base_epoch``).
+                #
+                # Reuse is conditional on the freshly built state having the same tree, shapes and
+                # dtypes, which is exactly the condition for it to be the same optimizer over the
+                # same parameters; change either and the fresh state is used. To ask for a genuine
+                # restart, build a new ``jno.core`` -- states live on the instance.
+                _prev = (self._opt_states or {}).get(k)
+                if _prev is not None and _optimizer_states_match(_prev, state):
+                    state = _prev
             # Copy every array leaf so that aliased buffers (e.g. from
             # L-BFGS zero-initialised history arrays that share the same
             # underlying allocation) become distinct.  Without this,
@@ -4676,6 +4712,8 @@ class core:
                 wandb_log_model(self)
 
         self._total_epochs += epochs
+        # Hand the optimizer states to the next solve() so schedules continue across the call.
+        self._opt_states = opt_states
 
         # --- callbacks: on_training_end ---
         if callbacks:

--- a/tests/test_optimizer_state_persists.py
+++ b/tests/test_optimizer_state_persists.py
@@ -1,0 +1,99 @@
+"""A second ``solve()`` continues the first, rather than restarting the optimizer.
+
+optax carries its step count inside the optimizer state. Re-initialising that state on every
+``solve()`` restarts every optax schedule, so a loop that trains in chunks -- to checkpoint, to
+diagnose, to advance a curriculum -- never leaves the first few steps of its schedule. Nothing
+raises; the run just trains at the wrong rate for its whole life.
+
+jNO's own :class:`LearningRateSchedule` is immune already: it reads the persistent
+``self._total_epochs``. These tests are about the optax side.
+"""
+
+import foundax
+import jax
+import numpy as np
+import optax
+import pytest
+
+import jno
+
+
+def _fit(chunks, epochs, lr_schedule):
+    """Train `sum(chunks)` epochs, split as given, and return the final parameter."""
+    # A MESHED domain, so `variable("interior")` is the fixed node set. A mesh-free domain draws
+    # fresh points on every call, and that alone changes the answer between runs -- which would
+    # mask exactly the effect these tests measure.
+    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
+    x, y, _ = d.variable("interior", split=True)
+    net = jno.nn(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(0)))
+    net.optimizer(optax.adam(lr_schedule))
+    u = net(x, y).scalar
+    crux = jno.core([(u - 1.0).mse])
+    for n in chunks:
+        crux.solve(n)
+    return float(np.asarray(crux.eval([(u - 1.0).mse])[0]).ravel()[0])
+
+
+def test_a_chunked_run_matches_one_long_run():
+    """The headline contract: HOW the epochs are split must not change what training does.
+
+    Under a decaying schedule a restart holds the rate at its initial value, so a chunked run
+    trains FASTER than it should -- the two losses come out different, and neither is a warning.
+    """
+    sched = optax.exponential_decay(1e-2, transition_steps=40, decay_rate=0.3, end_value=1e-6)
+    one = _fit([200], 200, sched)
+    many = _fit([50, 50, 50, 50], 200, sched)
+    assert one == pytest.approx(many, rel=1e-4), (
+        f"splitting 200 epochs into 4 chunks changed the result: {one:.6e} vs {many:.6e}"
+    )
+
+
+def test_a_warmup_boundary_is_crossed_by_chunked_training():
+    """A schedule that is ZERO until step N must still release when the epochs arrive in chunks.
+
+    This is the shape of a curriculum -- hold a parameter while something else is solved, then let
+    it move. With the state restarted per call, and chunks shorter than the boundary, the release
+    never happens and the held parameter stays at its initial value forever.
+    """
+    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
+    x, y, _ = d.variable("interior", split=True)
+    net = jno.nn(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(1)))
+    held = jno.np.parameter((1,), key=jax.random.PRNGKey(2), name="held")
+
+    frozen_then_free = optax.join_schedules([optax.constant_schedule(0.0), optax.constant_schedule(1e-1)], boundaries=[100])
+    net.optimizer(optax.adam(1e-3))
+    held.optimizer(optax.adam(frozen_then_free))
+
+    crux = jno.core([(net(x, y).scalar + held[0] - 1.0).mse])
+    read = lambda: float(np.asarray(crux.eval([held])[0]).ravel()[0])  # noqa: E731
+
+    start = read()
+    for _ in range(4):  # 4 x 40 = 160 epochs, crossing the boundary at 100
+        crux.solve(40)
+    assert abs(read() - start) > 1e-3, "the held parameter never moved: the boundary was never crossed"
+
+
+def test_a_fresh_core_starts_the_optimizer_over():
+    """The escape hatch. States live on the core, so a new one is a genuine restart -- which is
+    what makes the carry-over safe to have by default."""
+    sched = optax.exponential_decay(1e-2, transition_steps=40, decay_rate=0.3, end_value=1e-6)
+    a = _fit([200], 200, sched)
+    b = _fit([200], 200, sched)
+    assert a == pytest.approx(b, rel=1e-9), "two independent cores must train identically"
+
+
+def test_changing_the_optimizer_reinitialises_rather_than_reusing():
+    """A carried state is reused only when it FITS. Swap the optimizer for one with a different
+    state and the fresh one is taken, instead of a shape error deep in the update."""
+    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
+    x, y, _ = d.variable("interior", split=True)
+    net = jno.nn(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(3)))
+    net.optimizer(optax.adam(1e-3))
+    u = net(x, y).scalar
+    crux = jno.core([(u - 1.0).mse])
+    crux.solve(20)
+
+    net.optimizer(optax.sgd(1e-2))  # different state tree
+    crux2 = jno.core([(u - 1.0).mse])
+    crux2.solve(20)  # must not raise
+    assert np.isfinite(float(np.asarray(crux2.eval([(u - 1.0).mse])[0]).ravel()[0]))


### PR DESCRIPTION
optax carries its step count inside the optimizer state, and that state was re-initialised on every
`solve()` (`core.py`, the `per_model_opts[k].init(...)` loop). A training loop that calls `solve()` in
chunks — to checkpoint, to read a diagnostic, to advance a curriculum — therefore restarted every
optax schedule on each call and never left the first few steps of it.

Nothing raised. The run simply trained at the wrong rate for its whole life, and reported a plausible
result.

## Measured

| | one call | split into chunks |
|---|---|---|
| 200 epochs, `exponential_decay` | 2.077e-03 | 2.288e-03 |

A schedule held at zero until step 100 (`join_schedules`) never released at all when the chunks were
40 epochs long: the parameter it was holding sat at its initial value for the entire run.

## The change

The states are carried on the instance and reused — but only when the freshly built state has the
same tree, leaf shapes and dtypes, which is exactly the condition for it to be the same optimizer
over the same parameters. Change either and the fresh state is taken, rather than a shape error
surfacing deep inside an update.

A new `jno.core` still starts clean. States live on the instance, so constructing one is how to ask
for a genuine restart — which is what makes carrying state safe as the default.

jNO's own `LearningRateSchedule` was never affected: it reads the persistent `_total_epochs` via
`base_epoch`. Only optax's internal count was being reset.

## Tests

`tests/test_optimizer_state_persists.py`, four tests. The first two fail without this change
(verified by stashing it); the last two guard the new behaviour and pass either way.

- a chunked run matches one long run
- a warmup boundary is crossed by chunked training
- a fresh core starts the optimizer over
- changing the optimizer reinitialises rather than reusing

They use a **meshed** domain deliberately: with a mesh-free one each `variable()` call draws fresh
points, and that noise alone is larger than the effect under test.

## Verification

- 235 passed, 0 failed — `test_core`, `test_resampling`, `test_checkpointing`, `test_adaptive`,
  `test_engd_optimizer`, `test_integration`, `test_tune_sequence`, `test_ad_mode`.
- All 68 test files that construct a `jno.core` (found by grep, not by judgement), on GPU:
  2038 passed, 30 failed.
- Every one of those 30 was then run standalone on GPU against `origin/main`. The branch gives
  **2 failed / 109 passed** where base gives **3 failed / 108 passed**, and the branch's two are a
  subset of base's three. The remaining 27 do not reproduce standalone — they are full-suite
  context effects across 68 files sharing one process.