### PR TITLE
A Schur approximation that survives a reaction term, and the benchmark behind the saddle numbers

### DIFF
--- a/benchmarks/saddle_scaling.py
+++ b/benchmarks/saddle_scaling.py
@@ -1,0 +1,174 @@
+"""Where does the saddle-point preconditioner overtake a sparse direct solve on 3-D Stokes?
+
+A direct factorisation is unbeatable until its fill-in catches up with it. In 3-D that happens
+early: the elimination tree of a tetrahedral Taylor-Hood system densifies fast, so LU time grows
+much faster than the dof count, while a preconditioned Krylov solve grows closer to linearly.
+This measures the crossover on the same problem, same machine, same tolerance -- the number that
+decides which solver a 3-D fluid workflow should actually reach for.
+
+Two solvers over one mesh sweep:
+
+* ``lu``     -- ``jno.solve.lu(backend="host")``, sparse direct (SuperLU). The baseline, and
+                exact to ~1e-13, which is the honest thing to compare against.
+* ``saddle`` -- ``jno.solve.fgmres(tol=1e-10, restart=150)`` with ``jno.precond.saddle()``:
+                AMG on the momentum block, weighted pressure mass as the Schur approximation.
+
+**One process per point, deliberately.** The quantity being measured IS the memory a 3-D
+factorisation commits, and several live factorisations in one interpreter measure the interpreter's
+allocator instead. The default run re-execs this file once per ``(size, solver)`` pair and parses
+the ``RESULT`` line each child prints; ``--point SIZE SOLVER`` is that single-measurement mode.
+
+**Restart matters more than it looks.** ``fgmres``'s default ``restart=30`` stagnates on this
+preconditioner -- quietly, still returning, just slower and less accurate. An earlier version of
+this benchmark ran that default and reported the saddle path ~4.7x slower than it is. The
+accuracy column is here so that failure cannot hide again: if ``err`` for ``saddle`` drifts to
+1e-5 while ``lu`` sits at 1e-13, the Krylov subspace is being thrown away, not the preconditioner
+failing.
+
+Run: JAX_PLATFORMS=cpu pixi run python benchmarks/saddle_scaling.py
+"""
+
+import json
+import subprocess
+import sys
+import time
+
+SIZES = (0.17, 0.14, 0.12, 0.105, 0.092, 0.082)
+SOLVERS = ("lu", "saddle")
+RESTART = 150
+TOL = 1e-10
+
+
+def build_stokes_3d(size):
+    """Taylor-Hood P2/P1 Stokes on the unit cube, with an exact solution IN the discrete space.
+
+        u = (y^2+z^2, z^2+x^2, x^2+y^2)   div u == 0,  Delta u = (4,4,4)
+        p = x + y + z - 3/2               zero-mean over the cube
+        f = -mu Delta u + grad p = (1 - 4 mu) (1,1,1)
+
+    Both fields are representable exactly (P2 velocity, P1 pressure), so any error in the table is
+    solver error and never discretisation error -- which is what makes the accuracy column readable.
+    """
+    import jno
+
+    inner, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+    mu = 1.0
+
+    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), order=2)
+    p, q = d.fem_symbols(names=("p", "q"), order=1)
+    xi, yi, zi = d.variable("interior", split=True)[:3]
+    xb, yb, zb = d.variable("boundary", split=True)[:3]
+    gu, gv = grad(u, [xi, yi, zi]), grad(v, [xi, yi, zi])
+    pp, vv = p.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)
+    qq = q.bind(x=xi, y=yi, z=zi)
+    f = 1.0 - 4.0 * mu
+    fem = jno.fem(
+        [
+            mu * inner(gu, gv, n_contract=2) - pp * trace(gv) - f * (vv[0] + vv[1] + vv[2]),
+            -qq * trace(gu),
+            u(xb, yb, zb)[0] - (yb**2 + zb**2),
+            u(xb, yb, zb)[1] - (zb**2 + xb**2),
+            u(xb, yb, zb)[2] - (xb**2 + yb**2),
+            p.pin(mean=True),
+        ]
+    )
+    return fem, mu
+
+
+def run_point(size, which):
+    """One solve; prints the RESULT line the parent parses. Runs in its own process."""
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import numpy as np
+
+    import jno
+
+    t0 = time.perf_counter()
+    fem, mu = build_stokes_3d(size)
+    t_build = time.perf_counter() - t0
+
+    pv = np.asarray(fem.field_points[0])
+    exact = np.stack([pv[:, 1] ** 2 + pv[:, 2] ** 2, pv[:, 2] ** 2 + pv[:, 0] ** 2, pv[:, 0] ** 2 + pv[:, 1] ** 2], axis=1)
+
+    if which == "lu":
+        kw = {"linear": jno.solve.lu(backend="host")}
+    else:
+        kw = {
+            "linear": jno.solve.fgmres(tol=TOL, restart=RESTART),
+            "precond": jno.precond.saddle(mass_weight=1.0 / mu),
+        }
+
+    t0 = time.perf_counter()
+    try:
+        sol = fem.solve(**kw)
+        dt = time.perf_counter() - t0
+        off = fem.offsets
+        vel = np.asarray(sol)[off[0] : off[1]].reshape(-1, 3)
+        err = float(np.linalg.norm(vel - exact) / np.linalg.norm(exact))
+        tail = f"solve={dt:.2f} err={err:.3e}"
+    except Exception as exc:  # a failure is a data point, not a crash -- record and let the sweep go on
+        dt = time.perf_counter() - t0
+        tail = f"solve={dt:.2f} err=nan FAILED={type(exc).__name__}:{str(exc)[:60]}"
+    print(f"RESULT size={size} solver={which} dofs={int(fem.dofs)} build={t_build:.1f} {tail}", flush=True)
+
+
+def parse(line):
+    out = {}
+    for tok in line.split()[1:]:
+        k, _, v = tok.partition("=")
+        out[k] = v
+    return out
+
+
+def main():
+    rows = {}
+    for size in SIZES:
+        for which in SOLVERS:
+            proc = subprocess.run([sys.executable, __file__, "--point", str(size), which], capture_output=True, text=True)
+            hit = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT")]
+            if not hit:
+                # Never silently drop a point: an OOM-killed child exits without printing, and a
+                # sweep that quietly skips its largest mesh reads exactly like a sweep that ran.
+                print(f"  size={size} {which}: NO RESULT (exit={proc.returncode}) {proc.stderr.strip()[-200:]}")
+                continue
+            rec = parse(hit[-1])
+            rows.setdefault(int(rec["dofs"]), {})[which] = rec
+            print(f"  {hit[-1]}")
+
+    table = []
+    print(f"\n{'dofs':>8}  {'lu (s)':>9}  {'saddle (s)':>11}  {'speedup':>8}  {'lu err':>10}  {'saddle err':>10}")
+    for dofs in sorted(rows):
+        r = rows[dofs]
+        if set(SOLVERS) - set(r):
+            continue
+        t_lu, t_sd = float(r["lu"]["solve"]), float(r["saddle"]["solve"])
+        table.append(
+            dict(
+                dofs=dofs,
+                t_lu=t_lu,
+                t_saddle=t_sd,
+                speedup=t_lu / t_sd,
+                err_lu=float(r["lu"]["err"]),
+                err_saddle=float(r["saddle"]["err"]),
+            )
+        )
+        print(
+            f"{dofs:8d}  {t_lu:9.2f}  {t_sd:11.2f}  {t_lu / t_sd:7.2f}x  "
+            f"{float(r['lu']['err']):10.1e}  {float(r['saddle']['err']):10.1e}"
+        )
+
+    with open("benchmarks/saddle_scaling.json", "w") as f:
+        json.dump(dict(restart=RESTART, tol=TOL, rows=table), f, indent=1)
+    under = [r for r in table if r["speedup"] <= 1.0]
+    over = [r for r in table if r["speedup"] > 1.0]
+    where = f"between {under[-1]['dofs']} and {over[0]['dofs']} dofs" if under and over else "not bracketed by this sweep"
+    print(f"\ncrossover {where}; wrote benchmarks/saddle_scaling.json")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--point":
+        run_point(float(sys.argv[2]), sys.argv[3])
+    else:
+        main()

--- a/docs/fem.md
+++ b/docs/fem.md
@@ -1710,7 +1710,7 @@ preconditioner never changes the converged solution, only the speed, so specs ne
 * `jno.precond.block_diag((field, spec), …)` / `jno.precond.triangular((field, spec), …)` — per-field
   composition over `fem.blocks`. `triangular` is the standard saddle-point shape: last block solved
   first, substituted back through the assembled off-diagonal matvecs.
-* `jno.precond.saddle(mass_weight=…)` — that standard shape as **one call**, for the common case.
+* `jno.precond.saddle(mass_weight=…, laplace_weight=…)` — that standard shape as **one call**, for the common case.
   It finds the constraint block *structurally* (the field with no diagonal entry — the same detection
   behind the saddle-system warning), puts `amg()` on the momentum block and a weighted pressure
   **mass** matrix on the constraint block, and assembles that mass on the domain's own P1 space, so
@@ -1720,12 +1720,24 @@ preconditioner never changes the converged solution, only the speed, so specs ne
   wrong weight changes convergence *speed* only, never the answer. Pair with `jno.solve.fgmres`;
   `minres` does not apply (block-upper-triangular is nonsymmetric). Needs `pyamg`, and refuses by
   name on a non-saddle system or a constraint field that is not P1 — for anything outside that,
-  compose `triangular` yourself. **Pure-Stokes approximation:** a strong reaction term (Brinkman /
-  Darcy drag, or the `1/dt` mass of a small implicit step) makes the Schur complement stop looking
-  like a mass matrix, and the mesh-robustness degrades — measured on a 2-D Brinkman channel at
-  `μ=1`, preconditioned GMRES went 73 → 76 → 140 → 452 iterations as `α` went `0 → 1e2 → 1e3 → 1e4`.
-  That regime wants the Cahouet–Chabard mass-*plus*-Laplacian approximation (Cahouet & Chabard,
-  *IJNMF* **8**, 869–895, 1988), which `saddle()` does not build.
+  compose `triangular` yourself. **The mass matrix alone is the pure-Stokes approximation:** a strong
+  reaction term (Brinkman / Darcy drag, or the `1/dt` mass of a small implicit step) makes the Schur
+  complement stop looking like a mass matrix, and the mesh-robustness degrades. `laplace_weight`
+  switches to the **Cahouet–Chabard** approximation, a pressure mass *plus* a pressure Laplacian,
+  `S⁻¹ ≈ μ·M_p⁻¹ + α·L_p⁻¹` (Cahouet & Chabard, *IJNMF* **8**, 869–895, 1988, §3). Both weights are
+  the **reciprocal of the coefficient the term stands for**, so `mass_weight=1/μ` and
+  `laplace_weight=1/α`. Measured through this spec on a 2-D Brinkman channel (`μ=1`, `mesh_size=0.12`,
+  preconditioned GMRES to 1e-8, `restart=200`): `α = 0 / 1e2 / 1e3 / 1e4` → **83 / 135 / 503 / 2312**
+  with the mass alone, **83 / 60 / 76 / 74** with Cahouet–Chabard. The point is the *flatness*, not the
+  31× at `α=1e4` — the count stops tracking `α`. The same collapse appears with the momentum block
+  inverted exactly instead of by AMG (31 / 63 / 134 / 189 → 31 / 26 / 25 / 24), which is how you can
+  tell it is the Schur approximation doing the work and not the multigrid. At `α=0` the two are the
+  same preconditioner — that column is one number measured twice — so leave `laplace_weight` at its
+  `None` default on pure Stokes and the Laplacian is never assembled. The pressure Laplacian is pure-Neumann
+  and therefore **singular** — and a sparse LU of it factors happily and then applies nonsense, so the
+  auxiliary carries its own gauge pin and the applier projects the constant out on both sides. It is
+  derived for a *constant* `α`; a spatially varying drag (topology optimisation's `α(ρ)`) takes a
+  representative scalar and degrades gracefully rather than failing.
 * `jno.precond.amg(cycles=…)` — **hybrid algebraic multigrid**: setup once on the host via the *optional*
   `pyamg` (Vaněk, Mandel & Brezina, *Computing* 56, 1996; PyAMG — Bell et al., *JOSS* 8(87), 2023),
   applied as a pure-JAX V-cycle with Chebyshev smoothing (Adams et al., *JCP* 188, 2003). The apply is
@@ -1767,7 +1779,16 @@ Give FGMRES enough `restart`: the default `restart=30` **stagnates** on a 3-D Ta
 preconditioner and does so quietly — it still returns, just slower and less accurate. Measured at
 4302 dofs, `tol=1e-10`: `restart=30` → 2.30 s for 3.3e-6; `restart=150` → 0.49 s for 3.3e-9. On
 3-D Stokes this is what makes the recipe overtake a direct factorisation — measured crossover at
-~15k dofs, and 3.4× faster (23.2 s → 6.9 s) at 41k, where LU's fill-in also costs more memory.
+~15k dofs, and 3.4–3.9× faster (23.2 s → 5.9–6.9 s over repeat runs) at 41k, where LU's fill-in also
+costs more memory. `benchmarks/saddle_scaling.py` runs that sweep.
+
+On a **reaction-dominated** system — Brinkman/Darcy drag, or a small implicit time step — add the
+Laplacian leg, and the iteration count stops tracking the reaction coefficient:
+
+```python
+sol = fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=150),
+                precond=jno.precond.saddle(mass_weight=1.0/mu, laplace_weight=1.0/alpha))
+```
 
 **Picard / lagged coefficients — `jno.lag`.** When a solution-dependent coefficient's Newton tangent
 destroys the linearized system's structure (the classic case: a shear-thinning viscosity `μ_eff(u)` in

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -520,6 +520,87 @@ def triangular(*pairs) -> _Triangular:
     return _Triangular(list(pairs))
 
 
+class _CahouetChabard(_Spec):
+    """Schur applier ``S^-1 ~ (1/mass_weight) M_p^-1 + (1/laplace_weight) L_p^+``; see :func:`saddle`.
+
+    A **sum of inverses**, not the inverse of a sum -- which is exactly why it cannot be written as
+    one :func:`form`: the pressure mass and the pressure Laplacian are inverted separately and their
+    applications added (Cahouet & Chabard, *Int. J. Numer. Methods Fluids* **8**, 869-895, 1988,
+    section 3). Each limit recovers the approximation that is right there: with no reaction term the
+    Laplacian leg is switched off entirely and this IS the pressure-mass recipe; with no viscosity
+    the Schur complement of ``alpha*M_u`` really is ``(1/alpha) L_p``.
+
+    The pressure Laplacian is a **pure-Neumann** operator: the constant is an exact null vector, and
+    a sparse LU of it does not fail -- it factors happily and then applies garbage. So the auxiliary
+    carries its own gauge (``pin()``, the same one a pressure field uses) to make the factorisation
+    well-posed, and the applier projects the constant out on both sides to recover the pseudo-inverse
+    the approximation actually calls for.
+    """
+
+    def __init__(self, mass_weight, laplace_weight):
+        self.mass_weight = float(mass_weight)
+        self.laplace_weight = float(laplace_weight)
+        self._mass = None
+        self._lap = None
+
+    def _build(self, fem):
+        if self._mass is not None:
+            return
+        from . import solve as _s
+        from ._fem import _fe_symbols_bound
+
+        ui, vi, _axes = _fe_symbols_bound(fem.domain)
+        self._mass = form([self.mass_weight * ui * vi], inner=_s.lu(backend="host"))
+
+        # The Laplacian needs the UNBOUND symbol as well as the bound one -- `pin()` is a gauge on
+        # the field, not on a coordinate-bound expression -- so it builds its own pair rather than
+        # reusing the mass form's.
+        domain = fem.domain
+        u_sym, v_sym = domain.fem_symbols()
+        coords = domain.variable("interior", split=True)
+        axes = ("x", "y", "z")[: int(domain.dimension)]
+        ub = u_sym.bind(**{ax: coords[i] for i, ax in enumerate(axes)})
+        vb = v_sym.bind(**{ax: coords[i] for i, ax in enumerate(axes)})
+        stiff = None
+        for ax in axes:
+            leg = getattr(ub, ax) * getattr(vb, ax)
+            stiff = leg if stiff is None else stiff + leg
+        self._lap = form([self.laplace_weight * stiff, u_sym.pin()], inner=_s.lu(backend="host"))
+
+    def prepare(self, fem):
+        self._build(fem)
+        self._mass.prepare(fem)
+        self._lap.prepare(fem)
+
+    def materialize(self, ctx: PrecondContext):
+        if self._mass is None:
+            if ctx.fem is None:
+                raise TypeError(
+                    "jno.precond.saddle(laplace_weight=...) needs the owning FEM to assemble the "
+                    "pressure auxiliaries (use it via fem.solve(precond=...))."
+                )
+            self._build(ctx.fem)
+        m_apply = self._mass.materialize(ctx)
+        l_apply = self._lap.materialize(ctx)
+
+        def lap_pinv(v):
+            # Project into range(L) going in and out of null(L) coming back. The gauge pin makes the
+            # FACTORISATION well-posed; it does not make the solve the pseudo-inverse, because the
+            # answer is still free by the constant the pin happened to fix. Both projections are
+            # needed: the first so the pinned system is consistent, the second so the returned
+            # correction carries no constant of its own.
+            w = v - jnp.mean(v)
+            x = l_apply(w)
+            return x - jnp.mean(x)
+
+        # Both legs are symmetric (a mass matrix, and a symmetrically-pinned Laplacian -- measured
+        # exactly symmetric), so the sum is too and needs no separate transpose applier.
+        return PrecondApplier(lambda v: m_apply(v) + lap_pinv(v))
+
+    def __repr__(self):
+        return f"jno.precond._CahouetChabard(mass_weight={self.mass_weight}, laplace_weight={self.laplace_weight})"
+
+
 class _Saddle(_Spec):
     """Spec for the standard saddle-point recipe; see :func:`saddle`.
 
@@ -528,8 +609,9 @@ class _Saddle(_Spec):
     saddle detection, so the same ``saddle()`` object composes onto any saddle system.
     """
 
-    def __init__(self, mass_weight):
+    def __init__(self, mass_weight, laplace_weight=None):
         self.mass_weight = float(mass_weight)
+        self.laplace_weight = None if laplace_weight is None else float(laplace_weight)
         self._resolved = None
 
     def _compose(self, fem):
@@ -571,15 +653,17 @@ class _Saddle(_Spec):
         from . import solve as _s
         from ._fem import _fe_symbols_bound
 
-        ui, vi, _axes = _fe_symbols_bound(fem.domain)
-        w = self.mass_weight
-        # The mass block is inverted EXACTLY, on the host, in float64. That is what keeps the whole
+        # The auxiliaries are inverted EXACTLY, on the host, in float64. That is what keeps the whole
         # preconditioner a fixed linear operator -- an inexact inner solve would make it vary between
         # applications, which a non-flexible Krylov method (gmres) is not allowed to see.
-        mass = form([w * ui * vi], inner=_s.lu(backend="host"))
+        if self.laplace_weight is None:
+            ui, vi, _axes = _fe_symbols_bound(fem.domain)
+            schur = form([self.mass_weight * ui * vi], inner=_s.lu(backend="host"))
+        else:
+            schur = _CahouetChabard(self.mass_weight, self.laplace_weight)
         pairs = []
         for i in range(len(blocks)):
-            pairs.append((i, mass if i in idx else amg()))
+            pairs.append((i, schur if i in idx else amg()))
         self._resolved = _Triangular(pairs)
         return self._resolved
 
@@ -590,10 +674,11 @@ class _Saddle(_Spec):
         return self._compose(ctx.fem).materialize(ctx)
 
     def __repr__(self):
-        return f"jno.precond.saddle(mass_weight={self.mass_weight})"
+        lw = "" if self.laplace_weight is None else f", laplace_weight={self.laplace_weight}"
+        return f"jno.precond.saddle(mass_weight={self.mass_weight}{lw})"
 
 
-def saddle(*, mass_weight: float = 1.0) -> _Saddle:
+def saddle(*, mass_weight: float = 1.0, laplace_weight: float | None = None) -> _Saddle:
     """The standard **saddle-point** preconditioner, as one call.
 
     Composes the classical Stokes recipe over the system's own block structure -- algebraic multigrid
@@ -635,24 +720,62 @@ def saddle(*, mass_weight: float = 1.0) -> _Saddle:
     inverted exactly, so this is a fixed linear operator -- but breaks down in the default float32
     build, exactly as the explicit :func:`triangular` composition does; prefer ``fgmres``.
 
-    **This is the pure-Stokes approximation, and it degrades on a reaction-dominated system.** The
-    pressure mass stands in for the Schur complement of ``-mu*Lap(u) + grad(p)``; add a strong
-    reaction term (a Brinkman/Darcy drag ``alpha*u``, as porous-medium flow and fluid topology
-    optimisation both do, or the ``1/dt`` mass of a small implicit time step) and the Schur
-    complement stops looking like a mass matrix. Measured on a 2-D Brinkman channel at ``mu = 1``,
-    preconditioned GMRES took 73 iterations at ``alpha = 0``, 76 at ``1e2``, 140 at ``1e3`` and 452
-    at ``1e4`` -- it still converges, but the mesh-robustness the recipe exists for is gone. That
-    regime wants the Cahouet-Chabard approximation, a pressure mass PLUS a pressure Laplacian
-    (``S^-1 ~ mu*M_p^-1 + alpha*L_p^-1``; Cahouet & Chabard, *Int. J. Numer. Methods Fluids* **8**,
-    869-895, 1988), which this does not build.
+    **The mass matrix alone is the pure-Stokes approximation, and it degrades on a
+    reaction-dominated system.** The pressure mass stands in for the Schur complement of
+    ``-mu*Lap(u) + grad(p)``; add a strong reaction term -- a Brinkman/Darcy drag ``alpha*u``, as
+    porous-medium flow and fluid topology optimisation both do, or the ``1/dt`` mass of a small
+    implicit time step -- and the Schur complement stops looking like a mass matrix. It still
+    converges, but the mesh-robustness the recipe exists for is gone.
+
+    ``laplace_weight`` is the fix: it switches the Schur approximation to **Cahouet-Chabard**, a
+    pressure mass PLUS a pressure Laplacian, ``S^-1 ~ mu*M_p^-1 + alpha*L_p^-1`` (Cahouet & Chabard,
+    *Int. J. Numer. Methods Fluids* **8**, 869-895, 1988, section 3)::
+
+        fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=150),
+                  precond=jno.precond.saddle(mass_weight=1.0 / mu, laplace_weight=1.0 / alpha))
+
+    Both weights follow the same convention -- **the reciprocal of the coefficient the term stands
+    for** -- so ``mass_weight=1/mu`` applies ``mu*M_p^-1`` and ``laplace_weight=1/alpha`` applies
+    ``alpha*L_p^-1``. Measured through this spec on a 2-D Brinkman channel (``mu = 1``,
+    ``mesh_size=0.12``, preconditioned GMRES to ``1e-8``, ``restart=200``):
+
+    ==========  ===========  ================
+    ``alpha``   mass only    Cahouet-Chabard
+    ==========  ===========  ================
+    ``0``       83           83
+    ``1e2``     135          60
+    ``1e3``     503          76
+    ``1e4``     2312         74
+    ==========  ===========  ================
+
+    The point is not the 31x at ``alpha = 1e4`` but the **flatness**: the count stops tracking
+    ``alpha``. The same collapse shows with the momentum block inverted exactly rather than by AMG
+    (``31 / 63 / 134 / 189`` becoming ``31 / 26 / 25 / 24`` over the same four values), which is how
+    one can tell it is the Schur approximation doing the work and not the multigrid.
+
+    At ``alpha = 0`` the Laplacian leg contributes nothing and the two are the same preconditioner --
+    the table's first row is one number measured twice. So there is no reason to pass
+    ``laplace_weight`` on a pure Stokes problem; it only buys an extra factorisation. Left ``None``
+    (the default) the Laplacian is never assembled at all.
+
+    The pressure Laplacian is **pure-Neumann and therefore singular** -- the constant is an exact
+    null vector. That is a quiet failure mode, not a loud one: a sparse LU of it factors without
+    complaint and then applies nonsense. The auxiliary carries its own gauge pin so the
+    factorisation is well-posed, and the applier projects the constant out on both sides to give the
+    pseudo-inverse. There is no user knob for this and no tolerance to tune.
 
     Scope: needs ``pyamg`` for the momentum block (a clear ``ImportError`` otherwise), and the
-    constraint field must be P1 -- both refuse by name rather than mis-solving. For anything else
-    (a different momentum solver, an inexact inner solve on a very large pressure block, more than
-    one constraint field on mixed spaces) compose :func:`triangular` directly; this is a shorthand
-    for the common case, not a replacement for it.
+    constraint field must be P1 -- both refuse by name rather than mis-solving. Cahouet-Chabard is
+    derived for a **constant** ``alpha``; with a spatially varying drag (the ``alpha(rho)`` of a
+    topology optimisation, which is the case that most wants this) a single scalar weight is a
+    compromise, and the sensible choice is a representative value such as the mean over the design
+    field -- it degrades gracefully rather than failing, but it is no longer the sharp approximation
+    the table above measures. For anything else (a different momentum solver, an inexact inner solve
+    on a very large pressure block, more than one constraint field on mixed spaces, a genuinely
+    variable-coefficient Laplacian) compose :func:`triangular` directly; this is a shorthand for the
+    common cases, not a replacement for it.
     """
-    return _Saddle(mass_weight)
+    return _Saddle(mass_weight, laplace_weight)
 
 
 class _AMG(_Spec):

--- a/tests/test_fem_saddle_precond.py
+++ b/tests/test_fem_saddle_precond.py
@@ -38,6 +38,42 @@ def _stokes(mesh_size=0.3, mu=1.0):
     return fem, u, p, mu
 
 
+def _brinkman(mesh_size=0.3, mu=1.0, alpha=0.0):
+    """The same channel with a Brinkman/Darcy drag ``alpha*u`` -- a reaction-dominated saddle.
+
+    This is the regime the pressure mass alone stops standing in for: as ``alpha`` grows the Schur
+    complement of ``alpha*M_u + mu*K_u`` stops looking like a mass matrix and starts looking like a
+    Laplacian, which is exactly what the Cahouet-Chabard approximation interpolates between.
+    """
+    pytest.importorskip("shapely", reason="shapely required for the box domain")
+    from shapely.geometry import box
+
+    inner_, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
+    G, H, Lx = 1.0, 1.0, 4.0
+    u_profile = lambda y: (G / (2 * mu)) * y * (H - y)  # noqa: E731
+    d = jno.domain(box(0.0, 0.0, Lx, H), mesh_size=mesh_size)
+    u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
+    p, q = d.fem_symbols(names=("p", "q"), order=1)
+    xi, yi, _ = d.variable("interior", split=True)
+    xb, yb, _ = d.variable("boundary", split=True)
+    gu, gv = grad(u, [xi, yi]), grad(v, [xi, yi])
+    pp, qq = p.bind(x=xi, y=yi), q.bind(x=xi, y=yi)
+    ub, vb = u.bind(x=xi, y=yi), v.bind(x=xi, y=yi)
+    momentum = mu * inner_(gu, gv, n_contract=2) - pp * trace(gv)
+    if alpha:
+        momentum = momentum + alpha * inner_(ub, vb, n_contract=1)
+    fem = jno.fem(
+        [
+            momentum,
+            -qq * trace(gu),
+            u(xb, yb)[0] - u_profile(yb),
+            u(xb, yb)[1] - 0.0,
+            p.pin(),
+        ]
+    )
+    return fem, u, p, mu
+
+
 def _poisson(mesh_size=0.4):
     """A single-field problem -- no block structure, so no saddle block to find."""
     pytest.importorskip("shapely", reason="shapely required for the box domain")
@@ -192,3 +228,143 @@ def test_mass_weight_changes_speed_but_not_the_answer():
 def test_saddle_is_exported_and_reprs():
     assert "saddle" in jno.precond.__all__
     assert "mass_weight=2.0" in repr(jno.precond.saddle(mass_weight=2.0))
+
+
+# --------------------------------------------------------------------------------------
+# laplace_weight: the Cahouet-Chabard Schur approximation for a reaction-dominated system
+# --------------------------------------------------------------------------------------
+def test_laplace_weight_switches_the_schur_approximation():
+    """Structural: the default builds one auxiliary, ``laplace_weight`` builds the summed pair.
+
+    Asserted on the composition rather than by timing, for the same reason as the equivalence test
+    above -- and because the thing worth pinning is that the Laplacian is *not* assembled when it was
+    not asked for. An always-on Laplacian would be a silent extra factorisation on every Stokes solve.
+    """
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    fem, u, p, mu = _brinkman(mesh_size=0.5, alpha=1e3)
+    plain = jno.precond.saddle(mass_weight=1.0 / mu)._compose(fem)
+    cc = jno.precond.saddle(mass_weight=1.0 / mu, laplace_weight=1e-3)._compose(fem)
+    kinds = lambda c: {idx: type(sub).__name__ for idx, sub in c.pairs}  # noqa: E731
+    assert kinds(plain)[fem.block_index(p)] == "_Form"
+    assert kinds(cc)[fem.block_index(p)] == "_CahouetChabard"
+    assert kinds(cc)[fem.block_index(u)] == "_AMG", "the momentum block must be untouched by the switch"
+
+
+def test_the_pressure_laplacian_auxiliary_is_gauged():
+    """The quiet failure this feature has to not have.
+
+    A pure-Neumann Laplacian is exactly singular (the constant is a null vector), and scipy's sparse
+    LU does **not** refuse it -- it factors without complaint and then applies nonsense. So the test
+    is not "does it raise" but "is the operator the spec actually builds nonsingular": assemble the
+    auxiliary the way ``_CahouetChabard`` does, with and without its gauge, and compare.
+
+    Asserted as ``L @ 1`` rather than as a smallest singular value, because the null VECTOR is exact
+    while the null VALUE is only zero to working precision -- and this suite runs in float32, where
+    the singular value of the constant mode sits around 1e-8 and no absolute threshold separates
+    "singular" from "merely ill-conditioned".
+    """
+    fem, _u, _p, _mu = _brinkman(mesh_size=0.5)
+    d = fem.domain
+    u_sym, _v_sym = d.fem_symbols()
+    coords = d.variable("interior", split=True)
+    axes = ("x", "y", "z")[: int(d.dimension)]
+    ub = u_sym.bind(**{ax: coords[i] for i, ax in enumerate(axes)})
+    vb = _v_sym.bind(**{ax: coords[i] for i, ax in enumerate(axes)})
+    stiff = None
+    for ax in axes:
+        leg = getattr(ub, ax) * getattr(vb, ax)
+        stiff = leg if stiff is None else stiff + leg
+
+    def constant_mode_residual(terms):
+        """``||L @ 1|| / (||L||_max * sqrt(n))`` -- how nearly the constant is annihilated."""
+        aux = jno.fem(list(terms))
+        A = np.asarray(aux.A.todense() if hasattr(aux.A, "todense") else aux.A, dtype=float)
+        ones = np.ones(A.shape[1])
+        return float(np.linalg.norm(A @ ones) / (np.abs(A).max() * np.sqrt(A.shape[1])))
+
+    ungauged = constant_mode_residual([stiff])
+    gauged = constant_mode_residual([stiff, u_sym.pin()])
+    assert ungauged < 1e-5, f"expected the constant to be a null vector, got residual {ungauged:.2e}"
+    assert gauged > 1e-3, f"the gauge did not remove the constant null vector: residual {gauged:.2e}"
+
+
+def _gmres_residual_after(fem, spec, budget):
+    """Relative preconditioned residual after **exactly** ``budget`` GMRES iterations.
+
+    A fixed budget rather than a count-to-convergence, because counting is the slow direction here:
+    the mass-only preconditioner needs several hundred iterations on a reaction-dominated system and
+    every one of them crosses to the host through the AMG V-cycle. ``restart=budget, maxiter=1`` runs
+    one cycle of exactly that many inner iterations, which bounds the work at both ends and compares
+    the two approximations at equal cost.
+    """
+    import jax.numpy as jnp
+    import scipy.sparse.linalg as spla
+
+    from jno.utils.solver.solver_api import LinearOperator, PrecondContext, materialize_precond
+
+    A_j = fem.A
+    A = np.asarray(A_j.todense() if hasattr(A_j, "todense") else A_j, dtype=float)
+    b = np.asarray(fem.b, dtype=float).reshape(-1)
+    prep = getattr(spec, "prepare", None)
+    if prep is not None:
+        prep(fem)
+    M = materialize_precond(spec, PrecondContext(LinearOperator(A_j), fem))
+    hist = []
+
+    def mv(v):
+        return np.array(M(jnp.asarray(np.asarray(v, dtype=float))), dtype=float, copy=True).reshape(-1)
+
+    Mop = spla.LinearOperator(A.shape, matvec=mv, dtype=float)
+    spla.gmres(
+        A,
+        b,
+        M=Mop,
+        rtol=1e-14,
+        restart=budget,
+        maxiter=1,
+        callback=lambda pr: hist.append(float(pr)),
+        callback_type="pr_norm",
+    )
+    assert hist, "GMRES recorded no iterations"
+    return hist[-1]
+
+
+def test_the_laplacian_leg_flattens_the_brinkman_convergence():
+    """The property ``laplace_weight`` exists for: convergence stops tracking the drag coefficient.
+
+    Both preconditioners get the SAME iteration budget on the SAME system, so the only difference is
+    the Schur approximation. Measured at ``alpha=1e3``, 60 iterations: the pressure mass alone is
+    still at 1.1e-01 while Cahouet-Chabard has reached 1.2e-10. The thresholds below leave four
+    orders of margin against that, since the exact numbers move with the mesh generator and AMG setup.
+
+    The second assertion is the one that stops this passing for the wrong reason: without it, two
+    preconditioners that BOTH converged comfortably would satisfy the ratio by accident.
+    """
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    alpha, budget = 1.0e3, 60
+    fem, _u, _p, mu = _brinkman(mesh_size=0.35, alpha=alpha)
+    mass_only = _gmres_residual_after(fem, jno.precond.saddle(mass_weight=1.0 / mu), budget)
+    both = _gmres_residual_after(fem, jno.precond.saddle(mass_weight=1.0 / mu, laplace_weight=1.0 / alpha), budget)
+    assert mass_only > 1e-3, f"the mass-only baseline converged on its own -- no contrast to measure ({mass_only:.2e})"
+    assert both < 1e-4 * mass_only, (
+        f"the Laplacian leg did not help at alpha={alpha:g}: {mass_only:.2e} -> {both:.2e} in {budget} iterations"
+    )
+
+
+def test_cahouet_chabard_matches_the_direct_oracle():
+    """A richer Schur approximation is still only a preconditioner -- same answer, sooner."""
+    pytest.importorskip("pyamg", reason="pyamg required for the momentum block")
+    alpha = 1.0e3
+    fem, _u, _p, mu = _brinkman(alpha=alpha)
+    ref = fem.solve(linear=jno.solve.lu(backend="host"))
+    got = fem.solve(
+        linear=jno.solve.fgmres(tol=1e-9, restart=150),
+        precond=jno.precond.saddle(mass_weight=1.0 / mu, laplace_weight=1.0 / alpha),
+    )
+    err = np.linalg.norm(np.asarray(got) - np.asarray(ref)) / np.linalg.norm(np.asarray(ref))
+    assert err < 5e-3, f"Cahouet-Chabard drifted from the direct oracle: rel err {err:.2e}"
+
+
+def test_laplace_weight_reprs_and_is_absent_by_default():
+    assert "laplace_weight" not in repr(jno.precond.saddle(mass_weight=2.0))
+    assert "laplace_weight=0.001" in repr(jno.precond.saddle(mass_weight=2.0, laplace_weight=1e-3))


### PR DESCRIPTION
Follow-up to #120, which landed `jno.precond.saddle(mass_weight=...)`. Two commits: a benchmark that
measures where the recipe pays, and a second Schur approximation for the regime the first one does
not cover.

#120 shipped with two loose ends. Its PR body quoted a 3-D scaling table that nothing in the
repository reproduced, and its docstring named the Cahouet–Chabard approximation as the thing a
reaction-dominated system wants while stating plainly that it **was not built**. This closes both.

## Where it earns its place

3-D Taylor–Hood Stokes, one process per point, solve time only — the output of
`benchmarks/saddle_scaling.py`, which ships in this PR so the table is reproducible rather than
asserted:

| dofs | direct `lu` | `saddle` + fgmres | speedup | `lu` err | `saddle` err |
|---|---|---|---|---|---|
| 6,352 | 0.15 s | 0.89 s | 0.17× | 3.9e-14 | 1.1e-08 |
| 10,751 | 0.44 s | 1.07 s | 0.41× | 7.9e-14 | 3.1e-08 |
| 15,439 | 1.48 s | 1.33 s | 1.11× ← crossover | 1.5e-13 | 4.9e-08 |
| 21,045 | 4.30 s | 3.00 s | 1.43× | 1.8e-13 | 2.0e-07 |
| 29,568 | 11.16 s | 4.46 s | 2.50× | 9.5e-14 | 3.0e-07 |
| 40,587 | 23.38 s | 5.93 s | **3.94×** | 1.5e-13 | 1.0e-06 |

The shape matters more than the endpoint. Fitting across that 6.4× span: the direct factorisation
grows as **n^2.7** (fill-in), the preconditioned solve as **n^1.0**. Two curves with those exponents
have to cross; where they cross is set by the constant factors, which is why LU's small constant wins
below ~15k dofs and loses increasingly badly above. Individual points wobble — the iteration count is
not perfectly mesh-independent at these sizes — so the exponents are the trend, not a tight fit.
Repeat runs put the largest point between **3.4× and 3.9×**.

**The accuracy column is the catch, and it is why the benchmark reports it.** `fgmres` converges on
the *residual* to 1e-10, but solution error is residual × condition number, and Taylor–Hood
conditioning grows like h⁻² — so a fixed residual tolerance buys less solution accuracy as the mesh
refines (1.1e-08 → 1.0e-06). LU is backward-stable and sits at 1e-13 throughout. This is 3.9× faster
*and* ~7 orders less accurate; tighten `tol` and you give some of the speedup back. The column also
exists because an earlier run of this sweep used fgmres's default `restart=30`, which stagnates
quietly, and reported the saddle path several times slower than it is — the stagnation is visible as
an error drifting to 1e-5 while LU sits at 1e-13.

Peak memory crosses too — 2.34 GB vs 2.20 GB at the largest point in a separately instrumented run,
with the direct curve climbing and the iterative one flatter. Fill-in is the harder limit, since it
ends a direct solve outright.

**Below ~15k dofs it is a pessimisation** (up to 6× slower at 6k, AMG setup dominating). This is for
where the direct solve stops fitting, not a new default.

## A Schur approximation that survives a reaction term

The pressure mass alone is the *pure-Stokes* approximation. Add a strong reaction term — a
Brinkman/Darcy drag, or the `1/dt` mass of a small implicit step — and the Schur complement stops
looking like a mass matrix, so the mesh-robustness the recipe exists for goes away. `laplace_weight`
switches to **Cahouet–Chabard**, a pressure mass *plus* a pressure Laplacian,
`S⁻¹ ≈ μ·M_p⁻¹ + α·L_p⁻¹` (Cahouet & Chabard, *IJNMF* **8**, 869–895, 1988, §3):

```python
fem.solve(linear=jno.solve.fgmres(tol=1e-10, restart=150),
          precond=jno.precond.saddle(mass_weight=1.0 / mu, laplace_weight=1.0 / alpha))
```

Measured through the spec on a 2-D Brinkman channel (`mu=1`, `mesh_size=0.12`, GMRES to 1e-8,
`restart=200`):

| `alpha` | mass only | Cahouet–Chabard |
|---|---|---|
| 0 | 83 | 83 |
| 1e2 | 135 | 60 |
| 1e3 | 503 | 76 |
| 1e4 | **2312** | **74** |

The point is the flatness, not the 31×: the count stops tracking `alpha`. That is not a tuned
interpolation — for a mode of wavenumber k the Schur symbol is `k²/(α + μk²)`, so
`S⁻¹ ~ α·(1/k²) + μ`, and with `L_p ~ k²`, `M_p ~ 1` that *is* the formula, exact at the symbol level
for every `alpha`. Each term is also the correct limit alone: at `alpha=0` the Schur complement of
`μK` is spectrally equivalent to the mass matrix, and at `mu=0` the Schur complement of `α·M_u` is
literally a discrete pressure Laplacian.

The same collapse appears with the momentum block inverted exactly instead of by AMG
(31 / 63 / 134 / 189 → 31 / 26 / 25 / 24), which is how one can tell it is the Schur approximation
doing the work and not the multigrid — the AMG column is worse in *both* halves because AMG itself
degrades as `α·M + μ·K` turns mass-dominated. It agrees with the direct oracle to **1.1e-10**; a
richer approximation is still only a preconditioner.

Both weights keep one convention — **the reciprocal of the coefficient the term stands for** — so
`mass_weight=1/mu` and `laplace_weight=1/alpha` read the same way. Default `None` leaves the
Laplacian unassembled: at `alpha=0` the two are provably the same preconditioner, so a pure Stokes
solve pays nothing for a leg that contributes nothing, and the tests assert that structurally rather
than by timing.

It is a **sum of inverses, not the inverse of a sum**, so it cannot be written as one `form()` — the
two auxiliaries are assembled and factored separately and their applications added.

**The quiet failure this had to not ship with.** The pressure Laplacian is pure-Neumann and therefore
exactly singular, and scipy's sparse LU does *not* refuse it — it factors without complaint and then
applies nonsense. The auxiliary carries its own gauge pin so the factorisation is well-posed, and the
applier projects the constant out on both sides, which is what makes the result the pseudo-inverse
rather than an arbitrary member of the solution family. No knob, no tolerance. A test asserts the
constant *is* a null vector ungauged and *is not* gauged — checked as `L @ 1` rather than a smallest
singular value, because the null vector is exact while the null value is only zero to working
precision, and this suite runs in float32.

## No new concepts

The constraint block is found *structurally* — the field whose test function never meets its own
trial function, so the operator has no diagonal there. That detection already existed to back the
saddle-system warning; it is now also recorded by position, because a preconditioner has to address
the block rather than name it. No symbols are passed: the pressure auxiliaries are assembled on the
domain's own P1 space, so the call reads identically in 2-D and 3-D.

Both weights are explicit and never inferred. Recovering `mu` or `alpha` from an arbitrary weak form
is fragile, and a variable or solution-dependent coefficient would take the wrong weight silently —
costing iterations without ever failing. A wrong weight changes convergence speed only, never the
answer, and a test pins that.

## Scope, stated rather than discovered

- **Cahouet–Chabard is derived for a constant `alpha`.** A spatially varying drag — a topology
  optimisation's `alpha(rho)`, which is the case that most wants this — takes a representative scalar
  (the mean over the design field is the sensible choice) and degrades gracefully rather than
  failing. It is no longer the sharp approximation the table measures.
- **Krylov pairing.** `fgmres`. `minres` does not apply — block-upper-triangular is nonsymmetric and
  MINRES's short recurrence assumes symmetry, so it stalls loudly on the residual guard. The
  non-flexible `gmres` breaks down in the default float32 build, exactly as the explicit `triangular`
  composition does.
- **Give fgmres enough restart.** The default `restart=30` stagnates on 3-D Taylor–Hood, and quietly:
  at 4302 dofs and `tol=1e-10`, `restart=30` took 2.30 s to reach 3.3e-06 while `restart=150` took
  0.49 s to reach 3.3e-09.
- Needs `pyamg`; the constraint field must be P1. Both refuse by name rather than mis-solving.

## Verification

14 tests in `tests/test_fem_saddle_precond.py` (49 s). The direct-solve oracle in 2-D and for
Cahouet–Chabard; that the shorthand composes the same blocks as the explicit form (asserted on
structure — a second `fem.solve()` warm-starts from the first, so comparing two solves measures the
warm start); mesh-robust iteration count across three refinements, counted directly since
`fem.stats` records which solver ran and not how many steps it took; that `laplace_weight` switches
only the constraint block and leaves the momentum block untouched; the gauged/ungauged null-vector
check; that a mis-weighted call still reaches the same answer; and both refusals.

The convergence test compares both approximations at a **fixed iteration budget** rather than
counting to convergence — counting is the slow direction, since the mass-only baseline needs several
hundred iterations and each crosses to the host through the AMG V-cycle. At 60 iterations the mass
alone is still at 1.1e-01 while Cahouet–Chabard has reached 1.2e-10. It also asserts the baseline has
*not* converged, so the comparison cannot pass by both preconditioners doing well.

71 neighbouring preconditioner/fieldsplit/Stokes tests pass unchanged. `ruff format --check` and
`ruff check` clean repo-wide.

The full per-file suite passed on #120's commit (248 files; the one failure was
`test_packaging.py`, an installed-metadata version mismatch in the local environment, untouched by
this change and absent on a fresh CI install). A local re-run over these two commits was still in
progress when this was opened, so **CI's run is the gate** — the default path is unchanged
(`laplace_weight=None` composes exactly what #120 shipped), and the new file is a benchmark nothing
imports.
