### PR TITLE
tests: keep jax_enable_x64 inside the test that wants it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,41 @@ os.environ.setdefault("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
 # many dtype-sensitive tests (bayesian/blackjax, pdeformer/equinox, the dtype defaults). FEM tests
 # that genuinely need float64 opt in per-test via their local ``_x64`` autouse fixture.
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_x64():
+    """Put ``jax_enable_x64`` back the way the test found it.
+
+    The flag is process-wide, and it decides the float width of every subsequent computation. A test
+    that flips it and does not put it back silently changes the precision of every test that runs
+    after it, in whatever order pytest happened to pick -- so the failure reproduces only in
+    company, never alone, and lands on a file that did nothing wrong.
+
+    Measured before this fixture existed::
+
+        pytest tests/test_fdm.py                          ->  41 passed
+        pytest tests/test_node_eval.py tests/test_fdm.py  ->  16 failed, 33 passed
+
+    One unrelated 8-test file in front, and `newton_krylov` in test_fdm stops converging, because
+    its solves dropped to float32. Restoring per test makes the suite order-independent; the warning
+    keeps the offending test named rather than quietly healed.
+    """
+    prev = jax.config.jax_enable_x64
+    yield
+    if jax.config.jax_enable_x64 != prev:
+        jax.config.update("jax_enable_x64", prev)
+        warnings.warn(
+            f"this test left jax_enable_x64 as {not prev} instead of {prev}; it has been restored, "
+            "but set the flag through a save/restore fixture rather than in the test body",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_concat_temporal.py
+++ b/tests/test_concat_temporal.py
@@ -20,9 +20,12 @@ import jno
 
 @pytest.fixture(autouse=True)
 def _x64():
+    prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
-    yield
-    jax.config.update("jax_enable_x64", False)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 def test_bare_temporal_matches_manual_broadcast():

--- a/tests/test_domain_decomposition.py
+++ b/tests/test_domain_decomposition.py
@@ -21,7 +21,17 @@ from shapely.geometry import Point, box  # noqa: E402
 
 import jno  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 def _region_mask(points, geometry):

--- a/tests/test_engd_optimizer.py
+++ b/tests/test_engd_optimizer.py
@@ -8,10 +8,24 @@ import equinox as eqx
 import jax
 import numpy as _np
 import optax
+import pytest
 
 import jno
 from jno.optimizers import ENGDOptimizer, engd
 from jno.optimizers.engd import ENGDOptimizer as _ENGDOptimizerDirect
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """ENGD's Gram solve needs float64. The session default is x64-off (see tests/conftest.py), and
+    the flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 # ---------------------------------------------------------------------------
 # Inline Poisson2D fixture (jno.baseline lives on a separate branch)
@@ -118,9 +132,6 @@ def test_engd_repr():
 
 def test_engd_optimizer_auto_detect_smoke():
     """net.optimizer(engd()) resolves gram_terms automatically during solve."""
-    import jax
-
-    jax.config.update("jax_enable_x64", True)
 
     net, losses, _, eval_error = _build_poisson2d(seed=0)
     net.optimizer(engd())  # no optax.sgd, no gram_terms
@@ -139,9 +150,6 @@ def test_engd_optimizer_auto_detect_smoke():
 
 def test_engd_optimizer_explicit_gram_terms():
     """Explicit gram_terms= bypasses auto-detection and is forwarded."""
-    import jax
-
-    jax.config.update("jax_enable_x64", True)
 
     net, losses, gram_terms, eval_error = _build_poisson2d(seed=0)
     net.optimizer(engd(gram_terms=gram_terms))
@@ -159,9 +167,6 @@ def test_engd_optimizer_explicit_gram_terms():
 
 def test_engd_optimizer_convergence():
     """jno.optimizers.engd() must reach rel-L² < 1e-3 in 200 epochs (=callbacks form)."""
-    import jax
-
-    jax.config.update("jax_enable_x64", True)
 
     net, losses, _, eval_error = _build_poisson2d(seed=0)
     net.optimizer(engd(line_search=True))
@@ -182,9 +187,6 @@ def test_engd_optimizer_orphan_model_is_ignored():
     """A model with ENGDOptimizer that isn't in any constraint is not detected
     (it never appears in all_ops), so no error is raised and no ENGDCallback
     is injected.  The primary model still trains normally."""
-    import jax
-
-    jax.config.update("jax_enable_x64", True)
 
     import foundax
 
@@ -216,9 +218,6 @@ def test_engd_optimizer_orphan_model_is_ignored():
 
 def test_engd_optimizer_idempotent_solve():
     """fm._opt_fn stays an ENGDOptimizer across multiple solve() calls."""
-    import jax
-
-    jax.config.update("jax_enable_x64", True)
 
     net, losses, _, eval_error = _build_poisson2d(seed=0)
     net.optimizer(engd(gram_interval=2))
@@ -244,11 +243,8 @@ def test_engd_optimizer_custom_reduction_unwrapped_via_reduces_axis():
     """Auto-detect strips reduction wrappers via FunctionCall.reduces_axis,
     not by name — so a custom reduction function still gets unwrapped
     correctly and the raw residual is passed to .grad()."""
-    import jax
 
     from jno.trace import FunctionCall
-
-    jax.config.update("jax_enable_x64", True)
 
     net, losses, _, eval_error = _build_poisson2d(seed=0)
 
@@ -273,7 +269,6 @@ def test_engd_optimizer_custom_reduction_unwrapped_via_reduces_axis():
 
 def test_engd_optimizer_in_compare():
     """engd() dict style works end-to-end when run against Adam."""
-    jax.config.update("jax_enable_x64", True)
 
     results = {}
     for name, opt in [("Adam", optax.adam(1e-3)), ("ENGD-new", engd(line_search=True))]:

--- a/tests/test_fdm.py
+++ b/tests/test_fdm.py
@@ -13,7 +13,17 @@ from shapely.geometry import box  # noqa: E402
 
 import jno  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 def _nodes(d):

--- a/tests/test_fdm_structured.py
+++ b/tests/test_fdm_structured.py
@@ -19,7 +19,17 @@ from shapely.geometry import box  # noqa: E402
 
 import jno  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 def _nodes(d):

--- a/tests/test_fem_adaptive_load_path.py
+++ b/tests/test_fem_adaptive_load_path.py
@@ -35,7 +35,18 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno
 

--- a/tests/test_fem_bounds.py
+++ b/tests/test_fem_bounds.py
@@ -42,7 +42,18 @@ import jax
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno
 

--- a/tests/test_fem_dirichlet_symmetry.py
+++ b/tests/test_fem_dirichlet_symmetry.py
@@ -32,8 +32,20 @@ os.environ.setdefault("JAX_PLATFORMS", "cpu")
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno
 

--- a/tests/test_fem_history_march.py
+++ b/tests/test_fem_history_march.py
@@ -29,7 +29,18 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno
 

--- a/tests/test_fem_load_path_field.py
+++ b/tests/test_fem_load_path_field.py
@@ -20,7 +20,18 @@ import jax
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno
 

--- a/tests/test_fem_phase_field_sent.py
+++ b/tests/test_fem_phase_field_sent.py
@@ -25,7 +25,18 @@ import jax
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno
 

--- a/tests/test_fem_staggered.py
+++ b/tests/test_fem_staggered.py
@@ -28,7 +28,18 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno
 

--- a/tests/test_geometric_mg.py
+++ b/tests/test_geometric_mg.py
@@ -13,7 +13,17 @@ import jno  # noqa: E402
 from jno.utils.solver.geometric_mg import _interior_mask, _neg_laplacian, build_vcycle  # noqa: E402
 from jno.utils.solver.solver_api import LinearOperator, PrecondContext  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 def _poisson(size, dim=2):

--- a/tests/test_newton_convergence_guard.py
+++ b/tests/test_newton_convergence_guard.py
@@ -11,7 +11,18 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 from jno.utils.solver.newton_krylov import newton_direct, newton_krylov  # noqa: E402
 

--- a/tests/test_node_eval.py
+++ b/tests/test_node_eval.py
@@ -11,9 +11,12 @@ import jno
 
 @pytest.fixture(autouse=True)
 def _x64():
+    prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
-    yield
-    jax.config.update("jax_enable_x64", False)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 def _heat(coef, size=0.4, steps=3):

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -12,7 +12,18 @@ import jax  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 import jno.jnp_ops as jnn  # noqa: E402

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -17,7 +17,18 @@ import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 from jno.trace import FunctionCall  # noqa: E402

--- a/tests/test_rcwa_anisotropic.py
+++ b/tests/test_rcwa_anisotropic.py
@@ -16,7 +16,18 @@ import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 from jno.trace.views import MatrixView  # noqa: E402

--- a/tests/test_rcwa_general_anisotropic.py
+++ b/tests/test_rcwa_general_anisotropic.py
@@ -14,7 +14,18 @@ os.environ.setdefault("JAX_PLATFORMS", "cpu")  # the fmmax solve OOMs on a small
 import jax  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 from jno.rcwa import Rcwa  # noqa: E402
 

--- a/tests/test_rcwa_incidence.py
+++ b/tests/test_rcwa_incidence.py
@@ -17,7 +17,18 @@ import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 from jno.utils.solver.fem_adapt import _domain_from_arrays  # noqa: E402

--- a/tests/test_rcwa_pml.py
+++ b/tests/test_rcwa_pml.py
@@ -25,7 +25,18 @@ import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 from jno.rcwa import RcwaError  # noqa: E402

--- a/tests/test_rcwa_profile.py
+++ b/tests/test_rcwa_profile.py
@@ -15,7 +15,18 @@ import jax  # noqa: E402
 import jax.numpy as jnp  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 

--- a/tests/test_rcwa_smoothing.py
+++ b/tests/test_rcwa_smoothing.py
@@ -18,7 +18,18 @@ import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 from jno.rcwa import RcwaError, _sample_grid_direct  # noqa: E402

--- a/tests/test_rcwa_source.py
+++ b/tests/test_rcwa_source.py
@@ -19,7 +19,18 @@ import jax.numpy as jnp  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 from jno.rcwa import Rcwa, RcwaError  # noqa: E402

--- a/tests/test_rcwa_vector.py
+++ b/tests/test_rcwa_vector.py
@@ -17,7 +17,18 @@ import jax.numpy as jnp  # noqa: E402
 import numpy as np
 import pytest
 
-jax.config.update("jax_enable_x64", True)
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """These tests run in float64. The session default is x64-off (see tests/conftest.py), and this
+    flag is process-wide -- save/restore keeps it from leaking to whatever module runs next."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
 
 import jno  # noqa: E402
 

--- a/tests/test_symbol_positional_time.py
+++ b/tests/test_symbol_positional_time.py
@@ -14,9 +14,12 @@ import jno
 
 @pytest.fixture(autouse=True)
 def _x64():
+    prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
-    yield
-    jax.config.update("jax_enable_x64", False)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 def _periodic_transient(splat: bool):

--- a/tests/test_x64_isolation.py
+++ b/tests/test_x64_isolation.py
@@ -1,0 +1,55 @@
+"""``jax_enable_x64`` is process-wide, so nothing may set it where the setting outlives one test.
+
+The flag decides the float width of every subsequent computation. Set at module scope it fires
+during COLLECTION -- before a single test runs, for every module pytest imported -- and there is no
+scope for it to be restored at. The result is a suite whose outcome depends on which files were
+selected and in what order.
+
+That is not hypothetical. Before this was fixed::
+
+    pytest tests/test_fdm.py                          ->  41 passed
+    pytest tests/test_node_eval.py tests/test_fdm.py  ->  16 failed, 33 passed
+
+One unrelated 8-test file in front, and `newton_krylov` in test_fdm stopped converging, because its
+solves had dropped to float32. Cross-file effects of exactly this shape were repeatedly mistaken for
+GPU contention and for real regressions, and cost hours of re-running to rule out.
+
+In-test mutations are caught at runtime by the ``_restore_x64`` fixture in conftest. Module-scope
+ones cannot be, which is what this test is for.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+TESTS = pathlib.Path(__file__).parent
+# Not collected as a test module -- it is executed as a subprocess, where module scope is the only
+# scope there is and nothing can leak out of the process.
+EXEMPT = {"_sharding_inner.py"}
+
+
+def _module_scope_x64_writes(path: pathlib.Path) -> list[int]:
+    """Line numbers where this module sets ``jax_enable_x64`` at module scope."""
+    tree = ast.parse(path.read_text())
+    hits = []
+    for node in tree.body:  # top level ONLY: a write inside a def/class is scoped and fine
+        for sub in ast.walk(node) if isinstance(node, (ast.Expr, ast.If, ast.Try, ast.With)) else []:
+            if not isinstance(sub, ast.Call):
+                continue
+            if not (isinstance(sub.func, ast.Attribute) and sub.func.attr == "update"):
+                continue
+            if sub.args and isinstance(sub.args[0], ast.Constant) and sub.args[0].value == "jax_enable_x64":
+                hits.append(sub.lineno)
+    return hits
+
+
+@pytest.mark.parametrize("path", sorted(p for p in TESTS.glob("*.py") if p.name not in EXEMPT), ids=lambda p: p.name)
+def test_no_module_scope_x64_mutation(path):
+    """Set it in an autouse fixture that restores it, the way ``tests/test_fem_1d.py`` does."""
+    lines = _module_scope_x64_writes(path)
+    assert not lines, (
+        f"{path.name} sets jax_enable_x64 at module scope (line{'s' if len(lines) > 1 else ''} "
+        f"{', '.join(map(str, lines))}). That runs at import, for every module in the selection, and "
+        f"cannot be undone -- put it in an autouse fixture that saves and restores the previous value."
+    )


### PR DESCRIPTION
`jax_enable_x64` is process-wide and decides the float width of everything computed after it. The
suite had 22 modules setting it at **module scope** — which runs during collection, before any test,
for every module in the selection, with no scope left to restore it at — and four more setting it
inside a test body and either never putting it back or restoring it to a hardcoded constant that
happens to match today's session default.

Two of those coincided, and the result was a suite whose outcome depended on which files were
selected and in what order:

```
pytest tests/test_fdm.py                          ->  41 passed
pytest tests/test_node_eval.py tests/test_fdm.py  ->  16 failed, 33 passed
```

`test_fdm` asserted x64 once at import; `test_node_eval`'s fixture restored to a literal `False`.
Run `node_eval` first and every `test_fdm` solve dropped to float32, so `newton_krylov` stopped
converging — on a file that had changed nothing, with an error that looks exactly like a real
numerical regression.

That is not a hypothetical cost. Cross-file effects of this shape were repeatedly mistaken for GPU
contention and for genuine regressions, and each one had to be re-run standalone against the base
commit to be ruled out.

## The change

Both spellings now go through the save/restore autouse fixture the suite **already used**, in
`tests/test_fem_1d.py`:

```python
@pytest.fixture(autouse=True)
def _x64():
    prev = jax.config.jax_enable_x64
    jax.config.update("jax_enable_x64", True)
    try:
        yield
    finally:
        jax.config.update("jax_enable_x64", prev)
```

- **22 files** converted from module scope.
- **4 files** fixed to restore what they found rather than a constant (`test_node_eval`,
  `test_concat_temporal`, `test_symbol_positional_time`, `test_engd_optimizer` — the last collapsing
  seven duplicated in-body flips into one fixture).

`tests/_sharding_inner.py` is deliberately untouched: it runs as a subprocess, where module scope is
the only scope and nothing escapes the process.

## Two guards, because one cannot cover both spellings

- `conftest.py` restores the flag after every test and warns naming the test that moved it. This
  covers in-test leaks — it found `test_engd_optimizer`'s seven unrestored sites on its first run,
  unprompted.
- `tests/test_x64_isolation.py` walks each module's AST for module-scope writes. The fixture cannot
  see those, because they happen at import. Verified to fire: reintroducing the line into `test_fdm`
  fails with the file, the line number, and the fix.

## Verification

```
pytest tests/test_node_eval.py tests/test_fdm.py   ->  49 passed   (was 16 failed, 33 passed)
every converted file run together                  ->  459 passed, 0 failed
converted set + guards                             ->  301 passed, 0 leak warnings
static guard over 235 modules                      ->  235 passed; fails on a reintroduced violation
```

The 60 files `ruff format --check` reports repo-wide are pre-existing — `origin/main` reports the
same 60 — and are left alone. The 28 files touched here are format- and lint-clean.