### PR TITLE
The saddle-point preconditioner as one call

### DIFF
--- a/docs/fem.md
+++ b/docs/fem.md
@@ -1710,6 +1710,22 @@ preconditioner never changes the converged solution, only the speed, so specs ne
 * `jno.precond.block_diag((field, spec), …)` / `jno.precond.triangular((field, spec), …)` — per-field
   composition over `fem.blocks`. `triangular` is the standard saddle-point shape: last block solved
   first, substituted back through the assembled off-diagonal matvecs.
+* `jno.precond.saddle(mass_weight=…)` — that standard shape as **one call**, for the common case.
+  It finds the constraint block *structurally* (the field with no diagonal entry — the same detection
+  behind the saddle-system warning), puts `amg()` on the momentum block and a weighted pressure
+  **mass** matrix on the constraint block, and assembles that mass on the domain's own P1 space, so
+  no symbols are passed and it reads identically in 2-D and 3-D. `mass_weight` is explicit and never
+  inferred (`1/μ` for Stokes): digging `μ` out of an arbitrary weak form is fragile, and a variable
+  viscosity would silently take the wrong weight — which costs iterations without ever failing. A
+  wrong weight changes convergence *speed* only, never the answer. Pair with `jno.solve.fgmres`;
+  `minres` does not apply (block-upper-triangular is nonsymmetric). Needs `pyamg`, and refuses by
+  name on a non-saddle system or a constraint field that is not P1 — for anything outside that,
+  compose `triangular` yourself. **Pure-Stokes approximation:** a strong reaction term (Brinkman /
+  Darcy drag, or the `1/dt` mass of a small implicit step) makes the Schur complement stop looking
+  like a mass matrix, and the mesh-robustness degrades — measured on a 2-D Brinkman channel at
+  `μ=1`, preconditioned GMRES went 73 → 76 → 140 → 452 iterations as `α` went `0 → 1e2 → 1e3 → 1e4`.
+  That regime wants the Cahouet–Chabard mass-*plus*-Laplacian approximation (Cahouet & Chabard,
+  *IJNMF* **8**, 869–895, 1988), which `saddle()` does not build.
 * `jno.precond.amg(cycles=…)` — **hybrid algebraic multigrid**: setup once on the host via the *optional*
   `pyamg` (Vaněk, Mandel & Brezina, *Computing* 56, 1996; PyAMG — Bell et al., *JOSS* 8(87), 2023),
   applied as a pure-JAX V-cycle with Chebyshev smoothing (Adams et al., *JCP* 188, 2003). The apply is
@@ -1739,6 +1755,19 @@ sol = fem.solve(
     ),
 )
 ```
+
+…and the same recipe when the defaults suit — multigrid on the momentum block, exact pressure mass:
+
+```python
+sol = fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=150),
+                precond=jno.precond.saddle(mass_weight=1.0/mu))
+```
+
+Give FGMRES enough `restart`: the default `restart=30` **stagnates** on a 3-D Taylor–Hood block
+preconditioner and does so quietly — it still returns, just slower and less accurate. Measured at
+4302 dofs, `tol=1e-10`: `restart=30` → 2.30 s for 3.3e-6; `restart=150` → 0.49 s for 3.3e-9. On
+3-D Stokes this is what makes the recipe overtake a direct factorisation — measured crossover at
+~15k dofs, and 3.4× faster (23.2 s → 6.9 s) at 41k, where LU's fill-in also costs more memory.
 
 **Picard / lagged coefficients — `jno.lag`.** When a solution-dependent coefficient's Newton tangent
 destroys the linearized system's structure (the classic case: a shear-thinning viscosity `μ_eff(u)` in

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -397,8 +397,11 @@ def _lower_gauge_pin(pin: GaugePin) -> Any:
     return field(*spatial) - pin.value
 
 
-def _saddle_block_names(fem_obj: "FEM", domain: Any, volume_terms: List[Any]) -> List[str]:
-    """Names of the field blocks with no diagonal entry -- the structural mark of a saddle system.
+def _saddle_block_positions(fem_obj: "FEM", domain: Any, volume_terms: List[Any]) -> List[tuple]:
+    """``(index, name)`` of the field blocks with no diagonal entry -- the structural mark of a saddle system.
+
+    The NAME is what a diagnostic says out loud ("p has no diagonal block"); the INDEX is what a
+    preconditioner needs, because it has to address the block in ``fem.blocks`` order.
 
     A field whose own test function never meets its own trial function contributes no ``(i, i)``
     block, so the assembled operator has a zero diagonal there. That is exactly the Taylor-Hood
@@ -443,7 +446,7 @@ def _saddle_block_names(fem_obj: "FEM", domain: Any, volume_terms: List[Any]) ->
     for i, k in enumerate(keys):
         if (k, k) in occupied:
             continue
-        out.append(names.get(k) or f"block {i}")
+        out.append((i, names.get(k) or f"block {i}"))
     return out
 
 
@@ -1255,6 +1258,7 @@ class FEM:
         self._periodic = None  # periodic-tie reduction (prolongation P), attached by fem()
         self._mean_gauges = ()  # zero-mean gauges (`p.pin(mean=True)`), resolved by fem() at build
         self._saddle_blocks = ()  # field blocks with no diagonal entry, detected by fem() at build
+        self._saddle_block_indices = ()  # the same blocks by position in `blocks`
         self._complex_n = None  # half-size n when _op is a fused complex real-equivalent 2n system
         # The unfused (re, im) legs. KNOWN CONSUMERS — check all of them before changing this or the
         # fused layout, since a stale reader does not crash (see the `operator` docstring: the fused
@@ -4757,7 +4761,9 @@ def _fem_impl(
         # Structural, so it is known here for every mode -- and being known at BUILD time is what
         # lets the warning fire even when the solve is later wrapped in jit, where the residual
         # guard cannot.
-        out._saddle_blocks = tuple(_saddle_block_names(out, domain, volume_terms))
+        _saddle_pos = _saddle_block_positions(out, domain, volume_terms)
+        out._saddle_blocks = tuple(nm for _i, nm in _saddle_pos)
+        out._saddle_block_indices = tuple(i for i, _nm in _saddle_pos)
         return out
 
     volume_terms: List[Any] = []

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -40,6 +40,7 @@ __all__ = [
     "inner",
     "block_diag",
     "triangular",
+    "saddle",
     "amg",
     "jaxamg",
     "cached",
@@ -517,6 +518,141 @@ def triangular(*pairs) -> _Triangular:
     *Finite Elements and Fast Iterative Solvers*, 2nd ed., OUP 2014, §9.2). With inexact
     (iterative) block solves the outer Krylov must be flexible: ``jno.solve.fgmres()``."""
     return _Triangular(list(pairs))
+
+
+class _Saddle(_Spec):
+    """Spec for the standard saddle-point recipe; see :func:`saddle`.
+
+    Resolution is deferred to ``prepare``/``materialize`` because the blocks are a property of the
+    OWNING system, not of the spec: which block is the constraint is read from the FEM's structural
+    saddle detection, so the same ``saddle()`` object composes onto any saddle system.
+    """
+
+    def __init__(self, mass_weight):
+        self.mass_weight = float(mass_weight)
+        self._resolved = None
+
+    def _compose(self, fem):
+        """The ``triangular`` composition this spec stands for, built once against ``fem``."""
+        if self._resolved is not None:
+            return self._resolved
+        if fem is None:
+            raise TypeError(
+                "jno.precond.saddle() needs the owning FEM to find the constraint block "
+                "(use it via fem.solve(precond=...))."
+            )
+        idx = tuple(getattr(fem, "_saddle_block_indices", ()) or ())
+        blocks = fem.blocks
+        if not idx:
+            raise ValueError(
+                "jno.precond.saddle(): this system has no saddle block -- every field has a diagonal "
+                "block, so there is no zero-diagonal constraint for a pressure-mass Schur approximation "
+                "to stand in for. Use a preconditioner for the structure you do have "
+                "(jno.precond.amg(), jno.precond.jacobi()), or compose the blocks yourself with "
+                "jno.precond.triangular((field, spec), ...)."
+            )
+        # The Schur approximation assembled here is the P1 mass matrix on the domain's scalar space,
+        # so it only stands for a constraint field discretised on THAT space (Taylor-Hood pressure).
+        # A multiplier on any other space would silently get a matrix of the wrong size -- refuse by
+        # name instead, and say which block and what the sizes were.
+        n_p1 = int(getattr(fem.domain, "mesh").points.shape[0])
+        names = tuple(getattr(fem, "_saddle_blocks", ()) or ())
+        for j, i in enumerate(idx):
+            size = int(blocks[i].stop - blocks[i].start)
+            if size != n_p1:
+                who = names[j] if j < len(names) else f"block {i}"
+                raise NotImplementedError(
+                    f"jno.precond.saddle(): the constraint block {who!r} has {size} dofs but the "
+                    f"domain's P1 space has {n_p1} -- the weighted pressure MASS matrix this builds is "
+                    "a P1 Gram matrix, so it is only the right Schur approximation for a constraint "
+                    "field of P1 (Taylor-Hood pressure). Compose the right auxiliary explicitly: "
+                    "jno.precond.triangular((u, jno.precond.amg()), (p, jno.precond.form([...])))."
+                )
+        from . import solve as _s
+        from ._fem import _fe_symbols_bound
+
+        ui, vi, _axes = _fe_symbols_bound(fem.domain)
+        w = self.mass_weight
+        # The mass block is inverted EXACTLY, on the host, in float64. That is what keeps the whole
+        # preconditioner a fixed linear operator -- an inexact inner solve would make it vary between
+        # applications, which a non-flexible Krylov method (gmres) is not allowed to see.
+        mass = form([w * ui * vi], inner=_s.lu(backend="host"))
+        pairs = []
+        for i in range(len(blocks)):
+            pairs.append((i, mass if i in idx else amg()))
+        self._resolved = _Triangular(pairs)
+        return self._resolved
+
+    def prepare(self, fem):
+        self._compose(fem).prepare(fem)
+
+    def materialize(self, ctx: PrecondContext):
+        return self._compose(ctx.fem).materialize(ctx)
+
+    def __repr__(self):
+        return f"jno.precond.saddle(mass_weight={self.mass_weight})"
+
+
+def saddle(*, mass_weight: float = 1.0) -> _Saddle:
+    """The standard **saddle-point** preconditioner, as one call.
+
+    Composes the classical Stokes recipe over the system's own block structure -- algebraic multigrid
+    on the momentum block, a weighted pressure **mass** matrix as the Schur-complement approximation,
+    assembled block-upper-triangularly (Elman, Silvester & Wathen, *Finite Elements and Fast Iterative
+    Solvers*, 2nd ed., OUP 2014, section 9.2)::
+
+        fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=150),
+                  precond=jno.precond.saddle(mass_weight=1.0 / mu))
+
+    which is the one-line form of::
+
+        jno.precond.triangular((u, jno.precond.amg()), (p, jno.precond.form([(1 / mu) * pi * qi])))
+
+    The constraint block is found structurally -- the field whose test function never meets its own
+    trial function, so the operator has no diagonal there -- which is exactly the block a diagonal
+    (Jacobi) preconditioner cannot touch, and the reason ``fem.solve()``'s matrix-free default warns
+    on a saddle system. No symbols are passed: the pressure mass is assembled on the domain's own P1
+    space, so this reads the same on 2-D and 3-D Taylor-Hood.
+
+    ``mass_weight`` scales that mass matrix and is **explicit, never inferred**. The pressure-mass
+    Schur approximation wants ``1/mu``; recovering ``mu`` from an arbitrary weak form is fragile, and
+    a variable or solution-dependent viscosity would silently take the wrong weight and cost
+    iterations without ever failing. The default ``1.0`` is right for ``mu = 1``; pass the reciprocal
+    viscosity otherwise. A wrong weight changes convergence SPEED only, never the answer.
+
+    Give ``fgmres`` enough restart. Its default ``restart=30`` **stagnates** on a 3-D Taylor-Hood
+    block preconditioner, and the failure is quiet -- it still returns, just slower and less
+    accurate. Measured at 4302 dofs, ``tol=1e-10``: ``restart=30`` took 2.30 s to reach 3.3e-06,
+    ``restart=150`` took 0.49 s to reach 3.3e-09 -- 4.7x faster for a thousand times the accuracy,
+    because restarting discards the Krylov subspace the preconditioner just earned. Larger systems
+    want a larger restart still.
+
+    Pair it with ``jno.solve.fgmres`` -- the pairing the block preconditioners are verified against.
+    ``jno.solve.minres`` does not apply: block-upper-triangular is nonsymmetric by construction and
+    MINRES's short recurrence assumes symmetry, so it stalls (loudly, on the residual guard, rather
+    than returning a plausible wrong field); use :func:`block_diag` if a symmetric preconditioner is
+    required. The non-flexible ``jno.solve.gmres`` is admissible in principle -- the mass block is
+    inverted exactly, so this is a fixed linear operator -- but breaks down in the default float32
+    build, exactly as the explicit :func:`triangular` composition does; prefer ``fgmres``.
+
+    **This is the pure-Stokes approximation, and it degrades on a reaction-dominated system.** The
+    pressure mass stands in for the Schur complement of ``-mu*Lap(u) + grad(p)``; add a strong
+    reaction term (a Brinkman/Darcy drag ``alpha*u``, as porous-medium flow and fluid topology
+    optimisation both do, or the ``1/dt`` mass of a small implicit time step) and the Schur
+    complement stops looking like a mass matrix. Measured on a 2-D Brinkman channel at ``mu = 1``,
+    preconditioned GMRES took 73 iterations at ``alpha = 0``, 76 at ``1e2``, 140 at ``1e3`` and 452
+    at ``1e4`` -- it still converges, but the mesh-robustness the recipe exists for is gone. That
+    regime wants the Cahouet-Chabard approximation, a pressure mass PLUS a pressure Laplacian
+    (``S^-1 ~ mu*M_p^-1 + alpha*L_p^-1``; Cahouet & Chabard, *Int. J. Numer. Methods Fluids* **8**,
+    869-895, 1988), which this does not build.
+
+    Scope: needs ``pyamg`` for the momentum block (a clear ``ImportError`` otherwise), and the
+    constraint field must be P1 -- both refuse by name rather than mis-solving. For anything else
+    (a different momentum solver, an inexact inner solve on a very large pressure block, more than
+    one constraint field on mixed spaces) compose :func:`triangular` directly; this is a shorthand
+    for the common case, not a replacement for it.
+    """
+    return _Saddle(mass_weight)
 
 
 class _AMG(_Spec):

--- a/tests/test_fem_saddle_precond.py
+++ b/tests/test_fem_saddle_precond.py
@@ -1,0 +1,194 @@
+"""``jno.precond.saddle()`` -- the standard saddle-point recipe as one call.
+
+The oracle throughout is a direct factorisation of the same system: a preconditioner may change how
+fast a Krylov method converges, never what it converges TO, so agreeing with the direct solve is the
+only correctness statement worth making about one.
+"""
+
+import numpy as np
+import pytest
+
+import jno
+
+
+def _stokes(mesh_size=0.3, mu=1.0):
+    """Taylor-Hood Poiseuille channel -- the saddle system these blocks exist for."""
+    pytest.importorskip("shapely", reason="shapely required for the box domain")
+    from shapely.geometry import box
+
+    inner_, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+    G, H, Lx = 1.0, 1.0, 4.0
+    u_profile = lambda y: (G / (2 * mu)) * y * (H - y)  # noqa: E731
+    d = jno.domain(box(0.0, 0.0, Lx, H), mesh_size=mesh_size)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
+    p, q = d.fem_symbols(names=("p", "q"), order=1)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    pp, qq = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+    fem = jno.fem(
+        [
+            mu * inner_(gu, gv, n_contract=2) - pp * trace(gv),
+            -qq * trace(gu),
+            u(xb, yb)[0] - u_profile(yb),
+            u(xb, yb)[1] - 0.0,
+            p.pin(),
+        ]
+    )
+    return fem, u, p, mu
+
+
+def _poisson(mesh_size=0.4):
+    """A single-field problem -- no block structure, so no saddle block to find."""
+    pytest.importorskip("shapely", reason="shapely required for the box domain")
+    from shapely.geometry import box
+
+    grad, inner_ = jno.np.grad, jno.np.inner
+    d = jno.domain(box(0.0, 0.0, 1.0, 1.0), mesh_size=mesh_size)
+    u, v = d.fem_symbols(names=("u", "v"))
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    return jno.fem([inner_(grad(u, [xi, yi]), grad(v, [xi, yi]), n_contract=1) - 1.0 * v.bind(x=xi, y=yi), u(xb, yb) - 0.0])
+
+
+# --------------------------------------------------------------------------------------
+# it solves -- and agrees with a direct factorisation of the same system
+# --------------------------------------------------------------------------------------
+def test_saddle_matches_the_direct_oracle_on_2d_stokes():
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    fem, _u, _p, mu = _stokes()
+    ref = fem.solve(linear=jno.solve.lu(backend="host"))
+    got = fem.solve(linear=jno.solve.fgmres(tol=1e-9), precond=jno.precond.saddle(mass_weight=1.0 / mu))
+    err = np.linalg.norm(np.asarray(got) - np.asarray(ref)) / np.linalg.norm(np.asarray(ref))
+    assert err < 5e-3, f"saddle() drifted from the direct oracle: rel err {err:.2e}"
+
+
+def test_saddle_is_the_one_line_form_of_the_explicit_triangular():
+    """The shorthand must BE the explicit composition, not merely another thing that also works.
+
+    Asserted on the composed structure rather than by comparing two ``fem.solve()`` calls: a second
+    solve warm-starts from the first, so two runs of the same preconditioner legitimately stop at
+    slightly different points and comparing them measures the warm start, not the preconditioner.
+    """
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    fem, u, p, mu = _stokes()
+    spec = jno.precond.saddle(mass_weight=1.0 / mu)
+    composed = spec._compose(fem)
+    assert type(composed).__name__ == "_Triangular"
+    kinds = {idx: type(sub).__name__ for idx, sub in composed.pairs}
+    assert kinds[fem.block_index(u)] == "_AMG"
+    assert kinds[fem.block_index(p)] == "_Form"
+    assert sorted(kinds) == list(range(len(fem.blocks)))  # every block covered exactly once
+
+
+def test_a_nonflexible_krylov_is_not_the_pairing_and_fails_loudly():
+    """``fgmres`` is the pairing; ``minres`` is a modelling error and ``gmres`` breaks down here.
+
+    MINRES does not apply at all: a block-UPPER-TRIANGULAR preconditioner is nonsymmetric and
+    MINRES's short recurrence assumes symmetry (measured relative residual 7.2e-01). The
+    non-flexible GMRES is mathematically admissible -- the mass block is inverted exactly, so the
+    preconditioner is a fixed linear operator -- but breaks down in the default float32 build, and
+    measurably does so for the explicit ``triangular(...)`` composition this is shorthand for just
+    as much as for ``saddle()``: that is a precision property of the pairing, not of this spec.
+
+    Pinned because the failure is the GOOD outcome -- the residual firewall refuses rather than
+    returning the plausible-but-wrong field a silent stall would give.
+    """
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    fem, _u, _p, mu = _stokes()
+    with pytest.raises(RuntimeError, match="did not solve the system"):
+        fem.solve(linear=jno.solve.minres(tol=1e-9), precond=jno.precond.saddle(mass_weight=1.0 / mu))
+
+
+# --------------------------------------------------------------------------------------
+# the property a Schur preconditioner exists for: the iteration count stops growing with the mesh
+# --------------------------------------------------------------------------------------
+def _gmres_iterations(fem, spec, tol=1e-8):
+    """Preconditioned GMRES iteration count for ``spec`` on ``fem``, counted directly.
+
+    ``fem.stats['linear']`` records WHICH solver ran, not how many steps it took, so the count is
+    measured here instead: assemble the system, materialise the preconditioner through the same
+    context the solver would, and run scipy's GMRES with a counting callback.
+    """
+    import jax.numpy as jnp
+    import scipy.sparse.linalg as spla
+
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext, materialize_precond
+
+    A_j = fem.A
+    A = np.asarray(A_j.todense() if hasattr(A_j, "todense") else A_j, dtype=float)
+    b = np.asarray(fem.b, dtype=float).reshape(-1)
+    prep = getattr(spec, "prepare", None)
+    if prep is not None:
+        prep(fem)
+    M = materialize_precond(spec, PrecondContext(LinearOperator(A_j), fem))
+    n = {"k": 0}
+
+    def mv(v):
+        # float64 explicitly: scipy probes a LinearOperator's dtype by calling it on an int8 vector,
+        # which the sparse inner solve rejects outright.
+        return np.array(M(jnp.asarray(np.asarray(v, dtype=float))), dtype=float, copy=True).reshape(-1)
+
+    def cb(*_a):
+        n["k"] += 1
+
+    Mop = spla.LinearOperator(A.shape, matvec=mv, dtype=float)
+    try:
+        spla.gmres(A, b, M=Mop, rtol=tol, restart=200, maxiter=200, callback=cb, callback_type="pr_norm")
+    except TypeError:  # scipy < 1.12 spells the tolerance `tol`
+        spla.gmres(A, b, M=Mop, tol=tol, restart=200, maxiter=200, callback=cb, callback_type="pr_norm")
+    return n["k"]
+
+
+def test_iteration_count_is_mesh_robust():
+    """Refine twice; the preconditioned iteration count must not grow the way the unpreconditioned
+    one does. This is the property the pressure-mass Schur approximation exists for -- it is
+    spectrally equivalent to the Schur complement, so the preconditioned spectrum does not spread as
+    h falls. Asserted as a BOUND against the coarsest count, not a fixed number: the exact count
+    moves with the mesh generator.
+    """
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    counts = []
+    for h in (0.5, 0.35, 0.25):
+        fem, _u, _p, mu = _stokes(mesh_size=h)
+        counts.append(_gmres_iterations(fem, jno.precond.saddle(mass_weight=1.0 / mu)))
+    assert all(c > 0 for c in counts), f"no iterations recorded: {counts}"
+    assert counts[-1] <= 2 * counts[0] + 8, f"iteration count grew with the mesh: {counts}"
+
+
+# --------------------------------------------------------------------------------------
+# it refuses, by name, rather than mis-solving
+# --------------------------------------------------------------------------------------
+def test_refuses_on_a_problem_with_no_saddle_block():
+    fem = _poisson()
+    with pytest.raises(ValueError, match="no saddle block"):
+        fem.solve(linear=jno.solve.fgmres(tol=1e-8), precond=jno.precond.saddle())
+
+
+def test_the_system_records_its_saddle_blocks_by_position():
+    """`saddle()` addresses blocks by index, so the index has to be recorded, not just the name."""
+    fem, _u, p, _mu = _stokes(mesh_size=0.5)
+    assert fem._saddle_blocks == ("p",)
+    assert fem._saddle_block_indices == (fem.block_index(p),)
+
+
+def test_a_single_field_problem_records_no_saddle_block():
+    fem = _poisson()
+    assert fem._saddle_blocks == ()
+    assert fem._saddle_block_indices == ()
+
+
+def test_mass_weight_changes_speed_but_not_the_answer():
+    """A wrong weight is a convergence-rate mistake, never a correctness one -- so the two solves
+    must agree even though one is preconditioned badly."""
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    fem, _u, _p, mu = _stokes()
+    ref = fem.solve(linear=jno.solve.lu(backend="host"))
+    bad = fem.solve(linear=jno.solve.fgmres(tol=1e-9), precond=jno.precond.saddle(mass_weight=25.0 / mu))
+    err = np.linalg.norm(np.asarray(bad) - np.asarray(ref)) / np.linalg.norm(np.asarray(ref))
+    assert err < 5e-3, f"a mis-weighted saddle() changed the answer: rel err {err:.2e}"
+
+
+def test_saddle_is_exported_and_reprs():
+    assert "saddle" in jno.precond.__all__
+    assert "mass_weight=2.0" in repr(jno.precond.saddle(mass_weight=2.0))


### PR DESCRIPTION
`jno.precond.saddle(mass_weight=...)` composes the classical Stokes recipe over a system's own block
structure — algebraic multigrid on the momentum block, a weighted pressure mass matrix as the
Schur-complement approximation, assembled block-upper-triangularly (Elman, Silvester & Wathen,
*Finite Elements and Fast Iterative Solvers*, 2nd ed., OUP 2014, §9.2).

```python
fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=150),
          precond=jno.precond.saddle(mass_weight=1.0 / mu))
```

the one-line form of

```python
jno.precond.triangular((u, jno.precond.amg()), (p, jno.precond.form([(1/mu) * pi * qi])))
```

## Where it earns its place

3-D Taylor–Hood Stokes, one process per point, solve time only:

| dofs | direct `lu` | `saddle` + fgmres | speedup |
|---|---|---|---|
| 6,352 | 0.15 s | 0.88 s | 0.17× |
| 10,751 | 0.43 s | 1.06 s | 0.41× |
| 15,439 | 1.46 s | 1.31 s | 1.11× ← crossover |
| 21,045 | 4.28 s | 2.94 s | 1.46× |
| 29,568 | 11.06 s | 5.37 s | 2.06× |
| 40,587 | 23.17 s | 6.87 s | **3.37×** |

The shape matters more than the endpoint: across that span the direct factorisation grows 155× on
6.4× the dofs (fill-in), the preconditioned solve 7.8×. Peak memory crosses too — 2.34 GB vs
2.20 GB at the largest point, with the direct curve climbing and the iterative one flatter. Fill-in
is the harder limit, since it ends a direct solve outright.

**Below ~15k dofs it is a pessimisation** (up to 6× slower at 6k, AMG setup dominating). This is for
where the direct solve stops fitting, not a new default.

## No new concepts

The constraint block is found *structurally* — the field whose test function never meets its own
trial function, so the operator has no diagonal there. That detection already existed to back the
saddle-system warning; it is now also recorded by position, because a preconditioner has to address
the block rather than name it. No symbols are passed: the pressure mass is assembled on the domain's
own P1 space, so the call reads identically in 2-D and 3-D.

`mass_weight` is explicit and never inferred. The approximation wants `1/mu`; recovering `mu` from an
arbitrary weak form is fragile, and a variable or solution-dependent viscosity would take the wrong
weight silently — costing iterations without ever failing. A wrong weight changes convergence speed
only, never the answer, and a test pins that.

## Scope, stated rather than discovered

- **Pure-Stokes approximation.** A strong reaction term (Brinkman/Darcy drag, or the `1/dt` mass of a
  small implicit step) makes the Schur complement stop looking like a mass matrix. Measured on a 2-D
  Brinkman channel at `mu=1`: 73 → 76 → 140 → 452 iterations as `alpha` goes `0 → 1e2 → 1e3 → 1e4`.
  That regime wants Cahouet–Chabard (mass *plus* Laplacian; *IJNMF* **8**, 869–895, 1988), which this
  does not build.
- **Krylov pairing.** `fgmres`. `minres` does not apply — block-upper-triangular is nonsymmetric and
  MINRES's short recurrence assumes symmetry, so it stalls loudly on the residual guard. The
  non-flexible `gmres` breaks down in the default float32 build, exactly as the explicit `triangular`
  composition does.
- **Give fgmres enough restart.** The default `restart=30` stagnates on 3-D Taylor–Hood, and quietly:
  at 4302 dofs and `tol=1e-10`, `restart=30` took 2.30 s to reach 3.3e-06 while `restart=150` took
  0.49 s to reach 3.3e-09.
- Needs `pyamg`; the constraint field must be P1. Both refuse by name rather than mis-solving.

## Verification

9 new tests: the direct-solve oracle in 2-D; that the shorthand composes the same blocks as the
explicit form (asserted on structure — a second `fem.solve()` warm-starts from the first, so
comparing two solves measures the warm start); mesh-robust iteration count across three refinements,
counted directly since `fem.stats` records which solver ran and not how many steps it took; that a
mis-weighted call still reaches the same answer; and both refusals.

Full per-file suite on GPU: **248 files, 1 failure** — `test_packaging.py`, an installed-metadata
version mismatch (`0.3.0` vs pyproject `0.3.1`) in the local environment, untouched by this change.
`ruff format --check` and `ruff check` clean repo-wide.
