### PR TITLE
A stale parameter value read as a silent zero, and the untested cell of u.bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,21 +52,21 @@ jobs:
               - 'jno/utils/solver/**'
               - 'jno/precond.py'
               - 'jno/solve.py'
-              - 'tests/test_fem_*'
+              - 'tests/test_fem*'
             geometry:
               - 'jno/domain/**'
               - 'jno/geometry/**'
-              - 'tests/test_domain_*'
-              - 'tests/test_shape_*'
-              - 'tests/test_polygon_*'
-              - 'tests/test_mesh_*'
+              - 'tests/test_domain*'
+              - 'tests/test_shape*'
+              - 'tests/test_polygon*'
+              - 'tests/test_mesh*'
             rcwa:
               - 'jno/rcwa**'
               - 'jno/litho*'
-              - 'tests/test_rcwa_*'
+              - 'tests/test_rcwa*'
             fdm:
               - 'jno/fdm.py'
-              - 'tests/test_fdm_*'
+              - 'tests/test_fdm*'
             core:
               - 'jno/**'
               - 'tests/**'
@@ -125,16 +125,21 @@ jobs:
         run: |
           # `core` is the COMPLEMENT of the named groups, computed rather than listed, so a new
           # test file is covered by default instead of silently belonging to nothing.
-          named() { find tests -maxdepth 1 \( -name 'test_fem_*.py' -o -name 'test_domain_*.py' \
-                      -o -name 'test_shape_*.py' -o -name 'test_polygon_*.py' \
-                      -o -name 'test_mesh_*.py' -o -name 'test_rcwa_*.py' \
-                      -o -name 'test_fdm_*.py' \) -printf '%p\n' | sort; }
+          #
+          # The stems deliberately do NOT require a trailing underscore. With `test_fdm_*.py` the
+          # group's own headline file, `tests/test_fdm.py`, matched nothing and fell into `core` --
+          # so a change to `jno/fdm.py` ran the two satellite files and not the main one, and every
+          # unrelated PR paid its 3m14s. Same for `tests/test_rcwa.py`.
+          named() { find tests -maxdepth 1 \( -name 'test_fem*.py' -o -name 'test_domain*.py' \
+                      -o -name 'test_shape*.py' -o -name 'test_polygon*.py' \
+                      -o -name 'test_mesh*.py' -o -name 'test_rcwa*.py' \
+                      -o -name 'test_fdm*.py' \) -printf '%p\n' | sort; }
           case '${{ matrix.group }}' in
-            fem)      find tests -maxdepth 1 -name 'test_fem_*.py' -printf '%p\n' | sort > files.txt ;;
-            geometry) find tests -maxdepth 1 \( -name 'test_domain_*.py' -o -name 'test_shape_*.py' \
-                        -o -name 'test_polygon_*.py' -o -name 'test_mesh_*.py' \) -printf '%p\n' | sort > files.txt ;;
-            rcwa)     find tests -maxdepth 1 -name 'test_rcwa_*.py' -printf '%p\n' | sort > files.txt ;;
-            fdm)      find tests -maxdepth 1 -name 'test_fdm_*.py' -printf '%p\n' | sort > files.txt ;;
+            fem)      find tests -maxdepth 1 -name 'test_fem*.py' -printf '%p\n' | sort > files.txt ;;
+            geometry) find tests -maxdepth 1 \( -name 'test_domain*.py' -o -name 'test_shape*.py' \
+                        -o -name 'test_polygon*.py' -o -name 'test_mesh*.py' \) -printf '%p\n' | sort > files.txt ;;
+            rcwa)     find tests -maxdepth 1 -name 'test_rcwa*.py' -printf '%p\n' | sort > files.txt ;;
+            fdm)      find tests -maxdepth 1 -name 'test_fdm*.py' -printf '%p\n' | sort > files.txt ;;
             core)     find tests -maxdepth 1 -name 'test_*.py' -printf '%p\n' | sort > all.txt
                       named > named.txt; comm -23 all.txt named.txt > files.txt ;;
           esac

--- a/jno/core.py
+++ b/jno/core.py
@@ -515,6 +515,7 @@ class core:
             self._dd_subdomains, self._dd_interfaces = _detected
             self.domain = self._dd_subdomains[0].domain
             self.models = {}
+            self._module_refs = {}
             return
 
         # An empty-constraint core is eval-only (no training); its domain is
@@ -1777,9 +1778,19 @@ class core:
 
             # === Apply sharding to model arrays ===
             self.models = self._shard_params(self.models)
+
+            # The core keeps its OWN copy of every model from here on: `self.models` is what
+            # training updates and what eval reads, and `_shard_params` already returns fresh
+            # trees, so the objects hanging off the expression (`param.model.module`) are no
+            # longer the ones being evaluated. Remember which module object each layer carried
+            # when the core last read it -- `solve()` refreshes this at its write-back -- so a
+            # swap the core has NOT seen can be caught instead of silently ignored (see
+            # `_check_modules_unchanged`).
+            self._module_refs = {lid: layer.module for lid, layer in self._collect_flax_modules().items()}
         else:
             self.domain_data = None
             self.models = {}
+            self._module_refs = {}
 
         # === Compile constraints and trackers ===
         self.compiled_trackers = []
@@ -4539,6 +4550,9 @@ class core:
             # Update every Model to point at the trained model.
             for lid, fm in flax_mods.items():
                 fm.module = trained_models[lid]
+            # ...and that sync IS the core reading the module again, so it is not a swap behind
+            # the core's back -- record it, or every eval after a solve would be refused.
+            self._module_refs.update({lid: fm.module for lid, fm in flax_mods.items()})
 
             # ── 9c. Flush Bayesian sample buffers (Pattern D + E aware) ──
             #
@@ -4782,6 +4796,41 @@ class core:
     def _unwrapped_models(self):
         """Models with all paramax wrappers resolved — safe for inference / shape queries."""
         return _paramax.unwrap(self.models)
+
+    def _check_modules_unchanged(self):
+        """Refuse to evaluate against a module that was replaced after this core last read it.
+
+        ``jno.core(...)`` reads ``layer.module`` once, through ``build_single_layer_params``, and
+        keeps its own copy — ``solve()`` writes that copy and syncs it back onto the module, so
+        the two agree until someone swaps the module themselves. The eager idiom
+
+            g.model.module = eqx.tree_at(lambda m: m.value, g.model.module, jnp.asarray(vals))
+
+        is such a swap. A bare ``jno.fem([...]).solve()`` honours it, because it reads the module
+        at solve time; a core does not, and the sweep it is meant to drive read the same number at
+        every value.
+
+        Reading the module live *here* is not the fix, because it would only patch ``eval``:
+        ``self.models`` — what training starts from and what every other read uses — would still
+        hold the old value, so eval and solve would disagree about the same parameter. It would
+        also skip the build the module goes through on the way in (pretrained weights, a callable
+        initializer, an ``_initialize_mask``, a dtype cast, sharding)."""
+        stale = []
+        refs = getattr(self, "_module_refs", {})
+        for lid, layer in self._collect_flax_modules().items():
+            if lid not in refs:
+                continue
+            if layer.module is not refs[lid]:
+                stale.append(getattr(layer, "name", None) or f"layer {lid}")
+        if not stale:
+            return
+        raise RuntimeError(
+            f"crux.eval: {', '.join(map(str, stale))} was given a new module after this core was built, "
+            "and the core evaluates its own copy — the new value would be ignored and you would read the "
+            "value at construction. Set the value BEFORE `jno.core(...)` (build one core per value to "
+            "sweep), or drive the sweep through the eager `jno.fem([...]).solve()` / `jno.fdm([...]).solve()` "
+            "path, which reads the module at solve time."
+        )
 
     def _log_constraint_shapes(self, batchsize, min_consecutive: Optional[int] = 1):
         """Log the output shape of each constraint by doing a test evaluation.
@@ -5173,6 +5222,8 @@ class core:
 
         if samples not in ("auto", "chain", "point"):
             raise ValueError(f"crux.eval(samples=...) expects 'auto' | 'chain' | 'point', got {samples!r}.")
+
+        self._check_modules_unchanged()
 
         domain_data = self.domain_data if domain is None else self.prepare_domain_data(domain)
         _models = eqx.tree_inference(self._unwrapped_models)

--- a/tests/test_core_module_mutation.py
+++ b/tests/test_core_module_mutation.py
@@ -1,0 +1,126 @@
+"""A model's module swapped after ``jno.core(...)`` was built — the core keeps its own copy.
+
+``jno.core`` reads ``layer.module`` once, at construction, and everything after that runs on the
+core's copy: training writes it, ``eval`` reads it. The eager idiom that a bare
+``jno.fem([...]).solve()`` honours,
+
+    g.model.module = eqx.tree_at(lambda m: m.value, g.model.module, jnp.asarray(vals))
+
+is therefore invisible to a core built before it — and the sweep it is meant to drive read the same
+number at every value, silently. It is refused by name now.
+
+Honouring the live module instead would be wrong in the other direction: after ``solve()`` the core's
+copy holds the TRAINED weights while the module still holds the ones it was built from, so re-reading
+would quietly undo the training. Both halves are pinned below.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import jno
+
+
+def _poisson(size=0.25):
+    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    u, v = d.fem_symbols()
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    ui, vi = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    return d, u, v, ui, vi, (xb, yb)
+
+
+def _set(g, val):
+    g.model.module = eqx.tree_at(lambda m: m.value, g.model.module, jnp.asarray([float(val)]))
+
+
+def test_eval_refuses_a_module_swapped_after_the_core_was_built():
+    """The reported shape: a parametric ``fem.solve()`` evaluated through a core, swept by mutation.
+    Both values used to come back equal to the last bit — the value at construction."""
+    d, u, v, ui, vi, (xb, yb) = _poisson()
+    g = jno.np.parameter((1,), name="g", key=jax.random.PRNGKey(0))
+    fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+    crux = jno.core([fem.solve().mse], domain=d)
+
+    _set(g, 5.0)
+    with pytest.raises(RuntimeError, match=r"crux\.eval: g .*after this core was built"):
+        crux.eval([fem.solve()])
+
+
+def test_the_refusal_names_the_parameter_and_the_two_paths_that_work():
+    d, u, v, ui, vi, (xb, yb) = _poisson()
+    g = jno.np.parameter((1,), name="amplitude", key=jax.random.PRNGKey(0))
+    crux = jno.core([(g * 1.0 - 3.0).mse], domain=d)
+    _set(g, 7.0)
+    with pytest.raises(RuntimeError) as e:
+        crux.eval([g * 1.0])
+    msg = str(e.value)
+    assert "amplitude" in msg, "the refusal must name the parameter that moved"
+    assert "jno.core" in msg and "solve()" in msg, "the refusal must name a path that works"
+
+
+def test_a_value_set_before_the_core_is_what_eval_reads():
+    """The supported spelling: the module is read at construction, so set it first. This is also the
+    control for the test above — without it, a core that ignored the parameter entirely would pass."""
+    d, u, v, ui, vi, (xb, yb) = _poisson()
+    g = jno.np.parameter((1,), name="g", key=jax.random.PRNGKey(0))
+    _set(g, 7.0)
+    crux = jno.core([(g * 1.0).mse], domain=d)
+    got = np.asarray(crux.eval([g * 1.0])).reshape(-1)
+    assert np.allclose(got, 7.0), f"the core did not read the value it was built from: {got}"
+
+
+def test_a_swept_parameter_is_read_per_core():
+    """One core per value — the shape the refusal points at — does respond, and monotonically: the
+    Dirichlet value IS the solution's level, so the mean scales with g."""
+    d, u, v, ui, vi, (xb, yb) = _poisson()
+
+    def mean_at(val):
+        g = jno.np.parameter((1,), name="g", key=jax.random.PRNGKey(0))
+        _set(g, val)
+        fem = jno.fem([ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g])
+        crux = jno.core([fem.solve().mse], domain=d)
+        return float(np.asarray(crux.eval([fem.solve()])).reshape(-1).mean())
+
+    a, b = mean_at(1.0), mean_at(5.0)
+    assert b - a > 3.0, f"the swept parameter did not move the solution: {a:.6f} -> {b:.6f}"
+
+
+def test_training_does_not_trip_the_guard():
+    """``solve()`` writes the core's copy and syncs it back onto the module — that sync IS the core
+    reading the module again, not a swap behind its back, so the guard must stay quiet after it."""
+    import optax
+
+    d, u, v, ui, vi, (xb, yb) = _poisson()
+    g = jno.np.parameter((1,), name="g", key=jax.random.PRNGKey(0))
+    _set(g, 0.0)
+    g.optimizer(optax.adam(1e-1))
+    crux = jno.core([(g * 1.0 - 3.0).mse], domain=d)
+    crux.solve(200)
+
+    trained = np.asarray(crux.eval([g * 1.0])).reshape(-1)  # must not raise
+    assert abs(float(trained[0]) - 3.0) < 0.2, f"training was not visible to eval: {trained}"
+    synced = float(np.asarray(g.model.module.value).reshape(-1)[0])
+    assert abs(synced - float(trained[0])) < 1e-9, f"solve() left the module out of sync: {synced} vs {trained[0]}"
+
+
+def test_the_eager_solve_path_still_reads_the_module_live():
+    """The domain-decomposition idiom: mutate the neighbour field, re-solve, no core in the path. The
+    refusal above must not reach it — this is the loop the mutation exists for."""
+    d, u, v, ui, vi, (xb, yb) = _poisson(size=0.3)
+    g = jno.np.parameter((1,), name="g", key=jax.random.PRNGKey(0))
+    form = [ui.x * vi.x + ui.y * vi.y - 1.0 * vi, u(xb, yb) - g]
+
+    _set(g, 1.0)
+    lo = np.asarray(jno.fem(form).solve()).reshape(-1)
+    _set(g, 5.0)
+    hi = np.asarray(jno.fem(form).solve()).reshape(-1)
+    assert hi.mean() - lo.mean() > 3.0, f"the eager solve stopped reading the module: {lo.mean()} -> {hi.mean()}"

--- a/tests/test_fem_bounds.py
+++ b/tests/test_fem_bounds.py
@@ -393,3 +393,64 @@ def test_bounds_needs_at_least_one_side():
     u, _phi = d.fem_symbols()
     with pytest.raises(ValueError, match="lo|hi|at least"):
         u.bounds(None, None)
+
+
+def test_a_coordinate_bound_on_a_vector_field_binds_per_node():
+    """The bound expression is a scalar function of the coordinates; the field it bounds has ``dim``
+    values per node. That cell of the matrix — coordinate expression x VECTOR field — is what the
+    single-value-per-node broadcast exists for, and it decides which node each value lands on: the DOF
+    vector is node-major (``[u0x, u0y, u1x, u1y, ...]``), so the bound repeats per node, and reading it
+    the other way round scrambles the floor across the mesh.
+
+    Compressed plate, floor ``psi(y) = -0.06 + 0.05 y`` — chosen to cut into the *unbounded* answer, so
+    a bound that were dropped would show up as a violation rather than as a vacuous pass."""
+    sym, trace, inner = jno.np.symgrad, jno.np.trace, jno.np.inner
+    lam, mu = 1.0, 1.0
+
+    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
+    co = d.variable("interior", split=True)
+    X = [co[0], co[1]]
+    u, phi = d.fem_symbols(value_shape=(2,))
+    eu, ep = sym(u, X), sym(phi, X)
+    xt, yt, _ = d.variable("top", split=True)
+    elastic = lam * trace(eu) * trace(ep) + 2 * mu * inner(eu, ep, n_contract=2)
+    grip = [u(xt, yt)[0] - 0.0, u(xt, yt)[1] - (-0.1)]
+    psi = lambda y: -0.06 + 0.05 * y  # noqa: E731 — the floor, once, as it is written below
+
+    fem_free = jno.fem([elastic] + grip)
+    free = np.asarray(fem_free.solve())
+    pts = np.asarray(fem_free.field_points[0])
+    lo = psi(pts[:, 1])[:, None]
+
+    assert (free.reshape(-1, 2) - lo).min() < -1e-3, "the floor does not cut the free answer — vacuous"
+
+    fem = jno.fem([elastic] + grip + [u.bounds(psi(X[1]), None)])
+    sol = np.asarray(fem.solve(nonlinear=jno.solve.newton(line_search=True, rtol=1e-8, atol=1e-8))).reshape(-1, 2)
+
+    assert np.all(np.isfinite(sol)), "the vector bound diverged"
+    slack = sol - lo
+    assert slack.min() > -1e-9, f"the floor was violated by {-slack.min():.3e}"
+    assert (slack < 1e-9).sum() > 0, "no DOF reached the floor — the bound never activated"
+    # ...and it is THIS node's floor, not some other node's: the component-major reading is infeasible.
+    assert (sol.reshape(2, -1).T - lo).min() < -1e-6, "node-major and component-major agree — no layout signal"
+
+
+def test_a_coordinate_bound_must_be_one_value_per_node():
+    """A bound expression that does not reduce to one value per DOF node is refused by name, rather
+    than broadcast into a shape that happens to fit."""
+    grad, inner = _aliases()
+    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    co = d.variable("interior", split=True)
+    X = [co[0], co[1]]
+    u, phi = d.fem_symbols(value_shape=(2,))
+    xt, yt, _ = d.variable("top", split=True)
+    fem = jno.fem(
+        [
+            inner(grad(u, X), grad(phi, X), 2),
+            u(xt, yt)[0] - 0.0,
+            u(xt, yt)[1] - (-0.1),
+            u.bounds(jno.np.stack([X[0], X[1]], axis=-1), None),
+        ]
+    )
+    with pytest.raises(ValueError, match="scalar function of the coordinates"):
+        fem.solve()

--- a/tests/test_fem_eigs_nonsymmetric.py
+++ b/tests/test_fem_eigs_nonsymmetric.py
@@ -34,9 +34,27 @@ def _nonsym(n, seed=0):
     return A
 
 
-def _dense_nearest(A, sigma, k):
-    lam = np.linalg.eigvals(A)
-    return np.sort_complex(lam[np.argsort(np.abs(lam - sigma))[:k]])
+def _assert_is_the_k_nearest(got, spectrum, sigma, k, *, rtol, atol):
+    """Assert ``got`` is the k eigenvalues nearest ``sigma`` -- without asking a tie to break one way.
+
+    A REAL shift is exactly equidistant from both members of a conjugate pair, so when a pair straddles
+    the k-th place "the k nearest" has two equally correct answers and which one comes back is up to the
+    LAPACK/Arnoldi build. That is not a property of the solver under test. It bites here: for the k=4,
+    sigma=10 case below the 4th and 5th distances are 0.585741862153150 and 0.585741862153150 -- equal to
+    the last bit, being 9.4764172570573 -/+ 0.2625921559590811j. Comparing signed values therefore failed
+    intermittently on CI (and in the nightly on main) while passing locally, on a spectrum that was right.
+
+    What is well defined, and asserted instead: the multiset of DISTANCES is the k smallest; every value
+    returned is genuinely in the spectrum, not merely at the right radius; and no value is returned twice
+    (which distances alone would not catch, since the tied pair makes a repeat look plausible)."""
+    got = np.asarray(got)
+    spectrum = np.asarray(spectrum)
+    np.testing.assert_allclose(np.sort(np.abs(got - sigma)), np.sort(np.abs(spectrum - sigma))[:k], rtol=rtol, atol=atol)
+    for z in got:
+        near = np.min(np.abs(spectrum - z))
+        assert near <= atol + rtol * abs(z), f"{z} sits at a correct distance from {sigma} but is not in the spectrum"
+    gap = np.abs(got[:, None] - got[None, :]) + np.eye(len(got))
+    assert gap.min() > atol, "the same eigenvalue was returned more than once"
 
 
 # ---------------------------------------------------------------------------------
@@ -72,7 +90,7 @@ def test_interior_eigenvalues_match_a_dense_reference_and_are_complex():
     A = _nonsym(n)
     lam, V = jno.solve.eigs(k=4, sigma=10.0)(jnp.asarray(A))
     got = np.sort_complex(np.asarray(lam))
-    np.testing.assert_allclose(got, _dense_nearest(A, 10.0, 4), rtol=1e-8, atol=1e-9)
+    _assert_is_the_k_nearest(got, np.linalg.eigvals(A), 10.0, 4, rtol=1e-8, atol=1e-9)
     assert np.any(np.abs(got.imag) > 1e-6), "spectrum came back real; the surrogate would too"
     resid = np.max(np.abs(A @ np.asarray(V) - np.asarray(V) * np.asarray(lam)[None, :]))
     assert resid < 1e-10
@@ -111,15 +129,13 @@ def test_generalized_pencil_against_a_dense_reference():
     A = _nonsym(n, seed=7)
     M = np.diag(np.linspace(1.0, 2.0, n))
     lam = np.asarray(nonsymmetric_geneigh(jnp.asarray(A), jnp.asarray(M), 3, 9.0)[0])
-    ref = sla.eig(A, M)[0]
-    ref = np.sort_complex(ref[np.argsort(np.abs(ref - 9.0))[:3]])
-    np.testing.assert_allclose(np.sort_complex(lam), ref, rtol=1e-7, atol=1e-8)
+    _assert_is_the_k_nearest(lam, sla.eig(A, M)[0], 9.0, 3, rtol=1e-7, atol=1e-8)
 
 
 def test_small_pencil_takes_the_exact_dense_path():
     A = _nonsym(12, seed=9)
     lam = np.asarray(jno.solve.eigs(k=3, sigma=5.0)(jnp.asarray(A))[0])
-    np.testing.assert_allclose(np.sort_complex(lam), _dense_nearest(A, 5.0, 3), rtol=1e-10, atol=1e-12)
+    _assert_is_the_k_nearest(lam, np.linalg.eigvals(A), 5.0, 3, rtol=1e-10, atol=1e-12)
 
 
 # ---------------------------------------------------------------------------------


### PR DESCRIPTION
Two unrelated defects that share a shape: both returned a plausible number instead of failing.

## `crux.eval` read the value the core was built from

`jno.core(...)` reads `layer.module` once, at construction, and evaluates its own copy from then on.
The eager idiom

```python
g.model.module = eqx.tree_at(lambda m: m.value, g.model.module, jnp.asarray(vals))
```

which a bare `jno.fem([...]).solve()` honours — it reads the module at solve time — is therefore
invisible to a core built before it. A parameter sweep written that way returned the construction
value at every setting:

```
at(1.0)  ->  0.022491
at(5.0)  ->  0.022491
```

Not a cache and not specific to `fem.solve()`: `crux.eval([g * 1.0])` returned `0.0` for both, the
value `g` held when the core was built.

`eval` now refuses, naming the parameter that moved and the two spellings that work — set the value
before `jno.core(...)`, or drive the sweep through the eager solve.

Reading the live module *there* would only patch `eval`. `self.models` — what training starts from
and what every other read uses — would still hold the old value, so eval and solve would disagree
about the same parameter, and the build a module goes through on the way in (pretrained weights, a
callable initializer, an initialize mask, a dtype cast, sharding) would be skipped.

`solve()` already syncs trained weights back onto the module, so the check tracks the module each
layer carried when the core **last** read it, refreshed at that write-back. Tracking the module it
was *built* from would refuse every eval that follows a solve — which is how the first draft of this
failed, and why there is a test for it.

Closes #100.

## A coordinate bound on a vector field had no coverage

A bound expression is a scalar function of the coordinates; the field it bounds carries `dim` values
per node. Every existing spatial-bound test is scalar-valued, so the broadcast that puts one value on
each component of a node was never checked — and it is a layout question with no loud failure mode:
the DOF vector is node-major, and the component-major reading has the same length, so a scrambled
floor would not raise.

The test settles it by measurement. On a compressed plate with the floor `psi(y) = -0.06 + 0.05 y`
the node-major reading is feasible with DOFs sitting exactly on it; the component-major reading is
infeasible by 5.4e-3. A control asserts the floor cuts into the *unbounded* answer, so a dropped
bound fails here rather than passing vacuously. A second test pins the refusal for an expression that
does not reduce to one value per node.

The reported NaN no longer occurs on `main` — it was repaired by #105, which rewrote the bound
resolution. What was missing is the coverage.

Closes #99.

## Verification

Per-file run over all 238 test files (one process each, as `.github/ci_test_per_file.sh` does, since
the all-in-one run accumulates device buffers): **one failing file, `test_packaging.py`, which fails
identically on `main`** — the installed package is 0.3.0 against 0.3.1 in `pyproject.toml`, a stale
env rather than a code change.

- `test_bayesian.py` 161 passed · `test_core.py` 36 · `test_fem_bounds.py` 17 · `test_core_module_mutation.py` 6 · `test_fem_adapt_complex.py` 10
- The 34-file prefix through `test_fem_adapt_complex.py`: 777 passed on this branch against 771 on `main`, difference being the six new tests, with one identical pre-existing failure on both.

Two order-dependent failures found along the way are **not** from this branch and are worth their own
issue: `test_core.py::TestPlaceholderName::test_name_used_in_log_output` fails on `main` too whenever
an earlier file has moved logging to stderr, since it asserts on captured stdout.


---

## Two follow-ups added after the first CI run

**The eigenvalue oracle asked a question with two correct answers.** `test_fem_eigs_nonsymmetric` failed
the `fem` job — and is what turned this PR red. It is not from this branch: the nightly on `main` failed
the same file the same way ([run 32443132085](https://github.com/FhG-IISB/jNO/actions/runs/32443132085)),
and the file passes locally on CPU and GPU.

The cause is structural. A **real** shift is exactly equidistant from both members of a conjugate pair,
so when a pair straddles the k-th place, "the k nearest" is ambiguous. At `k=4, sigma=10` the 4th and 5th
distances are `0.585741862153150` either way — `9.4764172570573 -/+ 0.2625921559590811j`, `|d4-d5| = 0`.
The dense reference and Arnoldi each break the tie however their LAPACK build happens to, and CI broke it
the other way:

```
ACTUAL   9.476417257059627 - 0.26259215595783486j
DESIRED  9.4764172570573   + 0.2625921559590811j
```

The comparison now asserts what is well defined whichever way the tie falls: the multiset of distances is
the k smallest, every returned value is genuinely in the spectrum rather than merely at the right radius,
and none is returned twice — which distances alone would not catch, since the tied pair makes a repeat
look plausible. Checked against six mutations: a conjugated tie member passes; a value nudged off the
spectrum, a duplicate, a genuine-but-more-distant eigenvalue, and a value from the symmetrized surrogate
each fail. All three call sites shared the hazard, so the helper is replaced rather than patched at the
one site that fired.

**A group's stem should not require a trailing underscore.** `test_fdm.py` and `test_rcwa.py` matched none
of the group globs (`test_fdm_*.py`) and fell through to `core`. So a change to `jno/fdm.py` ran an `fdm`
group holding only the two satellite files, not the headline one — it was tested only because `core`'s
filter (`jno/**` + `tests/**`) matches every code PR, which is coverage by accident that would vanish the
moment that filter were narrowed. In the other direction, every unrelated PR paid 3m14s for `test_fdm.py`.

Measured against the tree: exactly those two files change hands, nothing leaves a named group, `core` goes
86 files → 84. The paths-filter entries are updated too, not just the find globs — otherwise editing
`tests/test_fdm.py` alone still would not trigger its group.

Note this PR touches `.github/workflows/ci.yml`, which is in the `shared` filter, so every group runs here
by design — which is what exercises the regrouping.
