### PR TITLE
Rename Shape to shape, and the three things a mechanical rename breaks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -598,7 +598,7 @@ per-order objective can be optimised straight through the modal solve.
 
 ## Geometry
 
-::: jno.geometry.shape.Shape
+::: jno.geometry.shape.shape
 
 ::: jno.geometry.path.Path
 

--- a/docs/Domain-and-Geometry.md
+++ b/docs/Domain-and-Geometry.md
@@ -1,14 +1,14 @@
 # Domain & Geometry
 
 `jno.domain` holds a meshed geometry, its named regions, and the collocation points sampled on
-them. Build the geometry with the **`Shape`** DSL (gmsh-OpenCASCADE), load a mesh file, or pass a
+them. Build the geometry with the **`shape`** DSL (gmsh-OpenCASCADE), load a mesh file, or pass a
 point cloud.
 
 ```python
 import jno
-from jno import Shape
+from jno import shape
 
-solid = (Shape.rect(0, 0, 4, 1) - Shape.disk(2, 1, 0.4)).extrude(0.6)   # a strip under a roll
+solid = (shape.rect(0, 0, 4, 1) - shape.disk(2, 1, 0.4)).extrude(0.6)   # a strip under a roll
 d = solid.domain()                                                      # one-liner; == jno.domain(solid)
 
 x, y, z, t = d.variable("interior")                                     # coords (+ a trailing time coord t)
@@ -17,9 +17,9 @@ xb, yb, zb, tb, nx, ny, nz = d.variable("top", normals=True, split=True)  # a na
 
 ---
 
-## The `Shape` DSL
+## The `shape` DSL
 
-A `Shape` is an immutable build-plan: make **primitives**, combine them with **boolean operators**,
+A `shape` is an immutable build-plan: make **primitives**, combine them with **boolean operators**,
 reshape with **transforms**, then hand the result to `jno.domain`. Every call returns a new shape.
 
 ### Primitives
@@ -28,12 +28,12 @@ Each takes an optional `size=` (target element size near it).
 
 | Primitive | Auto-named boundaries |
 |---|---|
-| `Shape.rect(x0, y0, x1, y1)` | `left` `right` `top` `bottom` |
-| `Shape.disk(cx, cy, r)` | `arc` |
-| `Shape.polygon(points)` | `e0 e1 … eN` (one per edge) |
-| `Shape.box(x0, y0, z0, x1, y1, z1)` | `left right top bottom front back` |
-| `Shape.cylinder(x, y, z, dx, dy, dz, r)` | `side` `top` `bottom` (any axis) |
-| `Shape.sphere(cx, cy, cz, r)` | `surface` |
+| `shape.rect(x0, y0, x1, y1)` | `left` `right` `top` `bottom` |
+| `shape.disk(cx, cy, r)` | `arc` |
+| `shape.polygon(points)` | `e0 e1 … eN` (one per edge) |
+| `shape.box(x0, y0, z0, x1, y1, z1)` | `left right top bottom front back` |
+| `shape.cylinder(x, y, z, dx, dy, dz, r)` | `side` `top` `bottom` (any axis) |
+| `shape.sphere(cx, cy, cz, r)` | `surface` |
 | `Path(…).face()` | per-segment (see [Contours](#contours-with-arcs)) |
 
 `interior` (the area/volume) and `boundary` (all of it) are always present.
@@ -112,7 +112,7 @@ Control element size by attaching `size=` to a shape — gmsh's mesh-size fields
 (a Distance+Threshold field near a shape, a size callback for `f(x,y,z)`), combined by `min`:
 
 ```python
-Shape.disk(2, 1, 0.4, size=0.02)               # fine in the band around this shape's boundary
+shape.disk(2, 1, 0.4, size=0.02)               # fine in the band around this shape's boundary
 (strip - roll).sized(0.05)                      # a global size cap for the whole shape
 solid.sized(lambda x, y, z: 0.03 + 0.10 * y)    # graded: denser where the function is smaller
 ```
@@ -126,7 +126,7 @@ Meshes are simplicial by default (triangles, tetrahedra). `.quad()` asks gmsh to
 **quadrilaterals**, which works on any 2-D geometry:
 
 ```python
-d = Shape.disk(0, 0, 1, size=0.1).quad().domain()      # pure quads, curved boundary and all
+d = shape.disk(0, 0, 1, size=0.1).quad().domain()      # pure quads, curved boundary and all
 (plate.quad() - hole).sized(0.05)                       # survives the plan operators, like .sized()
 ```
 
@@ -136,8 +136,8 @@ Like `size=` and `.curved()`, this is a property of the shape rather than an arg
 plain box returns 944 tetrahedra and no hexahedra — so hexes come from a regular lattice:
 
 ```python
-d = Shape.box(0, 0, 0, 1, 1, 1).structured(n=16).quad().domain()    # 4096 hexahedra
-d = Shape.rect(0, 0, 1, 1).structured(n=40).quad().domain()          # 1600 quadrilaterals
+d = shape.box(0, 0, 0, 1, 1, 1).structured(n=16).quad().domain()    # 4096 hexahedra
+d = shape.rect(0, 0, 1, 1).structured(n=40).quad().domain()          # 1600 quadrilaterals
 ```
 
 `.quad()` and `.structured()` compose in either order.
@@ -154,8 +154,8 @@ things follow that a gmsh mesh cannot give:
   than holding to a tolerance.
 
 ```python
-d = Shape.rect(0, 0, 1, 1, size=0.1).structured().domain()   # counts from size=: 10x10 cells
-d = Shape.box(...).structured(n=(32, 16, 16)).domain()       # explicit, per axis
+d = shape.rect(0, 0, 1, 1, size=0.1).structured().domain()   # counts from size=: 10x10 cells
+d = shape.box(...).structured(n=(32, 16, 16)).domain()       # explicit, per axis
 
 d.grid          # {"shape": (Nx, Ny[, Nz]), "spacing": (...), "origin": (...)}
 u.reshape(d.grid["shape"])                                    # nodes are C-ordered
@@ -183,8 +183,8 @@ contains its centroid. Each region becomes its own variable set; the outer bound
 auto-names and internal interface facets are not boundary.
 
 ```python
-plate = Shape.rect(0, 0, 2, 1)
-core  = Shape.disk(1, 0.5, 0.3)
+plate = shape.rect(0, 0, 2, 1)
+core  = shape.disk(1, 0.5, 0.3)
 d = (core.name("inclusion") + plate.name("matrix")).sized(0.05).domain()
 
 d.variable("inclusion")     # the disk's cells/points (a distinct material)
@@ -193,7 +193,7 @@ d.boundary_tags()           # {left, right, top, bottom, boundary} — the plate
 ```
 
 `+` keeps the pieces as distinct materials with a conforming interface — unlike `|` (fuse), which
-merges them into one. It composes n-ary (`a + b + c`), and `Shape.regions(inclusion=core,
+merges them into one. It composes n-ary (`a + b + c`), and `shape.regions(inclusion=core,
 matrix=plate)` is the equivalent keyword form. Regions may overlap: here the disk overlaps the plate,
 and `inclusion` wins inside the disk because it is listed first. Use each region tag to restrict a
 `jno.fem` term or coefficient to that material (per-region volume integration), or to sample it in a
@@ -201,7 +201,7 @@ PINN. A multi-material shape is a top-level construct — call `.domain()` on it
 compose with boolean operators or transforms.
 
 Region names that are not valid Python identifiers go through the dict form:
-`Shape.regions({"Quartz.1": q1, "Quartz.2": q2})`. Dict order is priority order exactly as for
+`shape.regions({"Quartz.1": q1, "Quartz.2": q2})`. Dict order is priority order exactly as for
 keywords, and the two forms combine (dict entries first).
 
 ### Material properties — `.attach(...)`
@@ -217,8 +217,8 @@ the mapping is *data* rather than a material — values computed elsewhere, or a
 `default=` for regions that genuinely have no value.
 
 ```python
-kri = Shape.polygon(v).name("Kristall").attach(k=220.0, eps=0.794)
-gas = Shape.polygon(w).name("Gas").attach(k=0.186, eps=1.0)
+kri = shape.polygon(v).name("Kristall").attach(k=220.0, eps=0.794)
+gas = shape.polygon(w).name("Gas").attach(k=0.186, eps=1.0)
 d   = (kri + gas).domain()
 
 heat = d.k * (T.x*s.x + T.y*s.y) - d.q * s      # one equation, both materials
@@ -243,7 +243,7 @@ Rules worth knowing:
 * `d.<name>` raises if **any** region failed to declare that name, listing the ones that did not — a
   forgotten material surfaces at first use rather than as a region that silently conducts nothing. Use
   `d.by_region({...}, default=...)` explicitly when some regions genuinely have none.
-  **This check covers `Shape` regions only.** It reads `_shape_regions`, so on a **mesh-file domain**
+  **This check covers `shape` regions only.** It reads `_shape_regions`, so on a **mesh-file domain**
   it never fires: a region you forgot to attach falls through to `by_region`'s own default rather than
   raising. That matters most for a coefficient whose absence changes the operator's character — a
   forgotten reluctivity leaves `nu = 0` and with it no curl-curl term at all — so on a mesh-file domain
@@ -255,7 +255,7 @@ Rules worth knowing:
   `d.attach(...)` below, where the kind is resolved when it is declared.
 
 A property can also be attached **after** the domain exists, which is the only way to attach to a
-`domain.tag` — or to a mesh-file domain, which has no `Shape` to declare on:
+`domain.tag` — or to a mesh-file domain, which has no `shape` to declare on:
 
 ```python
 d.tag("wall", lambda x, y: x < 1e-9)
@@ -283,14 +283,14 @@ alongside the union `"a|b"`.
 === "Bolt-circle plate"
 
     ```python
-    holes = Shape.disk(3, 0, 0.3).array(6, about=((0, 0, 0), (0, 0, 1)))   # 6 holes in a ring
-    d = jno.domain((Shape.rect(-5, -5, 5, 5) - holes).extrude(0.4))
+    holes = shape.disk(3, 0, 0.3).array(6, about=((0, 0, 0), (0, 0, 1)))   # 6 holes in a ring
+    d = jno.domain((shape.rect(-5, -5, 5, 5) - holes).extrude(0.4))
     ```
 
 === "Filleted, drilled bracket"
 
     ```python
-    part = (Shape.box(0, 0, 0, 8, 4, 1) - Shape.cylinder(2, 2, -1, 0, 0, 3, 0.5)) \
+    part = (shape.box(0, 0, 0, 8, 4, 1) - shape.cylinder(2, 2, -1, 0, 0, 3, 0.5)) \
         .fillet(0.2, where=lambda x, y, z: z > 0.9)                          # round the top edges
     d = jno.domain(part)
     ```
@@ -298,15 +298,15 @@ alongside the union `"a|b"`.
 === "Bent pipe (sweep)"
 
     ```python
-    pipe = Shape.disk(0, 0, 0.4).sweep(Path(0, 0, 0).arc_to(2, 0, 2, through=(0.6, 0, 1.4)))
+    pipe = shape.disk(0, 0, 0.4).sweep(Path(0, 0, 0).arc_to(2, 0, 2, through=(0.6, 0, 1.4)))
     d = jno.domain(pipe)
     ```
 
 === "Graded roll-gap"
 
     ```python
-    strip = Shape.rect(0, 0, 4, 1, size=0.1)          # coarse in the bulk
-    roll  = Shape.disk(2, 1, 0.4, size=0.02)          # fine near the contact arc
+    strip = shape.rect(0, 0, 4, 1, size=0.1)          # coarse in the bulk
+    roll  = shape.disk(2, 1, 0.4, size=0.02)          # fine near the contact arc
     d = jno.domain((strip - roll).extrude(0.6))       # the carved arc is auto-named "arc"
     xc, yc, zc, tc, nx, ny, nz = d.variable("arc", normals=True, split=True)   # contact points + normals
     ```
@@ -350,22 +350,22 @@ re-export.
 d = jno.domain.from_array({"interior": interior_coords, "boundary": boundary_coords})
 ```
 
-**1-D domains** — an open path, exactly like every other dimension's `Shape`:
+**1-D domains** — an open path, exactly like every other dimension's `shape`:
 `jno.Path(0, 0).line_to(1, 0).curve(size=0.01).domain()` (ends named `left`/`right`). This is the
 form used throughout the docs; the `jno.domain.line(...)` shorthand still exists. `jno.domain`
 also keeps the structured grids `equi_distant_rect` / `poseidon` and the point-cloud `from_array`.
-For 2-D/3-D geometry build the shape with `Shape` — `Shape.rect(...).domain()`,
-`Shape.box(...).domain()`, and so on. (Shapely geometries and vertex lists are also still accepted.)
+For 2-D/3-D geometry build the shape with `shape` — `shape.rect(...).domain()`,
+`shape.box(...).domain()`, and so on. (Shapely geometries and vertex lists are also still accepted.)
 
 ---
 
 ## Mesh-free sampling — what a PINN actually needs
 
-`shape.domain()` does **not** mesh. A `Shape` knows its own extent, its own membership test and its
+`shape.domain()` does **not** mesh. A `shape` knows its own extent, its own membership test and its
 own boundary in closed form, so collocation points are drawn from the geometry directly:
 
 ```python
-d = jno.Shape.box(0, 0, 0, 1, 1, 1).domain()          # no gmsh, in 1-D, 2-D or 3-D
+d = jno.shape.box(0, 0, 0, 1, 1, 1).domain()          # no gmsh, in 1-D, 2-D or 3-D
 x, y, z, t = d.variable("interior", sample=(20_000, None), split=True)
 ```
 
@@ -400,7 +400,7 @@ primitives' auto-names (`left`, `arc`, `surface`, …) are available before any 
 !!! note "Shapes with no closed form — the boundary tessellation"
     `fillet` has no analytic membership: it *removes* material near edges, so recursing to the child
     would answer for the un-filleted solid — a wrong-but-plausible mask. It is served by meshing the
-    **boundary only** — the perimeter in 2-D, the surface in 3-D — which `Shape.tessellate()` does
+    **boundary only** — the perimeter in 2-D, the surface in 3-D — which `shape.tessellate()` does
     once and caches. No volume fill runs, and `contains`, `sample_interior` and `sample_boundary`
     fall back to it automatically. The domain says which path it took:
 
@@ -423,7 +423,7 @@ primitives' auto-names (`left`, `arc`, `surface`, …) are available before any 
     through `.build()`, and the domain logs why rather than doing it silently.
 
 !!! warning "Plans that stay eager"
-    `.name(...)` / `Shape.regions(...)` (region and interface tags are the mesher's conforming
+    `.name(...)` / `shape.regions(...)` (region and interface tags are the mesher's conforming
     sub-bodies) and `.structured()` (already a lattice) mesh at construction as before, rather than
     being half-served.
 
@@ -452,7 +452,7 @@ you:
 ValueError: domain.variable('interior'): this domain is mesh-free and no mesh size was declared,
 so the tag has no node set to hand back and no natural point count. Say which you want:
   - continuous collocation points:  variable('interior', sample=(n, None))
-  - a mesh's nodes:                 give the shape a size, e.g. Shape.rect(..., size=0.05),
+  - a mesh's nodes:                 give the shape a size, e.g. shape.rect(..., size=0.05),
                                     or read d.mesh first
 ```
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -29,7 +29,7 @@ returns the coordinates of a named region (`"interior"`, `"boundary"`, …); a d
 (effectively infinite) collocation points for a PINN.
 
 ```python
-dom = jno.Shape.rect(0, 0, 1, 1, size=0.04).domain()
+dom = jno.shape.rect(0, 0, 1, 1, size=0.04).domain()
 x, y, _ = dom.variable("interior")     # interior collocation coordinates
 ```
 
@@ -83,7 +83,7 @@ Epoch  1000/10000 | L: 1.2345e-03 | C0: 1.2345e-03
 [Evaluate](training/evaluation.md) the trained model on its own output — on a finer mesh if you like:
 
 ```python
-pred, xt, yt = crux.eval([u, x, y], domain=jno.Shape.rect(0, 0, 1, 1, size=0.01).domain())
+pred, xt, yt = crux.eval([u, x, y], domain=jno.shape.rect(0, 0, 1, 1, size=0.01).domain())
 print(pred.shape)                       # the learned field, sampled on the fine mesh
 ```
 

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -58,7 +58,7 @@ and worked examples in [Operations → Part B](operations.md#part-b-operations-t
 Two distinct concepts share the word "mesh":
 
 - **Spatial mesh** — the unstructured triangular / tetrahedral / line
-  mesh defining the simulation domain (`jno.Shape.rect(...).domain()`,
+  mesh defining the simulation domain (`jno.shape.rect(...).domain()`,
   loaded from `.msh` / `.npz`, or built from a polygon). Collocation
   and integration points come from this mesh.
 - **Device mesh** — the JAX `(batch, model)` device topology passed via

--- a/docs/Hyperparameter-Tuning.md
+++ b/docs/Hyperparameter-Tuning.md
@@ -111,7 +111,7 @@ class MyMLP(eqx.Module):
         return self.out_layer(h)
 
 
-domain = jno.Shape.disk(0, 0, 1.0, size=0.05).domain()
+domain = jno.shape.disk(0, 0, 1.0, size=0.05).domain()
 x, y = domain.variable("interior")
 
 u = jnn.nn.wrap(MyMLP, space=a_space)(x, y)
@@ -194,7 +194,7 @@ import jax.numpy as jnp
 import equinox as eqx
 
 dire = jno.setup(__file__)
-domain = jno.Shape.disk(0, 0, 1.0, size=0.05).domain()
+domain = jno.shape.disk(0, 0, 1.0, size=0.05).domain()
 x, y = domain.variable("interior")
 
 # Architecture search space

--- a/docs/Save-Load-and-Configuration.md
+++ b/docs/Save-Load-and-Configuration.md
@@ -100,7 +100,7 @@ crux = jno.load("runs/crux.pkl")
 pred = crux.eval(u)
 
 # Evaluate on a different domain
-test_domain = jno.Shape.rect(0, 0, 1, 1, size=0.01).domain()
+test_domain = jno.shape.rect(0, 0, 1, 1, size=0.01).domain()
 pred_fine = crux.eval(u, domain=test_domain)
 ```
 

--- a/docs/adaptive/resampling.md
+++ b/docs/adaptive/resampling.md
@@ -160,7 +160,7 @@ Attach the strategy when creating variables from a tagged point set using
 ```python
 from jno import sampler
 
-domain = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+domain = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 x, y = domain.variable(
     "interior",
     sample=(None, None),

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -48,7 +48,7 @@ import jax.numpy as jnp
 import optax
 import jno
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.2).domain()
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
 u, v = d.fem_symbols()

--- a/docs/domain-decomposition.md
+++ b/docs/domain-decomposition.md
@@ -70,15 +70,15 @@ which you want when the region is not a named tag or you want the convergence re
 ```python
 from jno.dd import couple
 
-sA, sB = jno.Shape.rect(0.0, 0.0, 0.6, 1.0), jno.Shape.rect(0.4, 0.0, 1.0, 1.0)
+sA, sB = jno.shape.rect(0.0, 0.0, 0.6, 1.0), jno.shape.rect(0.4, 0.0, 1.0, 1.0)
 sol, info = couple([(a, sA), (b, sB)]).solve(tol=1e-7, max_iter=60, return_info=True)
 
 info    # {'mode': 'overlap-Schwarz', 'iterations': 11, 'overlap_jump': 3.59e-08,
         #  'interfaces': {'count': 0, 'flux': 0, 'value': 0}}
 ```
 
-The region is a `jno.Shape`, resolved to a node subset by the analytic, shapely-free
-[`Shape.contains`](Domain-and-Geometry.md) — 2-D **and** 3-D.
+The region is a `jno.shape`, resolved to a node subset by the analytic, shapely-free
+[`shape.contains`](Domain-and-Geometry.md) — 2-D **and** 3-D.
 
 ## Two coupling modes, chosen by the geometry
 

--- a/docs/fdm.md
+++ b/docs/fdm.md
@@ -118,8 +118,8 @@ For an axis-aligned **rectangle** or **box**, build a **regular grid** instead o
 asking the shape for a regular lattice with `.structured()`:
 
 ```python
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.02).structured().domain()           # 2-D
-d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.05).structured().domain()   # 3-D
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.02).structured().domain()           # 2-D
+d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.05).structured().domain()   # 3-D
 ```
 
 This meshes the rectangle as a uniform right-triangulation — or, in 3-D, the box as a Kuhn
@@ -153,7 +153,7 @@ field rather than silently dropping the imaginary part, matching the unstructure
     `fem.solve(linear=jno.solve.gmres(), precond=jno.precond.gmg())` on a structured domain. Override the
     inner solver with `.solve(nonlinear=…)` as usual.
 
-    Supported: **2-D axis-aligned rectangles** (`Shape.rect`) and **3-D boxes** (`Shape.box`). A
+    Supported: **2-D axis-aligned rectangles** (`shape.rect`) and **3-D boxes** (`shape.box`). A
     composite/CSG shape or a spatially varying `size=` raises; composite / cut-cell geometry is planned.
 
 ---
@@ -304,11 +304,11 @@ array eagerly, as in every section above.
 ## 3-D tetrahedral meshes
 
 Everything above dispatches on `domain.dimension`: give `jno.fdm` a **3-D tetrahedral** domain and the
-same constraint list solves in 3-D. Build the mesh with [`jno.Shape`](Domain-and-Geometry.md) — a box, sphere,
+same constraint list solves in 3-D. Build the mesh with [`jno.shape`](Domain-and-Geometry.md) — a box, sphere,
 cylinder, or any boolean combination — and add the third coordinate:
 
 ```python
-d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.1).domain()
+d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.1).domain()
 x, y, z, _   = d.variable("interior", split=True)          # note the z coordinate
 xb, yb, zb, _ = d.variable("boundary", split=True)
 u  = d.unknown()
@@ -321,7 +321,7 @@ sol = jno.fdm([
 ]).solve()
 ```
 
-A cube from `jno.Shape.box` auto-names its six faces `left/right/front/back/bottom/top`, so **flux**
+A cube from `jno.shape.box` auto-names its six faces `left/right/front/back/bottom/top`, so **flux**
 conditions work per face exactly as in 2-D — bind to the face and take the normal derivative
 (`nr = d.variable("right", normals=True)`, then `ui.d(nr) - h` or `ur.d(nr) + alpha*(ur - u_inf)`).
 
@@ -373,7 +373,7 @@ A periodic tie `u(left) - u(right)` (opposite faces) wraps that axis on a
 **Planned:** periodic on unstructured meshes and periodic geometric multigrid (a periodic structured solve
 is currently un-preconditioned, so it is slow on fine grids); composite / cut-cell structured geometry
 (axis-aligned rectangles and boxes are supported, above); 1-D meshes; transient / flux BCs on coupled
-multi-field systems. Authoring a `jno.Shape` sub-region
+multi-field systems. Authoring a `jno.shape` sub-region
 through `domain.region(name, shape)` + `d.variable`, and 3-D coupled solves, additionally need
 region-tag support on the base 3-D domain (a separate 3-D domain-decomposition feature). A pure-Neumann
 problem (no Dirichlet node anywhere) is singular — the solution is defined only up to an additive

--- a/docs/fem/elements.md
+++ b/docs/fem/elements.md
@@ -149,7 +149,7 @@ N1E tet curl-curl form). After binding, the no-arg `u.div()` / `u.curl()` reuse 
 
 For the RT mixed-Poisson saddle, a Dirichlet condition on the scalar `p` is *natural* — add the weak
 term `p_D * (v[0]*nx + v[1]*ny)`, no essential constraint on the flux. A BC may target a sub-region
-(a `Shape.rect` edge tag or any `d.tag(...)` boundary subset; sub-region normals are computed from the
+(a `shape.rect` edge tag or any `d.tag(...)` boundary subset; sub-region normals are computed from the
 geometry).
 
 Tutorials: `mixed_poisson_rt_2d.py` (H(div)), `maxwell_nedelec_2d.py` (H(curl): magnetostatics + eddy
@@ -165,12 +165,12 @@ available two ways, and which one you can use is decided by what a mesher can ac
 
 ```python
 # 2-D quadrilaterals on ARBITRARY geometry, via gmsh recombination
-d = jno.Shape.disk(0, 0, 1, size=0.1).quad().domain()
+d = jno.shape.disk(0, 0, 1, size=0.1).quad().domain()
 u, v = d.fem_symbols(order=2)          # Q2 / Q3 work exactly as P2 / P3 do
 
 # structured grids, no mesher involved — a rectangle of quads, a box of hexes
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=40).quad().domain()
-d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).structured(n=16).quad().domain()
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=40).quad().domain()
+d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).structured(n=16).quad().domain()
 ```
 
 Nothing else in the term list changes — the weak form, the boundary conditions and the solve are
@@ -184,7 +184,7 @@ better conditioned and far cheaper per node than tetrahedra.
 
 **Why 3-D is structured-only.** gmsh cannot hexahedral-mesh general geometry. Measured here,
 `Recombine3DAll` on a plain box returns **944 tetrahedra and zero hexahedra**; hexes come only from
-sweeping/extruding or transfinite meshing. `Shape.quad()` therefore refuses a 3-D shape by name
+sweeping/extruding or transfinite meshing. `shape.quad()` therefore refuses a 3-D shape by name
 rather than quietly handing back tetrahedra. 2-D recombination has no such limit — a disk
 recombines to pure quadrilaterals just as a rectangle does.
 
@@ -194,7 +194,7 @@ recombines to pure quadrilaterals just as a rectangle does.
 |---|---|---|
 | structured quads, Q1 | 1.87, 1.92, 1.96 | same error as the triangulation of the same grid, from half the cells |
 | structured hexes, Q1 | 1.79, 1.86 | same error as the tetrahedralisation, from a sixth the cells |
-| recombined quads (`Shape.quad()`), Q1 | 1.83, 1.91 | ~5× the L2 error of triangles at equal node count on this smooth problem |
+| recombined quads (`shape.quad()`), Q1 | 1.83, 1.91 | ~5× the L2 error of triangles at equal node count on this smooth problem |
 | structured quads, **Q2** | 3.94, 3.96 | ~8× *lower* error than P2 triangles at the same node count |
 | structured quads, **Q3** | 3.87, 3.95 | ~5× lower than P3 triangles at the same node count |
 | structured hexes, **Q2** | 4.27, 4.29 | ~10× lower than P2 tetrahedra at the same node count |
@@ -211,7 +211,7 @@ The tensor-product advantage is in bending and near-incompressibility, not here.
 
 The geometry map is formed **per quadrature point**, because a bilinear quad or trilinear hex has a
 Jacobian that varies within the cell even when the cell looks straight-sided — the same machinery
-`Shape.curved()` introduced. The quadrature degree is raised by 2 for the same reason it is on curved
+`shape.curved()` introduced. The quadrature degree is raised by 2 for the same reason it is on curved
 cells: the map makes the integrand rational, so no rule is exact.
 
 **Scope — what is not supported yet**, each refusing by name rather than approximating:
@@ -231,7 +231,7 @@ onto one DOF, so the periodicity holds exactly rather than to a tolerance.
 | **r-adaptivity** (`relocate=`) on quad/hex | the monitor, the cell measures and the validity check are all barycentric; a bilinear cell's validity is the sign of the sampled `det J`, not one determinant |
 | 4th-order forms (plates, phase-field) | the physical-Hessian push-forward assumes an affine cell — the same refusal curved simplices already carry |
 | non-nodal families (N1E, RT, Argyris, Morley) | Argyris and Morley are *defined* on triangles; the quad analogues (RTCF/NCE, Bogner–Fox–Schmit) are different elements |
-| `Shape.quad().curved()` | a curved quadrilateral is a 9-node block the emitter does not produce |
+| `shape.quad().curved()` | a curved quadrilateral is a 9-node block the emitter does not produce |
 
 The **recovery error estimator** runs on both cell families. On a simplex the P1 gradient is constant
 per cell, so inverting the edge matrix is the answer; on a bilinear cell the gradient varies, and the
@@ -281,10 +281,10 @@ order 1 it would evaluate to nothing.
 **h-adaptivity on quadrilaterals** works, by a different mechanism than on simplices. mmg adapts
 triangles and tets by local edge split/collapse/swap and has no quad analogue — but a quad mesh in
 jNO *is* a triangulation gmsh recombined, and the size field driving it is already part of the
-`Shape` plan. So the remesh stage **rebuilds the plan** at the marked size field:
+`shape` plan. So the remesh stage **rebuilds the plan** at the marked size field:
 
 ```python
-d = jno.Shape.polygon(L_SHAPE, size=0.12).quad().domain()
+d = jno.shape.polygon(L_SHAPE, size=0.12).quad().domain()
 u = fem.solve(adapt=jno.solve.remesh(theta=0.6, max_iters=4))     # refines at the corner, stays all-quad
 ```
 
@@ -315,7 +315,7 @@ weights are linearly complete and are what a hex tie — and a hanging node — 
 
 ### Local refinement with hanging nodes (quadrilaterals and hexahedra)
 
-`adapt=jno.solve.remesh()` refines a quad mesh by rebuilding its `Shape` plan at a finer size field,
+`adapt=jno.solve.remesh()` refines a quad mesh by rebuilding its `shape` plan at a finer size field,
 which is global and needs a geometry to rebuild from. Splitting marked cells into four needs neither —
 it works on a mesh loaded from a file, every old node survives, and it is the mechanism 3-D hexes will
 use, since no all-hex mesher exists to remesh *to*.
@@ -369,7 +369,7 @@ The same call refines a hex mesh, splitting each marked cell into 8. This is the
 a hex mesh has, for the reason in the scope table above: there is no all-hex mesher to remesh to.
 
 ```python
-d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=4).quad().domain()   # .quad() on a 3-D lattice = hexes
+d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=4).quad().domain()   # .quad() on a 3-D lattice = hexes
 ...
 u = fem.solve(adapt=jno.solve.refine(theta=0.4, max_iters=3))         # the same slot, in 3-D
 ```
@@ -452,7 +452,7 @@ and flux integrals included.
 
 ### Higher order on independently meshed bodies
 
-`Shape.regions(..., conforming=False)` meshes each body on its own, so a shared face carries **two**
+`shape.regions(..., conforming=False)` meshes each body on its own, so a shared face carries **two**
 coincident node sets — that duplication is the point, and it is what a contact gap opens. Promoting
 such a mesh to P2/P3 has to synthesise new nodes on that face, and the question is when two of them
 are the same node.

--- a/docs/fem/formulations.md
+++ b/docs/fem/formulations.md
@@ -184,7 +184,7 @@ a function of the pseudo-time coordinate `tau`, the domain carries a `tau=` load
 **marches** the path with **nothing passed** — triggered by `.i(k)` exactly as `u.t` triggers transient:
 
 ```python
-d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.1).domain(tau=(0.0, 1.0, 40))   # pseudo-time load path
+d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.1).domain(tau=(0.0, 1.0, 40))   # pseudo-time load path
 x, y, z, tau = d.variable("interior", split=True)            # τ is a coordinate, like t
 dev = lambda A: A - trace(A) / 3 * I3                         # I3 = jno.np.identity(3)
 nrm = lambda A: sqrt(maximum(inner(A, A, 2), 0) + 1e-30)      # safe Frobenius norm

--- a/docs/fem/geometry.md
+++ b/docs/fem/geometry.md
@@ -9,7 +9,7 @@ gmsh mesh-size callback and composes with every other size control by `min`, so 
 ```python
 # THREE arguments, in 2-D as well as 3-D: gmsh calls a size function as f(x, y, z).
 h_of = lambda x, y, z: H_FINE + (H_COARSE - H_FINE) * min(1.0, max(0.0, (LY - y) / BAND))
-d = jno.Shape.rect(0.0, 0.0, LX, LY, size=h_of).domain()
+d = jno.shape.rect(0.0, 0.0, LX, LY, size=h_of).domain()
 ```
 
 This is what makes a thin feature affordable. Measured on a 1.2 × 0.4 mm rectangle graded from 4 µm at
@@ -38,7 +38,7 @@ the 16 µm mesh that resolved nothing.
     `.domain()` does not build a mesh; the first thing that asks for one does. So a size callable is
     not called — and a wrong one not diagnosed — until then.
 
-## Curved (isoparametric) geometry — `Shape.curved()`
+## Curved (isoparametric) geometry — `shape.curved()`
 
 By default jNO meshes straight-sided and *synthesises* higher-order nodes at the straight-edge
 midpoints, so the domain stays a polygon however high the element order goes. That approximation
@@ -47,7 +47,7 @@ round boundary, no matter how good the basis is. `curved()` asks the CAD kernel 
 the true surface instead:
 
 ```python
-d = jno.Shape.disk(0, 0, 1, size=0.1).curved().domain()
+d = jno.shape.disk(0, 0, 1, size=0.1).curved().domain()
 u, v = d.fem_symbols(order=2)          # the basis order must MATCH the geometry order
 ```
 

--- a/docs/fem/index.md
+++ b/docs/fem/index.md
@@ -14,7 +14,7 @@ escape hatch — see the [weak-form vocabulary](../weak_form_vocabulary.md).
 import jax.numpy as jnp
 import jno
 
-d = jno.domain(jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1))
+d = jno.domain(jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1))
 u, phi = d.fem_symbols()                                   # trial / test functions
 xi, yi, _ = d.variable("interior", split=True)            # volume quadrature coords
 xb, yb, _ = d.variable("boundary", split=True)            # boundary coords
@@ -50,7 +50,7 @@ u_h = fem.solve()          # matrix-free default; slots pick anything else (see 
 
 ## Domain, symbols, and derivatives
 
-* **Domain** — any jNO domain works (a `jno.Shape`, `jno.domain.cube`, a CSG/`gmsh` constructor).
+* **Domain** — any jNO domain works (a `jno.shape`, `jno.domain.cube`, a CSG/`gmsh` constructor).
   Add `time=(t0, t1, n_steps)` to make it transient.
 * **Symbols** — `u, phi = d.fem_symbols(value_shape=(), names=("u", "phi"), order=1)`.
   Use `value_shape=(2,)` for a vector unknown (elasticity, flow velocity), `order=k` for degree-`k`
@@ -60,7 +60,7 @@ u_h = fem.solve()          # matrix-free default; slots pick anything else (see 
   limitations* for the measured rates before paying for P3 there.
 * **Quadrature coordinates** — `d.variable("interior", split=True)` returns the volume
   coordinates; `d.variable("<edge>", split=True)` returns a boundary edge's coordinates. A
-  `Shape.rect` auto-tags `"left"`, `"right"`, `"bottom"`, `"top"` (and `"front"`/`"back"` for a box);
+  `shape.rect` auto-tags `"left"`, `"right"`, `"bottom"`, `"top"` (and `"front"`/`"back"` for a box);
   `"boundary"` is the whole boundary and `"initial"` the `t = t0` slice. To define a custom region
   and fetch its coordinates in one call, pass a predicate: `d.variable("port", where=lambda x, y: x < 1e-6)`
   tags `"port"` (exactly as `d.tag` would) and returns its split coordinates.
@@ -274,7 +274,7 @@ the `"initial"`-slice coordinates *and time*, `u.bind(x=xi0, y=yi0, t=ti0).t`; a
 defaults to zero).
 
 ```python
-d = jno.domain(jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1), time=(0.0, 2.0, 200))
+d = jno.domain(jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1), time=(0.0, 2.0, 200))
 u, phi = d.fem_symbols()
 xi, yi, ti = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)

--- a/docs/fem/limitations.md
+++ b/docs/fem/limitations.md
@@ -11,7 +11,7 @@ path is unaffected.
 
     - **Affine geometry on a curved boundary** — by **default** the mesh is straight-sided, so the
       domain is approximated to O(h²), which caps every element order above it. The solve is simply
-      suboptimal. `Shape.curved()` fixes it (order 2, simplices) — see
+      suboptimal. `shape.curved()` fixes it (order 2, simplices) — see
       [Curved geometry](geometry.md#curved-isoparametric-geometry-shapecurved).
     - **The `2πr` measure on an axisymmetric *vector* form** — exact for scalars, wrong for vectors.
 
@@ -31,7 +31,7 @@ path is unaffected.
 | `dom.cell_size` / `dom.cell_metric` | native 2-D/3-D **volume** terms only — a 1-D form or a non-nodal family packs no element Jacobian | raises |
 | Element order on RT / N1E / P0 / Hermite / Argyris / Morley | each family has one intrinsic order | raises |
 | `eigs` on a non-symmetric pencil | eigenvalues differentiate, **eigenvectors do not** | NaN, not a silent zero |
-| **Curved-boundary geometry** | straight-sided **by default**; `Shape.curved()` is the fix | **silent** |
+| **Curved-boundary geometry** | straight-sided **by default**; `shape.curved()` is the fix | **silent** |
 | **Axisymmetric vector forms** | the `2πr` measure is wrong for vectors | **silent** |
 
 ### The detail
@@ -124,7 +124,7 @@ path is unaffected.
 
     On a **polygonal** domain the advertised rates hold exactly (the suite measures P2/P3 there).
 
-    The fix on a curved one is `Shape.curved()`, which places the midside nodes on the true surface
+    The fix on a curved one is `shape.curved()`, which places the midside nodes on the true surface
     and recovers P2's own third order — **570× more accurate** at the finest resolution in the same
     study. It is order 2 and simplices only, and non-nodal families keep affine geometry, so where it
     does not apply the advice above still stands: prefer `h`-refinement (or the adaptive loop) over

--- a/docs/foundation_models/index.md
+++ b/docs/foundation_models/index.md
@@ -53,6 +53,6 @@ For Poseidon-style structured 2D workflows, build the grid on the unit square. `
 so a 128x128 *pixel* grid — the resolution these models expect — is `n=127`:
 
 ```python
-domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=127).domain()
+domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=127).domain()
 domain.grid["shape"]     # (128, 128) — nodes; a nodal field reshapes straight to it
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ boundary — written twice. Only the *form* changes; the language does not.
 ```python
 import jno
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
 
@@ -91,7 +91,7 @@ Maturity is stated per capability; each link goes to the page that documents it.
 | **Time integration** | [stable](fdm.md) | θ-method (backward-Euler / Crank–Nicolson), exponential integrators, adaptive step size — the same slot for `jno.fem` and `jno.fdm` |
 | **Adaptive & moving meshes** | [beta](fem/geometry.md) | Hessian-metric remeshing (AFEM), r-adaptivity, moving meshes stated in the term list |
 | **Differentiable inverse / PDE-constrained** | [stable](inverse-problems.md) | Recover a scalar, a field `k(x)`, the geometry, or a **neural coefficient** through any solve — the gradient flows through the whole march |
-| **Geometry** — `jno.Shape` / `jno.Path` | [stable](Domain-and-Geometry.md) | CSG via gmsh-OCC; conforming multi-material regions |
+| **Geometry** — `jno.shape` / `jno.Path` | [stable](Domain-and-Geometry.md) | CSG via gmsh-OCC; conforming multi-material regions |
 
 ### Pillar 2 — Scientific machine learning
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -42,13 +42,13 @@ single Laplacian node in the trace.
 
 Available on a bound view: `.x .y .z .t`, `.xx .yy .zz .tt`, `.xy` and other mixed partials.
 
-### 1.2 Domains: `jno.Shape` / `jno.Path` only
+### 1.2 Domains: `jno.shape` / `jno.Path` only
 
 ```python
-d = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()                    # 2-D
-d = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, 0.5, 4))    # 2-D + time
+d = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()                    # 2-D
+d = jno.shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, 0.5, 4))    # 2-D + time
 d = jno.Path(0, 0).line_to(1, 0).curve(size=0.02).domain()            # 1-D, ends named left/right
-d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.1).domain()                # 3-D
+d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.1).domain()                # 3-D
 ```
 
 Never `shapely.geometry.box`, never `jno.domain.rect(...)` / `.line(...)` / `.cube(...)` /
@@ -71,7 +71,7 @@ One line per idea. Chain the controls that return `self`. Build the constraint l
 
 ```python
 run = jno.setup(__file__)
-d = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 x, y, _ = d.variable("interior")
 
 net = jno.nn(foundax.mlp(in_features=2, hidden_dims=64, num_layers=4, key=jax.random.PRNGKey(0)))
@@ -161,18 +161,18 @@ x, y, _ = d.variable("interior", sample=(500, None))      # 500 sampled points
 x0, y0, t0 = d.variable("initial")                        # the t = t0 slice
 ```
 
-### The `Shape` DSL
+### The `shape` DSL
 
-A `Shape` is an immutable build-plan (gmsh-OpenCASCADE); every call returns a new shape.
+A `shape` is an immutable build-plan (gmsh-OpenCASCADE); every call returns a new shape.
 
 | Primitive | Auto-named boundaries |
 |---|---|
-| `Shape.rect(x0, y0, x1, y1)` | `left` `right` `top` `bottom` |
-| `Shape.disk(cx, cy, r)` | `arc` |
-| `Shape.polygon(points)` | `e0 e1 … eN` |
-| `Shape.box(x0, y0, z0, x1, y1, z1)` | `left right top bottom front back` |
-| `Shape.cylinder(x, y, z, dx, dy, dz, r)` | `side` `top` `bottom` |
-| `Shape.sphere(cx, cy, cz, r)` | `surface` |
+| `shape.rect(x0, y0, x1, y1)` | `left` `right` `top` `bottom` |
+| `shape.disk(cx, cy, r)` | `arc` |
+| `shape.polygon(points)` | `e0 e1 … eN` |
+| `shape.box(x0, y0, z0, x1, y1, z1)` | `left right top bottom front back` |
+| `shape.cylinder(x, y, z, dx, dy, dz, r)` | `side` `top` `bottom` |
+| `shape.sphere(cx, cy, cz, r)` | `surface` |
 | `Path(…).face()` | per-segment, `name=` as you draw |
 
 `interior` and `boundary` always exist. Combine with `a - b` (cut), `a | b` (fuse), `a & b`
@@ -205,8 +205,8 @@ listed by `d.interface_tags()` and kept **out** of `d.boundary_tags()`.
 ```python
 d = jno.domain("part.msh")                                        # physical groups become tags
 d = jno.domain.from_array({"interior": pts, "boundary": bpts})    # point cloud (no mesh ⇒ no integrate/FD)
-d = jno.Shape.rect(0, 0, 1, 1, size=0.02).domain(structured=True) # uniform grid → fast FD stencils
-dom = 500 * jno.Shape.rect(0, 0, 2, 1, size=0.05).domain()        # replicate for operator learning
+d = jno.shape.rect(0, 0, 1, 1, size=0.02).domain(structured=True) # uniform grid → fast FD stencils
+dom = 500 * jno.shape.rect(0, 0, 2, 1, size=0.05).domain()        # replicate for operator learning
 ```
 
 `d.plot("domain.png")` renders mesh, regions and normals. Node coordinates: `d.built_mesh.points`,
@@ -551,7 +551,7 @@ rather than returning a wrong answer. In 2-D a corner node shared by two flux ed
 normal and falls back to the interior residual — give it an explicit Dirichlet value if it needs
 anchoring.
 
-**Structured grids.** `structured=True` on an axis-aligned `Shape.rect`/`Shape.box` builds a
+**Structured grids.** `structured=True` on an axis-aligned `shape.rect`/`shape.box` builds a
 uniform grid and switches the interior operators to direct 5-point (2-D) / 7-point (3-D) stencils
 by array reshaping. Same answer as the unstructured cotangent operator, cheaper. The inner Krylov
 defaults to **GMRES + geometric-multigrid V-cycle** because row-replaced Dirichlet makes the
@@ -662,9 +662,9 @@ remain the part worth keeping loaded.)
 
 | Stale | Current |
 |---|---|
-| `jno.domain.rect(mesh_size=…, time=…)` | `jno.Shape.rect(…, size=…).domain(time=…)` |
-| `jno.domain.cube(...)` | `jno.Shape.box(...).domain()` |
-| `jno.domain.l_shape(...)` | build it from `Shape` booleans |
+| `jno.domain.rect(mesh_size=…, time=…)` | `jno.shape.rect(…, size=…).domain(time=…)` |
+| `jno.domain.cube(...)` | `jno.shape.box(...).domain()` |
+| `jno.domain.l_shape(...)` | build it from `shape` booleans |
 | `jno.AdaptSpec` | gone |
 
 (`jno.domain.line(mesh_size=…)` still exists as a 1-D shorthand, but the house form — and what the
@@ -745,7 +745,7 @@ import foundax, jax, optax, jno
 run = jno.setup(__file__)
 pi, sin = jno.np.pi, jno.np.sin
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 x, y, _ = d.variable("interior")
 
 net = jno.nn(foundax.mlp(in_features=2, hidden_dims=64, num_layers=4, key=jax.random.PRNGKey(0)))
@@ -835,7 +835,7 @@ import foundax, jax, optax, jno
 run = jno.setup(__file__)
 pi, sin = jno.np.pi, jno.np.sin
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
 x, y, _ = d.variable("interior")
 
 f = 2 * pi**2 * sin(pi * x) * sin(pi * y) + sin(2 * pi * x) * sin(pi * y)
@@ -871,7 +871,7 @@ run = jno.setup(__file__)
 pi = jno.np.pi
 
 d = (jno.Path(3, 0).arc_to(-3, 0, through=(0, 3)).arc_to(3, 0, through=(0, -3))
-     .face().sized(0.25).domain())                       # a disc of radius 3, Shape/Path only
+     .face().sized(0.25).domain())                       # a disc of radius 3, shape/Path only
 x, y, _ = d.variable("interior")
 xb, yb, _ = d.variable("boundary")
 
@@ -965,7 +965,7 @@ import jax.numpy as jnp, numpy as np, jno
 
 run = jno.setup(__file__)
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.18).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.18).domain()
 u, phi = d.fem_symbols()                                  # trial / test
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
@@ -998,7 +998,7 @@ run = jno.setup(__file__)
 pi, sigma, a_r, a_t = np.pi, 4.0, 2.0, 3.0
 sin = jno.np.sin
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.22).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.22).domain()
 u, phi = d.fem_symbols()
 xi, yi, _ = d.variable("interior", split=True)
 xl, yl, _ = d.variable("left", split=True)
@@ -1035,7 +1035,7 @@ E, nu, L, H, q = 1000.0, 0.3, 10.0, 1.0, 0.1
 lam, mu = E * nu / (1.0 - nu**2), E / (2.0 * (1.0 + nu))       # plane stress
 inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
 
-d = jno.Shape.rect(0, 0, L, H, size=0.5).domain()
+d = jno.shape.rect(0, 0, L, H, size=0.5).domain()
 u, phi = d.fem_symbols(value_shape=(2,), order=2)              # P2 vector displacement
 xi, yi, _ = d.variable("interior", split=True)
 xl, yl, _ = d.variable("left", split=True)                     # clamped root
@@ -1064,7 +1064,7 @@ run = jno.setup(__file__)
 nu = 1.0
 dense = lambda A: jnp.asarray(A.todense()) if hasattr(A, "todense") else jnp.asarray(A)  # noqa: E731
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.08).domain(time=(0.0, 0.05, 26))
+d = jno.shape.rect(0, 0, 1, 1, size=0.08).domain(time=(0.0, 0.05, 26))
 u, phi = d.fem_symbols()
 xi, yi, ti = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
@@ -1103,7 +1103,7 @@ run = jno.setup(__file__)
 eps = 0.15
 exact = lambda x: np.tanh((x - 0.5) / (np.sqrt(2.0) * eps))  # noqa: E731
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.06).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.06).domain()
 u, phi = d.fem_symbols()
 xi, yi, _ = d.variable("interior", split=True)
 xl, yl, _ = d.variable("left", split=True)
@@ -1133,7 +1133,7 @@ import numpy as np, jno
 
 run = jno.setup(__file__)
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.06).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.06).domain()
 u, phi = d.fem_symbols()
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
@@ -1161,7 +1161,7 @@ import jax, jax.numpy as jnp, numpy as np, optax, jno
 
 run = jno.setup(__file__)
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
 u, phi = d.fem_symbols()
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
@@ -1208,7 +1208,7 @@ import jno  # noqa: E402
 
 run = jno.setup(__file__)
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.06).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.06).domain()
 x, y, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
 u = d.unknown()                                 # valued P1 nodal field
@@ -1241,7 +1241,7 @@ import jno  # noqa: E402
 
 run = jno.setup(__file__)
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 x, y, _ = d.variable("interior", split=True)
 xbo, ybo, _ = d.variable("bottom", split=True)
 xl, yl, _ = d.variable("left", split=True)
@@ -1278,7 +1278,7 @@ import foundax, jax, optax, jno
 run = jno.setup(__file__)
 KEY, N, EPOCHS = jax.random.PRNGKey(0), 50, 2_000
 
-d = N * jno.Shape.rect(0, 0, 2, 1, size=0.05).domain()
+d = N * jno.shape.rect(0, 0, 2, 1, size=0.05).domain()
 x, y, _ = d.variable("interior")
 k = d.variable("k", jax.random.uniform(KEY, shape=(N, 1, 1), minval=0.5, maxval=1.5))
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -16,7 +16,7 @@ end-to-end examples — is one file:
 - [Installation](https://fhg-iisb.github.io/jNO/Installation/): pip / extras / pixi / Docker; CPU by default, GPU via the [cuda] extra
 - [Getting started](https://fhg-iisb.github.io/jNO/Getting-Started/): first end-to-end problem
 - [Concepts](https://fhg-iisb.github.io/jNO/concepts/): the trace, constraints, crux, models
-- [Domain and geometry](https://fhg-iisb.github.io/jNO/Domain-and-Geometry/): jno.Shape / jno.Path CSG, tags, sampling
+- [Domain and geometry](https://fhg-iisb.github.io/jNO/Domain-and-Geometry/): jno.shape / jno.Path CSG, tags, sampling
 - [FEM](https://fhg-iisb.github.io/jNO/fem/): weak forms as term lists, solver slots, eigenproblems, contact
 - [FDM](https://fhg-iisb.github.io/jNO/fdm/): strong-form collocation from the same term lists
 - [RCWA](https://fhg-iisb.github.io/jNO/rcwa/): periodic-layered electromagnetics

--- a/docs/misc/wandb.md
+++ b/docs/misc/wandb.md
@@ -113,7 +113,7 @@ from jno.utils.config import get_wandb_run, wandb_log, wandb_log_model
 
 run = jno.setup(__file__, wandb=True)          # False (default) disables; a dict is passed to wandb.init
 
-dom = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+dom = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 x, y, _ = dom.variable("interior")
 
 net = jno.nn(foundax.mlp(2, hidden_dims=64, num_layers=4, key=jax.random.PRNGKey(0)))

--- a/docs/model-controls/iree.md
+++ b/docs/model-controls/iree.md
@@ -107,7 +107,7 @@ import jax.numpy as jnp
 import numpy as np
 
 # --- train ---
-domain = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+domain = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 x, y, _ = domain.variable("interior")
 
 net = jno.nn(foundax.mlp(in_features=2, hidden_dims=64, num_layers=4,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -85,7 +85,7 @@ assumes. So the choice for a PINO residual is between those two, and AD is simpl
 ```python
 jno.setup(__file__, diff_type="spectral")
 
-d = jno.Shape.rect(0, 0, 1, 1, size=1/24).domain(structured=True)
+d = jno.shape.rect(0, 0, 1, 1, size=1/24).domain(structured=True)
 x, y, _ = d.variable("interior")
 d.variable("_f", forcing)
 _f = d.variable("_f")
@@ -111,7 +111,7 @@ transform for all its terms, halving the transforms against separate per-axis se
     both ends** (Neumann-like). That is narrower than "non-periodic": a ramp has `u' ≠ 0` at the
     ends, so its mirrored extension has a kink and still rings — better by ~44×, but still `O(1)`.
 
-    Both need a **uniform** grid: `jno.Shape.rect(...).domain(structured=True)`, or any domain
+    Both need a **uniform** grid: `jno.shape.rect(...).domain(structured=True)`, or any domain
     carrying `_grid_shape`. Non-uniform spacing and unstructured meshes raise rather than guess.
 
 **Choose the scheme per direction.** `jno.fdm` gets the spectral backend with no wiring, but it is

--- a/docs/rcwa.md
+++ b/docs/rcwa.md
@@ -266,7 +266,7 @@ standing wave of period `λ/(2·n_resist)`. `bulk` is scalar (`E_x`) with a sing
 
 **3-D PEB.** Pass a `Film` to `CAResist` and it switches from the 2-D aerial-driven bake to a full **3-D
 `(x, y, z)`** reaction-diffusion PEB: the acid is seeded from the standing-wave `bulk` image, the species
-diffuse in x, y *and* z on a `jno.Shape` box (periodic in x, y via a conforming remesh; free in z), and a
+diffuse in x, y *and* z on a `jno.shape` box (periodic in x, y via a conforming remesh; free in z), and a
 developed `(n, n, film.nz)` volume is returned:
 
 ```python

--- a/docs/training/evaluation.md
+++ b/docs/training/evaluation.md
@@ -11,7 +11,7 @@ After training, use `crux.eval()` to evaluate any symbolic expression:
 pred = crux.eval(u)    # shape: (B, T, N, out_dim)
 
 # On a different domain (e.g., fine test grid)
-test_domain = jno.Shape.rect(0, 0, 1, 1, size=0.01).domain()
+test_domain = jno.shape.rect(0, 0, 1, 1, size=0.01).domain()
 pred_fine = crux.eval(u, domain=test_domain)
 
 # Prediction on arbitrary point arrays

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -114,7 +114,7 @@ The two things worth checking first, because neither can raise:
   will not reach its tolerance without it. `jax.config.update("jax_enable_x64", True)` **before**
   building any domain, array or model — the flag affects only what is created after it.
 - **The geometry is straight-sided.** By default a curved boundary is approximated to O(h²), which
-  caps every element order above it. `Shape.curved()` fixes it. This and the axisymmetric-vector
+  caps every element order above it. `shape.curved()` fixes it. This and the axisymmetric-vector
   measure are the only two limits in `jno.fem` that are silent; every other one raises. See
   [Limits](fem/limitations.md).
 

--- a/docs/tutorial_examples/02_elliptic/variable_coefficient_poisson_2d.py
+++ b/docs/tutorial_examples/02_elliptic/variable_coefficient_poisson_2d.py
@@ -1,5 +1,5 @@
 # --8<-- [start:code]
-"""02 — 2-D variable-coefficient Poisson  (Shape domain + named partials + tracker)"""
+"""02 — 2-D variable-coefficient Poisson  (shape domain + named partials + tracker)"""
 
 from pathlib import Path
 
@@ -12,7 +12,7 @@ import jno
 π = jno.np.pi
 
 # --8<-- [start:setup]
-domain = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+domain = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 x, y, _ = domain.variable("interior")
 
 κ = 1 + x + y

--- a/docs/tutorial_examples/03_parabolic/allen_cahn_2d.py
+++ b/docs/tutorial_examples/03_parabolic/allen_cahn_2d.py
@@ -11,8 +11,8 @@ import jno
 ε = 0.1
 T_end = 1.0
 
-# Time-dependent unit square: the Shape one-liner forwards ``time=`` to the domain.
-domain = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, T_end, 4))
+# Time-dependent unit square: the shape one-liner forwards ``time=`` to the domain.
+domain = jno.shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, T_end, 4))
 x, y, t = domain.variable("interior")
 
 S = jno.np.sin(π * x) * jno.np.sin(π * y)
@@ -79,7 +79,7 @@ plt.rcParams.update(
 # Re-evaluate the trained model on a finer time grid (the network is continuous
 # in t, so this is still its own output) for a smooth animation.
 n_frames = 16
-_dg = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, T_end, n_frames))
+_dg = jno.shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, T_end, n_frames))
 _uf, _uef, _xf, _yf, _tf = crux.eval([u, u_exact, x, y, t], domain=_dg, min_consecutive=n_frames)
 uf = np.asarray(_uf)[0, :, :, 0]  # (frame, node)
 uef = np.asarray(_uef)[0, :, :, 0]

--- a/docs/tutorial_examples/07_analysis/gradient_conflict.py
+++ b/docs/tutorial_examples/07_analysis/gradient_conflict.py
@@ -102,7 +102,7 @@ print(f"  Cond. number = {cond:.1f}")
 # A thin, anisotropic domain (Lx=1, Ly=1/20). Geometry ALONE puts the two diffusion
 # terms of the Laplacian at very different scales — no material coefficient needed.
 Lx, Ly, U = 1.0, 0.05, 3.0
-adom = jno.Shape.rect(0.0, 0.0, Lx, Ly, size=0.1).domain()
+adom = jno.shape.rect(0.0, 0.0, Lx, Ly, size=0.1).domain()
 ax, ay, _ = adom.variable("interior", split=True)
 ax = ax.unit("m").scale(Lx)  # characteristic length along x
 ay = ay.unit("m").scale(Ly)  # 20× shorter characteristic length along y

--- a/docs/tutorial_examples/07_stochastic/fokker_planck_2d.py
+++ b/docs/tutorial_examples/07_stochastic/fokker_planck_2d.py
@@ -1,5 +1,5 @@
 # --8<-- [start:code]
-"""07 — 2-D Fokker–Planck on a disc  (Shape + RAD resampling + residual tracker)"""
+"""07 — 2-D Fokker–Planck on a disc  (shape + RAD resampling + residual tracker)"""
 
 from pathlib import Path
 
@@ -14,7 +14,7 @@ import jno
 
 # --8<-- [start:setup]
 # Disc of radius 3 centred at the origin — captures the Gaussian's effective support.
-domain = jno.Shape.disk(0, 0, 3.0, size=0.25).domain()
+domain = jno.shape.disk(0, 0, 3.0, size=0.25).domain()
 x, y, _ = domain.variable("interior")
 xb, yb, _ = domain.variable("boundary")
 

--- a/docs/tutorial_examples/08_fem_and_varpinns/adaptive_l_shape.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/adaptive_l_shape.py
@@ -74,7 +74,7 @@ def _movable(x, y):
 
 
 def build(size, space="Lagrange", movable=False):
-    d = jno.Shape.polygon(L_SHAPE, size=size).domain()
+    d = jno.shape.polygon(L_SHAPE, size=size).domain()
     if movable:
         # `.trainable()` on a spatial coordinate turns that region's mesh VERTICES into a design
         # variable: the assembler routes them into the element geometry, so `fem.solve()` becomes

--- a/docs/tutorial_examples/08_fem_and_varpinns/cavity_3d_equal_order.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/cavity_3d_equal_order.py
@@ -47,7 +47,7 @@ RE_LADDER = [5.0, 10.0, 25.0, 50.0, 100.0]
 
 
 def cavity3d(n=N, order=1, stabilised=True):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=n).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=n).domain()
     d.tag("lid", lambda x, y, z: z > 1 - 1e-9)
     d.tag("wall", lambda x, y, z: (z < 1e-9) | (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     d.point_region("ppin", (0.0, 0.0, 0.0))

--- a/docs/tutorial_examples/08_fem_and_varpinns/cavity_high_reynolds.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/cavity_high_reynolds.py
@@ -51,7 +51,7 @@ RE_LADDER = [100.0, 200.0, 400.0, 700.0, 1000.0, 1500.0, 2000.0, 3000.0, 5000.0]
 
 def cavity(n=N, order=1, stabilised=True):
     """The cavity with `nu` left as a runtime parameter, so continuation can sweep it."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
     d.tag("lid", lambda x, y: y > 1 - 1e-9)
     d.tag("wall", lambda x, y: (y < 1e-9) | (x < 1e-9) | (x > 1 - 1e-9))
     d.point_region("ppin", (0.0, 0.0))

--- a/docs/tutorial_examples/08_fem_and_varpinns/deep_ritz_poisson_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/deep_ritz_poisson_2d.py
@@ -47,7 +47,7 @@ import jno.jnp_ops as jnn  # noqa: E402
 jax.config.update("jax_enable_x64", True)  # the mesh integral accumulates in float64
 
 # ---- domain, network trial, energy functional ----------------------------------------------
-dom = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+dom = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
 xi, yi, _ = dom.variable("interior", split=True)  # .integrate() re-evaluates at the quadrature points
 
 # a capable network — the Gauss quadrature below keeps its energy honest (see the consistency note)
@@ -67,7 +67,7 @@ crux = jno.core([energy], domain=dom)  # the *signed* energy is the loss (it con
 crux.solve(4000)
 
 # ---- verify the trained network against the analytic solution (on a fresh grid) ------------
-test_dom = jno.Shape.rect(0, 0, 1, 1, size=0.035).domain()
+test_dom = jno.shape.rect(0, 0, 1, 1, size=0.035).domain()
 xt, yt, _ = test_dom.variable("interior", split=True)
 exact_expr = xt * (1 - xt) * yt * (1 - yt)
 pred = np.asarray(crux.eval([net(xt, yt) * exact_expr], domain=test_dom)).reshape(-1)

--- a/docs/tutorial_examples/08_fem_and_varpinns/helmholtz_pml_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/helmholtz_pml_2d.py
@@ -30,7 +30,7 @@ relu = lambda z: jno.np.maximum(z, 0.0)  # noqa: E731
 
 def solve_pml(sigma0):
     """Complex PML Helmholtz at absorber strength sigma0 (sigma0 = 0 -> no PML, u=0 cavity)."""
-    d = jno.Shape.rect(0.0, 0.0, L, L, size=0.022).domain()
+    d = jno.shape.rect(0.0, 0.0, L, L, size=0.022).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/docs/tutorial_examples/08_fem_and_varpinns/inverse_diffusivity_field.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/inverse_diffusivity_field.py
@@ -18,7 +18,7 @@ import optax
 
 import jno
 
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).domain()
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).domain()
 u, phi = d.fem_symbols()
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)

--- a/docs/tutorial_examples/08_fem_and_varpinns/les_subgrid_3d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/les_subgrid_3d.py
@@ -87,7 +87,7 @@ def cavity3d(model="none", n=N, nu=NU_MOL):
     The projection block is present in every variant, `none` included, so the systems being compared
     have identical structure and the difference between them is the model and nothing else.
     """
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=n).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=n).domain()
     d.tag("lid", lambda x, y, z: z > 1 - 1e-9)
     d.tag("wall", lambda x, y, z: (z < 1e-9) | (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     d.point_region("ppin", (0.0, 0.0, 0.0))
@@ -151,7 +151,7 @@ def couette3d(model="none", n=N, nu=NU_MOL):
     which Vreman and WALE are constructed to vanish. Note the flow itself cannot discriminate: nu_t is
     spatially constant here, and a constant viscosity leaves a Couette profile unchanged. The
     discriminating quantity IS nu_t, which is why it is projected and read out."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=n).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=n).domain()
     d.tag("all", lambda x, y, z: (z < 1e-9) | (z > 1 - 1e-9) | (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     d.point_region("ppin", (0.0, 0.0, 0.0))
 

--- a/docs/tutorial_examples/08_fem_and_varpinns/linear_elasticity_cantilever.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/linear_elasticity_cantilever.py
@@ -23,7 +23,7 @@ lam, mu = E * nu / (1.0 - nu**2), E / (2.0 * (1.0 + nu))  # plane-stress Lame pa
 Iz = H**3 / 12.0  # second moment of area (unit thickness)
 inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
 
-d = jno.Shape.rect(0.0, 0.0, L, H, size=0.5).domain()
+d = jno.shape.rect(0.0, 0.0, L, H, size=0.5).domain()
 u, phi = d.fem_symbols(value_shape=(2,), order=2)  # P2 vector displacement
 xi, yi, _ = d.variable("interior", split=True)
 xl, yl, _ = d.variable("left", split=True)  # clamped root

--- a/docs/tutorial_examples/08_fem_and_varpinns/maxwell_2d_vector.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/maxwell_2d_vector.py
@@ -42,7 +42,7 @@ k2 = KR + 1j * KI  # the complex coefficient, written as a plain Python complex
 E_r = lambda X, Y: (pi * sin(pi * X) * cos(pi * Y), -pi * cos(pi * X) * sin(pi * Y))  # noqa: E731
 E_i = lambda X, Y: (2 * pi * sin(2 * pi * X) * cos(2 * pi * Y), -2 * pi * cos(2 * pi * X) * sin(2 * pi * Y))  # noqa: E731
 
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.06).domain()
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.06).domain()
 E, v = d.fem_symbols(value_shape=(2,), names=("E", "v"), order=2, complex=True)  # a P2 COMPLEX vector field + its test
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)

--- a/docs/tutorial_examples/08_fem_and_varpinns/melt_pool_laser.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/melt_pool_laser.py
@@ -67,7 +67,7 @@ NSTEPS = int(sys.argv[1]) if len(sys.argv) > 1 else 2000
 # Three arguments, not two: gmsh calls a mesh-size function as f(x, y, z) whatever the dimension.
 h_of = lambda x, y, z: H_FINE + (H_COARSE - H_FINE) * min(1.0, max(0.0, (LY - y) / BAND))  # noqa: E731
 
-d = jno.Shape.rect(0.0, 0.0, LX, LY, size=h_of).domain(time=(0.0, T_END, NSTEPS + 1))
+d = jno.shape.rect(0.0, 0.0, LX, LY, size=h_of).domain(time=(0.0, T_END, NSTEPS + 1))
 d.tag("top", lambda x, y: y > LY - 1e-9)
 d.tag("far", lambda x, y: (y < 1e-9) | (x < 1e-9) | (x > LX - 1e-9))
 d.tag("base", lambda x, y: y < 1e-9)

--- a/docs/tutorial_examples/08_fem_and_varpinns/navier_stokes_cavity_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/navier_stokes_cavity_2d.py
@@ -30,7 +30,7 @@ import jno  # noqa: E402
 inner, grad, trace = jno.np.inner, jno.np.grad, jno.np.trace
 nu = 0.005  # Re = U L / nu = 1 * 1 / 0.005 = 200
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.045).domain(time=(0.0, 8.0, 33))
+d = jno.shape.rect(0, 0, 1, 1, size=0.045).domain(time=(0.0, 8.0, 33))
 u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)  # P2 velocity
 p, q = d.fem_symbols(names=("p", "q"), order=1)  # P1 pressure
 xi, yi, ti = d.variable("interior", split=True)

--- a/docs/tutorial_examples/08_fem_and_varpinns/navier_stokes_cylinder_dfg.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/navier_stokes_cylinder_dfg.py
@@ -42,7 +42,7 @@ EPS = 1e-9
 CD_REF, CL_REF, DP_REF = 5.57953523384, 0.010618948146, 0.11752016697
 
 # CSG, with a finer size on the disk: drag accuracy lives on the boundary layer around the cylinder.
-shape = jno.Shape.rect(0, 0, L, H, size=0.035) - jno.Shape.disk(CX, CY, RR, size=0.006)
+shape = jno.shape.rect(0, 0, L, H, size=0.035) - jno.shape.disk(CX, CY, RR, size=0.006)
 d = shape.domain()
 d.tag("inlet", lambda x, y: x < EPS)
 d.tag("walls", lambda x, y: (y < EPS) | (y > H - EPS))

--- a/docs/tutorial_examples/08_fem_and_varpinns/phase_field_fracture_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/phase_field_fracture_2d.py
@@ -53,7 +53,7 @@ lam, mu = E * nu / ((1 + nu) * (1 - 2 * nu)), E / (2 * (1 + nu))
 Gc, ell, eta = 2.0e-3, 0.08, 1e-3
 h = 0.04
 
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=h).domain()
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=h).domain()
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("bottom", split=True)
 xt, yt, _ = d.variable("top", split=True)

--- a/docs/tutorial_examples/08_fem_and_varpinns/phase_field_fracture_sent.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/phase_field_fracture_sent.py
@@ -64,8 +64,8 @@ DELTA, NOUT = 1.4e-2, 8  # peak grip displacement, reported load levels
 
 # The notch is CUT, not painted on: a real slit in the geometry, so the stress concentration at its tip
 # is the mesh's own and no seeding of the damage field is needed.
-plate = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=h)
-slit = jno.Shape.rect(-0.01, 0.5 - w_slit, 0.5, 0.5 + w_slit, size=h)
+plate = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=h)
+slit = jno.shape.rect(-0.01, 0.5 - w_slit, 0.5, 0.5 + w_slit, size=h)
 dom = (plate - slit).domain(tau=(0.0, 1.0, NOUT))  # tau: the pseudo-time LOAD path
 dom.tag("bot", lambda x, y: y < 1e-9)
 dom.tag("top", lambda x, y: y > 1 - 1e-9)

--- a/docs/tutorial_examples/08_fem_and_varpinns/poisson_2d_fem.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/poisson_2d_fem.py
@@ -19,7 +19,7 @@ import jno
 
 exact = lambda x, y: x * (1 - x) * y * (1 - y)  # noqa: E731
 
-d = jno.Shape.rect(0, 0, 1, 1, size=0.18).domain()
+d = jno.shape.rect(0, 0, 1, 1, size=0.18).domain()
 u, phi = d.fem_symbols()
 xi, yi, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
@@ -47,7 +47,7 @@ plt.rcParams.update(
 
 def solve_at(size):
     """Rebuild + solve the whole problem on a fresh mesh of the given element size (real re-solve)."""
-    dd = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    dd = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     uu, pp = dd.fem_symbols()
     x_i, y_i, _ = dd.variable("interior", split=True)
     x_b, y_b, _ = dd.variable("boundary", split=True)

--- a/docs/tutorial_examples/08_fem_and_varpinns/rayleigh_benard_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/rayleigh_benard_2d.py
@@ -42,7 +42,7 @@ Lx, Ly = 2.0, 1.0  # a wide-ish pot -> a pair of counter-rotating rolls
 dt, nsteps, nframes = 0.009, 26, 13  # integration step / count -> fem.solve() reads dt from the domain
 #                                      time grid below (stop ~when the rolls establish, no static tail)
 
-d = jno.Shape.rect(0, 0, Lx, Ly, size=0.11).domain(time=(0.0, nsteps * dt, nsteps + 1))
+d = jno.shape.rect(0, 0, Lx, Ly, size=0.11).domain(time=(0.0, nsteps * dt, nsteps + 1))
 u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)  # P2 velocity
 p, q = d.fem_symbols(names=("p", "q"), order=1)  # P1 pressure
 T, sT = d.fem_symbols(names=("T", "sT"), order=1)  # P1 temperature

--- a/docs/tutorial_examples/08_fem_and_varpinns/reanalysis.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/reanalysis.py
@@ -45,7 +45,7 @@ TOL = 1e-6 * L
 
 def build(size, trainable=False):
     """The SAME weak form as the optimisation run: clamped left, unit traction on the right."""
-    d = jno.Shape.rect(0, 0, L, H, size=size).domain()
+    d = jno.shape.rect(0, 0, L, H, size=size).domain()
     if trainable:
         xm, ym, _ = d.variable("mv", where=lambda x, y: (x > TOL) & (x < L - TOL) & (y > TOL) & (y < H - TOL), split=True)
         xm.trainable(name="mesh_x"), ym.trainable(name="mesh_y")

--- a/docs/tutorial_examples/08_fem_and_varpinns/stokes_3d_duct_sphere.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/stokes_3d_duct_sphere.py
@@ -37,7 +37,7 @@ CX, CY, CZ, R = 0.35, 0.2, 0.2, 0.1  # sphere centre and radius
 U0 = 1.0  # peak inflow speed
 EPS = 1e-9
 
-duct = jno.Shape.box(0, 0, 0, L, H, H) - jno.Shape.sphere(CX, CY, CZ, R)
+duct = jno.shape.box(0, 0, 0, L, H, H) - jno.shape.sphere(CX, CY, CZ, R)
 d = duct.size(0.06).domain()
 
 # Boundary regions. The downstream face is deliberately left untagged -> natural (do-nothing).

--- a/docs/tutorial_examples/08_fem_and_varpinns/tied_coating_multiscale.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/tied_coating_multiscale.py
@@ -42,18 +42,18 @@ H_SUB, H_FILM = 0.12, 0.0125  # per-region mesh sizes: the coating needs ~4 elem
 
 # Two bodies, each meshed at its OWN size. `conforming=False` skips the fragment, so the shared
 # surface exists twice -- once per body -- and each is meshed independently.
-d = jno.Shape.regions(
-    substrate=jno.Shape.rect(0.0, 0.0, 1.0, L_SUB, size=H_SUB),
-    coating=jno.Shape.rect(0.0, L_SUB, 1.0, L_SUB + L_FILM, size=H_FILM),
+d = jno.shape.regions(
+    substrate=jno.shape.rect(0.0, 0.0, 1.0, L_SUB, size=H_SUB),
+    coating=jno.shape.rect(0.0, L_SUB, 1.0, L_SUB + L_FILM, size=H_FILM),
     conforming=False,
 ).domain()
-# `Shape` already auto-names each body's edges, and with the two bodies stacked the outer `bottom`
+# `shape` already auto-names each body's edges, and with the two bodies stacked the outer `bottom`
 # (y = 0, on the substrate) and `top` (y = 1.05, on the coating) are exactly the two surfaces wanted.
 
 T, phi = d.fem_symbols()
 # One conduction term per material region -- each integrates over that region's cells only. (The
 # `d.by_region({...})` shorthand is for regions declared as geometry parts or `d.tag` predicates; a
-# `Shape.regions` name is not one of those, so with two materials the explicit form is also the
+# `shape.regions` name is not one of those, so with two materials the explicit form is also the
 # clearer one.)
 xs, ys, _ = d.variable("substrate", split=True)
 xc, yc, _ = d.variable("coating", split=True)

--- a/docs/tutorial_examples/08_fem_and_varpinns/topology_optimisation_cantilever.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/topology_optimisation_cantilever.py
@@ -52,7 +52,7 @@ V0MAX, V0MIN = 0.75 * h**2, 0.05 * h**2  # element-volume bounds, scaled from ed
 MOVE_BOUND, SPAN, TOL, ITERS = 2.0 * h, 2.0 * h, 1e-6 * L, 400
 PSTAR, BETA, GAMMA, BETA_MIN = 650.0, 2e-4, 0.997, 1e-4  # perimeter target and barrier schedule
 
-d = jno.Shape.rect(0, 0, L, H, size=h).domain()
+d = jno.shape.rect(0, 0, L, H, size=h).domain()
 pts0 = np.asarray(d.mesh.points)[:, :2]
 cells = np.asarray(d._cells_p1())
 
@@ -163,7 +163,7 @@ C = float(np.asarray(crux.eval([compliance])).reshape(-1)[0])
 P = float(np.asarray(crux.eval([perim])).reshape(-1)[0])  # the smoothed perimeter, eq. (38)
 
 # --- the honesty check: re-solve the SAME design on a clean, undistorted mesh -------------------
-d_ref = jno.Shape.rect(0, 0, L, H, size=h / 2).domain()  # fresh, twice as fine, undeformed
+d_ref = jno.shape.rect(0, 0, L, H, size=h / 2).domain()  # fresh, twice as fine, undeformed
 rho_ref = d.transfer_cell_field(rho_f, d_ref, points=pts_f, outside=1e-3)  # `points=` -> deformed source
 u2, phi2 = d_ref.fem_symbols(value_shape=(2,))
 _r2, s2 = d_ref.fem_symbols(space="P0", names=("r2", "s2"))

--- a/docs/tutorial_examples/08_fem_and_varpinns/vortex_shedding_dfg_2d2.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/vortex_shedding_dfg_2d2.py
@@ -51,7 +51,7 @@ EPS, C_I = 1e-9, 36.0
 MS, T_END, NSTEPS = 0.022, 6.0, 1200  # ~90 s; the refinement table is in the tutorial page
 ST_REF = 0.30  # Schäfer & Turek (1996), benchmark 2D-2
 
-shape = jno.Shape.rect(0, 0, L, H, size=MS) - jno.Shape.disk(CX, CY, RR, size=MS / 5)
+shape = jno.shape.rect(0, 0, L, H, size=MS) - jno.shape.disk(CX, CY, RR, size=MS / 5)
 d = shape.domain(time=(0.0, T_END, NSTEPS + 1))
 d.tag("inlet", lambda x, y: x < EPS)
 d.tag("walls", lambda x, y: (y < EPS) | (y > H - EPS))

--- a/docs/tutorial_examples/08_fem_and_varpinns/vpinn_poisson_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/vpinn_poisson_2d.py
@@ -22,7 +22,7 @@ import jno.jnp_ops as jnn
 jax.config.update("jax_enable_x64", True)  # the assembler builds in float64
 
 # ---- domain, network trial, weak form -------------------------------------------------------
-dom = jno.Shape.rect(0, 0, 1, 1, size=0.07).domain()
+dom = jno.shape.rect(0, 0, 1, 1, size=0.07).domain()
 u, phi = dom.fem_symbols()
 xi, yi, _ = dom.variable("interior", split=True)
 xb, yb, _ = dom.variable("boundary", split=True)
@@ -43,7 +43,7 @@ crux = jno.core([pde.mse], domain=dom)
 crux.solve(2500)
 
 # ---- verify the trained network against the analytic solution (on a fresh grid) ------------
-test_dom = jno.Shape.rect(0, 0, 1, 1, size=0.04).domain()
+test_dom = jno.shape.rect(0, 0, 1, 1, size=0.04).domain()
 xt, yt, _ = test_dom.variable("interior", split=True)
 exact_expr = xt * (1 - xt) * yt * (1 - yt)
 pred = np.asarray(crux.eval([net(xt, yt) * exact_expr], domain=test_dom)).reshape(-1)

--- a/docs/tutorial_examples/08_fem_and_varpinns/wave_membrane_2d.py
+++ b/docs/tutorial_examples/08_fem_and_varpinns/wave_membrane_2d.py
@@ -33,7 +33,7 @@ OMEGA = C * PI * np.sqrt(2.0)  # fundamental modal frequency
 PERIOD = 2.0 * PI / OMEGA  # = √2 / C
 
 # One full period, resolved with 120 steps; a moderate mesh keeps the example quick.
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain(time=(0.0, float(PERIOD), 120))
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain(time=(0.0, float(PERIOD), 120))
 u, phi = d.fem_symbols()
 xi, yi, ti = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)

--- a/docs/tutorial_examples/09_fdm/heat_2d_fdm.py
+++ b/docs/tutorial_examples/09_fdm/heat_2d_fdm.py
@@ -21,7 +21,7 @@ import jno  # noqa: E402
 import jno.jnp_ops as jnn  # noqa: E402
 
 nu, T = 0.05, 0.5
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.06).domain(time=(0.0, T, 200))
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.06).domain(time=(0.0, T, 200))
 x, y, t = d.variable("interior", split=True)  # note the temporal Variable t
 xb, yb, _ = d.variable("boundary", split=True)
 xi, yi, _ = d.variable("initial", split=True)  # the t = t0 slice
@@ -91,7 +91,7 @@ plt.close(figg)
 
 def _final_rel_l2(size):
     """Re-run the transient solve at a given mesh size; return (h, rel_L2 at t=T)."""
-    dm = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, T, 200))
+    dm = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, T, 200))
     xx, yy, tt = dm.variable("interior", split=True)
     xxb, yyb, _ = dm.variable("boundary", split=True)
     xxi, yyi, _ = dm.variable("initial", split=True)

--- a/docs/tutorial_examples/09_fdm/inverse_source_fdm.py
+++ b/docs/tutorial_examples/09_fdm/inverse_source_fdm.py
@@ -21,7 +21,7 @@ import optax  # noqa: E402
 import jno  # noqa: E402
 import jno.jnp_ops as jnn  # noqa: E402
 
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain()
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain()
 x, y, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
 f_base = 2 * np.pi**2 * jnn.sin(np.pi * x) * jnn.sin(np.pi * y)

--- a/docs/tutorial_examples/09_fdm/mixed_bc_fdm.py
+++ b/docs/tutorial_examples/09_fdm/mixed_bc_fdm.py
@@ -23,7 +23,7 @@ import numpy as np  # noqa: E402
 
 import jno  # noqa: E402
 
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.05).domain()
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.05).domain()
 x, y, _ = d.variable("interior", split=True)
 xbo, ybo, _ = d.variable("bottom", split=True)
 xl, yl, _ = d.variable("left", split=True)
@@ -78,7 +78,7 @@ plt.rcParams.update(
 
 def _solve_mixed(size):
     """Re-run the mixed-BC solve at a given mesh size; return (h, rel_L2) against u* = y^2."""
-    dm = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    dm = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     xx, yy, _ = dm.variable("interior", split=True)
     xbo2, ybo2, _ = dm.variable("bottom", split=True)
     xl2, yl2, _ = dm.variable("left", split=True)

--- a/docs/tutorial_examples/09_fdm/poisson_2d_fdm.py
+++ b/docs/tutorial_examples/09_fdm/poisson_2d_fdm.py
@@ -21,7 +21,7 @@ import numpy as np  # noqa: E402
 import jno  # noqa: E402
 import jno.jnp_ops as jnn  # noqa: E402
 
-d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.06).domain()
+d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.06).domain()
 x, y, _ = d.variable("interior", split=True)
 xb, yb, _ = d.variable("boundary", split=True)
 u = d.unknown()  # valued P1 nodal field (strong-form counterpart of fem_symbols())
@@ -64,7 +64,7 @@ plt.rcParams.update(
 
 def _solve_poisson(size):
     """Re-run the identical strong-form solve at a given mesh size; return (h, rel_L2)."""
-    dm = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    dm = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     xx, yy, _ = dm.variable("interior", split=True)
     xxb, yyb, _ = dm.variable("boundary", split=True)
     uu = dm.unknown()

--- a/docs/tutorial_examples/11_operator_learning/create_domain.py
+++ b/docs/tutorial_examples/11_operator_learning/create_domain.py
@@ -64,7 +64,7 @@ def build_domain_from_arrays(forcing: np.ndarray, solution: np.ndarray, grid_siz
         raise ValueError(f"forcing and solution must have identical shapes, got {forcing.shape} and {solution.shape}")
 
     samples = int(forcing.shape[0])
-    base_domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=grid_size - 1).domain(compute_mesh_connectivity=True)
+    base_domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=grid_size - 1).domain(compute_mesh_connectivity=True)
     domain = samples * base_domain
     domain.variable("interior")
     domain.variable("_f", forcing[:, np.newaxis, np.newaxis, :, :, :])

--- a/docs/tutorial_examples/11_operator_learning/deeponet_poisson_2d.py
+++ b/docs/tutorial_examples/11_operator_learning/deeponet_poisson_2d.py
@@ -15,7 +15,7 @@ N_SAMPLES = 50
 EPOCHS = 2_000
 
 # ── Parametric domain — replicate one mesh across N_SAMPLES random k values ──
-dom = N_SAMPLES * jno.Shape.rect(0, 0, 2, 1, size=0.05).domain()
+dom = N_SAMPLES * jno.shape.rect(0, 0, 2, 1, size=0.05).domain()
 x, y, _ = dom.variable("interior")
 
 k_values = jax.random.uniform(KEY, shape=(N_SAMPLES, 1, 1), minval=0.5, maxval=1.5)

--- a/docs/tutorial_examples/12_rcwa/01_binary_grating_orders.py
+++ b/docs/tutorial_examples/12_rcwa/01_binary_grating_orders.py
@@ -59,7 +59,7 @@ ORDERS = 40
 
 def grating(period, orders=ORDERS):
     """Solve one binary grating and return its order-resolved efficiencies."""
-    d = jno.Shape.box(0, 0, 0, period, PY, 1.0, size=0.25).domain()  # coarse: ε is analytic
+    d = jno.shape.box(0, 0, 0, period, PY, 1.0, size=0.25).domain()  # coarse: ε is analytic
     e = 1e-6
     d.tag("bottom", lambda x, y, z: z < e)
     d.tag("top", lambda x, y, z: z > 1.0 - e)

--- a/docs/tutorials/03-parabolic/allen-cahn-2d.md
+++ b/docs/tutorials/03-parabolic/allen-cahn-2d.md
@@ -19,7 +19,7 @@ The exact solution is substituted into the PDE to derive a forcing term that mak
 eps = 0.1
 T_end = 1.0
 
-domain = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, T_end, 4))
+domain = jno.shape.rect(0, 0, 1, 1, size=0.05).domain(time=(0, T_end, 4))
 x, y, t = domain.variable("interior")
 
 S = sin(π * x) * sin(π * y)

--- a/docs/tutorials/04-hyperbolic/burgers-viscous-1d.md
+++ b/docs/tutorials/04-hyperbolic/burgers-viscous-1d.md
@@ -33,7 +33,7 @@ strategy = sampler.rad(
 `mesh_size=0.05` on `[0,1]²` gives 513 interior nodes in the candidate pool. With `sample=(60, None)`, the network trains on a 60-point working set — an **8× pool-to-sample ratio** that gives RAD substantial room to move points into high-residual regions.
 
 ```python
-domain = 1 * jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.05).domain()
+domain = 1 * jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.05).domain()
 vars_int = domain.variable("interior", sample=(60, None), resampling_strategy=strategy)
 x, t = vars_int[0], vars_int[1]
 

--- a/docs/tutorials/07-analysis/gradient-conflict.md
+++ b/docs/tutorials/07-analysis/gradient-conflict.md
@@ -176,7 +176,7 @@ Take a **thin, anisotropic** domain ($L_x = 1$, $L_y = \tfrac{1}{20}$). Geometry
 
 ```python
 Lx, Ly, U = 1.0, 0.05, 3.0
-adom = jno.Shape.rect(0.0, 0.0, Lx, Ly, size=0.1).domain()
+adom = jno.shape.rect(0.0, 0.0, Lx, Ly, size=0.1).domain()
 ax, ay, _ = adom.variable("interior", split=True)
 ax = ax.unit("m").scale(Lx)          # characteristic length along x
 ay = ay.unit("m").scale(Ly)          # 20× shorter characteristic length along y

--- a/docs/tutorials/08-fem-and-varpinns/melt-pool-laser.md
+++ b/docs/tutorials/08-fem-and-varpinns/melt-pool-laser.md
@@ -61,7 +61,7 @@ a gmsh mesh-size callback:
 ```python
 # THREE arguments, not two: gmsh calls a size function as f(x, y, z) whatever the dimension.
 h_of = lambda x, y, z: H_FINE + (H_COARSE - H_FINE) * min(1.0, max(0.0, (LY - y) / BAND))
-d = jno.Shape.rect(0.0, 0.0, LX, LY, size=h_of).domain(time=(0.0, T_END, NSTEPS + 1))
+d = jno.shape.rect(0.0, 0.0, LX, LY, size=h_of).domain(time=(0.0, T_END, NSTEPS + 1))
 ```
 
 | mesh | nodes | through the pool depth |

--- a/docs/tutorials/08-fem-and-varpinns/phase-field-fracture-sent.md
+++ b/docs/tutorials/08-fem-and-varpinns/phase-field-fracture-sent.md
@@ -36,12 +36,12 @@ hand-derived stress anywhere. Irreversibility comes from the history field $H=\m
 crack cannot heal (Miehe, Welschinger & Hofacker, *IJNME* **83** (2010) 1273–1311), and the damage
 equation is the standard AT2 form $(G_c/\ell)\,d - G_c\ell\,\Delta d = 2(1-d)H$.
 
-The notch is **cut**, not painted on: a real slit removed from the geometry with `jno.Shape`, so the
+The notch is **cut**, not painted on: a real slit removed from the geometry with `jno.shape`, so the
 stress concentration at its tip is the mesh's own and the damage field needs no seeding.
 
 ```python
-plate = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=h)
-slit  = jno.Shape.rect(-0.01, 0.5 - w_slit, 0.5, 0.5 + w_slit, size=h)
+plate = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=h)
+slit  = jno.shape.rect(-0.01, 0.5 - w_slit, 0.5, 0.5 + w_slit, size=h)
 dom   = (plate - slit).domain(tau=(0.0, 1.0, NOUT))     # tau: the pseudo-time LOAD path
 ```
 

--- a/docs/tutorials/08-fem-and-varpinns/stokes-3d-duct-sphere.md
+++ b/docs/tutorials/08-fem-and-varpinns/stokes-3d-duct-sphere.md
@@ -18,7 +18,7 @@ core of the inflow profile is blocked.](/jNO/assets/stokes_3d_duct_sphere.png)
 The obstacle needs no bespoke mesh — subtract it:
 
 ```python
-duct = jno.Shape.box(0, 0, 0, L, H, H) - jno.Shape.sphere(CX, CY, CZ, R)
+duct = jno.shape.box(0, 0, 0, L, H, H) - jno.shape.sphere(CX, CY, CZ, R)
 d = duct.size(0.06).domain()
 ```
 

--- a/docs/tutorials/08-fem-and-varpinns/tied-coating-multiscale.md
+++ b/docs/tutorials/08-fem-and-varpinns/tied-coating-multiscale.md
@@ -46,9 +46,9 @@ Two bodies, each meshed at its own size; `conforming=False` skips the fragment, 
 exists twice — once per body — and each is meshed independently.
 
 ```python
-d = jno.Shape.regions(
-    substrate=jno.Shape.rect(0.0, 0.0, 1.0, L_SUB, size=H_SUB),
-    coating=jno.Shape.rect(0.0, L_SUB, 1.0, L_SUB + L_FILM, size=H_FILM),
+d = jno.shape.regions(
+    substrate=jno.shape.rect(0.0, 0.0, 1.0, L_SUB, size=H_SUB),
+    coating=jno.shape.rect(0.0, L_SUB, 1.0, L_SUB + L_FILM, size=H_FILM),
     conforming=False,
 ).domain()
 

--- a/docs/tutorials/09-fdm/heat-2d-fdm.md
+++ b/docs/tutorials/09-fdm/heat-2d-fdm.md
@@ -28,7 +28,7 @@ flag. The time window and step count come from `domain.time = (t0, t1, n)`, and 
 the time derivative:
 
 ```python
-d = jno.Shape.rect(0, 0, 1, 1, size=0.06).domain(time=(0.0, 0.5, 200))
+d = jno.shape.rect(0, 0, 1, 1, size=0.06).domain(time=(0.0, 0.5, 200))
 x, y, t   = d.variable("interior", split=True)     # temporal Variable t
 xi, yi, _ = d.variable("initial",  split=True)     # the t = t0 slice
 ui = u.bind(x=x, y=y, t=t)

--- a/docs/tutorials/11-operator-learning/deeponet-poisson-2d.md
+++ b/docs/tutorials/11-operator-learning/deeponet-poisson-2d.md
@@ -21,7 +21,7 @@ Multiplying a domain by an integer `B` replicates it across `B` independent samp
 
 ```python
 N_SAMPLES = 50
-dom = N_SAMPLES * jno.Shape.rect(0, 0, 2, 1, size=0.05).domain()
+dom = N_SAMPLES * jno.shape.rect(0, 0, 2, 1, size=0.05).domain()
 x, y, _ = dom.variable("interior")
 
 k_values = jax.random.uniform(jax.random.PRNGKey(0), shape=(N_SAMPLES, 1, 1), minval=0.5, maxval=1.5)

--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -16,7 +16,7 @@ from .core import core
 from .differential_operators import DifferentialOperators
 from .domain import domain
 from .fdm import fdm
-from .geometry import Path, Shape
+from .geometry import Path, Shape, shape
 from .integration_operators import IntegrationOperators
 from .noise import noise
 from .rcwa import Rcwa, RcwaError, rcwa
@@ -147,7 +147,8 @@ __all__ = [
     "Constraint",
     "sampler",
     "domain",
-    "Shape",
+    "shape",
+    "Shape",  # deprecated alias of `shape`
     "Path",
     "do",
     "fem",

--- a/jno/_fem.py
+++ b/jno/_fem.py
@@ -2288,7 +2288,7 @@ class FEM:
                     "carries per-quadrature-point state across every step, so the state would have to be "
                     "transferred onto each new mesh — wired for the transient stepper, not for `tau=`. "
                     "For a fixed graded mesh instead, put the refinement in the geometry: "
-                    "`Shape.box(...).sized(lambda x, y, z: fine if <in band> else coarse)`."
+                    "`shape.box(...).sized(lambda x, y, z: fine if <in band> else coarse)`."
                 )
             if getattr(adapt, "enrich", False):
                 # p-adaptivity: raise the local order by switching interpolation covers on at the marked
@@ -3725,7 +3725,7 @@ def _build_periodic_reduction(
 
     # Multidirectional periodicity needs each face to carry its shared corners (a corner is a secondary in
     # several directions). A ``domain.tag`` predicate face includes corners by construction. An auto face
-    # (from Shape/emit) does too now that a face chain keeps both endpoints (``_chain_edges_to_loop``) --
+    # (from shape/emit) does too now that a face chain keeps both endpoints (``_chain_edges_to_loop``) --
     # accept it when the mesh confirms corners are shared: every pair of perpendicular periodic faces
     # must share a node. Otherwise (older partitioned tagging) reject rather than silently mis-solve.
     if len(ties) > 1:
@@ -4414,7 +4414,7 @@ def _annotate_reduced_dirichlet(periodic: Any, pairs: list, tv: list) -> Any:
             "jno.fem: a node carrying a TIME-VARYING essential value sits on a non-matching tied/periodic "
             "interface, where the tie reduction destroys the row that holds it. The constant-value "
             "restoration cannot be used, because the held value changes every step. Either make the "
-            "interface conforming (`jno.Shape.regions(..., conforming=True)`), or move the time-varying "
+            "interface conforming (`jno.shape.regions(..., conforming=True)`), or move the time-varying "
             "condition off the tied face."
         )
     return periodic
@@ -4668,7 +4668,7 @@ def _reduce_transient_block_periodic(block: Any, periodic: dict) -> Any:
                 "whose operator or load is rebuilt every step (a runtime-parametric march). The tie "
                 "reduction destroys the row holding the prescribed value and the constant-payload repair "
                 "does not reach a per-step operator. Make the interface conforming "
-                "(`jno.Shape.regions(..., conforming=True)`), or move the condition off the tied face."
+                "(`jno.shape.regions(..., conforming=True)`), or move the condition off the tied face."
             )
         M_red, A_red, c_red = impose_reduced_dirichlet(periodic, A_red, c_red, mass=M_red)
         if f_red is not None:
@@ -5055,10 +5055,10 @@ def fem(
 
 
 def _is_volume_region(domain, name: str) -> bool:
-    """Is ``name`` a ``Shape.regions`` BODY — a cell set carrying volume cells?
+    """Is ``name`` a ``shape.regions`` BODY — a cell set carrying volume cells?
 
     ``_source_regions`` only ever holds the *polygon* domain's regions (``polygon_domain`` writes it);
-    a ``Shape.regions(...)`` domain is built through the gmsh emitter and never appears there. Keying
+    a ``shape.regions(...)`` domain is built through the gmsh emitter and never appears there. Keying
     the sub-region pin on that dict alone therefore rejected ``v(flap) - 0`` on exactly the domains the
     tie machinery exists for, while ``_region_node_ids_from_cells`` was already able to resolve such a
     region's nodes from cell topology -- the resolution existed and the gate would not let it be
@@ -5178,7 +5178,7 @@ def _fem_impl(
 
     # Nédélec (N1E) periodic ties need a CONFORMING periodic mesh — the per-edge DOFs must line up
     # one-to-one across the tied faces, which gmsh's default unstructured mesh does not guarantee. Infer
-    # this from the constraint list: when periodic ties are present on an N1E field, re-mesh the (Shape-
+    # this from the constraint list: when periodic ties are present on an N1E field, re-mesh the (shape-
     # backed) domain once with gmsh setPeriodic on the tied face pairs. No `periodic=` arg — driven purely
     # by the periodic conditions the user already authored. (Nodal fields tie by interpolation and need no
     # re-mesh, so this is gated on N1E.)
@@ -5647,7 +5647,7 @@ def _fem_impl(
                 raise ValueError(
                     "jno.fem: a residual with the trial but no test function must live on a boundary "
                     "region (Dirichlet), the 'initial' region (IC), a named interior sub-region "
-                    "(domain.region(...)), or a Shape.regions body. Got the whole-domain volume — did "
+                    "(domain.region(...)), or a shape.regions body. Got the whole-domain volume — did "
                     "you forget the test function?"
                 )
             comp, value, value_node = _dirichlet_spec(_bare(c))

--- a/jno/core.py
+++ b/jno/core.py
@@ -198,9 +198,9 @@ def _trivial_domain():
     collocation machinery. Built once and reused (read-only)."""
     global _TRIVIAL_DOMAIN
     if _TRIVIAL_DOMAIN is None:
-        from .geometry.shape import Shape
+        from .geometry.shape import shape
 
-        _TRIVIAL_DOMAIN = Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+        _TRIVIAL_DOMAIN = shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     return _TRIVIAL_DOMAIN
 
 

--- a/jno/dd.py
+++ b/jno/dd.py
@@ -29,14 +29,14 @@ import numpy as np
 
 def _region_mask(pts, geom):
     """Boolean mask of points ``pts`` inside a region ``geom`` (nodes or element centroids). A
-    ``jno.Shape`` is tested by the analytic, shapely-free :meth:`Shape.contains` (2-D and 3-D alike — the
+    ``jno.shape`` is tested by the analytic, shapely-free :meth:`shape.contains` (2-D and 3-D alike — the
     primary, 3-D-capable path). A shapely geometry falls back to shapely containment; that path survives
     only for 2-D regions whose mesh is conformed to the region in ``polygon_domain`` (interface /
     partition tags), which stays shapely by scope."""
-    from jno.geometry import Shape
+    from jno.geometry import shape
 
     p = np.asarray(pts)
-    if isinstance(geom, Shape):
+    if isinstance(geom, shape):
         return np.asarray(geom.contains(p[:, : geom.dim]))
     import shapely
 
@@ -618,7 +618,7 @@ def couple(subdomains, interface_conditions=None):
 
     ``subdomains``: a list of ``(problem, region)`` pairs, where ``problem`` is a subdomain solve
     (``jno.fdm([...])`` / ``jno.fem([...])``) authored with its PDE + outer boundary conditions, and
-    ``region`` is the ``jno.Shape`` it owns (resolved to a node subset by ``Shape.contains``, no shapely).
+    ``region`` is the ``jno.shape`` it owns (resolved to a node subset by ``shape.contains``, no shapely).
     ``interface_conditions``: optional residuals declaring the
     coupling in jNO syntax (value ``uA(iface)-uB(iface)`` / flux ``k*uA.d(n)-...`` on an ``interface_*``
     tag). The interface is inferred from the regions: a single line (partitioning tags) is coupled by

--- a/jno/differential_operators.py
+++ b/jno/differential_operators.py
@@ -234,7 +234,7 @@ class DifferentialOperators:
                        ``"inverse_distance"``, ``"least_squares"``.
             grid:      Optional structured-grid descriptor
                        ``{"shape": (Nx, Ny), "spacing": (hx, hy), ...}`` (from
-                       ``jno.Shape.rect(...).structured().domain()``, node order
+                       ``jno.shape.rect(...).structured().domain()``, node order
                        ``idx(i, j) = i·Ny + j``). When given, the triangulation
                        is bypassed and the derivative is the direct central
                        finite difference on the regular grid (2nd-order
@@ -386,7 +386,7 @@ class DifferentialOperators:
                        or ``"lsq_of_gradient"``.
             grid:      Optional structured-grid descriptor
                        ``{"shape": (Nx, Ny), "spacing": (hx, hy), ...}`` (from
-                       ``jno.Shape.rect(...).structured().domain()``). When given, ``Δu``
+                       ``jno.shape.rect(...).structured().domain()``). When given, ``Δu``
                        is the direct 5-point finite-difference stencil
                        ``Σ_d (u₊ − 2u + u₋)/h_d²`` on the regular grid — the fast
                        path ``jno.fdm`` takes on a structured mesh; the
@@ -521,7 +521,7 @@ class DifferentialOperators:
             triangles: Triangle connectivity, shape ``(M, 3)``.
             var_dims:  List of ``(i, vi_dim, j, vj_dim)`` tuples.
             grid:      Optional structured-grid descriptor (from
-                       ``jno.Shape.rect(...).structured().domain()``). When given, the
+                       ``jno.shape.rect(...).structured().domain()``). When given, the
                        second derivatives are the direct grid stencils
                        (``∂²/∂x²``, ``∂²/∂y²`` central; the mixed ``∂²/∂x∂y`` a
                        nested central difference) instead of the triangulation

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -430,7 +430,7 @@ class domain(MeshIOMixin):
         """Instantiate a Shapely-backed polygon CSG domain.
 
         ``domain.poly(...)`` returns the lazy CSG domain class (no mesh until
-        sampled). For a meshed polygon, build one with ``jno.Shape.polygon(...)``
+        sampled). For a meshed polygon, build one with ``jno.shape.polygon(...)``
         and realize it via ``.domain()``.
         """
         from .polygon_domain import PolygonDomain
@@ -520,23 +520,23 @@ class domain(MeshIOMixin):
     ):
         if "mesh_size" in _ignored_kwargs:
             raise ValueError(
-                "jno.domain(<Shape or callable>, mesh_size=...) does not read `mesh_size`. It is only "
+                "jno.domain(<shape or callable>, mesh_size=...) does not read `mesh_size`. It is only "
                 "honoured on the POLYGON path -- `domain.__new__` routes there for a constructor that "
-                "is not callable, and a `jno.Shape` defines `__call__`, so a Shape goes to the generic "
+                "is not callable, and a `jno.shape` defines `__call__`, so a shape goes to the generic "
                 "domain instead and the size lands in **_ignored_kwargs. Measured on a unit box: "
                 "mesh_size=0.5, 0.3, 0.18 and 0.1 ALL returned the same 340-node mesh, with nothing "
                 "reported -- a refinement study that never refined. Put the size on the shape, which is "
-                "where it belongs: `jno.Shape.box(0, 0, 0, 1, 1, 1).sized(h).domain()`, or "
-                "`jno.Shape.rect(0, 0, 1, 1, size=h).domain()`. Passing raw polygon points instead of a "
-                "Shape keeps `mesh_size=` working, because that is the path it was written for."
+                "where it belongs: `jno.shape.box(0, 0, 0, 1, 1, 1).sized(h).domain()`, or "
+                "`jno.shape.rect(0, 0, 1, 1, size=h).domain()`. Passing raw polygon points instead of a "
+                "shape keeps `mesh_size=` working, because that is the path it was written for."
             )
         if "structured" in _ignored_kwargs:
             raise ValueError(
-                "jno.domain(..., structured=True) was replaced by Shape.structured() and is no longer "
+                "jno.domain(..., structured=True) was replaced by shape.structured() and is no longer "
                 "read. It was being swallowed by **_ignored_kwargs, so the domain came back WITHOUT a "
                 "grid descriptor and the failure surfaced far away (scheme='spectral' refusing a "
                 "domain the caller believed was structured). Spell it "
-                "jno.Shape.rect(0, 0, 1, 1, size=h).structured().domain() instead."
+                "jno.shape.rect(0, 0, 1, 1, size=h).structured().domain() instead."
             )
         """
         Initialize the domain.
@@ -552,7 +552,7 @@ class domain(MeshIOMixin):
                 (e.g. an elasto-plastic load→unload cycle). Pass ``time`` **or** ``tau``, not both.
             mesh_connectivity: Wether or not to compute the some hyperparameters about the mesh (needed for finite_difference methods)
 
-        A geometry built with :meth:`jno.Shape.structured` is meshed as a regular lattice rather than
+        A geometry built with :meth:`jno.shape.structured` is meshed as a regular lattice rather than
         by gmsh, and records its grid descriptor on :attr:`grid` / ``mesh_connectivity["grid"]``.
         """
         # `tau=` is a pseudo-time (load-path) alias of `time=`: reuse the whole grid/coordinate/tiling
@@ -634,7 +634,7 @@ class domain(MeshIOMixin):
         # assembled operator). Off by default via keep_orphan_nodes=True. Applied in _apply_mesh.
         self._keep_orphan_nodes = keep_orphan_nodes
 
-        # A `Shape.structured()` plan is meshed as a regular lattice instead of by gmsh: swap in the
+        # A `shape.structured()` plan is meshed as a regular lattice instead of by gmsh: swap in the
         # lattice constructor and remember the grid descriptor to stamp on mesh_connectivity below.
         # `_plan` keeps the ORIGINAL shape, because the region-name/attachment collection further down
         # reads it off the constructor -- and the swapped-in closure carries neither, so a
@@ -654,11 +654,11 @@ class domain(MeshIOMixin):
                 self._load_mesh(constructor)
                 self.log.info(f"Loaded mesh from {constructor}")  # type: ignore[attr-defined]
         elif callable(constructor):
-            # A `jno.Shape` whose membership and extent are closed-form does NOT get meshed here.
+            # A `jno.shape` whose membership and extent are closed-form does NOT get meshed here.
             # It can be tagged and sampled from the geometry, which is everything a PINN needs, and
             # the mesh is built only if something later actually reads `.mesh` (see that property).
             # A structured plan is excluded: it has already been swapped for its lattice closure,
-            # which is not a Shape and carries no analytic membership.
+            # which is not a shape and carries no analytic membership.
             # A NAMED or multi-region plan also stays eager: its `interior_<name>` and
             # `interface_<a>_<b>` tags are the mesher's conforming sub-bodies and shared facets,
             # which no amount of point sampling reconstructs. Supporting those mesh-free is a
@@ -698,7 +698,7 @@ class domain(MeshIOMixin):
                     self.log.info(f"This plan cannot be sampled mesh-free ({_why_eager}); meshing it.")
                 self._generate_mesh(constructor, algorithm)
                 self.log.info(f"Loaded mesh from {constructor}")  # type: ignore[attr-defined]
-            # A Shape.regions() plan carries named sub-region shapes; remember them so jno.fem
+            # A shape.regions() plan carries named sub-region shapes; remember them so jno.fem
             # per-region integration can restrict a term to a region's cells (centroid membership
             # via the region shape's ``contains`` — see ``_cell_region_mask``).
             #
@@ -720,7 +720,7 @@ class domain(MeshIOMixin):
                 # The other half of the same hole: properties attached to a shape that was never
                 # named have no region to belong to, and would be silently discarded here.
                 raise ValueError(
-                    f"Shape.attach({', '.join(sorted(map(str, _shape._attach)))}): this shape has no "
+                    f"shape.attach({', '.join(sorted(map(str, _shape._attach)))}): this shape has no "
                     "region name, so the attached propert"
                     f"{'ies have' if len(_shape._attach) > 1 else 'y has'} nothing to attach to. "
                     "Name the region first -- `shape.name('steel').attach(...)`."
@@ -846,7 +846,7 @@ class domain(MeshIOMixin):
         self.reference_solutions: List[Callable] = []
         self.sample_dict: List = []
 
-        # Meshio mesh. `_lazy_plan` holds the Shape a deferred build would mesh; while it is set,
+        # Meshio mesh. `_lazy_plan` holds the shape a deferred build would mesh; while it is set,
         # `.mesh` is a promise rather than an absence (see the `mesh` property).
         self._lazy_plan = None
         self._algorithm = algorithm
@@ -1301,7 +1301,7 @@ class domain(MeshIOMixin):
     def mesh(self):
         """The meshio mesh, or ``None`` if this domain has none and never will.
 
-        A domain built from an analytic :class:`jno.Shape` plan starts **mesh-free**: it can be
+        A domain built from an analytic :class:`jno.shape` plan starts **mesh-free**: it can be
         tagged and sampled from the geometry itself, which is all a PINN needs, and gmsh is never
         run. Reading this property is what *asks* for a mesh, so the first read builds it and says
         so in one ``INFO`` line naming what asked. Code inside ``jno.domain`` that only wants to
@@ -1429,14 +1429,14 @@ class domain(MeshIOMixin):
 
     @property
     def grid(self):
-        """The regular-lattice descriptor of a :meth:`jno.Shape.structured` domain, else ``None``.
+        """The regular-lattice descriptor of a :meth:`jno.shape.structured` domain, else ``None``.
 
         ``{"shape": (Nx, Ny[, Nz]), "spacing": (hx, hy[, hz]), "origin": (x0, y0[, z0])}`` with
         ``shape`` in **nodes** (one more per axis than the cell count passed to ``structured(n=...)``).
         Nodes are stored in C order — ``idx = ((i·Ny + j)·Nz + k)`` — so a nodal field reshapes
         straight to ``grid["shape"]``::
 
-            d = jno.Shape.rect(0, 0, 1, 1).structured(n=63).domain()
+            d = jno.shape.rect(0, 0, 1, 1).structured(n=63).domain()
             u.reshape(d.grid["shape"])          # (64, 64)
 
         This is also the key ``jno.fdm`` reads to take its assembly-free stencil path.
@@ -1465,7 +1465,7 @@ class domain(MeshIOMixin):
         return sorted(self._boundary_registry.keys())
 
     def interface_tags(self, *regions: str):
-        """Internal material-interface tags from a :meth:`Shape.regions` domain.
+        """Internal material-interface tags from a :meth:`shape.regions` domain.
 
         With no arguments, every interface tag (``"a|b"``) — facet regions between two materials, on
         which you can impose a coupling or flux condition. They are deliberately *not* part of
@@ -1508,7 +1508,7 @@ class domain(MeshIOMixin):
                 raise ValueError(
                     f"domain.interface_tags({regions[0]!r}, {regions[1]!r}): this is a CONFORMING "
                     f"interface, so the two regions share one surface ({pair!r}) and there are no "
-                    "separate sides to tie. Build the domain with Shape.regions(..., conforming=False) "
+                    "separate sides to tie. Build the domain with shape.regions(..., conforming=False) "
                     "to mesh each body independently."
                 )
             known = sorted({t.rpartition(".")[0] or t for t in registry})
@@ -2059,7 +2059,7 @@ class domain(MeshIOMixin):
         """Define a named region from a **spatial** predicate ``where(x, y[, z]) -> bool``.
 
         ``region=`` restricts the predicate to **one body's** nodes. It exists because a spatial
-        predicate cannot always separate what you mean: a ``Shape.regions(..., conforming=False)``
+        predicate cannot always separate what you mean: a ``shape.regions(..., conforming=False)``
         domain meshes each body independently, so the shared surface exists *twice* -- two coincident
         sets of nodes at identical coordinates. No function of ``(x, y, z)`` can tell them apart.
         Naming which body owns the facet supplies the missing discriminator::
@@ -2115,7 +2115,7 @@ class domain(MeshIOMixin):
             if str(region) not in known:
                 raise ValueError(
                     f"tag({name!r}, region={region!r}): unknown region. Known: {sorted(known)}. "
-                    "`region=` names the BODY that owns the facets (a Shape.regions name), which is "
+                    "`region=` names the BODY that owns the facets (a shape.regions name), which is "
                     "what tells two coincident interface surfaces apart."
                 )
             self._tag_regions = getattr(self, "_tag_regions", {})
@@ -2128,7 +2128,7 @@ class domain(MeshIOMixin):
         geom = getattr(self, "_active_geometry", None)
         if poly_tags is not None and geom is not None and name not in poly_tags:
             poly_tags[name] = ("interior", geom)
-        # The same idea for an analytic Shape plan, in any dimension: the predicate is the region,
+        # The same idea for an analytic shape plan, in any dimension: the predicate is the region,
         # and it is applied to a fresh draw each step. Whether it carves the interior or a slice of
         # the boundary is measured (see `_classify_predicate_region`) rather than assumed, because a
         # boundary predicate applied to an interior draw matches nothing and would look like an
@@ -2225,10 +2225,10 @@ class domain(MeshIOMixin):
         and an unknown region name raises. Desugars to ``sum_r RegionMask(r) * values[r]`` -- the proven
         per-region integration path (``tests/test_fem_per_region.py``); ``jno.fem`` logs the expansion.
         """
-        # ``_shape_regions`` are the named sub-regions of a ``Shape.regions`` / ``a.name(..) + b.name(..)``
+        # ``_shape_regions`` are the named sub-regions of a ``shape.regions`` / ``a.name(..) + b.name(..)``
         # plan. They belong here for the same reason geometry parts do -- ``RegionMask`` resolves them
         # through the same centroid-membership path (``_cell_region_mask``). Without them a
-        # Shape-built multi-material domain could not use ``by_region`` at all.
+        # shape-built multi-material domain could not use ``by_region`` at all.
         # A mesh file declares its materials as gmsh physical volumes, which land in
         # ``mesh.cell_sets``. They are a fourth source of regions, resolved LAST everywhere so a
         # same-named tag predicate keeps winning.
@@ -2243,7 +2243,7 @@ class domain(MeshIOMixin):
         if unknown:
             raise ValueError(
                 f"domain.by_region: unknown region(s) {sorted(unknown)}; each key must be a geometry part, "
-                f"a Shape.regions sub-region, a domain.tag predicate, or a named volume region of the mesh "
+                f"a shape.regions sub-region, a domain.tag predicate, or a named volume region of the mesh "
                 f"file. Known regions: {sorted(valid)}."
             )
         # ``by_region`` is ``sum_r RegionMask(r) * values[r]``, so two keys covering the same cell ADD
@@ -2253,7 +2253,7 @@ class domain(MeshIOMixin):
         # declaration order cannot resolve it: the user writing the enclosing group first would get
         # the opposite of the intent. Refuse, and name the pair.
         #
-        # Only checked for MESH regions: shapely / Shape.regions masks are disjoint by construction
+        # Only checked for MESH regions: shapely / shape.regions masks are disjoint by construction
         # (the priority subtraction in `_cell_region_mask`), and evaluating those masks here would
         # turn a symbolic O(1) call into a geometry query on every `d.<attr>` in a weak form.
         _mr = [r for r in values if r in mesh_regions]
@@ -2309,21 +2309,21 @@ class domain(MeshIOMixin):
         return expr
 
     def _collect_region_attachments(self, items):
-        """Index ``Shape.attach(...)`` properties as ``{property: {region: value}}`` for ``__getattr__``."""
+        """Index ``shape.attach(...)`` properties as ``{property: {region: value}}`` for ``__getattr__``."""
         attached: dict = {}
         kinds: dict = {}
         for name, sub in items:
             for prop, value in (getattr(sub, "_attach", None) or {}).items():
                 attached.setdefault(str(prop), {})[str(name)] = value
-                kinds[str(name)] = "volume"  # a Shape region is a body: always per-cell
+                kinds[str(name)] = "volume"  # a shape region is a body: always per-cell
         self._region_attachments = attached
         self._attachment_kind = kinds
 
     def attach(self, target: str, **props):
         """Declare material properties on an existing **region or boundary tag**, after the domain is built.
 
-        The runtime counterpart of :meth:`Shape.attach`, and the only way to attach to a
-        ``domain.tag`` — or to a mesh-file domain, which has no ``Shape`` to declare them on::
+        The runtime counterpart of :meth:`shape.attach`, and the only way to attach to a
+        ``domain.tag`` — or to a mesh-file domain, which has no ``shape`` to declare them on::
 
             d.tag("wall", lambda x, y: x < 1e-9)
             d.tag("lid",  lambda x, y: y > 1 - 1e-9)
@@ -2416,7 +2416,7 @@ class domain(MeshIOMixin):
             )
 
     def __getattr__(self, name):
-        """Resolve ``d.<prop>`` for a property attached via :meth:`Shape.attach`.
+        """Resolve ``d.<prop>`` for a property attached via :meth:`shape.attach`.
 
         Only reached when normal attribute lookup fails, so it can never shadow a real method; the
         build-time check in ``_check_attachment_clashes`` covers the reverse direction.
@@ -2454,7 +2454,7 @@ class domain(MeshIOMixin):
         raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
 
     def attached(self, name: str) -> dict:
-        """The raw ``{region: value}`` mapping for a property declared with :meth:`Shape.attach`.
+        """The raw ``{region: value}`` mapping for a property declared with :meth:`shape.attach`.
 
         ``d.<name>`` gives the per-region *coefficient*, ready for a weak form. This gives the values
         themselves, for the consumers that need a mapping rather than an expression -- most notably
@@ -2474,7 +2474,7 @@ class domain(MeshIOMixin):
         """A plain function attached as a property value is called here with this domain's spatial
         variables, so ``.attach(k=lambda r, z: 2.0 + 0.5*z)`` becomes a symbolic coefficient.
 
-        It cannot be resolved at ``Shape.attach`` time: a spatially varying value has to be built from
+        It cannot be resolved at ``shape.attach`` time: a spatially varying value has to be built from
         ``d.variable(...)``, and the domain does not exist while the geometry plan is being written.
         ``isroutine`` rather than ``callable`` on purpose -- symbolic expressions define ``__call__``
         (that is how ``u(x, y)`` binds), so ``callable`` would try to invoke them as size functions.
@@ -2607,7 +2607,7 @@ class domain(MeshIOMixin):
 
     # ----- mesh-free geometry sampling -------------------------------------------------------
     #
-    # A domain built from an analytic `jno.Shape` draws its collocation points from the geometry
+    # A domain built from an analytic `jno.shape` draws its collocation points from the geometry
     # instead of from mesh nodes. The tag vocabulary is identical -- `interior`, `boundary`, the
     # primitives' auto-names, and anything `tag(name, where)` adds -- so nothing above this layer
     # has to know which source it got. What changes is that the points are continuous: there is no
@@ -2803,7 +2803,7 @@ class domain(MeshIOMixin):
 
     # Generators
     def _structured_grid_setup(self, shape):
-        """Resolve a :meth:`jno.Shape.structured` plan into a lattice constructor.
+        """Resolve a :meth:`jno.shape.structured` plan into a lattice constructor.
 
         Returns ``(constructor, grid_meta)`` where ``constructor(geo) -> (meshio.Mesh, dim, ds)`` builds
         the regular grid over the rectangle (:meth:`Geometries.equi_distant_rect`) or box
@@ -2814,7 +2814,7 @@ class domain(MeshIOMixin):
         ``jno.fdm``'s kernels read to take the assembly-free 5-/7-point-stencil path (node order
         ``idx = ((i·Ny + j)·Nz + k)``).
 
-        The cell comes from the plan's own :meth:`jno.Shape.quad` choice: a lattice is the one 3-D plan
+        The cell comes from the plan's own :meth:`jno.shape.quad` choice: a lattice is the one 3-D plan
         that CAN be hex-meshed, so ``.structured().quad()`` is how a hexahedral mesh is spelled.
 
         Refuses by name rather than falling back to gmsh — a caller who then reads ``domain.grid`` or
@@ -2831,20 +2831,20 @@ class domain(MeshIOMixin):
                 else ("no plan at all" if node is None else f"a {node[0]!r} plan")
             )
             raise NotImplementedError(
-                f"Shape.structured() needs a single axis-aligned rect/box; this is {_what}. Mesh it "
+                f"shape.structured() needs a single axis-aligned rect/box; this is {_what}. Mesh it "
                 "unstructured (drop .structured()), or decompose it into mapped blocks. Cut-cell and "
                 "transfinite/swept structured meshing are planned."
             )
         if int(getattr(shape, "_mesh_order", 1)) > 1:
             raise NotImplementedError(
-                "Shape.structured().curved() is not supported: a curved lattice cell is a 9-/27-node "
+                "shape.structured().curved() is not supported: a curved lattice cell is a 9-/27-node "
                 "block the lattice builder does not emit. Use .curved() on an unstructured plan, or "
                 "raise the BASIS order instead (jno.fem(..., order=2) on a straight mesh)."
             )
         cells = shape.cell_choices()
         if len(cells) > 1:
             raise NotImplementedError(
-                f"Shape.structured(): this plan asks for more than one cell type ({', '.join(sorted(cells))})."
+                f"shape.structured(): this plan asks for more than one cell type ({', '.join(sorted(cells))})."
             )
         tensor = "quad" in cells
 
@@ -2853,13 +2853,13 @@ class domain(MeshIOMixin):
         if not counts:
             if callable(size):
                 raise NotImplementedError(
-                    "Shape.structured() derives its cell counts from the shape's size=, and a spatially "
+                    "shape.structured() derives its cell counts from the shape's size=, and a spatially "
                     "varying size=<callable> (a graded mesh) has no single count. Pass explicit counts "
                     "-- .structured(n=32) or .structured(n=(32, 16)) -- or drop .structured()."
                 )
             h = float(size) if isinstance(size, (int, float)) and size > 0 else 0.1
             if not (isinstance(size, (int, float)) and size > 0):
-                self.log.info(f"Shape.structured(): no scalar size= on the shape; defaulting to spacing h={h}.")
+                self.log.info(f"shape.structured(): no scalar size= on the shape; defaulting to spacing h={h}.")
         else:
             h = None
 
@@ -3066,23 +3066,23 @@ class domain(MeshIOMixin):
         return self
 
     def _remesh_periodic(self, pairs) -> bool:
-        """Re-mesh IN PLACE from the stored ``jno.Shape`` geometry, making the named opposite-face ``pairs``
+        """Re-mesh IN PLACE from the stored ``jno.shape`` geometry, making the named opposite-face ``pairs``
         (``[(main, secondary), ...]``) conforming via gmsh ``setPeriodic`` — so a Nédélec (edge) field's
         per-edge DOFs line up one-to-one across the periodic faces. Inferred from the constraint list (the
         periodic ties), never requested explicitly. Idempotent: returns ``False`` (a no-op) when the domain
-        is not ``Shape``-backed (a user-supplied conforming mesh is used as-is) or the pairs are already
+        is not ``shape``-backed (a user-supplied conforming mesh is used as-is) or the pairs are already
         applied; ``True`` after a re-mesh."""
-        from ..geometry.shape import Shape
+        from ..geometry.shape import shape as _shape
 
-        shape = getattr(self, "_constructor_source", None)
-        if not isinstance(shape, Shape):
+        src = getattr(self, "_constructor_source", None)
+        if not isinstance(src, _shape):
             return False  # no geometry to re-mesh; rely on the mesh as given (fails loudly if non-conforming)
         want = frozenset(frozenset(p) for p in pairs)
         if want <= getattr(self, "_periodic_meshed", frozenset()):
             return False  # already conforming for these face pairs
         from ..geometry.emit import build as _emit_build
 
-        mesh, _dim, ds = _emit_build(shape, periodic=list(pairs))
+        mesh, _dim, ds = _emit_build(src, periodic=list(pairs))
         self.mesh, self.ds = mesh, ds
         if hasattr(self, "_reset_custom_tag_state"):
             self._reset_custom_tag_state()
@@ -3425,7 +3425,7 @@ class domain(MeshIOMixin):
                             tol=tol,
                         )
 
-                        # An internal material interface (auto-named "a|b" by Shape.regions) is a facet
+                        # An internal material interface (auto-named "a|b" by shape.regions) is a facet
                         # region you can impose a coupling/flux condition on, but it is NOT the outer
                         # boundary -- keep it out of boundary_tags() so `dirichlet(boundary_tags())`
                         # never pins it. It stays queryable via d.variable("a|b") / interface_tags().
@@ -4129,7 +4129,7 @@ class domain(MeshIOMixin):
                         f"count. Say which you want:\n"
                         f"  - continuous collocation points:  variable({tag!r}, sample=(n, None))\n"
                         f"  - a mesh's nodes:                 give the shape a size, e.g. "
-                        f"Shape.rect(..., size=0.05), or read d.mesh first\n"
+                        f"shape.rect(..., size=0.05), or read d.mesh first\n"
                         f"Mesh-free sampling is opt-in precisely so that neither is chosen for you."
                     )
                 self._build_deferred_mesh()  # a declared resolution: hand back that mesh's nodes
@@ -5098,7 +5098,7 @@ class domain(MeshIOMixin):
                     source_tag = "interior"
 
             if self._is_geometry_tag(source_tag):
-                # Mesh-free: draw from the Shape itself. No node pool, so no cap on `n_samples`
+                # Mesh-free: draw from the shape itself. No node pool, so no cap on `n_samples`
                 # and no two draws alike.
                 ii, og_tag = 0, tag
                 while tag in self.context and tag not in self._param_tags:

--- a/jno/domain/enclosure.py
+++ b/jno/domain/enclosure.py
@@ -943,10 +943,10 @@ def _classify_triangles(domain, triangles: np.ndarray, pts: np.ndarray) -> np.nd
     cent = pts[triangles].mean(axis=1)
     region_of = np.full(triangles.shape[0], None, dtype=object)
     if not regions:
-        # A ``Shape.regions`` domain carries its regions as Shapes, not shapely geometries. They answer
-        # the same question through ``Shape.contains`` (analytic CSG membership, already vectorised
+        # A ``shape.regions`` domain carries its regions as Shapes, not shapely geometries. They answer
+        # the same question through ``shape.contains`` (analytic CSG membership, already vectorised
         # over points), and dict order is declaration order == region priority, matching the first-hit
-        # rule below. Without this an enclosure cannot be built on a Shape-built domain at all: every
+        # rule below. Without this an enclosure cannot be built on a shape-built domain at all: every
         # centroid stays unclassified, so no solid|medium interface edge is ever found.
         for name, sub in (getattr(domain, "_shape_regions", {}) or {}).items():
             try:
@@ -1177,7 +1177,7 @@ def build_enclosure(
         _transparent = {str(t) for t in medium_tags}
         solid_geoms = [g for name, g in _regions.items() if str(name) not in _transparent]
         if not solid_geoms and getattr(domain, "_shape_regions", None):
-            # A Shape.regions domain has no shapely regions, so the line above yields NOTHING and the
+            # A shape.regions domain has no shapely regions, so the line above yields NOTHING and the
             # enclosure would be built with an empty occluder model -- every pair mutually visible,
             # through solid metal and insulation alike. It fails silently: closure and reciprocity stay
             # perfect (they are enforced), so the F that comes out looks entirely plausible. Measured on

--- a/jno/domain/mesh_utils.py
+++ b/jno/domain/mesh_utils.py
@@ -79,7 +79,7 @@ def base_cell_type(name):
 
 def curved_block_of(mesh):
     """The curved volume/facet block names present on ``mesh``, or ``()``. Non-empty means the mesh
-    came from :meth:`jno.Shape.curved` and carries geometry a straight-sided path must not silently
+    came from :meth:`jno.shape.curved` and carries geometry a straight-sided path must not silently
     reinterpret."""
     return tuple(k for k in _CURVED_BLOCKS if k in mesh.cells_dict)
 
@@ -89,14 +89,14 @@ def refuse_curved(mesh, what: str):
 
     Deliberately a refusal rather than a fallback. Reading a curved mesh through
     :func:`p1_cells_dict` would make these paths *appear* to work while quietly reinstating the O(h²)
-    straight-sided geometry error that ``Shape.curved()`` exists to remove -- the answer would look
+    straight-sided geometry error that ``shape.curved()`` exists to remove -- the answer would look
     plausible and be wrong, which is the failure mode this codebase keeps paying for.
     """
     blocks = curved_block_of(mesh)
     if blocks:
         raise NotImplementedError(
             f"{what} does not support curved (isoparametric) geometry; this mesh carries {blocks[0]!r} "
-            "cells from Shape.curved(). Drop .curved() for this path -- reading it as straight-sided "
+            "cells from shape.curved(). Drop .curved() for this path -- reading it as straight-sided "
             "would silently restore the O(h^2) geometry error that curving removes."
         )
 
@@ -130,7 +130,7 @@ def mc_cells(mesh_connectivity):
 def p1_cells_dict(mesh):
     """``mesh.cells_dict`` with the P1 blocks filled in from any curved ones.
 
-    A mesh from ``Shape.curved()`` stores ``triangle6`` / ``tetra10`` / ``line3``, and the first
+    A mesh from ``shape.curved()`` stores ``triangle6`` / ``tetra10`` / ``line3``, and the first
     ``dim+1`` columns of such a cell are its vertices. Everything that works on mesh *topology* —
     boundary extraction, apex orientation, nodal volumes, the FD connectivity — wants those vertices
     and is unchanged by the curving, so it reads through here instead of each site learning the

--- a/jno/domain/polygon_domain.py
+++ b/jno/domain/polygon_domain.py
@@ -719,7 +719,7 @@ class PolygonDomain(domain):
         return self
 
     def _register_tag_boundary_region(self, name, where, region=None):
-        # `region=` (a d.tag restriction to one body) only arises on a multi-body Shape.regions
+        # `region=` (a d.tag restriction to one body) only arises on a multi-body shape.regions
         # domain, which does not take this polygon path; accepted so the signatures match.
         """Polygon override: promote a *pure-boundary* ``domain.tag(name, where)`` to a normals-bearing
         boundary tag. The base method records the selected boundary facets as a region (so a Dirichlet

--- a/jno/fdm.py
+++ b/jno/fdm.py
@@ -44,8 +44,8 @@ boundaries are a tie constraint ``u(left) - u(right)`` (opposite faces, exactly 
 one-sided edge), structured-only since a strong-form stencil must wrap. A pure-Neumann
 problem (no Dirichlet node) is singular (solution up to a constant) and is solved as-is.
 
-**Structured grid.** ``jno.Shape.rect(x0, y0, x1, y1, size=h).structured().domain()`` (2-D) or
-``jno.Shape.box(x0, y0, z0, x1, y1, z1, size=h).structured().domain()`` (3-D) builds a regular
+**Structured grid.** ``jno.shape.rect(x0, y0, x1, y1, size=h).structured().domain()`` (2-D) or
+``jno.shape.box(x0, y0, z0, x1, y1, z1, size=h).structured().domain()`` (3-D) builds a regular
 grid — a right-triangulation in 2-D, a Kuhn 6-tets-per-voxel mesh in 3-D — and records a grid descriptor
 on ``mesh_connectivity["grid"]``; the interior operators (``jno.fdm.laplacian`` / ``gradient`` and the
 constraint-list ``u.d2(x)`` authoring) then take the assembly-free direct finite-difference stencils (the
@@ -336,13 +336,13 @@ def _has_unknown_derivative(node, unknown):
 def _mesh_nodes_in(pts, geom):
     """Indices of the mesh nodes ``pts`` inside a geometric region ``geom`` (registered via
     ``domain.region(name, region)``) — resolves the region to a node subset for pinning/solving on a
-    subdomain. A ``jno.Shape`` uses the analytic, shapely-free :meth:`Shape.contains` (2-D and 3-D — the
+    subdomain. A ``jno.shape`` uses the analytic, shapely-free :meth:`shape.contains` (2-D and 3-D — the
     primary path); a shapely geometry falls back to shapely (2-D mesh-conforming regions in
     ``polygon_domain``, which stay shapely by scope)."""
-    from .geometry import Shape
+    from .geometry import shape
 
     p = np.asarray(pts)
-    if isinstance(geom, Shape):
+    if isinstance(geom, shape):
         mask = np.asarray(geom.contains(p[:, : geom.dim]))
     else:
         import shapely
@@ -517,7 +517,7 @@ class _TraceFDM:
             if grid is None:
                 raise NotImplementedError(
                     "jno.fdm([...]): a periodic tie `u(A) - u(B)` requires a STRUCTURED grid — build the "
-                    "domain with `jno.Shape.rect(...).structured().domain()`. Periodic on an unstructured mesh is "
+                    "domain with `jno.shape.rect(...).structured().domain()`. Periodic on an unstructured mesh is "
                     "not supported (the FD stencil must wrap the grid, which a boundary tie alone cannot)."
                 )
             per = list(grid.get("periodic") or (False,) * len(grid["shape"]))

--- a/jno/geometry/__init__.py
+++ b/jno/geometry/__init__.py
@@ -1,11 +1,11 @@
 """Friendly gmsh-OpenCASCADE geometry authoring for jNO.
 
-``Shape`` is an immutable build-plan (primitives + boolean operators + transforms) that
+``shape`` is an immutable build-plan (primitives + boolean operators + transforms) that
 meshes on demand and (later) also serves mesh-free membership sampling for PINNs. It is
 the single geometry entry that consolidates the mesh-backed and (Shapely) polygon paths.
 """
 
 from .path import Path
-from .shape import Selector, Shape
+from .shape import Selector, Shape, shape
 
-__all__ = ["Shape", "Selector", "Path"]
+__all__ = ["shape", "Shape", "Selector", "Path"]

--- a/jno/geometry/emit.py
+++ b/jno/geometry/emit.py
@@ -1,4 +1,4 @@
-"""Realize a :class:`~jno.geometry.shape.Shape` into a ``meshio.Mesh`` via gmsh-OCC.
+"""Realize a :class:`~jno.geometry.shape.shape` into a ``meshio.Mesh`` via gmsh-OCC.
 
 Pipeline: build the OCC entities from the plan -> synchronize -> classify the boundary
 (:mod:`jno.geometry.naming`) -> per-shape mesh-size fields -> generate -> assemble a
@@ -181,7 +181,7 @@ def _interior_probes(dim: int, coarse: float) -> Dict[int, "object"]:
 
 
 def _apply_region_sizes(dim: int, shape) -> Optional[float]:
-    """Per-**region** mesh size for a multi-material (:meth:`Shape.regions`) shape.
+    """Per-**region** mesh size for a multi-material (:meth:`shape.regions`) shape.
 
     The ordinary path (:func:`_apply_size_fields`) turns each ``size=`` into a Distance+Threshold
     *field*, which is a function of POSITION. That is wrong for a multi-material domain twice over.
@@ -334,7 +334,7 @@ def _apply_size_fields(dim: int, leaves, labels: Dict[int, Tuple[int, str]], sha
                 _f(0.0, 0.0, 0.0)
             except TypeError as _e:
                 raise TypeError(
-                    "jno.Shape(size=...): a mesh-size callable is called as f(x, y, z) -- three "
+                    "jno.shape(size=...): a mesh-size callable is called as f(x, y, z) -- three "
                     "coordinates, in 2-D as well as 3-D, where z is 0.0. Write "
                     "`size=lambda x, y, z: ...` (a 2-D function can simply ignore z). "
                     f"Calling it with three arguments raised: {_e}"
@@ -411,14 +411,14 @@ def _to_meshio(
 ):
     """Assemble the generated gmsh mesh into a ``meshio.Mesh`` with named ``cell_sets``.
 
-    ``region_items`` (``((name, sub_shape), ...)``, when the plan is a :meth:`Shape.regions`
+    ``region_items`` (``((name, sub_shape), ...)``, when the plan is a :meth:`shape.regions`
     multi-material domain) adds one volume ``cell_set`` per region — each cell assigned to the first
     region whose shape contains its centroid — plus one facet ``cell_set`` per material **interface**,
     auto-named by the region pair it separates (``"a|b"`` = every facet between those two materials,
     however many gmsh faces that spans). Only *topologically disjoint* interfaces of the same pair
     (e.g. two separate inclusions) additionally split into connected components ``"a|b.0"`` / ``"a|b.1"``.
 
-    ``nonconforming`` (``Shape.regions(conforming=False)``) changes how an interface is *found*. With
+    ``nonconforming`` (``shape.regions(conforming=False)``) changes how an interface is *found*. With
     the fragment skipped, the two sides of an interface are separate OCC entities each adjacent to a
     single volume, so the adjacency test above sees them as ordinary outer boundary. They are instead
     matched **geometrically** — two boundary faces of different regions occupying the same bounding
@@ -447,7 +447,7 @@ def _to_meshio(
             # because a quad's facet is a straight edge exactly as a triangle's is.
             if curved:
                 raise NotImplementedError(
-                    "Shape.quad().curved() is not supported: curved (isoparametric) geometry is order-2 "
+                    "shape.quad().curved() is not supported: curved (isoparametric) geometry is order-2 "
                     "simplices only, and a curved quadrilateral needs its own 9-node block."
                 )
             vtype, npv, vblock = _QUAD, 4, "quad"
@@ -673,25 +673,25 @@ def _build_once(shape, split_full, periodic=None, algorithm=None, threads=None, 
                 "mesh it -- recombination is per-surface, and in 2-D the two regions conform along a "
                 "shared edge -- but jNO's assembler carries ONE element table and ONE cell array, so the "
                 "mesh would build and fail to assemble. Use a single cell type for now; to combine two "
-                "meshes today, mesh the regions independently with Shape.regions(..., conforming=False) "
+                "meshes today, mesh the regions independently with shape.regions(..., conforming=False) "
                 "and tie them with u('a|b.a') - u('a|b.b')."
             )
         _cell = next(iter(_choices), None)
         if _cell == "quad" and dim == 3:
-            # Checked here rather than in `Shape.quad()` so that `.quad()` and `.structured()` compose
+            # Checked here rather than in `shape.quad()` so that `.quad()` and `.structured()` compose
             # in either order -- only the finished plan knows whether a lattice sits under the request.
             # A structured plan never reaches this function at all; it is meshed by `Geometries`.
             raise NotImplementedError(
-                "Shape.quad() on a 3-D shape needs a regular lattice: gmsh cannot hexahedral-mesh "
+                "shape.quad() on a 3-D shape needs a regular lattice: gmsh cannot hexahedral-mesh "
                 "general geometry (Recombine3DAll on a plain box returns 944 tetrahedra and no "
-                "hexahedra). Add .structured() -- `Shape.box(...).structured().quad()`."
+                "hexahedra). Add .structured() -- `shape.box(...).structured().quad()`."
             )
         if _cell == "quad":
             # Mesh triangles, then RECOMBINE them into quadrilaterals. This is gmsh's only general
             # route to a quad mesh and it works on arbitrary 2-D geometry -- measured, a disk
             # recombines to 69 pure quads and a rectangle to 78, neither leaving any triangle behind.
             # (The 3-D analogue does not exist: `Recombine3DAll` on a plain box returns 944 tets and
-            # no hexes, which is why `Shape.quad()` refuses a 3-D shape rather than quietly meshing
+            # no hexes, which is why `shape.quad()` refuses a 3-D shape rather than quietly meshing
             # it with tetrahedra.)
             gmsh.option.setNumber("Mesh.RecombineAll", 1)
         gmsh.model.mesh.generate(dim)
@@ -787,7 +787,7 @@ def _boundary_once(shape, split_full, *, algorithm=None, threads=None):
             if k is None:
                 raise NotImplementedError(
                     f"the boundary mesher returned gmsh element type {int(etype)}, which "
-                    f"jno.Shape.tessellate does not read. It reads 2-node lines and 3-node "
+                    f"jno.shape.tessellate does not read. It reads 2-node lines and 3-node "
                     f"triangles -- the straight-sided facets a normal is constant over."
                 )
             blocks.append(lookup[np.asarray(nodes, dtype=np.int64).reshape(-1, k)])

--- a/jno/geometry/path.py
+++ b/jno/geometry/path.py
@@ -2,7 +2,7 @@
 
 Chain ``.line_to`` / ``.arc_to`` from a start point. Used two ways:
 
-* **closed** -> ``.face()`` turns the contour into a 2-D :class:`~jno.geometry.shape.Shape`
+* **closed** -> ``.face()`` turns the contour into a 2-D :class:`~jno.geometry.shape.shape`
   region (a diameter + arc becomes a half-disk; all-line is a polygon).
 * **open** -> passed to ``profile.sweep(path)`` as a 3-D sweep trajectory.
 
@@ -49,19 +49,20 @@ class Path:
         return Path._extend(self._start, self._segs + (seg,))
 
     def face(self, name: str = "interior", size=None):
-        """Close the contour (using its x,y) and return it as a 2-D :class:`~jno.geometry.shape.Shape`."""
-        from . import shape as _shape
+        """Close the contour (using its x,y) and return it as a 2-D :class:`~jno.geometry.shape.shape`."""
         from .primitives import Contour
+        from .shape import _LEAF_KEYS
+        from .shape import shape as _shape
 
         start2 = (self._start[0], self._start[1])
         segs2 = tuple(
             (s[0], (s[1][0], s[1][1]), s[2]) if s[0] == "line" else (s[0], (s[1][0], s[1][1]), (s[2][0], s[2][1]), s[3])
             for s in self._segs
         )
-        return _shape.Shape(("leaf", Contour(start2, segs2), next(_shape._LEAF_KEYS)), 2, size)
+        return _shape(("leaf", Contour(start2, segs2), next(_LEAF_KEYS)), 2, size)
 
     def curve(self, size=None):
-        """Return this *open* path as a 1-D :class:`~jno.geometry.shape.Shape` (a curve domain).
+        """Return this *open* path as a 1-D :class:`~jno.geometry.shape.shape` (a curve domain).
 
         The 1-D sibling of :meth:`face`: ``face`` closes the contour into a 2-D region, ``curve``
         keeps it open as a 1-D manifold. The two overall endpoints are named ``left`` (start) and
@@ -70,12 +71,13 @@ class Path:
         keep their 3-D points, so ``arc_to`` gives a curved 1-D manifold and multiple segments a
         polyline (intermediate junctions are interior).
         """
-        from . import shape as _shape
         from .primitives import Curve
+        from .shape import _LEAF_KEYS
+        from .shape import shape as _shape
 
         if not self._segs:
             raise ValueError("curve() needs at least one segment -- call .line_to(...) / .arc_to(...) first")
-        return _shape.Shape(("leaf", Curve(self._start, self._segs), next(_shape._LEAF_KEYS)), 1, size)
+        return _shape(("leaf", Curve(self._start, self._segs), next(_LEAF_KEYS)), 1, size)
 
     # ----- trajectory use (for profile.sweep) -----------------------------------
     def _wire(self, occ):

--- a/jno/geometry/primitives.py
+++ b/jno/geometry/primitives.py
@@ -1,4 +1,4 @@
-"""Analytic primitives for the gmsh-OCC :class:`~jno.geometry.shape.Shape` layer.
+"""Analytic primitives for the gmsh-OCC :class:`~jno.geometry.shape.shape` layer.
 
 Each primitive knows two things:
 

--- a/jno/geometry/shape.py
+++ b/jno/geometry/shape.py
@@ -1,6 +1,6 @@
-"""``Shape`` -- a friendly, immutable geometry build-plan over gmsh-OpenCASCADE.
+"""``shape`` -- a friendly, immutable geometry build-plan over gmsh-OpenCASCADE.
 
-A ``Shape`` records *what to build*, not a mesh: primitive leaves combined by boolean
+A ``shape`` records *what to build*, not a mesh: primitive leaves combined by boolean
 operators (``-`` cut, ``|`` fuse, ``&`` intersect) and dimension transitions
 (``.extrude``). It touches gmsh only inside :meth:`build` (delegated to
 :mod:`jno.geometry.emit`), so authoring and the naming/selection algebra stay
@@ -29,7 +29,7 @@ from .primitives import Box, Cylinder, Disk, Polygon, Rect, Sphere, _to3
 # Nodes with no closed-form point membership. `sweep` follows an arbitrary path and `fillet`
 # *removes* material near edges, so recursing to the child would silently answer for the
 # un-filleted solid -- a superset, i.e. a wrong-but-plausible mask. `fillet` is served by
-# :meth:`Shape.tessellate` instead, which meshes the boundary and nothing else; a curved `sweep`
+# :meth:`shape.tessellate` instead, which meshes the boundary and nothing else; a curved `sweep`
 # is refused there too, because gmsh returns that surface with its seam open.
 _NO_ANALYTIC_MEMBERSHIP = ("sweep", "fillet")
 
@@ -142,7 +142,7 @@ def _leaf_surfaces(node, A=None, b=None):
         return _leaf_surfaces(node[1]._node, R @ A, R @ (b - ap) + ap)
     raise NotImplementedError(
         f"sample_on_boundary has no traceable surface for a {kind!r} plan. extrude/revolve/sweep/"
-        f"fillet boundaries are available host-side through Shape.sample_boundary."
+        f"fillet boundaries are available host-side through shape.sample_boundary."
     )
 
 
@@ -323,11 +323,11 @@ def _node_contains(node, pts, tol):
             swept = (azimuth <= span + atol) | (azimuth >= 2.0 * math.pi - atol)
         return swept & _node_contains(node[1]._node, meridian, tol)
     raise NotImplementedError(
-        f"Shape.contains has no closed-form point membership for a {kind!r} node. Supported "
+        f"shape.contains has no closed-form point membership for a {kind!r} node. Supported "
         f"analytically: primitive leaves, '-'/'|'/'&' (cut/fuse/inter), regions, translate, "
         f"rotate, extrude and revolve. A {kind!r} shape is sampled through its boundary "
-        f"tessellation instead — call Shape.sample_interior/sample_boundary rather than "
-        f"Shape.contains, or tag that region another way."
+        f"tessellation instead — call shape.sample_interior/sample_boundary rather than "
+        f"shape.contains, or tag that region another way."
     )
 
 
@@ -384,8 +384,8 @@ def _node_bounds(node):
         r = max(abs(lo[1]), abs(hi[1]))
         return np.array([lo[0], -r, -r]), np.array([hi[0], r, r])
     raise NotImplementedError(
-        f"Shape.bounds has no closed-form bounding box for a {kind!r} node; its extent comes "
-        f"from the boundary tessellation instead (Shape.tessellate)."
+        f"shape.bounds has no closed-form bounding box for a {kind!r} node; its extent comes "
+        f"from the boundary tessellation instead (shape.tessellate)."
     )
 
 
@@ -566,7 +566,7 @@ def _node_boundary_pieces(node):
     """``[(source, measure)]`` whose ``sample_boundary(n, rng)`` draws in **world** coordinates.
 
     These are *candidate* surfaces — a leaf contributes its whole boundary even where a later
-    boolean cut it away. :meth:`Shape.sample_boundary` trims them with an exact membership probe,
+    boolean cut it away. :meth:`shape.sample_boundary` trims them with an exact membership probe,
     so this only has to enumerate and weight, never to resolve the booleans itself.
     """
     kind = node[0]
@@ -595,7 +595,7 @@ def _node_boundary_pieces(node):
         return [(surf, surf.boundary_measure())]
     raise NotImplementedError(
         f"no analytic boundary sampler for a {kind!r} node; sample it through the boundary "
-        f"tessellation instead (Shape.tessellate)."
+        f"tessellation instead (shape.tessellate)."
     )
 
 
@@ -609,7 +609,7 @@ Size = Union[float, Callable[..., float], None]
 class Selector:
     """A set-valued reference to boundary entities: by auto-name and/or by provenance key.
 
-    Returned by :meth:`Shape.edge` / :meth:`Shape.edges_from`; combined with ``|``.
+    Returned by :meth:`shape.edge` / :meth:`shape.edges_from`; combined with ``|``.
     Resolved against a built mesh's classified boundary (name + originating leaf key).
     """
 
@@ -624,10 +624,10 @@ class Selector:
 
 
 @dataclass(frozen=True)
-class Shape:
+class shape:
     """An immutable geometry build-plan. Operators return new shapes.
 
-    **Derive with :func:`dataclasses.replace`, never by calling ``Shape(...)`` positionally.** Every
+    **Derive with :func:`dataclasses.replace`, never by calling ``shape(...)`` positionally.** Every
     method here returns a copy with one or two fields changed, and a positional constructor has to
     re-list every *other* field to carry it — so a field added later is silently dropped by whichever
     derivation forgets it, and the plan quietly meshes as something the caller did not ask for. That
@@ -653,19 +653,19 @@ class Shape:
 
     # ----- primitive constructors ------------------------------------------------
     @classmethod
-    def rect(cls, x0: float, y0: float, x1: float, y1: float, size: Size = None) -> "Shape":
+    def rect(cls, x0: float, y0: float, x1: float, y1: float, size: Size = None) -> "shape":
         return cls(("leaf", Rect(x0, y0, x1, y1), next(_LEAF_KEYS)), 2, size)
 
     @classmethod
-    def disk(cls, cx: float, cy: float, r: float, size: Size = None) -> "Shape":
+    def disk(cls, cx: float, cy: float, r: float, size: Size = None) -> "shape":
         return cls(("leaf", Disk(cx, cy, r), next(_LEAF_KEYS)), 2, size)
 
     @classmethod
-    def box(cls, x0: float, y0: float, z0: float, x1: float, y1: float, z1: float, size: Size = None) -> "Shape":
+    def box(cls, x0: float, y0: float, z0: float, x1: float, y1: float, z1: float, size: Size = None) -> "shape":
         return cls(("leaf", Box(x0, y0, z0, x1, y1, z1), next(_LEAF_KEYS)), 3, size)
 
     @classmethod
-    def polygon(cls, points, size: Size = None) -> "Shape":
+    def polygon(cls, points, size: Size = None) -> "shape":
         """Arbitrary 2-D polygon from ordered ``(x, y)`` vertices; edges auto-named ``e0, e1, ...``."""
         pts = tuple((float(px), float(py)) for px, py in points)
         return cls(("leaf", Polygon(pts), next(_LEAF_KEYS)), 2, size)
@@ -673,17 +673,17 @@ class Shape:
     @classmethod
     def cylinder(
         cls, x: float, y: float, z: float, dx: float, dy: float, dz: float, r: float, size: Size = None
-    ) -> "Shape":
+    ) -> "shape":
         """Right cylinder: base centre ``(x,y,z)``, axis vector ``(dx,dy,dz)``, radius ``r``."""
         return cls(("leaf", Cylinder(x, y, z, dx, dy, dz, r), next(_LEAF_KEYS)), 3, size)
 
     @classmethod
-    def sphere(cls, cx: float, cy: float, cz: float, r: float, size: Size = None) -> "Shape":
+    def sphere(cls, cx: float, cy: float, cz: float, r: float, size: Size = None) -> "shape":
         """Sphere centred ``(cx,cy,cz)`` radius ``r``."""
         return cls(("leaf", Sphere(cx, cy, cz, r), next(_LEAF_KEYS)), 3, size)
 
     @classmethod
-    def regions(cls, mapping=None, /, **named: "Shape") -> "Shape":
+    def regions(cls, mapping=None, /, **named: "shape") -> "shape":
         """A multi-material domain: named sub-regions meshed **conforming** to their interfaces.
 
         Each keyword names a sub-region shape (all same ``dim``); the pieces are fragmented
@@ -693,7 +693,7 @@ class Shape:
         region as its own variable set (``d.variable("core")``) alongside ``interior``/``boundary``,
         and the outer boundary keeps its auto-names; internal interface facets are not boundary.
 
-        Regions may overlap: ``Shape.regions(inclusion=disk, matrix=plate)`` labels the disk
+        Regions may overlap: ``shape.regions(inclusion=disk, matrix=plate)`` labels the disk
         ``inclusion`` (higher priority) and the remainder ``matrix``. Equivalent to combining named
         shapes with ``+`` — ``disk.name("inclusion") + plate.name("matrix")``. Must be the top-level
         shape (call ``.domain()`` on it); it is not composable with boolean operators/transforms.
@@ -706,24 +706,24 @@ class Shape:
         region name.
 
         A positional ``{name: shape}`` **dict** is accepted for names that are not valid Python
-        identifiers -- ``Shape.regions({"Quartz.1": q1, "Quartz.2": q2})``. Dict order is priority
+        identifiers -- ``shape.regions({"Quartz.1": q1, "Quartz.2": q2})``. Dict order is priority
         order, exactly as for keywords, and the two forms may be combined (dict entries first).
         """
         conforming = named.pop("conforming", True)
         if not isinstance(conforming, bool):
-            raise TypeError(f"Shape.regions: `conforming` must be a bool, got {type(conforming).__name__}")
-        items: Tuple[Tuple[str, "Shape"], ...] = ()
+            raise TypeError(f"shape.regions: `conforming` must be a bool, got {type(conforming).__name__}")
+        items: Tuple[Tuple[str, "shape"], ...] = ()
         if mapping is not None:
             if not isinstance(mapping, dict):
                 raise TypeError(
-                    f"Shape.regions: the positional argument must be a {{name: shape}} dict, got "
+                    f"shape.regions: the positional argument must be a {{name: shape}} dict, got "
                     f"{type(mapping).__name__}. Pass shapes as keywords, or as one dict."
                 )
             items += tuple((str(k), v) for k, v in mapping.items())
         return cls._from_region_items(items + tuple(named.items()), conforming=conforming)
 
     @classmethod
-    def _from_region_items(cls, items, conforming: bool = True) -> "Shape":
+    def _from_region_items(cls, items, conforming: bool = True) -> "shape":
         if len(items) < 2:
             raise ValueError("a multi-material domain needs at least two named regions")
         names = [n for n, _ in items]
@@ -737,22 +737,22 @@ class Shape:
         order = max(int(getattr(sub, "_mesh_order", 1)) for _n, sub in items)
         return cls(("regions", tuple(items), bool(conforming)), items[0][1].dim, None, None, order)
 
-    def name(self, name: str) -> "Shape":
+    def name(self, name: str) -> "shape":
         """Label this shape as a named material region, for combining with ``+`` (see :meth:`regions`).
 
         ``core.name("core") + clad.name("clad")`` builds a multi-material domain whose regions are
         ``core`` and ``clad``. Apply ``name`` last (a later transform drops the label)."""
         return replace(self, _region_name=str(name))
 
-    def attach(self, **props) -> "Shape":
+    def attach(self, **props) -> "shape":
         """Attach material properties to this region: ``.attach(k=220.0, eps=0.794)``.
 
         The realized domain exposes each attached name as a **per-region coefficient** ready to drop
         into a weak form -- ``d.k`` is exactly ``d.by_region({"Kristall": 220.0, ...})`` assembled from
         every region that attached a ``k``::
 
-            kri = Shape.polygon(v).name("Kristall").attach(k=220.0, eps=0.794)
-            gas = Shape.polygon(w).name("Gas").attach(k=0.186, eps=1.0)
+            kri = shape.polygon(v).name("Kristall").attach(k=220.0, eps=0.794)
+            gas = shape.polygon(w).name("Gas").attach(k=0.186, eps=1.0)
             d   = (kri + gas).domain()
             heat = d.k * (T.x*s.x + T.y*s.y) - d.q * s
 
@@ -774,7 +774,7 @@ class Shape:
         merged.update(props)
         return replace(self, _attach=merged)
 
-    def size(self, size: Size) -> "Shape":
+    def size(self, size: Size) -> "shape":
         """Alias for :meth:`sized` -- ``.size(h)`` reads better in a chain than ``.sized(h)``."""
         return self.sized(size)
 
@@ -786,39 +786,39 @@ class Shape:
             raise ValueError("combine regions with '+' only after naming each with .name('...')")
         return ((self._region_name, self),)
 
-    def __add__(self, other: "Shape") -> "Shape":
+    def __add__(self, other: "shape") -> "shape":
         """Combine named regions into a conforming multi-material domain (sugar for :meth:`regions`).
 
         ``a.name("x") + b.name("y")`` keeps ``a`` and ``b`` as distinct materials with a conforming
         interface — unlike ``a | b`` (fuse), which merges them into one. Left-to-right order is region
         priority; composes n-ary (``a + b + c``)."""
-        if not isinstance(other, Shape):
+        if not isinstance(other, shape):
             return NotImplemented
-        return Shape._from_region_items(self._region_items() + other._region_items())
+        return shape._from_region_items(self._region_items() + other._region_items())
 
     # ----- boolean operators -----------------------------------------------------
-    def __sub__(self, other: "Shape") -> "Shape":
+    def __sub__(self, other: "shape") -> "shape":
         return replace(
             self, _node=("cut", self, other), _region_name=None, _mesh_order=max(self._mesh_order, other._mesh_order)
         )
 
-    def __or__(self, other: "Shape") -> "Shape":
+    def __or__(self, other: "shape") -> "shape":
         return replace(
             self, _node=("fuse", self, other), _region_name=None, _mesh_order=max(self._mesh_order, other._mesh_order)
         )
 
-    def __and__(self, other: "Shape") -> "Shape":
+    def __and__(self, other: "shape") -> "shape":
         return replace(
             self, _node=("inter", self, other), _region_name=None, _mesh_order=max(self._mesh_order, other._mesh_order)
         )
 
     # ----- transforms ------------------------------------------------------------
-    def extrude(self, height: float) -> "Shape":
+    def extrude(self, height: float) -> "shape":
         if self.dim != 2:
             raise ValueError("extrude requires a 2-D shape")
         return replace(self, _node=("extrude", self, float(height)), dim=3, _region_name=None)
 
-    def revolve(self, axis_point, axis_dir, angle: float = 2.0 * math.pi) -> "Shape":
+    def revolve(self, axis_point, axis_dir, angle: float = 2.0 * math.pi) -> "shape":
         """Sweep a 2-D shape around an axis by ``angle`` radians into a 3-D solid.
 
         ``angle == 2*pi`` gives a full solid of revolution; a partial angle gives a wedge
@@ -843,20 +843,20 @@ class Shape:
             )
         return replace(self, _node=("revolve", self, ap, ad, float(angle)), dim=3, _region_name=None)
 
-    def translate(self, vector) -> "Shape":
+    def translate(self, vector) -> "shape":
         """Move the shape by ``vector`` (2- or 3-component). Boundary names are preserved."""
         v = tuple(float(c) for c in vector)
         if len(v) == 2:
             v = (v[0], v[1], 0.0)
         return replace(self, _node=("translate", self, v), _region_name=None)
 
-    def rotate(self, axis_point, axis_dir, angle: float) -> "Shape":
+    def rotate(self, axis_point, axis_dir, angle: float) -> "shape":
         """Rotate ``angle`` radians about the axis through ``axis_point`` along ``axis_dir``."""
         ap = tuple(float(c) for c in axis_point)
         ad = tuple(float(c) for c in axis_dir)
         return replace(self, _node=("rotate", self, ap, ad, float(angle)), _region_name=None)
 
-    def sweep(self, path) -> "Shape":
+    def sweep(self, path) -> "shape":
         """Sweep this 2-D profile along an open :class:`~jno.geometry.path.Path` trajectory.
 
         The path must be smooth (line and arc segments); a sharp line->line corner is rejected
@@ -871,12 +871,12 @@ class Shape:
             return self.extrude(h)  # a straight vertical sweep IS an extrude -- reuse its rich naming
         return replace(self, _node=("sweep", self, path), dim=3, _region_name=None)
 
-    def array(self, n: int, step=None, about=None, angle: float = 2.0 * math.pi) -> "Shape":
+    def array(self, n: int, step=None, about=None, angle: float = 2.0 * math.pi) -> "shape":
         """``n`` fused copies of this shape: a **linear** array (``step=`` vector between copies)
         or a **polar** array (``about=(axis_point, axis_dir)`` spread over ``angle``).
 
         Pure composition over translate/rotate/fuse -- e.g. a bolt-circle of holes is
-        ``plate - Shape.disk(R, 0, r).array(8, about=((0,0,0),(0,0,1)))``.
+        ``plate - shape.disk(R, 0, r).array(8, about=((0,0,0),(0,0,1)))``.
         """
         if n < 1:
             raise ValueError("array needs n >= 1")
@@ -890,7 +890,7 @@ class Shape:
                 out = out | self.rotate(about[0], about[1], k * angle / n)
         return out
 
-    def fillet(self, radius: float, where=None) -> "Shape":
+    def fillet(self, radius: float, where=None) -> "shape":
         """Round the solid's edges by ``radius``.
 
         ``where=f(x, y, z)`` selects which edges to round by their midpoint (default: all
@@ -899,11 +899,11 @@ class Shape:
         """
         return replace(self, _node=("fillet", self, float(radius), where), _region_name=None)
 
-    def sized(self, size: Size) -> "Shape":
+    def sized(self, size: Size) -> "shape":
         """Return a copy of this shape with its target mesh size set (scalar or ``f(x,y,z)``)."""
         return replace(self, _size=size)
 
-    def curved(self, order: int = 2) -> "Shape":
+    def curved(self, order: int = 2) -> "shape":
         """Return a copy meshed with **curved (isoparametric)** geometry of the given order.
 
         By default jNO meshes straight-sided and *synthesises* any higher-order nodes at the
@@ -912,20 +912,20 @@ class Shape:
         what caps P2/P3 at second order on a round boundary — and leaves facet normals O(h) wrong.
         ``curved()`` asks the CAD kernel to place those nodes on the true surface instead::
 
-            d = jno.Shape.disk(0, 0, 1, size=0.1).curved().domain()
+            d = jno.shape.disk(0, 0, 1, size=0.1).curved().domain()
 
         Worth pairing with a matching element order (``jno.fem(..., order=2)``); a curved mesh under a
         P1 basis buys only the geometry, not the convergence rate. Meshing is a property of the shape,
         which is why this lives here beside :meth:`sized` rather than on the solve."""
         if int(order) not in (1, 2):
-            raise ValueError(f"Shape.curved: only order 1 (straight) or 2 is supported, got {order!r}.")
+            raise ValueError(f"shape.curved: only order 1 (straight) or 2 is supported, got {order!r}.")
         return replace(self, _mesh_order=int(order))
 
-    def quad(self) -> "Shape":
+    def quad(self) -> "shape":
         """Return a copy meshed with **quadrilaterals** — or, on a structured 3-D plan, hexahedra::
 
-            d = jno.Shape.disk(0, 0, 1, size=0.1).quad().domain()                  # quads
-            d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.1).structured().quad().domain()   # hexes
+            d = jno.shape.disk(0, 0, 1, size=0.1).quad().domain()                  # quads
+            d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.1).structured().quad().domain()   # hexes
 
         In 2-D gmsh meshes triangles and then recombines them, which works on arbitrary geometry — a
         disk recombines to pure quads just as a rectangle does. Quadrilaterals cost fewer cells for
@@ -944,7 +944,7 @@ class Shape:
         # and only the finished plan knows whether a 3-D quad request has a lattice under it.
         return replace(self, _cell="quad")
 
-    def tri(self) -> "Shape":
+    def tri(self) -> "shape":
         """Return a copy meshed with **simplices** — triangles in 2-D, tetrahedra in 3-D.
 
         Simplices are the default, so this is the explicit *opposite* of :meth:`quad`: it turns
@@ -962,12 +962,12 @@ class Shape:
         """
         return replace(self, _cell="simplex")
 
-    def structured(self, n=None) -> "Shape":
+    def structured(self, n=None) -> "shape":
         """Return a copy meshed as a **regular lattice** instead of by gmsh::
 
-            jno.Shape.rect(0, 0, 1, 1, size=0.1).structured().domain()
-            jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.1).structured().quad().domain()   # hexes
-            jno.Shape.box(...).structured(n=(32, 16, 16)).domain()
+            jno.shape.rect(0, 0, 1, 1, size=0.1).structured().domain()
+            jno.shape.box(0, 0, 0, 1, 1, 1, size=0.1).structured().quad().domain()   # hexes
+            jno.shape.box(...).structured(n=(32, 16, 16)).domain()
 
         Three things follow from a lattice that a gmsh mesh cannot give:
 
@@ -999,12 +999,12 @@ class Shape:
             axes = (n,) * int(self.dim) if isinstance(n, (int, np.integer)) else tuple(n)
             if len(axes) != int(self.dim):
                 raise ValueError(
-                    f"Shape.structured(n={n!r}): expected {self.dim} cell counts for a {self.dim}-D "
+                    f"shape.structured(n={n!r}): expected {self.dim} cell counts for a {self.dim}-D "
                     f"shape (or one scalar for all axes), got {len(axes)}."
                 )
             counts = tuple(int(a) for a in axes)
             if any(a < 1 for a in counts):
-                raise ValueError(f"Shape.structured(n={n!r}): every axis needs at least one cell.")
+                raise ValueError(f"shape.structured(n={n!r}): every axis needs at least one cell.")
         return replace(self, _structured=counts)
 
     def cell_choices(self) -> FrozenSet[str]:
@@ -1083,7 +1083,7 @@ class Shape:
                 # Letting it run under a trace surfaced as TracerArrayConversionError from inside the
                 # tessellation -- an error that names neither the shape nor the way out.
                 raise NotImplementedError(
-                    f"Shape.contains: a {self._node[0]!r} plan has no closed-form membership, so it "
+                    f"shape.contains: a {self._node[0]!r} plan has no closed-form membership, so it "
                     f"falls back to the boundary tessellation, which is host-side and cannot be "
                     f"traced. Evaluate it eagerly (pass a numpy array), or build the shape without "
                     f"sweep/fillet if it has to run inside jit."
@@ -1237,7 +1237,7 @@ class Shape:
         """Select boundary entities carrying auto-name ``name`` (``"top"``, ``"left"``, ...)."""
         return Selector(names=frozenset({name}))
 
-    def edges_from(self, sub: "Shape") -> Selector:
+    def edges_from(self, sub: "shape") -> Selector:
         """Select boundary entities that originate from the primitive(s) in ``sub``."""
         return Selector(keys=sub.keys())
 
@@ -1264,9 +1264,9 @@ class Shape:
 
         Forwards the *domain* keyword arguments (``time=``, ``sample=``, ``name=``, ...) to
         ``jno.domain`` -- but **not** a constructor or ``mesh_size``: the mesh size lives on the
-        shape itself (via ``size=`` / :meth:`sized`). So ``Shape.rect(0, 0, 1, 1, size=0.1).domain()``
-        replaces ``jno.domain(Shape.rect(0, 0, 1, 1, size=0.1))``, and batching still composes as
-        ``B * Shape.rect(...).domain()``.
+        shape itself (via ``size=`` / :meth:`sized`). So ``shape.rect(0, 0, 1, 1, size=0.1).domain()``
+        replaces ``jno.domain(shape.rect(0, 0, 1, 1, size=0.1))``, and batching still composes as
+        ``B * shape.rect(...).domain()``.
         """
         import jno
 
@@ -1297,7 +1297,7 @@ _RAY_ANGLES = (0.0, 1.0303768265243125, 2.2331904425884)
 
 @dataclass(frozen=True)
 class BoundaryMesh:
-    """A :class:`Shape`'s boundary, meshed, and nothing else -- no volume fill.
+    """A :class:`shape`'s boundary, meshed, and nothing else -- no volume fill.
 
     This is the fallback for a plan with no closed form -- in practice, ``fillet``, which *removes*
     material near edges and so has neither analytic membership nor an analytic boundary. One boundary
@@ -1523,3 +1523,9 @@ def _can_sample_meshfree(shape):
     except Exception as exc:  # noqa: BLE001 - any mesher failure means "cannot serve this plan"
         return False, str(exc).split(".")[0]
     return True, None
+
+
+# `Shape` was the spelling until this rename. Kept as an alias: every existing script, the tutorials
+# and any downstream code still says `jno.Shape`, and breaking all of them over a capital letter is
+# not a trade worth making. Prefer `shape`, which matches `jno.domain` / `jno.core` / `jno.fem`.
+Shape = shape

--- a/jno/jnp_ops.py
+++ b/jno/jnp_ops.py
@@ -660,7 +660,7 @@ def cellwise(x) -> Cellwise:
 
     **It is quadrature-weighted, not a plain mean over quadrature points.** The two coincide only when
     the rule's weights are equal — false for higher-degree simplex rules, and false on curved
-    (``Shape.curved()``) or tensor-product cells, where the measure varies inside the cell. The weighted
+    (``shape.curved()``) or tensor-product cells, where the measure varies inside the cell. The weighted
     form is the actual L2 projection, so it is the actual B-bar.
 
     **Where it does and does not help, measured.** B-bar cures locking only where the strain is not

--- a/jno/litho.py
+++ b/jno/litho.py
@@ -119,7 +119,7 @@ class CAResist:
         ``"positive"`` (default) returns the developed/soluble fraction ``1 − M``; ``"negative"`` returns ``M``.
     film:
         ``None`` (default) → **2-D** PEB driven by the aerial image (matching the dos Santos 2-D model),
-        returning a ``(n, n)`` pattern. A :class:`Film` → **3-D** ``(x, y, z)`` PEB on a ``jno.Shape`` box:
+        returning a ``(n, n)`` pattern. A :class:`Film` → **3-D** ``(x, y, z)`` PEB on a ``jno.shape`` box:
         the acid is seeded from the depth-resolved standing-wave bulk image (:meth:`_Exposure.bulk`), the
         species diffuse in x, y *and* z, and a developed ``(n, n, film.nz)`` volume is returned.
     """
@@ -198,7 +198,7 @@ def _peb_develop(img, period, r):
     d_a, d_b = r.rho_a**2 / (2.0 * r.t_peb), r.rho_b**2 / (2.0 * r.t_peb)
 
     dom = (
-        jno.Shape.rect(0.0, 0.0, Px, Py)
+        jno.shape.rect(0.0, 0.0, Px, Py)
         .structured(n=n)
         .domain(
             time=(0.0, r.t_peb, r.steps),
@@ -308,7 +308,7 @@ def _regrid3d(vals, coords, n, nz, period, thickness):
 
 
 def _peb_develop_3d(vol, period, film, r):
-    """3-D reaction-diffusion PEB on a ``jno.Shape`` box (periodic in x, y; free in z), seeded by the Dill
+    """3-D reaction-diffusion PEB on a ``jno.shape`` box (periodic in x, y; free in z), seeded by the Dill
     latent acid from the standing-wave bulk image ``vol`` (``(G, G, nz)``). The species diffuse in x, y and z;
     returns the developed ``(n, n, film.nz)`` volume. ``jno`` is imported lazily (no package import cycle)."""
     import jno
@@ -344,7 +344,7 @@ def _peb_develop_3d(vol, period, film, r):
             stacklevel=2,
         )
 
-    dom = jno.Shape.box(0.0, 0.0, 0.0, Px, Py, d, size=size).domain(
+    dom = jno.shape.box(0.0, 0.0, 0.0, Px, Py, d, size=size).domain(
         time=(0.0, r.t_peb, r.steps), compute_mesh_connectivity=False
     )
     ex, ey = 1e-6 * Px, 1e-6 * Py

--- a/jno/precond.py
+++ b/jno/precond.py
@@ -288,7 +288,7 @@ class _GMG(_Spec):
         if grid is None:
             raise ValueError(
                 "jno.precond.gmg() needs a structured grid — build the domain with "
-                "Shape.rect(...).structured() / Shape.box(...).structured(). This operator has "
+                "shape.rect(...).structured() / shape.box(...).structured(). This operator has "
                 "no grid descriptor, so there is no coarsening hierarchy to build."
             )
         from .utils.solver.geometric_mg import build_vcycle
@@ -731,7 +731,7 @@ def jacobi() -> _Jacobi:
 
 def gmg(*, n_pre: int = 2, n_post: int = 2, omega: float | None = None, min_size: int = 5) -> _GMG:
     """Geometric-multigrid V-cycle preconditioner for a **structured grid**
-    (``jno.Shape.rect(...).structured().domain()``).
+    (``jno.shape.rect(...).structured().domain()``).
 
     Builds a coarsen-by-2 grid hierarchy and applies one V-cycle as ``M⁻¹``: damped-Jacobi smoothing
     (``n_pre``/``n_post`` sweeps, ``omega`` damping — default the model-problem optimum ``2d/(2d+1)``),

--- a/jno/solve.py
+++ b/jno/solve.py
@@ -1133,10 +1133,10 @@ def refine(
     or 8 (a hexahedron): local, needs no mesher, works on a mesh loaded from a file, and every existing
     node survives with its value::
 
-        d = jno.Shape.rect(0, 0, 1, 1).quad().structured(n=8).domain()
+        d = jno.shape.rect(0, 0, 1, 1).quad().structured(n=8).domain()
         u = fem.solve(adapt=jno.solve.refine(theta=0.4, max_iters=4))
 
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=4).quad().domain()   # hexes
+        d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=4).quad().domain()   # hexes
         u = fem.solve(adapt=jno.solve.refine(criterion=jno.np.abs(ui.x)))     # composes with a criterion
 
     **For hexahedra this is the only h-adaptivity there is.** No general all-hex mesher exists -- gmsh's
@@ -1380,7 +1380,7 @@ def enrich(
 
     Example -- a gradient-magnitude criterion, the general-purpose choice::
 
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.02).domain()
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.02).domain()
         d.tag("walls", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
         co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
 

--- a/jno/trace/__init__.py
+++ b/jno/trace/__init__.py
@@ -955,7 +955,7 @@ class Placeholder:
         *named* update, not an operator (``==`` is reserved for identity, ``<`` for comparison).
 
         Args:
-            region: restrict the update to one region — a ``domain.tag`` name, a ``Shape.regions()``
+            region: restrict the update to one region — a ``domain.tag`` name, a ``shape.regions()``
                 sub-region, or a geometry part. ``None`` (default) advances the state on every cell, and
                 is what the update did before this argument existed. Outside the region the state is
                 **frozen**: its next value is the value it already has. That is what makes an ordinary
@@ -1626,7 +1626,7 @@ class Variable(Placeholder):
            named boundaries with a location function.
         3. The mesh's own tag, ``domain.tag_indices[tag]``.
 
-        Route 3 is what makes the built-in ``"interior"`` work. On a gmsh / ``jno.Shape`` domain it is
+        Route 3 is what makes the built-in ``"interior"`` work. On a gmsh / ``jno.shape`` domain it is
         a **volume** tag: it lives in ``tag_indices`` and never in ``_boundary_regions``, and it has no
         location function, so routes 1 and 2 both have nothing to say about it and this used to raise --
         even though ``domain.variable("interior").trainable()`` is the r-adaptivity API's own example.
@@ -4178,7 +4178,7 @@ class TrialFunction(_FieldComponentIndex, Placeholder):
             if tag not in breg:
                 raise ValueError(
                     f"{who}: {tag!r} is not a boundary region on this domain. Known: {sorted(breg)}. "
-                    "Tag each side of the interface first -- a non-conforming Shape.regions names them "
+                    "Tag each side of the interface first -- a non-conforming shape.regions names them "
                     "'a|b.a' / 'a|b.b' automatically."
                 )
         if secondary in mains and not listed:

--- a/jno/trace_evaluator.py
+++ b/jno/trace_evaluator.py
@@ -83,7 +83,7 @@ def _uniform_grid_spec(domain, n_values: int):
         if not shape:
             raise ValueError(
                 "scheme='spectral' requires a uniform grid, and this domain has none. Build it with "
-                "Shape.structured() -- e.g. jno.Shape.rect(0, 0, 1, 1, size=h).structured().domain() "
+                "shape.structured() -- e.g. jno.shape.rect(0, 0, 1, 1, size=h).structured().domain() "
                 "-- which records the grid descriptor, or use scheme='finite_difference' on an "
                 "unstructured mesh."
             )
@@ -220,7 +220,7 @@ def _spectral_diff(values_flat, shape, spacing, axis: int, order: int, *, mirror
         return _unmirror_axis(out, axis, n_orig).reshape(-1)
 
     # jNO's structured grids span the interval INCLUSIVE of both ends, so the last node along an
-    # axis is the periodic image of the first: `Shape.rect(0,0,1,1, size=1/16)` gives 17 nodes for
+    # axis is the periodic image of the first: `shape.rect(0,0,1,1, size=1/16)` gives 17 nodes for
     # 16 intervals. The FFT wants exactly one period with no duplicate, so drop that node, transform
     # over the remaining n, and put it back afterwards. The finite-difference periodic stencils do
     # the same thing (`differential_operators.py`, `uu = moveaxis(U, dim, 0)[:-1]`). Without this
@@ -2259,7 +2259,7 @@ class TraceEvaluator:
             if is_boundary:
                 reg_indices = np.asarray(domain._boundary_registry[tag]["point_indices"])
                 region_pts_np = np.asarray(mc["points"])[reg_indices]
-                # A boundary face that carries its own edge subset (a Shape/CSG source-edge tag such
+                # A boundary face that carries its own edge subset (a shape/CSG source-edge tag such
                 # as ``boundary_chamber_0``) shares its two end corners with the perpendicular faces.
                 # The global ``nodal_ds`` lumps a corner's measure over *all* boundary edges meeting at
                 # that node, so counting the corner in this face over-attributes its perpendicular-edge

--- a/jno/utils/solver/fem_1d.py
+++ b/jno/utils/solver/fem_1d.py
@@ -157,7 +157,7 @@ def _region_node_ids(domain: Any, region: str) -> List[int]:
     mask = domain.tag_node_mask(region, np.asarray(domain.mesh.points))
     if mask is not None:
         return list(np.where(mask)[0])
-    # No predicate: a `Shape.regions` BODY, which is defined by which cells it owns rather than by a
+    # No predicate: a `shape.regions` BODY, which is defined by which cells it owns rather than by a
     # location function. That is the only kind of region `domain.tag(..., region=...)` names on a
     # multi-body mesh, so refusing here made a Dirichlet on such a tag impossible -- `u(top) - g` on
     # `tag("top", ..., region="cyl")` raised "has no location function". Ownership by cell topology is
@@ -174,7 +174,7 @@ def _region_node_ids(domain: Any, region: str) -> List[int]:
             return list(np.unique(np.asarray(vol)[m > 0]))
     raise ValueError(
         f"jno.fem: region {region!r} has neither a location predicate nor cells on this mesh, so its "
-        "nodes cannot be determined. Name a `domain.tag` region or a `Shape.regions` body."
+        "nodes cannot be determined. Name a `domain.tag` region or a `shape.regions` body."
     )
 
 
@@ -448,7 +448,7 @@ def _hermite_element_1d(cells, n_vert: int, gp) -> _LineElement:
     fourth-order operator (``EI w'''' = q``) has a well-defined ``\int w'' v''`` weak form on it —
     the 1D counterpart of Argyris/Morley on triangles.
 
-    Shape functions on ``xi in [0,1]`` with ``x = x0 + h*xi`` (Hermite 1877; standard beam element,
+    shape functions on ``xi in [0,1]`` with ``x = x0 + h*xi`` (Hermite 1877; standard beam element,
     e.g. Hughes, *The Finite Element Method*, §1.16)::
 
         N1 = 1 - 3xi^2 + 2xi^3        N2 = h (xi - 2xi^2 + xi^3)

--- a/jno/utils/solver/fem_adapt.py
+++ b/jno/utils/solver/fem_adapt.py
@@ -476,7 +476,7 @@ def _apply_new_mesh(template: Any, new_mesh: Any, *, copy: bool):
 
 
 def _rebuild_to_size(domain: Any, vertex_size: np.ndarray, *, copy: bool = False):
-    """Remesh a **quadrilateral** domain by rebuilding its ``Shape`` plan at a new size field.
+    """Remesh a **quadrilateral** domain by rebuilding its ``shape`` plan at a new size field.
 
     There is no mmg for quads: mmg adapts by edge split/collapse/swap, operations defined on
     simplices. But a quadrilateral mesh in jNO is a triangle mesh that gmsh has recombined, and the
@@ -498,11 +498,11 @@ def _rebuild_to_size(domain: Any, vertex_size: np.ndarray, *, copy: bool = False
         raise NotImplementedError(
             "h-adaptive remeshing of a quadrilateral mesh rebuilds the geometry at a finer size field, "
             "and this domain has no geometry to rebuild from (it was loaded from a mesh file, not "
-            "built from a jno.Shape). Adapt a Shape-built domain, or refine the file's mesh outside jNO."
+            "built from a jno.shape). Adapt a shape-built domain, or refine the file's mesh outside jNO."
         )
     if getattr(plan, "_structured", None) is not None:
         raise NotImplementedError(
-            "h-adaptive remeshing cannot refine a Shape.structured() plan: a lattice's resolution is its "
+            "h-adaptive remeshing cannot refine a shape.structured() plan: a lattice's resolution is its "
             "cell COUNTS, so rebuilding it against a marked size field returns the same mesh -- a silent "
             "no-op. Drop .structured() to let gmsh mesh (and recombine) the geometry at a graded size, "
             "or rebuild the lattice yourself at a larger n."
@@ -547,7 +547,7 @@ def _rebuild_to_size(domain: Any, vertex_size: np.ndarray, *, copy: bool = False
 def _remesh_to_size(domain: Any, vertex_size, *, copy: bool = False, **mmg_kw):
     """Remesh to a per-vertex target size, by whichever mechanism the mesh's cell supports.
 
-    Simplices go to mmg, which adapts them locally; quadrilaterals rebuild from the ``Shape`` plan
+    Simplices go to mmg, which adapts them locally; quadrilaterals rebuild from the ``shape`` plan
     (:func:`_rebuild_to_size`). Everything else — a hexahedral mesh above all — refuses by name:
     there is no general all-hex mesher, so metric-driven hex remeshing is not a thing to implement.
     3-D tensor-product adaptivity needs octree refinement with hanging-node constraints instead.
@@ -573,7 +573,7 @@ def _capture_geometric_boundary_tags(domain: Any) -> None:
     """Give every named boundary region a **mesh-independent predicate**, so it survives a remesh.
 
     The mesh generator's named edge regions (``left`` / ``right`` / ``top`` / ``bottom`` / any
-    ``Shape`` sub-boundary) are baked into the ORIGINAL mesh as *cell sets*.  A remeshed mesh carries
+    ``shape`` sub-boundary) are baked into the ORIGINAL mesh as *cell sets*.  A remeshed mesh carries
     only ``interior`` and ``boundary`` (:func:`_domain_from_arrays` builds exactly those), so those
     names vanish at the first remesh — and a Dirichlet condition bound to one of them then reaches
     ``jno.fem`` as a whole-domain residual with a trial but no test function, failing with an error
@@ -2816,7 +2816,7 @@ def run_adaptive_solve(fem: Any, spec: AdaptSpec, *, solve_fn: Any = None, **kwa
         if spec.split:
             # Local refinement: split the marked cells and constrain the hanging nodes. No mesher, so
             # this is the branch a hexahedral mesh takes (there is nothing to remesh it to) and the one
-            # that works on a mesh with no `Shape` plan behind it.
+            # that works on a mesh with no `shape` plan behind it.
             from .fem_refine import refine_domain
 
             refine_domain(d, marked, copy=False)

--- a/jno/utils/solver/fem_lagrange.py
+++ b/jno/utils/solver/fem_lagrange.py
@@ -388,7 +388,7 @@ def _refuse_curved_hessian(J: jnp.ndarray) -> None:
             "A 4th-order weak form (Argyris / Morley / Hermite, phase-field, plates) needs the physical "
             "Hessian, whose transform assumes an AFFINE cell -- on curved geometry it gains a curvature "
             "term this does not carry, and the result would be wrong with nothing to flag it. Drop "
-            "Shape.curved() for a 4th-order form, or use a straight-sided domain."
+            "shape.curved() for a 4th-order form, or use a straight-sided domain."
         )
 
 

--- a/jno/utils/solver/fem_native.py
+++ b/jno/utils/solver/fem_native.py
@@ -196,7 +196,7 @@ def _basix_ordered(cells: np.ndarray, cell_type: str) -> np.ndarray:
 
 
 def _refuse_nonconforming_promotion(domain, order: int) -> None:
-    """Refuse order > 1 on a ``Shape.regions(..., conforming=False)`` domain.
+    """Refuse order > 1 on a ``shape.regions(..., conforming=False)`` domain.
 
     `_promote_to_degree` dedups synthesised nodes by physical COORDINATE, which is the right
     conformity test for one body and the wrong one for two: a non-conforming interface is coincident
@@ -218,7 +218,7 @@ def _refuse_nonconforming_promotion(domain, order: int) -> None:
     ):
         raise NotImplementedError(
             f"order-{order} elements on a mesh that is BOTH locally refined (hanging nodes) and has "
-            "a Shape.regions(..., conforming=False) interface: the higher-order promotion must MERGE "
+            "a shape.regions(..., conforming=False) interface: the higher-order promotion must MERGE "
             "coincident nodes across a 2:1 refinement and must NOT merge them across two coincident "
             "bodies, and those cannot both hold on one mesh. Use order-1, or drop one of the two."
         )
@@ -266,7 +266,7 @@ def _get_mesh(domain, dim: int, order: int):
     pts_all = np.asarray(domain.mesh.points)[:, :dim]
 
     if curved_key in cd:
-        # CURVED (isoparametric) mesh from `Shape.curved()`: gmsh already placed the higher-order nodes
+        # CURVED (isoparametric) mesh from `shape.curved()`: gmsh already placed the higher-order nodes
         # on the CAD surface, so they must be USED, never re-synthesised. The first dim+1 columns of a
         # curved cell are its vertices, giving the P1 sub-mesh the facet/region machinery wants -- kept
         # in the SAME id space as the curved mesh so a node id means one thing everywhere (the promoted
@@ -278,7 +278,7 @@ def _get_mesh(domain, dim: int, order: int):
             # the midside DOF coordinates (on the arc) and the geometric map (from the chord) in
             # disagreement -- an inconsistent discretisation, not merely a coarse one.
             raise ValueError(
-                f"Shape.curved() gives order-2 geometry but this field is P{order}. Isoparametric "
+                f"shape.curved() gives order-2 geometry but this field is P{order}. Isoparametric "
                 f"geometry needs a matching basis: pass element_type='{'TRI6' if dim == 2 else 'TET10'}' "
                 "(or order=2) to jno.fem, or drop .curved() to mesh straight-sided."
             )
@@ -1587,7 +1587,7 @@ def assemble_fem_native(
                 raise ValueError(
                     f"tag({region!r}, region={_owner!r}): {_owner!r} has no nodes on this mesh, so the "
                     "two sides of the interface cannot be told apart. `region=` must name a body "
-                    f"(a Shape.regions name). Known: {sorted(getattr(domain, 'tag_indices', {}) or {})}."
+                    f"(a shape.regions name). Known: {sorted(getattr(domain, 'tag_indices', {}) or {})}."
                 )
             _rnodes &= {int(n) for n in np.asarray(_own).reshape(-1)}
         _mask = np.array(
@@ -3165,7 +3165,7 @@ def assemble_fem_native(
     def _drop_interface_only_nodes(bf: np.ndarray, bnodes: np.ndarray, pts_all: np.ndarray) -> np.ndarray:
         """Remove nodes that sit **only** on a non-conforming interface from the catch-all boundary.
 
-        ``Shape.regions(conforming=False)`` meshes each body independently, so the two sides of an
+        ``shape.regions(conforming=False)`` meshes each body independently, so the two sides of an
         interface are each a facet of exactly one cell -- topologically boundary, and correctly so.
         Semantically they are internal: a tie glues them. Without this filter a plain
         ``u(boundary) - g`` pins the interface, which silently solves two disconnected bodies. Measured

--- a/jno/utils/solver/fem_refine.py
+++ b/jno/utils/solver/fem_refine.py
@@ -1,7 +1,7 @@
 """Local refinement of a quadrilateral or hexahedral mesh, with hanging-node constraints.
 
 This is the *other* h-adaptivity, and the one the tensor-product world actually uses. mmg adapts
-simplices by edge split/collapse/swap and has no quad analogue; rebuilding a ``Shape`` plan at a finer
+simplices by edge split/collapse/swap and has no quad analogue; rebuilding a ``shape`` plan at a finer
 size field works but is a global remesh that needs a geometry to rebuild from. Splitting a quadrilateral
 into 4 (a hexahedron into 8) needs neither -- it is local and works on a mesh loaded from a file. In 3-D
 it is the only option at all: no general all-hex mesher exists, so there is nothing to remesh *to*.
@@ -268,7 +268,7 @@ def refine_domain(domain, marked, *, copy: bool = False):
     """Refine a quadrilateral or hexahedral domain's marked cells in place, keeping its geometry exactly.
 
     The counterpart to :func:`~jno.utils.solver.fem_adapt._rebuild_to_size`, and the reason this exists:
-    that path re-runs gmsh on the ``Shape`` plan, so it needs a geometry to rebuild from and produces a
+    that path re-runs gmsh on the ``shape`` plan, so it needs a geometry to rebuild from and produces a
     mesh that does not nest inside the old one. Splitting cells needs neither -- it works on a mesh
     loaded from a file, and the old mesh's nodes all survive with their values. In 3-D it is the *only*
     option: no general all-hex mesher exists, so there is nothing to remesh to.

--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -649,8 +649,8 @@ def _cell_region_mask(domain, region):
     elif region in preds:
         m = np.asarray(preds[region](*[centroids[:, i] for i in range(dim)]))
     elif region in shape_regions:
-        # A Shape.regions sub-region: analytic CSG membership of the cell centroid (2-D and 3-D),
-        # MINUS every higher-priority region, because Shape.regions lets regions overlap and resolves
+        # A shape.regions sub-region: analytic CSG membership of the cell centroid (2-D and 3-D),
+        # MINUS every higher-priority region, because shape.regions lets regions overlap and resolves
         # them by declaration order -- a cell belongs to the FIRST region containing it, which is how
         # the mesh itself is labelled (`emit._to_meshio`).
         #
@@ -686,7 +686,7 @@ def _cell_region_mask(domain, region):
         if region not in membership:
             raise ValueError(
                 f"jno.fem per-region integration: unknown region {region!r}. Define it with "
-                f"domain.tag(name, predicate), a Shape.regions() sub-region, or a geometry part, "
+                f"domain.tag(name, predicate), a shape.regions() sub-region, or a geometry part, "
                 f"or name a volume region of the mesh file. Mesh volume regions here: "
                 f"{sorted(membership)}."
             )
@@ -2321,7 +2321,7 @@ def _promote_to_degree(points, cells_p1, ref_pts, cell_type=None, *, entity_keys
     # merely COINCIDE in space.
     #
     # Coordinate keying was the right conformity test for one body and the wrong one for two. On a
-    # `Shape.regions(..., conforming=False)` mesh the interface is coincident *on purpose*: the seeding
+    # `shape.regions(..., conforming=False)` mesh the interface is coincident *on purpose*: the seeding
     # loop below used to collapse the two bodies' duplicated vertices into one map entry (last writer
     # wins), and every midpoint synthesised there then resolved to a single node -- welding the bodies,
     # silently. Measured on a two-body bar: 37 nodes referenced by BOTH bodies, all on the interface.
@@ -4730,7 +4730,7 @@ def elem_map(fn, xs, chunk):
 
     **What this costs.** Rebuilding an identical problem from scratch allocates fresh mesh arrays, so
     the key legitimately misses and that path pays a trace plus a compile where the old eager route
-    hit JAX's per-op cache (which keys on shapes): 283 -> 710 ms. Shape-keying instead would be faster
+    hit JAX's per-op cache (which keys on shapes): 283 -> 710 ms. shape-keying instead would be faster
     and WRONG -- it would hand a compilation baked with one mesh's coordinates to a different mesh of
     the same size. The honest fix for that case is to stop baking the geometry in at all and pass it
     as an argument, a restructure of how ``fem_native`` builds these closures. Until then the trade is

--- a/jno/utils/solver/geometric_mg.py
+++ b/jno/utils/solver/geometric_mg.py
@@ -1,6 +1,6 @@
 """Geometric multigrid (GMG) V-cycle for a **structured grid** — a matrix-free, differentiable
 preconditioner for the constant-coefficient Poisson/Helmholtz-type operators ``jno.fdm`` produces on a
-regular grid (see :func:`jno.Shape.rect(...).structured().domain()`).
+regular grid (see :func:`jno.shape.rect(...).structured().domain()`).
 
 The V-cycle approximates ``A⁻¹`` for ``A = -Δ`` with homogeneous Dirichlet on the interior:
 

--- a/jno/utils/solver/solver_api.py
+++ b/jno/utils/solver/solver_api.py
@@ -516,7 +516,7 @@ class PrecondContext:
     @property
     def grid(self):
         """Structured-grid descriptor ``{shape, spacing, origin}`` when the operator lives on a regular
-        grid (``jno.Shape.rect(...).structured().domain()``), else ``None`` — needed by geometric multigrid
+        grid (``jno.shape.rect(...).structured().domain()``), else ``None`` — needed by geometric multigrid
         (:func:`jno.precond.gmg`). An explicit override if given, else derived from the owning FEM's
         domain (``ctx.fem.domain.mesh_connectivity["grid"]``)."""
         if self._grid is not None:

--- a/tests/test_concat_temporal.py
+++ b/tests/test_concat_temporal.py
@@ -30,7 +30,7 @@ def _x64():
 
 def test_bare_temporal_matches_manual_broadcast():
     """`concat([x, y, t])` == `concat([x, y, t + 0*x])` — the alignment is what users hand-wrote."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain(time=(0.0, 1.0, 3))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain(time=(0.0, 1.0, 3))
     x, y, t = d.variable("interior")
 
     bare = jno.np.concat([x, y, t], axis=-1)
@@ -45,7 +45,7 @@ def test_bare_temporal_matches_manual_broadcast():
 
 def test_bare_temporal_trunk_compiles_promptly():
     """The regression: a 2D spatiotemporal trunk with a bare `t` used to hang forever."""
-    d = jno.Shape.rect(0.0, 0.0, 100.0, 100.0, size=25.0).domain(time=(0.0, 45.0, 4))
+    d = jno.shape.rect(0.0, 0.0, 100.0, 100.0, size=25.0).domain(time=(0.0, 45.0, 4))
     x, y, t = d.variable("interior")
 
     net = jno.nn(foundax.mlp(in_features=3, output_dim=1, hidden_dims=16, num_layers=2, key=jax.random.PRNGKey(0)))
@@ -60,7 +60,7 @@ def test_bare_temporal_trunk_compiles_promptly():
 
 
 def test_spatial_only_concat_unaffected():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     x, y, _ = d.variable("interior")
     out = jno.core([], domain=d).eval(jno.np.concat([x, y], axis=-1))
     assert jnp.asarray(out).shape[-1] == 2

--- a/tests/test_core_module_mutation.py
+++ b/tests/test_core_module_mutation.py
@@ -30,7 +30,7 @@ import jno
 
 
 def _poisson(size=0.25):
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_curved_geometry.py
+++ b/tests/test_curved_geometry.py
@@ -40,7 +40,7 @@ def _x64():
 
 
 def _disk(size, order):
-    return build(jno.Shape.disk(0.0, 0.0, 1.0, size=size), order=order)[0]
+    return build(jno.shape.disk(0.0, 0.0, 1.0, size=size), order=order)[0]
 
 
 def test_order_one_is_unchanged():
@@ -95,14 +95,14 @@ def test_a_polygon_is_unaffected_by_curving():
     """Affine is the special case: a straight-sided domain has no curvature to add, so the curved
     midside nodes must coincide with the chord midpoints. If they drift, the curving is inventing
     geometry rather than following the CAD."""
-    mesh = build(jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3), order=2)[0]
+    mesh = build(jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3), order=2)[0]
     pts = np.asarray(mesh.points)[:, :2]
     e = mesh.cells_dict["line3"]
     assert np.allclose(pts[e[:, 2]], 0.5 * (pts[e[:, 0]] + pts[e[:, 1]]), atol=1e-12)
 
 
 def test_curving_works_in_3d():
-    mesh = build(jno.Shape.sphere(0.0, 0.0, 0.0, 1.0, size=0.6), order=2)[0]
+    mesh = build(jno.shape.sphere(0.0, 0.0, 0.0, 1.0, size=0.6), order=2)[0]
     assert mesh.cells_dict["tetra10"].shape[1] == 10
     assert mesh.cells_dict["triangle6"].shape[1] == 6
     surf = np.unique(mesh.cells_dict["triangle6"])
@@ -111,7 +111,7 @@ def test_curving_works_in_3d():
 
 
 def _curved_disk_domain(size=0.3):
-    return jno.Shape.disk(0.0, 0.0, 1.0, size=size).curved().domain()
+    return jno.shape.disk(0.0, 0.0, 1.0, size=size).curved().domain()
 
 
 def test_the_domain_tags_the_whole_curved_facet():
@@ -128,11 +128,11 @@ def test_the_domain_tags_the_whole_curved_facet():
 
 
 def test_mesh_order_survives_the_csg_operators():
-    """`.curved()` must not be silently dropped by a later boolean or transform — every Shape
+    """`.curved()` must not be silently dropped by a later boolean or transform — every shape
     constructor rebuilds the dataclass, and each one that forgot the flag would lose the curving with
     no indication."""
-    disk = jno.Shape.disk(0.0, 0.0, 1.0, size=0.4).curved()
-    hole = jno.Shape.disk(0.0, 0.0, 0.3, size=0.4)
+    disk = jno.shape.disk(0.0, 0.0, 1.0, size=0.4).curved()
+    hole = jno.shape.disk(0.0, 0.0, 0.3, size=0.4)
     for shape, what in (
         (disk - hole, "cut"),
         (disk | hole, "fuse"),
@@ -153,7 +153,7 @@ def _poisson_terms(d, order):
 
 def _poisson_l2(curved, size, quad_degree=None):
     """-Δu = 1 on the unit disk (exact ``u = (1-r²)/4``), P2. Returns the RMS nodal error."""
-    sh = jno.Shape.disk(0.0, 0.0, 1.0, size=size)
+    sh = jno.shape.disk(0.0, 0.0, 1.0, size=size)
     d = (sh.curved() if curved else sh).domain()
     u, v = d.fem_symbols(order=2)
     c = d.variable("interior", split=True)

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -410,7 +410,7 @@ def _build_l_domain():
     """Build an L-shaped domain with fine mesh and return (dom, x, y, t, pts, interior_mask)."""
     import jno
 
-    dom = jno.Shape.polygon([(0, 0), (1.0, 0), (1.0, 0.5), (0.5, 0.5), (0.5, 1.0), (0, 1.0)], size=0.05).domain()
+    dom = jno.shape.polygon([(0, 0), (1.0, 0), (1.0, 0.5), (0.5, 0.5), (0.5, 1.0), (0, 1.0)], size=0.05).domain()
     (x, y, t) = dom.variable("interior")
 
     pts = jnp.array(dom.context["interior"][0, 0])  # (N, 2)
@@ -996,10 +996,10 @@ class TestFDOnStackedDomains:
         import jno
 
         # Two different geometries
-        dom = 3 * jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+        dom = 3 * jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
         dom += (
             2
-            * jno.Shape.polygon(
+            * jno.shape.polygon(
                 [(0, 0), (1, 0), (0.5, 1)],
                 size=0.1,
             ).domain()

--- a/tests/test_domain_cell_aspect.py
+++ b/tests/test_domain_cell_aspect.py
@@ -55,7 +55,7 @@ def test_a_regular_simplex_reads_exactly_one_in_2d():
     """The normalisation is the whole point of the measure: 1.0 is 'as good as a triangle gets'."""
     pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, np.sqrt(3) / 2], [2.0, 0.0], [3.0, 0.0], [2.5, 0.05]])
     cells = np.array([[0, 1, 2], [3, 4, 5]])
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     d._apply_mesh(
         meshio.Mesh(
             np.c_[pts, np.zeros(len(pts))],
@@ -89,7 +89,7 @@ def test_it_matches_a_direct_reference_in_3d():
 def test_the_gradient_in_the_vertices_matches_finite_differences():
     """It is a mesh-motion quantity, so the gradient is the half that has to be right -- and a
     nonzero gradient is not evidence, a wrong one is also nonzero."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
     _xm, ym, _ = d.variable("mov", where=lambda x, y: (x > 0.2) & (x < 0.8) & (y > 0.2) & (y < 0.8), split=True)
     ym.trainable(name="iy")
     node = d.cell_aspect()

--- a/tests/test_domain_cell_geometry.py
+++ b/tests/test_domain_cell_geometry.py
@@ -30,7 +30,7 @@ def _x64():
 
 
 def _rect(size=0.4):
-    return jno.Shape.rect(0, 0, 2, 1, size=size).domain()
+    return jno.shape.rect(0, 0, 2, 1, size=size).domain()
 
 
 class TestClosedForms:
@@ -63,7 +63,7 @@ class TestClosedForms:
         assert vol[0] == pytest.approx(np.sqrt(3) / 4, abs=1e-10)
 
     def test_cell_angles_is_two_dimensional_only(self):
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
         with pytest.raises(NotImplementedError, match="triangles only"):
             d.cell_angles()
 
@@ -85,7 +85,7 @@ class TestDifferentiableInTheMesh:
 
     @staticmethod
     def _moving_rect(size=0.5):
-        d = jno.Shape.rect(0, 0, 2, 1, size=size).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=size).domain()
         xm, ym, _ = d.variable("design", where=lambda *c: np.ones_like(np.asarray(c[0]), dtype=bool), split=True)
         xm.trainable(name="mx")
         ym.trainable(name="my")
@@ -224,7 +224,7 @@ class TestNormalisedPnorm:
         assert int(np.sum(np.abs(np.asarray(g_norm)) > 1e-12)) > 1, "must not collapse to one-hot"
 
     def test_it_reaches_the_trace_through_a_node(self):
-        d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
+        d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
         got = float(np.asarray(d.cell_volume().pnorm(50.0, normalize=True).eval()).reshape(-1)[0])
         assert got == pytest.approx(float(np.asarray(d.cell_volume().eval()).max()), rel=1e-9)
 
@@ -280,12 +280,12 @@ class TestLogBarrier:
             assert np.isfinite(float(self._f(x, b))) and np.isfinite(float(jax.grad(lambda z: self._f(z, b))(x)))
 
     def test_it_reaches_the_trace_through_a_node(self):
-        d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
+        d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
         total = d.cell_volume().sum  # the domain area, 2.0
         got = float(np.asarray(total.log_barrier(10.0).eval()).reshape(-1)[0])
         assert got == pytest.approx(float(-10.0 * np.log(10.0 - 2.0)), rel=1e-6)
 
     def test_a_non_positive_tau_is_refused(self):
-        d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
+        d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
         with pytest.raises(ValueError, match="tau must be positive"):
             d.cell_volume().sum.log_barrier(10.0, tau=0.0)

--- a/tests/test_domain_decomposition.py
+++ b/tests/test_domain_decomposition.py
@@ -409,7 +409,7 @@ def test_couple_driver_reproduces_monolithic():
 
     b1, b2 = box(0.0, 0.0, 0.6, 1.0), box(0.4, 0.0, 1.0, 1.0)
     d = jno.domain(b1.union(b2), mesh_size=0.06)
-    sA, sB = jno.Shape.rect(0.0, 0.0, 0.6, 1.0), jno.Shape.rect(0.4, 0.0, 1.0, 1.0)
+    sA, sB = jno.shape.rect(0.0, 0.0, 0.6, 1.0), jno.shape.rect(0.4, 0.0, 1.0, 1.0)
     p = np.asarray(d.mesh_connectivity["points"])[:, :2]
     exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])
     x, y, _ = d.variable("interior", split=True)
@@ -584,7 +584,7 @@ def test_material_interface_via_overlap_and_kx():
     a, b = 2 * kR / (kL + kR), 2 * kL / (kL + kR)  # analytic slopes: u = 1-a·x (left), u = b·(1-x) (right)
     boxA, boxB = box(0.0, 0.0, 0.6, 1.0), box(0.5, 0.0, 1.0, 1.0)  # FEM covers the jump; overlap [0.5,0.6] uniform kR
     d = jno.domain(boxA.union(boxB), mesh_size=0.05)
-    sA, sB = jno.Shape.rect(0.0, 0.0, 0.6, 1.0), jno.Shape.rect(0.5, 0.0, 1.0, 1.0)
+    sA, sB = jno.shape.rect(0.0, 0.0, 0.6, 1.0), jno.shape.rect(0.5, 0.0, 1.0, 1.0)
     p = np.asarray(d.mesh_connectivity["points"])[:, :2]
     on = np.abs(p[:, 0] - 0.5) < 1e-6
 
@@ -629,7 +629,7 @@ def test_overlap_coupled_solve_differentiable_in_fem_coefficient():
     kR, fsrc = 3.0, 10.0
     boxA, boxB = box(0.0, 0.0, 0.6, 1.0), box(0.5, 0.0, 1.0, 1.0)  # overlap x∈[0.5,0.6]
     d = jno.domain(boxA.union(boxB), mesh_size=0.08)
-    sA, sB = jno.Shape.rect(0.0, 0.0, 0.6, 1.0), jno.Shape.rect(0.5, 0.0, 1.0, 1.0)
+    sA, sB = jno.shape.rect(0.0, 0.0, 0.6, 1.0), jno.shape.rect(0.5, 0.0, 1.0, 1.0)
     p = np.asarray(d.mesh_connectivity["points"])[:, :2]
     in_a, in_b = _region_mask(p, boxA), _region_mask(p, boxB)
     overlap = jnp.asarray(in_a & in_b)

--- a/tests/test_domain_export.py
+++ b/tests/test_domain_export.py
@@ -16,8 +16,8 @@ def _assert_nonempty(path: Path):
     "constructor",
     [
         jno.domain.line(mesh_size=0.2),
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain(),
-        jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6),
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain(),
+        jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6),
     ],
 )
 def test_export_vtk_msh(constructor, tmp_path):
@@ -37,8 +37,8 @@ def test_export_vtk_msh(constructor, tmp_path):
     "constructor",
     [
         jno.domain.line(mesh_size=0.2),
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain(),
-        jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6),
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain(),
+        jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6),
     ],
 )
 def test_export_png_if_matplotlib_available(constructor, tmp_path):
@@ -51,7 +51,7 @@ def test_export_png_if_matplotlib_available(constructor, tmp_path):
 
 
 def test_export_dispatch_with_explicit_format(tmp_path):
-    dom = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=4).domain(compute_mesh_connectivity=True)
+    dom = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=4).domain(compute_mesh_connectivity=True)
 
     out = tmp_path / "mesh_any.ext"
     dom.export(str(out), fmt="vtk")
@@ -61,8 +61,8 @@ def test_export_dispatch_with_explicit_format(tmp_path):
 @pytest.mark.parametrize(
     "constructor",
     [
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain(),
-        jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.8),
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain(),
+        jno.shape.box(0, 0, 0, 1, 1, 1, size=0.8),
     ],
 )
 def test_export_html_if_plotly_available(constructor, tmp_path):

--- a/tests/test_domain_geometries.py
+++ b/tests/test_domain_geometries.py
@@ -4,8 +4,8 @@ Covers 1-D, 2-D, and 3-D domain construction both with and without a time
 dimension, always using ``compute_mesh_connectivity=True`` so that the full
 preprocessing pipeline (connectivity, normals, etc.) is exercised. 1-D lines and
 structured grids come from the ``jno.domain.line`` / ``equi_distant_rect`` /
-``poseidon`` classmethods; 2-D/3-D geometries come from ``jno.Shape`` (the CSG
-build-plan) realized via ``Shape(...).domain()``.
+``poseidon`` classmethods; 2-D/3-D geometries come from ``jno.shape`` (the CSG
+build-plan) realized via ``shape(...).domain()``.
 
 Mesh sizes are kept deliberately coarse to keep the suite fast.
 """
@@ -19,7 +19,7 @@ import jno
 
 
 def test_shape_domain_returns_domain_instance():
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(compute_mesh_connectivity=True)
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(compute_mesh_connectivity=True)
 
     assert isinstance(dom, jno.domain)
     assert dom.dimension == 2
@@ -151,11 +151,11 @@ class TestLine1DTimeDep:
 
 
 class TestRect2DStationary:
-    """``Shape.rect`` – unstructured gmsh mesh, no time."""
+    """``shape.rect`` – unstructured gmsh mesh, no time."""
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(compute_mesh_connectivity=True)
+        return jno.shape.rect(0, 0, 1, 1, size=0.3).domain(compute_mesh_connectivity=True)
 
     def test_no_exception_on_creation(self, dom):
         assert dom is not None
@@ -194,11 +194,11 @@ class TestRect2DStationary:
 
 
 class TestRect2DTimeDep:
-    """``Shape.rect`` with a time dimension ``(0, 2, 4)``."""
+    """``shape.rect`` with a time dimension ``(0, 2, 4)``."""
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(
+        return jno.shape.rect(0, 0, 1, 1, size=0.3).domain(
             time=(0, 2, 4),
             compute_mesh_connectivity=True,
         )
@@ -230,7 +230,7 @@ class TestEquiDistantRect2DStationary:
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=5).domain(compute_mesh_connectivity=True)
+        return jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=5).domain(compute_mesh_connectivity=True)
 
     def test_no_exception_on_creation(self, dom):
         assert dom is not None
@@ -259,11 +259,11 @@ class TestEquiDistantRect2DStationary:
 
 
 class TestCube3DStationary:
-    """``Shape.box`` – 3-D unstructured gmsh mesh, no time."""
+    """``shape.box`` – 3-D unstructured gmsh mesh, no time."""
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(compute_mesh_connectivity=True)
+        return jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(compute_mesh_connectivity=True)
 
     def test_no_exception_on_creation(self, dom):
         assert dom is not None
@@ -298,11 +298,11 @@ class TestCube3DStationary:
 
 
 class TestCube3DTimeDep:
-    """``Shape.box`` with a time dimension ``(0, 1, 3)``."""
+    """``shape.box`` with a time dimension ``(0, 1, 3)``."""
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(
+        return jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(
             time=(0, 1, 3),
             compute_mesh_connectivity=True,
         )
@@ -331,7 +331,7 @@ class TestTriangle:
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.polygon(((0, 0), (2, 0), (1, 1)), size=0.3).domain(
+        return jno.shape.polygon(((0, 0), (2, 0), (1, 1)), size=0.3).domain(
             compute_mesh_connectivity=True,
         )
 
@@ -359,7 +359,7 @@ class TestPolygon:
     @pytest.fixture(scope="class")
     def dom(self):
         verts = [(0, 0), (0, 2), (1, 3), (2, 2), (2, 0)]
-        return jno.Shape.polygon(verts, size=0.5).domain(compute_mesh_connectivity=True)
+        return jno.shape.polygon(verts, size=0.5).domain(compute_mesh_connectivity=True)
 
     def test_dimension_is_2(self, dom):
         assert dom.dimension == 2
@@ -374,13 +374,13 @@ class TestPolygon:
             assert name in tags, f"Missing boundary label '{name}'"
 
     def test_rect_has_named_side_labels(self):
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
         tags = set(dom._mesh_pool.keys())
         for name in ("left", "right", "top", "bottom"):
             assert name in tags
 
     def test_triangle_has_three_boundary_labels(self):
-        dom = jno.Shape.polygon(((0, 0), (1, 0), (0, 1)), size=0.4).domain()
+        dom = jno.shape.polygon(((0, 0), (1, 0), (0, 1)), size=0.4).domain()
         tags = set(dom._mesh_pool.keys())
         for name in ("e0", "e1", "e2"):
             assert name in tags
@@ -395,8 +395,8 @@ class TestDomainStacking:
     """Verify that combining domains via ``+`` correctly stacks batches."""
 
     def test_two_geometries_batch_shape(self):
-        dom = 3 * jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
-        dom += 2 * jno.Shape.disk(0, 0, 1, size=0.3).domain()
+        dom = 3 * jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
+        dom += 2 * jno.shape.disk(0, 0, 1, size=0.3).domain()
         x, y, _ = dom.variable("interior", (10, None))
         ctx = dom.context["interior"]
         assert ctx.shape[0] == 5  # 3 rect + 2 disk
@@ -404,24 +404,24 @@ class TestDomainStacking:
         assert ctx.shape[3] == 2
 
     def test_three_geometries_batch_shape(self):
-        dom = 4 * jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
-        dom += 3 * jno.Shape.disk(0, 0, 1, size=0.3).domain()
-        dom += 2 * jno.Shape.polygon([(0, 0), (1, 0), (1, 0.5), (0.5, 0.5), (0.5, 1), (0, 1)], size=0.3).domain()
+        dom = 4 * jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
+        dom += 3 * jno.shape.disk(0, 0, 1, size=0.3).domain()
+        dom += 2 * jno.shape.polygon([(0, 0), (1, 0), (1, 0.5), (0.5, 0.5), (0.5, 1), (0, 1)], size=0.3).domain()
         x, y, _ = dom.variable("interior", (8, None))
         ctx = dom.context["interior"]
         assert ctx.shape[0] == 9  # 4 + 3 + 2
         assert ctx.shape[2] == 8
 
     def test_boundary_also_stacks(self):
-        dom = 2 * jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
-        dom += 3 * jno.Shape.polygon(((0, 0), (1, 0), (0, 1)), size=0.3).domain()
+        dom = 2 * jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
+        dom += 3 * jno.shape.polygon(((0, 0), (1, 0), (0, 1)), size=0.3).domain()
         x, y, _ = dom.variable("boundary")
         ctx = dom.context["boundary"]
         assert ctx.shape[0] == 5  # 2 + 3
 
     def test_total_samples_updated(self):
-        dom = 5 * jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
-        dom += 3 * jno.Shape.disk(0, 0, 1, size=0.3).domain()
+        dom = 5 * jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
+        dom += 3 * jno.shape.disk(0, 0, 1, size=0.3).domain()
         assert dom.total_samples == 8
 
 
@@ -436,7 +436,7 @@ class TestDistanceFunction:
     def test_distances_nonnegative(self):
         import jno
 
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
         dom.variable("interior")  # populate context
         d = dom.distance_function("interior")
         # Variable tag should exist in context
@@ -450,7 +450,7 @@ class TestDistanceFunction:
 
         import jno
 
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
         dom.variable("boundary")
         dom.variable("interior")
         d_var = dom.distance_function("boundary", boundary_tags=["interior"])
@@ -463,7 +463,7 @@ class TestDistanceFunction:
 
         import jno
 
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.2).domain()
         dom.variable("interior")
         d_var = dom.distance_function("interior")
         dist_arr = np.array(dom.context[d_var.tag])
@@ -473,7 +473,7 @@ class TestDistanceFunction:
     def test_custom_name(self):
         import jno
 
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
         dom.variable("interior")
         d_var = dom.distance_function("interior", name="my_dist")
         assert d_var.tag == "my_dist"

--- a/tests/test_domain_meshfree.py
+++ b/tests/test_domain_meshfree.py
@@ -1,4 +1,4 @@
-"""A ``jno.Shape`` domain draws collocation points from the geometry, and does not mesh to do it.
+"""A ``jno.shape`` domain draws collocation points from the geometry, and does not mesh to do it.
 
 The contract, in one line: **the PINN source does not change.** The same `.domain()`, the same
 `tag(name, where)`, the same `variable(name, sample=(n, None))` — what changes is that no mesher
@@ -30,13 +30,13 @@ def _meshless(d):
     "make, dim",
     [
         (lambda: jno.Path(0.0, 0.0).line_to(1.0, 0.0).curve().domain(), 1),
-        (lambda: jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain(), 2),
-        (lambda: jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).domain(), 3),
-        (lambda: (jno.Shape.rect(0.0, 0.0, 1.0, 1.0) - jno.Shape.disk(0.5, 0.5, 0.25)).domain(), 2),
-        (lambda: (jno.Shape.box(0, 0, 0, 1, 1, 1) - jno.Shape.sphere(0.5, 0.5, 0.5, 0.3)).domain(), 3),
-        (lambda: jno.Shape.disk(0.0, 0.0, 1.0).extrude(2.0).domain(), 3),
-        (lambda: jno.Shape.rect(1, 0, 2, 1).revolve((0, 0, 0), (0, 1, 0), 2 * math.pi).domain(), 3),
-        (lambda: jno.Shape.rect(1, 0, 2, 1).revolve((0, 0, 0), (0, 1, 0), math.pi).domain(), 3),
+        (lambda: jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain(), 2),
+        (lambda: jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).domain(), 3),
+        (lambda: (jno.shape.rect(0.0, 0.0, 1.0, 1.0) - jno.shape.disk(0.5, 0.5, 0.25)).domain(), 2),
+        (lambda: (jno.shape.box(0, 0, 0, 1, 1, 1) - jno.shape.sphere(0.5, 0.5, 0.5, 0.3)).domain(), 3),
+        (lambda: jno.shape.disk(0.0, 0.0, 1.0).extrude(2.0).domain(), 3),
+        (lambda: jno.shape.rect(1, 0, 2, 1).revolve((0, 0, 0), (0, 1, 0), 2 * math.pi).domain(), 3),
+        (lambda: jno.shape.rect(1, 0, 2, 1).revolve((0, 0, 0), (0, 1, 0), math.pi).domain(), 3),
     ],
     ids=["1d-line", "2d-rect", "3d-box", "2d-csg", "3d-csg", "extrude", "revolve", "revolve-half"],
 )
@@ -47,7 +47,7 @@ def test_a_shape_domain_starts_without_a_mesh(make, dim):
 
 
 def test_sampling_and_tagging_never_trigger_a_mesh():
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).domain()
     d.tag("hot", lambda x, y, z: (x - 0.5) ** 2 + (y - 0.5) ** 2 + (z - 0.5) ** 2 < 0.04)
     d.variable("interior", sample=(3000, None), split=True)
     d.variable("hot", sample=(500, None), split=True)
@@ -61,7 +61,7 @@ def test_sampling_and_tagging_never_trigger_a_mesh():
 def test_auto_named_boundaries_exist_before_any_mesh():
     """The names come from the same classifier the mesher uses — applied to analytic boundary
     points instead of gmsh entities — so a CSG cut introduces its own name too."""
-    assert set(jno.Shape.rect(0, 0, 2, 1).domain()._geometry_tags) >= {
+    assert set(jno.shape.rect(0, 0, 2, 1).domain()._geometry_tags) >= {
         "interior",
         "boundary",
         "left",
@@ -69,14 +69,14 @@ def test_auto_named_boundaries_exist_before_any_mesh():
         "top",
         "bottom",
     }
-    holed = (jno.Shape.rect(0, 0, 1, 1) - jno.Shape.disk(0.5, 0.5, 0.25)).domain()
+    holed = (jno.shape.rect(0, 0, 1, 1) - jno.shape.disk(0.5, 0.5, 0.25)).domain()
     assert "arc" in holed._geometry_tags, "the cut introduced a circular edge; it should be nameable"
-    void = (jno.Shape.box(0, 0, 0, 1, 1, 1) - jno.Shape.sphere(0.5, 0.5, 0.5, 0.3)).domain()
+    void = (jno.shape.box(0, 0, 0, 1, 1, 1) - jno.shape.sphere(0.5, 0.5, 0.5, 0.3)).domain()
     assert "surface" in void._geometry_tags, "the spherical void's face should be nameable"
 
 
 def test_an_auto_named_boundary_samples_only_its_own_face():
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0).domain()
     d.variable("left", sample=(400, None), normals=True, split=True)
     pts = np.asarray(d.context["left"]).reshape(-1, 2)
     nrm = np.asarray(d.context["n_left"]).reshape(-1, 2)
@@ -89,7 +89,7 @@ def test_an_auto_named_boundary_samples_only_its_own_face():
 def test_a_boundary_predicate_is_recognised_and_sampled_on_the_boundary():
     """The case that decides whether "tagging works the same": `x < tol` names a face. It is
     classified by measuring which draw accepts it, not by inspecting the lambda."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain()
     d.tag("wall", lambda x, y: x < 1e-9)
     d.tag("blob", lambda x, y: (x - 0.5) ** 2 + (y - 0.5) ** 2 < 0.04)
     assert d._geometry_tags["wall"][0] == "boundary"
@@ -108,7 +108,7 @@ def test_a_boundary_predicate_is_recognised_and_sampled_on_the_boundary():
 def test_a_boundary_tag_becomes_a_boundary_region_without_a_mesh():
     """`jno.fem` reads `_boundary_regions` to tell an essential condition from a domain residual;
     a mesh-free boundary tag that registered no region would be read as the latter."""
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).domain()
     d.tag("inlet", lambda x, y, z: x < 1e-9)
     assert "inlet" in d._boundary_regions
     assert _meshless(d)
@@ -120,13 +120,13 @@ def test_a_boundary_tag_becomes_a_boundary_region_without_a_mesh():
 def test_the_count_is_honoured_and_uncapped():
     """On a mesh the count was silently clipped to the node count, with a warning. There is no node
     set here, so `n` means `n` — including counts far beyond any mesh of this shape."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain()
     d.variable("interior", sample=(50_000, None), split=True)
     assert np.asarray(d.context["interior"]).shape == (1, 1, 50_000, 2)
 
 
 def test_successive_draws_are_different_points():
-    d = jno.Shape.disk(0.0, 0.0, 1.0).domain()
+    d = jno.shape.disk(0.0, 0.0, 1.0).domain()
     d.variable("interior", sample=(400, None), split=True)
     first = np.asarray(d.context["interior"]).copy()
     d.sample({"interior": (400, None)})
@@ -135,7 +135,7 @@ def test_successive_draws_are_different_points():
 
 
 def test_points_land_inside_the_shape_they_name():
-    holed = (jno.Shape.rect(0, 0, 1, 1) - jno.Shape.disk(0.5, 0.5, 0.25)).domain()
+    holed = (jno.shape.rect(0, 0, 1, 1) - jno.shape.disk(0.5, 0.5, 0.25)).domain()
     holed.variable("interior", sample=(5000, None), split=True)
     pts = np.asarray(holed.context["interior"]).reshape(-1, 2)
     assert ((pts[:, 0] - 0.5) ** 2 + (pts[:, 1] - 0.5) ** 2 >= 0.25**2 - 1e-12).all()
@@ -147,7 +147,7 @@ def test_no_count_without_a_declared_size_refuses_rather_than_guessing():
     right depends on what the caller does *afterwards*. With no `size=` there is no declared
     resolution to fall back on, so it refuses and names both ways out — guessing would be silent,
     since finite differences over one collocation point return a number, just the wrong one."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain()  # no size=
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain()  # no size=
     with pytest.raises(ValueError, match="no mesh size was declared"):
         d.variable("interior", split=True)
 
@@ -160,13 +160,13 @@ def test_a_declared_size_makes_the_no_count_form_mean_that_mesh_s_nodes():
     """`size=` IS the declaration of a resolution: asking for a mesh of that density and then for
     'the interior' unambiguously means its nodes. That is what a convergence study over `size`
     rests on, so it keeps working — and an explicit count still opts out to mesh-free."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     assert _meshless(d), "declaring a size still does not mesh until the nodes are asked for"
     d.variable("interior", split=True)
     assert not _meshless(d)
     assert np.asarray(d.context["interior"]).shape[2] == len(d._mesh_pool["interior"])
 
-    sized = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    sized = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     sized.variable("interior", sample=(9_000, None), split=True)  # a count still wins
     assert np.asarray(sized.context["interior"]).shape == (1, 1, 9_000, 2)
     assert _meshless(sized)
@@ -176,7 +176,7 @@ def test_resampling_candidates_are_generated_not_reshuffled():
     """The no-count default IS a resampling strategy, so its candidates must come from the geometry
     every time. Drawing them from the reference pool would make "redrawn every step" mean "redrawn
     from the same frozen cloud every step" — the exact thing this feature removes."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain()
     d.variable("interior", sample=(50, None), split=True)
     a, _ = d.draw_candidates("interior")
     b, _ = d.draw_candidates("interior")
@@ -191,7 +191,7 @@ def test_resampling_candidates_are_generated_not_reshuffled():
 
 
 def test_reading_the_mesh_builds_it_once():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     assert _meshless(d)
     mesh = d.mesh
     assert mesh is not None and len(mesh.points) > 10
@@ -203,7 +203,7 @@ def test_a_tag_declared_while_mesh_free_survives_the_deferred_build():
     """The tag carried only a predicate while there was no mesh. Once there is one, it must gain
     the mesh-derived half too — otherwise an essential condition on it silently becomes a
     whole-domain residual."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     d.tag("wall", lambda x, y: x < 1e-9)
     _ = d.mesh  # trigger
     assert "wall" in d._tag_predicates
@@ -215,7 +215,7 @@ def test_a_tag_declared_while_mesh_free_survives_the_deferred_build():
 def test_a_facet_predicate_asks_for_the_mesh_it_needs():
     """A facet predicate reads facet centroids and normals — a statement about the discretisation,
     not the geometry. It should build the mesh rather than refuse."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
     assert _meshless(d)
     d.tag("top", lambda x, n, names: x[:, 1] > 1.0 - 1e-6)
     assert not _meshless(d)
@@ -231,7 +231,7 @@ def test_a_mesh_free_pinn_solves_poisson_to_the_exact_solution():
     optax = pytest.importorskip("optax")
     import jax
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain()
     x, y, _t = d.variable("interior", sample=(2000, None), split=True)
 
     net = jno.nn(foundax.mlp(in_features=2, hidden_dims=48, num_layers=4, key=jax.random.PRNGKey(0)))
@@ -253,7 +253,7 @@ def test_a_mesh_free_pinn_solves_poisson_to_the_exact_solution():
 
 
 def test_a_time_dependent_shape_domain_carries_the_time_axis():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain(time=(0.0, 1.0, 11))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain(time=(0.0, 1.0, 11))
     d.variable("interior", sample=(128, None), split=True)
     assert np.asarray(d.context["interior"]).shape == (1, 11, 128, 2)
     assert _meshless(d)
@@ -263,12 +263,12 @@ def test_a_time_dependent_shape_domain_carries_the_time_axis():
     "make, why",
     [
         (
-            lambda: jno.Shape.rect(0, 0, 1, 1, size=0.3).name("core").domain(),
+            lambda: jno.shape.rect(0, 0, 1, 1, size=0.3).name("core").domain(),
             "a named region's tags are the mesher's conforming sub-bodies",
         ),
         (
-            lambda: jno.Shape.rect(0, 0, 1, 1, size=0.3).structured().domain(),
-            "a structured plan is a lattice, not a Shape, by the time it is built",
+            lambda: jno.shape.rect(0, 0, 1, 1, size=0.3).structured().domain(),
+            "a structured plan is a lattice, not a shape, by the time it is built",
         ),
     ],
     ids=["named-region", "structured"],
@@ -283,7 +283,7 @@ def test_a_plan_that_cannot_be_served_still_meshes(make, why):
 
 
 def test_batching_draws_independently_per_row():
-    d = 4 * jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain()
+    d = 4 * jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain()
     d.variable("interior", sample=(200, None), split=True)
     arr = np.asarray(d.context["interior"])
     assert arr.shape == (4, 1, 200, 2)
@@ -291,14 +291,14 @@ def test_batching_draws_independently_per_row():
 
 
 def test_normals_are_refused_on_an_interior_tag():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).domain()
     with pytest.raises(ValueError, match="boundary"):
         d.variable("interior", sample=(10, None), normals=True, split=True)
 
 
 def test_a_curved_boundary_samples_exactly_on_the_curve():
     """A tessellation would put these on chords; the analytic sampler puts them on the circle."""
-    d = jno.Shape.disk(1.0, 2.0, 0.5).domain()
+    d = jno.shape.disk(1.0, 2.0, 0.5).domain()
     d.variable("arc", sample=(500, None), normals=True, split=True)
     pts = np.asarray(d.context["arc"]).reshape(-1, 2)
     r = np.linalg.norm(pts - np.array([1.0, 2.0]), axis=1)
@@ -319,8 +319,8 @@ def test_an_attached_mesh_is_not_overwritten_by_the_pending_plan():
 
     pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]])
     cells = np.array([[0, 1, 2]])
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
-    assert _meshless(d), "a Shape domain starts mesh-free -- otherwise this proves nothing"
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    assert _meshless(d), "a shape domain starts mesh-free -- otherwise this proves nothing"
 
     d._apply_mesh(
         meshio.Mesh(

--- a/tests/test_domain_normals.py
+++ b/tests/test_domain_normals.py
@@ -126,7 +126,7 @@ def test_boundary_face_normals_match_the_per_face_loop(with_apex):
     """A real tet mesh, with and without the apex orientation (the concave-safe path)."""
     from jno.utils.solver.fem_facets import _LOCAL_FACES_TET, _boundary_faces
 
-    mesh = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain().built_mesh
+    mesh = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain().built_mesh
     pts, cells = np.asarray(mesh.points), np.asarray(mesh.cells_dict["tetra"], dtype=np.int64)
     flat, sel, n_local = _boundary_faces(cells, _LOCAL_FACES_TET, 3)
     faces = flat[sel]
@@ -167,7 +167,7 @@ def test_coordinate_tag_gets_per_point_normals_like_a_facet_tag():
     of that dict saw a *silently missing* entry rather than an error. This is what broke RCWA's
     superstrate/substrate detection once a tag was re-derived from a predicate (a remesh, or
     ``_domain_from_arrays``) instead of coming from the mesh's cell sets."""
-    d = jno.domain(jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 2.0, size=0.5).domain())
+    d = jno.domain(jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 2.0, size=0.5).domain())
     e = 1e-6
     d.tag("zbot", lambda x, y, z: z < e)
     d.tag("ztop", lambda x, y, z: z > 2.0 - e)
@@ -187,7 +187,7 @@ def test_coordinate_tag_normals_survive_a_rebuild_from_arrays():
     they previously did not, which is how a face became invisible to anything reading them."""
     from jno.utils.solver.fem_adapt import _domain_from_arrays
 
-    src = jno.domain(jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 2.0, size=0.5).domain())
+    src = jno.domain(jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 2.0, size=0.5).domain())
     pts = np.asarray(src.mesh.points)
     tets = np.asarray(src.mesh.cells_dict["tetra"])
     faces = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])

--- a/tests/test_domain_tag.py
+++ b/tests/test_domain_tag.py
@@ -196,7 +196,7 @@ def test_variable_where_registers_tag_and_returns_coords_3d():
     """``variable("xlo", where=pred)`` on a 3D box tags the region (predicate lands in
     ``_tag_predicates``) and returns the split coordinate tuple ``(x, y, z, t)`` -- one call for what
     used to be ``tag`` + ``variable``."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
     ret = d.variable("xlo", where=lambda x, y, z: x < 1e-6)
     assert isinstance(ret, tuple) and len(ret) == 4, "3D coordinate tag must return (x, y, z, t)"
     assert "xlo" in d._tag_predicates, "where= must register the tag exactly like tag()"
@@ -340,7 +340,7 @@ def test_a_facet_predicate_tag_is_readable_on_a_time_dependent_domain():
     which made a facet-selected boundary unusable for anything time-dependent (a moving front, say).
     """
     for time in ((0.0, 0.2, 5), None):
-        d = jno.Shape.rect(0.0, 0.0, 0.3, 0.5, size=0.08).domain(**({"time": time} if time else {}))
+        d = jno.shape.rect(0.0, 0.0, 0.3, 0.5, size=0.08).domain(**({"time": time} if time else {}))
         d.tag("top", lambda x, n, names: x[:, 1] > 0.5 - 1e-6)
 
         parts = d.variable("top", normals=True, split=True)

--- a/tests/test_engd_optimizer.py
+++ b/tests/test_engd_optimizer.py
@@ -58,7 +58,7 @@ def _build_poisson2d(seed: int = 0, hidden_dims: int = 32, num_layers: int = 1):
     """Return (net, losses, gram_terms, eval_error) for Poisson2D on [0,1]²."""
     import foundax
 
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
     x, y, _ = dom.variable("interior")
     xb, yb, _ = dom.variable("boundary")
     dom.context["interior"] = _int_pts()[None, None]

--- a/tests/test_evaluator_derivative_reuse.py
+++ b/tests/test_evaluator_derivative_reuse.py
@@ -41,7 +41,7 @@ def _network_dispatches(build_residual, monkeypatch):
 
     monkeypatch.setattr(TraceEvaluator, "_eval_flax_module_call", counting)
 
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     x, y, _ = dom.variable("interior")
     net = jno.nn(foundax.mlp(in_features=2, output_dim=1, hidden_dims=4, num_layers=2, key=KEY))
     net.optimizer(optax.adam(1e-3))
@@ -68,7 +68,7 @@ def test_fd_laplacian_and_partial_share_one_mesh_evaluation(monkeypatch):
 
 def test_fd_derivatives_are_unchanged_by_the_sharing():
     """Reuse must not move the numbers: FD partials of a linear field are exact."""
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.2).domain()
     x, y, _ = dom.variable("interior")
     field = 3.0 * x + 5.0 * y
 
@@ -85,7 +85,7 @@ def test_fd_derivatives_are_unchanged_by_the_sharing():
 
 def _windowed_laplacian(n_points, n_time=2):
     """Drive ``_eval_hessian`` with a 3-D ``(T, N, D)`` point context."""
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     x, y, _ = dom.variable("interior")
     net = jno.nn(foundax.mlp(in_features=2, output_dim=1, hidden_dims=8, num_layers=2, key=KEY))
     lap = jno.np.laplacian(net(x, y), [x, y])
@@ -135,7 +135,7 @@ def test_windowed_laplacian_matches_jax_hessian():
 
 def test_positional_coordinates_raise_a_clear_error():
     """``laplacian(u, x, y)`` puts ``y`` in the ``scheme`` slot."""
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     x, y, _ = dom.variable("interior")
     net = jno.nn(foundax.mlp(in_features=2, output_dim=1, hidden_dims=4, num_layers=2, key=KEY))
     u = net(x, y)
@@ -148,7 +148,7 @@ def test_positional_coordinates_raise_a_clear_error():
 
 
 def test_the_list_form_and_the_method_form_still_work():
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     x, y, _ = dom.variable("interior")
     net = jno.nn(foundax.mlp(in_features=2, output_dim=1, hidden_dims=4, num_layers=2, key=KEY))
     u = net(x, y)

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -718,7 +718,7 @@ def test_engd_line_search_reduces_loss():
     )
     bdy_pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=np.float64)
 
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
     x, y, _ = dom.variable("interior")
     dom.context["interior"] = int_pts[np.newaxis, np.newaxis]
     xb, yb, _ = dom.variable("boundary")
@@ -812,7 +812,7 @@ def _fem_compliance_crux():
     e0, emin, nu, penal = 1.0, 1e-6, 0.3, 3.0
     lam, mu = e0 * nu / (1 - nu**2), e0 / (2 * (1 + nu))
 
-    d = jno.Shape.rect(0, 0, 2, 1, size=0.4).domain()
+    d = jno.shape.rect(0, 0, 2, 1, size=0.4).domain()
     u, phi = d.fem_symbols(value_shape=(2,))
     _r, s = d.fem_symbols(names=("r", "s"))
     xi, yi, _ = d.variable("interior", split=True)

--- a/tests/test_fdm.py
+++ b/tests/test_fdm.py
@@ -526,7 +526,7 @@ def test_periodic_poisson():
     Dirichlet u=0 in y ⇒ u = sin(2πx)sin(πy). The tie holds to machine precision."""
     import jno.jnp_ops as jnn
 
-    d = jno.domain(jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).structured())
+    d = jno.domain(jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).structured())
     p = _nodes(d)
     x, y, _ = d.variable("interior", split=True)
     xl, yl, _ = d.variable("left", split=True)
@@ -629,8 +629,8 @@ def _nodes3(d):
 
 
 def _cube(mesh_size):
-    """Unit cube meshed by jno.Shape (gmsh tets) — no shapely."""
-    return jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=mesh_size).domain()
+    """Unit cube meshed by jno.shape (gmsh tets) — no shapely."""
+    return jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=mesh_size).domain()
 
 
 def _poisson3d(mesh_size, method="cotangent"):
@@ -839,8 +839,8 @@ def test_constraint_list_poisson_3d():
 
 
 def test_mesh_nodes_in_3d_shape_box():
-    """Keystone 3-D containment: `jno.fdm._mesh_nodes_in` resolves a `jno.Shape.box` sub-region to the
-    exact tetrahedral-mesh node subset via the analytic 3-D `Shape.contains` — the production path both
+    """Keystone 3-D containment: `jno.fdm._mesh_nodes_in` resolves a `jno.shape.box` sub-region to the
+    exact tetrahedral-mesh node subset via the analytic 3-D `shape.contains` — the production path both
     `_TraceFDM._region_nodes` and `jno.dd._region_mask` route through to turn a geometric sub-region into
     a node set. This is what shapely could never do (it is 2-D only). (Wiring such a region into a *3-D
     coupled solve* additionally needs region-tag support on the base 3-D domain — a separate feature.)"""
@@ -848,7 +848,7 @@ def test_mesh_nodes_in_3d_shape_box():
 
     d = _cube(0.12)
     p = _nodes3(d)
-    core = jno.Shape.box(0.3, 0.3, 0.3, 0.7, 0.7, 0.7)
+    core = jno.shape.box(0.3, 0.3, 0.3, 0.7, 0.7, 0.7)
     idx = _mesh_nodes_in(p, core)
     # resolves exactly the analytic 3-D containment ...
     assert np.array_equal(np.sort(idx), np.sort(np.nonzero(core.contains(p))[0]))

--- a/tests/test_fdm_spectral.py
+++ b/tests/test_fdm_spectral.py
@@ -29,7 +29,7 @@ def _x64():
 
 def _dirichlet_poisson(scheme=None, size=0.05):
     """-Δu = f with u = sin(πx)sin(πy), zero on the boundary."""
-    d = jno.Shape.rect(0, 0, 1, 1).structured(n=round(1.0 / size)).domain()
+    d = jno.shape.rect(0, 0, 1, 1).structured(n=round(1.0 / size)).domain()
     x, y, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
     p = np.asarray(d.mesh_connectivity["points"])[:, :2]
@@ -82,7 +82,7 @@ class TestPeriodicProblem:
     """
 
     def _run(self, sx=None, sy=None, size=0.08):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=round(1.0 / size)).domain()
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=round(1.0 / size)).domain()
         p = np.asarray(d.mesh_connectivity["points"])[:, :2]
         x, y, _ = d.variable("interior", split=True)
         xl, yl, _ = d.variable("left", split=True)
@@ -119,7 +119,7 @@ class TestPeriodicProblem:
 
     def test_the_periodic_tie_still_holds(self):
         """Spectral must not break the wrap-around constraint the tie imposes."""
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=round(1.0 / 0.08)).domain()
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=round(1.0 / 0.08)).domain()
         x, y, _ = d.variable("interior", split=True)
         xl, yl, _ = d.variable("left", split=True)
         xr, yr, _ = d.variable("right", split=True)

--- a/tests/test_fdm_structured.py
+++ b/tests/test_fdm_structured.py
@@ -1,4 +1,4 @@
-"""``jno.fdm`` on a **structured grid** — ``jno.domain(Shape.rect(...).structured())``.
+"""``jno.fdm`` on a **structured grid** — ``jno.domain(shape.rect(...).structured())``.
 
 A structured request builds a regular right-triangulation and records a grid descriptor on
 ``mesh_connectivity["grid"]``; ``jno.fdm`` then takes the assembly-free direct finite-difference
@@ -37,11 +37,11 @@ def _nodes(d):
 
 
 def _structured(x0=0.0, y0=0.0, x1=1.0, y1=1.0, size=0.1, **kw):
-    return jno.domain(jno.Shape.rect(x0, y0, x1, y1, size=size).structured(), **kw)
+    return jno.domain(jno.shape.rect(x0, y0, x1, y1, size=size).structured(), **kw)
 
 
 def _structured_box(x0=0.0, y0=0.0, z0=0.0, x1=1.0, y1=1.0, z1=1.0, size=0.2, **kw):
-    return jno.domain(jno.Shape.box(x0, y0, z0, x1, y1, z1, size=size).structured(), **kw)
+    return jno.domain(jno.shape.box(x0, y0, z0, x1, y1, z1, size=size).structured(), **kw)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -227,7 +227,7 @@ def test_structured_constraint_list_transient():
     import jno.jnp_ops as jnn
 
     nu, T = 0.05, 0.3
-    d = jno.domain(jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).structured(), time=(0.0, T, 100))
+    d = jno.domain(jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).structured(), time=(0.0, T, 100))
     assert d.mesh_connectivity.get("grid") is not None
     p = _nodes(d)
     x, y, t = d.variable("interior", split=True)
@@ -255,7 +255,7 @@ def test_transient_time_schemes():
     nu, T = 0.05, 0.3
 
     def run(time):
-        d = jno.domain(jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).structured(), time=(0.0, T, 50))
+        d = jno.domain(jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).structured(), time=(0.0, T, 50))
         p = _nodes(d)
         x, y, t = d.variable("interior", split=True)
         xb, yb, _ = d.variable("boundary", split=True)
@@ -357,36 +357,36 @@ def test_structured_3d_constraint_list_solve():
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# fail-loud scope limits (v1: axis-aligned Shape.rect / .box only)
+# fail-loud scope limits (v1: axis-aligned shape.rect / .box only)
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 def test_structured_rejects_disk():
     with pytest.raises((ValueError, NotImplementedError)):
-        jno.domain(jno.Shape.disk(0.0, 0.0, 1.0, size=0.1).structured())
+        jno.domain(jno.shape.disk(0.0, 0.0, 1.0, size=0.1).structured())
 
 
 def test_structured_rejects_3d_composite():
     """A plain box is now supported (3-D); a composite/CSG 3-D shape still raises — cut-cell is planned."""
-    shape = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.2) - jno.Shape.sphere(0.5, 0.5, 0.5, 0.2)
+    shape = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.2) - jno.shape.sphere(0.5, 0.5, 0.5, 0.2)
     with pytest.raises((ValueError, NotImplementedError)):
         jno.domain(shape.structured())
 
 
 def test_structured_rejects_composite():
-    shape = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1) - jno.Shape.disk(0.5, 0.5, 0.2)
+    shape = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1) - jno.shape.disk(0.5, 0.5, 0.2)
     with pytest.raises((ValueError, NotImplementedError)):
         jno.domain(shape.structured())
 
 
 def test_structured_rejects_callable_size():
-    shape = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=lambda x, y: 0.1)
+    shape = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=lambda x, y: 0.1)
     with pytest.raises(NotImplementedError):
         jno.domain(shape.structured())
 
 
 def test_a_non_shape_geometry_cannot_ask_for_a_lattice():
     """A shapely polygon has no build plan to turn into a lattice, and now cannot ask: `.structured()`
-    is a `Shape` method, so the request is unspellable rather than refused at runtime."""
+    is a `shape` method, so the request is unspellable rather than refused at runtime."""
     assert not hasattr(box(0.0, 0.0, 1.0, 1.0), "structured")
     assert jno.domain(box(0.0, 0.0, 1.0, 1.0)).grid is None  # still meshes, just unstructured

--- a/tests/test_fem_3d.py
+++ b/tests/test_fem_3d.py
@@ -56,7 +56,7 @@ def _solve(fem):
 
 
 def _cube(mesh_size=0.4, **kwargs):
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(**kwargs)
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(**kwargs)
 
 
 def _xyz(d):

--- a/tests/test_fem_adapt.py
+++ b/tests/test_fem_adapt.py
@@ -94,7 +94,7 @@ def _l_shape_polygon(size: float = 1.0) -> Polygon:
 
 
 def _l_shape_domain(mesh_size: float = 0.15):
-    return jno.Shape.polygon([(0, 0), (1.0, 0), (1.0, 0.5), (0.5, 0.5), (0.5, 1.0), (0, 1.0)], size=mesh_size).domain()
+    return jno.shape.polygon([(0, 0), (1.0, 0), (1.0, 0.5), (0.5, 0.5), (0.5, 1.0), (0, 1.0)], size=mesh_size).domain()
 
 
 def _corner_focused_size(points: np.ndarray, corner=(0.5, 0.5), fine=0.03, coarse=0.3) -> np.ndarray:
@@ -471,7 +471,7 @@ def test_anisotropic_adapt_beats_isotropic_on_oblique_layer():
 
 
 def _cube(mesh_size=0.35):
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
 
 
 def test_remesh_and_solve_3d_recovers_linear_solution():
@@ -600,7 +600,7 @@ def test_adapt_vector_field_isotropic_refines_and_estimate_drops():
     """h-adaptivity on a VECTOR field: the ZZ estimator sums the per-component recovered-gradient errors,
     so one indicator refines the mesh where the vector solution varies sharply. The largest indicator sits
     at the feature, and the adaptive loop adds DOFs and cuts the global estimate (isotropic ZZ)."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
     u, phi = d.fem_symbols(value_shape=(2,))
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -628,7 +628,7 @@ def test_adapt_vector_field_isotropic_refines_and_estimate_drops():
 def test_adapt_vector_field_anisotropic_rejected():
     """The anisotropic Hessian metric is a single scalar-field Hessian, so a vector field must fall back to
     the (now vector-aware) isotropic ZZ path -- ``anisotropic=True`` on a vector field fails loud."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     u, phi = d.fem_symbols(value_shape=(2,))
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_adapt_complex.py
+++ b/tests/test_fem_adapt_complex.py
@@ -40,7 +40,7 @@ def _imag_layer_fem(d, eps=0.05):
 
 
 def test_anisotropic_adaptation_runs_on_a_complex_field():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
     n0 = len(d.mesh.points)
     _imag_layer_fem(d).solve(adapt=jno.solve.remesh(anisotropic=True, max_iters=4, refine_factor=1.6, max_dofs=2500))
     assert len(d.mesh.points) > n0, "the mesh did not refine at all"
@@ -50,7 +50,7 @@ def test_the_metric_follows_the_imaginary_feature():
     """The layer is at x + y = 1 and exists only in Im(u). If the reduction dropped the imaginary
     part the field would be flat and refinement would spread out, so this is what makes the test
     about the reduction rather than about adaptation running."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
     _imag_layer_fem(d).solve(adapt=jno.solve.remesh(anisotropic=True, max_iters=4, refine_factor=1.6, max_dofs=2500))
 
     p = np.asarray(d.mesh.points)
@@ -64,7 +64,7 @@ def test_hessian_metric_still_refuses_complex_input():
     """Called directly it must raise, not diagonalise a complex-symmetric Hessian with `eigh`."""
     from jno.utils.solver.fem_adapt import hessian_metric
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     n = len(d.mesh.points)
     u = np.ones(n) * (1.0 + 1.0j)
     with pytest.raises((NotImplementedError, ValueError), match="complex"):
@@ -75,7 +75,7 @@ def test_the_real_path_is_unchanged():
     """A real field must take exactly the path it did before."""
     from jno.utils.solver.fem_adapt import hessian_metric
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
     p = np.asarray(d.mesh.points)
     u = np.tanh((p[:, 0] + p[:, 1] - 1.0) / 0.1)
     M = hessian_metric(d, u, target_complexity=200.0, hmin=0.01, hmax=1.0)

--- a/tests/test_fem_adapt_constraint.py
+++ b/tests/test_fem_adapt_constraint.py
@@ -34,7 +34,7 @@ def _aspect(dom):
 
 
 def _poisson(skew=0.0, size=0.35):
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=size).domain()
     if skew:
         p = np.asarray(d.mesh.points)
         p[:, 1] = p[:, 1] * (1.0 - skew * p[:, 0] / 2.0 * p[:, 1])  # stretch the elements

--- a/tests/test_fem_adapt_criterion.py
+++ b/tests/test_fem_adapt_criterion.py
@@ -52,7 +52,7 @@ def _x64():
 
 def _ridge_problem(cell="simplex", size=0.09):
     """-Delta u = a thin diagonal ridge source. Returns the pieces a criterion is written from."""
-    s = jno.Shape.rect(0, 0, 1, 1, size=size)
+    s = jno.shape.rect(0, 0, 1, 1, size=size)
     d = (s.quad() if cell == "tensor" else s).domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
@@ -79,7 +79,7 @@ def _size_on_and_off_ridge(dom, halfwidth=0.10):
 def test_a_coordinate_criterion_refines_where_it_peaks(cell):
     """The headline. A criterion peaked on the ridge must put the small cells there — and the ridge is
     NOT where the ZZ estimator would refine, since the solution of this problem is smooth."""
-    if cell == "simplex":  # the tensor path rebuilds its Shape plan; only the simplex one calls mmg
+    if cell == "simplex":  # the tensor path rebuilds its shape plan; only the simplex one calls mmg
         pytest.importorskip("mmgpy", reason="mmgpy required for adaptive remeshing")
     d, fem, _ui, _vi, xi, yi = _ridge_problem(cell)
     crit = jno.np.exp(-(((xi + yi - 1.0) / 0.06) ** 2))
@@ -196,7 +196,7 @@ def _vector_ridge_problem(size=0.09):
     Written the way a vector form is always written -- componentwise, `t[0].x` and `t[1]`, never a bare
     `t` -- because that is exactly what the assembler supports and what makes the criterion's own test
     binding the odd one out."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(2,))
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_adapt_enrich.py
+++ b/tests/test_fem_adapt_enrich.py
@@ -61,7 +61,7 @@ def _grad_crit(ui):
 def _poisson(space="cover", size=0.25, rhs=None):
     """``-Δu = rhs`` with ``u = 0`` on the whole boundary of the unit square."""
     grad, inner = jno.np.grad, jno.np.inner
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     tol = 1e-9
     d.tag("walls", lambda *c: np.logical_or.reduce([(x < tol) | (x > 1 - tol) for x in c]))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
@@ -159,7 +159,7 @@ def test_a_gradient_criterion_finds_the_reentrant_corner():
     from the vertex values cannot see the cover coefficients, so it was removed rather than left as a
     default that reports a number anti-correlated with the error."""
     grad, inner = jno.np.grad, jno.np.inner
-    s = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.14) - jno.Shape.rect(0.5, 0.5, 1.0, 1.0, size=0.14)
+    s = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.14) - jno.shape.rect(0.5, 0.5, 1.0, 1.0, size=0.14)
     d = s.domain()
     d.tag("walls", lambda x, y: np.ones_like(x, dtype=bool))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
@@ -306,7 +306,7 @@ def test_a_vector_field_enriches_and_pins_every_component():
     """Covers on a VECTOR field. The layout is `(node*blk + slot)*vec + comp`, so an unenriched node
     has `vec` pins per cover slot, not one -- pinning by node index alone would leave every component
     but the first free, and the null space would come back with it."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.16).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.16).domain()
     tol = 1e-9
     d.tag("walls", lambda *c: np.logical_or.reduce([(x < tol) | (x > 1 - tol) for x in c]))
     xi, yi, _ = d.variable("interior", split=True)
@@ -406,7 +406,7 @@ def test_a_field_without_covers_is_refused_by_name():
 def test_a_transient_problem_is_refused_by_name():
     """The state transfer that carries a solution across an adapt round is written for a change of
     MESH; a change of SPACE mid-march is not wired, and must say so rather than march on garbage."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.1, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.1, 5))
     u, phi = d.fem_symbols(space="cover")
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _tb = d.variable("boundary", split=True)
@@ -437,7 +437,7 @@ def _poisson_3d(space, size=0.26):
     The manufactured solution vanishes on all six faces, so the homogeneous condition is EXACT and a
     cover field's inhomogeneous-trace limitation stays out of the measurement."""
     grad, inner = jno.np.grad, jno.np.inner
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size).domain()
     tol = 1e-9
     d.tag("walls", lambda *c: np.logical_or.reduce([(x < tol) | (x > 1 - tol) for x in c]))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)

--- a/tests/test_fem_adapt_multifield.py
+++ b/tests/test_fem_adapt_multifield.py
@@ -30,7 +30,7 @@ def _x64():
 
 def _stokes(size=0.4):
     """Taylor-Hood channel: fields are [u (vector, P2), p (scalar, P1)] -- p is NOT field 0."""
-    d = jno.Shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
     u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
     p, q = d.fem_symbols(names=("p", "q"), order=1)
     x, y, _ = d.variable("interior", split=True)
@@ -82,7 +82,7 @@ def test_a_criterion_on_a_non_first_field_is_not_silently_zero():
 def test_cell_size_is_usable_in_a_criterion():
     """`dom.cell_size` is a geometry symbol resolved from the domain context, not a region. The
     criterion's region resolver counted its tag as a region and looked for one called 'cell_size'."""
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
     u, phi = d.fem_symbols()
     x, y, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -95,7 +95,7 @@ def test_cell_size_is_usable_in_a_criterion():
 
 def test_a_single_field_problem_still_refines_on_the_zz_estimator():
     """The vertex view is now taken lazily; the estimator path must be untouched by that."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     u, phi = d.fem_symbols()
     x, y, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_adapt_quad.py
+++ b/tests/test_fem_adapt_quad.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
 def _domain(cell, n, dim=2):
-    s = (jno.Shape.rect(0, 0, 1, 1) if dim == 2 else jno.Shape.box(0, 0, 0, 1, 1, 1)).structured(n=n)
+    s = (jno.shape.rect(0, 0, 1, 1) if dim == 2 else jno.shape.box(0, 0, 0, 1, 1, 1)).structured(n=n)
     return (s.quad() if cell == "tensor" else s).domain()
 
 
@@ -207,7 +207,7 @@ def test_a_structured_quad_plan_refuses_rather_than_silently_doing_nothing():
     """A `.structured()` lattice's resolution is its cell COUNTS, not a size field — so rebuilding it
     against a marked size field returns the very same mesh. That is a silent no-op: the loop runs,
     reports rounds, and refines nothing. Refuse it and say which knob actually controls resolution."""
-    fem = _quad_fem()  # Shape.rect(...).structured(n=6).quad()
+    fem = _quad_fem()  # shape.rect(...).structured(n=6).quad()
     with pytest.raises(NotImplementedError, match="cell COUNTS"):
         fem.solve(adapt=jno.solve.remesh(theta=0.6, max_iters=2))
 
@@ -229,7 +229,7 @@ L_SHAPE = [(0, 0), (1, 0), (1, 0.5), (0.5, 0.5), (0.5, 1), (0, 1)]
 
 
 def _l_shape(cell, size=0.12):
-    s = jno.Shape.polygon(L_SHAPE, size=size)
+    s = jno.shape.polygon(L_SHAPE, size=size)
     d = (s.quad() if cell == "tensor" else s).domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
@@ -258,7 +258,7 @@ def _ritz_energy(d, sol):
 
 @pytest.mark.slow
 def test_the_quad_loop_refines_and_stays_all_quad():
-    """The loop end to end. mmg cannot adapt a quad mesh, so the remesh stage rebuilds the `Shape`
+    """The loop end to end. mmg cannot adapt a quad mesh, so the remesh stage rebuilds the `shape`
     plan at the marked size field — which means the result has to be checked for purity, not assumed:
     a leftover triangle would be a mixed mesh the assembler refuses less clearly."""
     d, fem = _l_shape("tensor")

--- a/tests/test_fem_adapt_refine.py
+++ b/tests/test_fem_adapt_refine.py
@@ -33,7 +33,7 @@ def x64():
 
 def _peaked_2d(n=8):
     """-Lap u = a narrow Gaussian at the centre: a local feature, so refinement should be local."""
-    d = jno.Shape.rect(0, 0, 1, 1).quad().structured(n=n).domain(compute_mesh_connectivity=False)
+    d = jno.shape.rect(0, 0, 1, 1).quad().structured(n=n).domain(compute_mesh_connectivity=False)
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -43,7 +43,7 @@ def _peaked_2d(n=8):
 
 
 def _peaked_3d(n=4):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=n).quad().domain(compute_mesh_connectivity=False)
+    d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=n).quad().domain(compute_mesh_connectivity=False)
     u, v = d.fem_symbols()
     xi, yi, zi = d.variable("interior", split=True)[:3]
     xb, yb, zb = d.variable("boundary", split=True)[:3]
@@ -158,7 +158,7 @@ def test_the_hex_loop_refines_locally(x64):
 def test_a_simplex_mesh_is_refused_by_name(x64):
     """Splitting a simplex is a different algorithm (and mmg already adapts them locally), so this says
     so rather than silently doing nothing."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(compute_mesh_connectivity=False)
+    d = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(compute_mesh_connectivity=False)
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_adapt_space_guard.py
+++ b/tests/test_fem_adapt_space_guard.py
@@ -23,7 +23,7 @@ from jno.utils.solver.fem_adapt import _vertex_view  # noqa: E402
 
 
 def _hermite_fem():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     xi, yi, _ = d.variable("interior", split=True)
     u, phi = d.fem_symbols(space="Hermite")
     ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)
@@ -40,7 +40,7 @@ def test_a_hermite_field_is_refused_not_reinterpreted():
 
 def test_a_lagrange_field_still_works():
     """P1 and higher-order Lagrange are the case the branch was written for and must be untouched."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     xi, yi, _ = d.variable("interior", split=True)
     u, phi = d.fem_symbols()
     ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)

--- a/tests/test_fem_adapt_transient.py
+++ b/tests/test_fem_adapt_transient.py
@@ -40,7 +40,7 @@ def _x64():
 
 def _heat_fem(mesh_size=0.1, kappa=0.1, t_end=0.3, nt=21, order=1):
     """Scalar heat equation u_t = κΔu on the unit square, mode-(1,1) IC, homogeneous Dirichlet."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=mesh_size).domain(time=(0.0, t_end, nt))
+    d = jno.shape.rect(0, 0, 1, 1, size=mesh_size).domain(time=(0.0, t_end, nt))
     u, phi = d.fem_symbols(order=order)
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -63,7 +63,7 @@ def test_transient_adaptive_matches_analytic_heat_decay():
     assert abs(times[0]) < 1e-12 and abs(times[-1] - 0.3) < 1e-9  # spans [0, t_end], no drift
     assert fem.adapt_history, "expected at least one remesh during the march"
 
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.08).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.08).domain()
     ys = np.asarray(traj.resample(ref))  # (n_save, n_ref) uniform array
     xr = np.asarray(ref.mesh.points)[:, :2]
     base = np.sin(PI * xr[:, 0]) * np.sin(PI * xr[:, 1])
@@ -93,7 +93,7 @@ def test_transient_adaptive_holds_a_constant_budget():
 def test_resample_shape_and_final():
     fem, _ = _heat_fem(mesh_size=0.14, t_end=0.15, nt=13)
     traj = fem.solve(adapt=jno.solve.remesh(anisotropic=True, every=4))
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
     ys = np.asarray(traj.resample(ref))
     assert ys.shape == (len(traj), len(np.asarray(ref.mesh.points)))
     state_final, (pts, cells) = traj.final()
@@ -110,7 +110,7 @@ def test_solve_fn_with_transient_adapt_raises():
 # ── basis-aware transfer: the ordering-invariant locks (no remesh needed) ─────
 def _p2_scalar_layout():
     """A P2 scalar transient fem + its per-field layout and P1 base mesh."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.34).domain(time=(0.0, 0.1, 3))
+    d = jno.shape.rect(0, 0, 1, 1, size=0.34).domain(time=(0.0, 0.1, 3))
     u, phi = d.fem_symbols(order=2)
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -162,7 +162,7 @@ def test_transient_adaptive_p2_scalar_matches_reference():
     traj = fem.solve(adapt=jno.solve.remesh(anisotropic=True, every=4, max_dofs=8000))
     assert isinstance(traj, AdaptiveTrajectory)
     assert fem.adapt_history, "expected at least one remesh"
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.08).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.08).domain()
     ys = np.asarray(traj.resample(ref))  # single scalar field -> (n_save, n_ref)
     xr = np.asarray(ref.mesh.points)[:, :2]
     base = np.sin(PI * xr[:, 0]) * np.sin(PI * xr[:, 1])
@@ -185,7 +185,7 @@ def test_transient_adaptive_two_coupled_scalar_fields():
     decay rates would be wrong — so matching each field's analytic decay proves the multifield state is
     split, transferred, and re-assembled correctly. Also exercises the (n_save, n_fields, n_ref) resample."""
     ku, kw = 0.12, 0.04
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain(time=(0.0, 0.3, 21))
+    d = jno.shape.rect(0, 0, 1, 1, size=0.1).domain(time=(0.0, 0.3, 21))
     u, v = d.fem_symbols(names=("u", "v"))
     w, q = d.fem_symbols(names=("w", "q"))
     xi, yi, ti = d.variable("interior", split=True)
@@ -207,7 +207,7 @@ def test_transient_adaptive_two_coupled_scalar_fields():
     traj = fem.solve(adapt=jno.solve.remesh(anisotropic=True, every=5, max_dofs=6000, metric_field=0))
     assert isinstance(traj, AdaptiveTrajectory)
 
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.08).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.08).domain()
     ys = np.asarray(traj.resample(ref))  # (n_save, n_fields=2, n_ref)
     assert ys.ndim == 3 and ys.shape[1] == 2
     xr = np.asarray(ref.mesh.points)[:, :2]
@@ -226,7 +226,7 @@ def test_transient_adaptive_mixed_order_fields():
     bookkeeping). Each must reproduce its analytic decay through the remeshes, proving the mixed-space
     offsets/transfer carry heterogeneous blocks correctly (not a uniform-n_verts assumption)."""
     ku, kw = 0.12, 0.05
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.12).domain(time=(0.0, 0.3, 21))
+    d = jno.shape.rect(0, 0, 1, 1, size=0.12).domain(time=(0.0, 0.3, 21))
     u, v = d.fem_symbols(names=("u", "v"), order=2)  # P2 field
     w, q = d.fem_symbols(names=("w", "q"), order=1)  # P1 field
     xi, yi, ti = d.variable("interior", split=True)
@@ -250,7 +250,7 @@ def test_transient_adaptive_mixed_order_fields():
     traj = fem.solve(adapt=jno.solve.remesh(anisotropic=True, every=5, max_dofs=9000, metric_field=0))
     assert isinstance(traj, AdaptiveTrajectory)
 
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.08).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.08).domain()
     xr = np.asarray(ref.mesh.points)[:, :2]
     base = np.sin(PI * xr[:, 0]) * np.sin(PI * xr[:, 1])
     ys = np.asarray(traj.resample(ref))  # both scalar -> (n_save, 2, n_ref)
@@ -265,7 +265,7 @@ def test_transient_adaptive_mixed_order_fields():
 
 def _nonlinear_reaction_fem(size, r=2.0, t_end=0.2, nt=21):
     """Semilinear heat u_t = Δu + r·u(1-u) — a NONLINEAR transient block (mass + residual)."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain(time=(0.0, t_end, nt))
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain(time=(0.0, t_end, nt))
     u, phi = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -290,7 +290,7 @@ def test_transient_adaptive_nonlinear_matches_manufactured():
         us = ustar(x, y, t)
         return (2 * PI**2 - lam) * us - r * us * (1.0 - us)
 
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain(time=(0.0, 0.3, 21))
+    d = jno.shape.rect(0, 0, 1, 1, size=0.1).domain(time=(0.0, 0.3, 21))
     u, phi = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -303,7 +303,7 @@ def test_transient_adaptive_nonlinear_matches_manufactured():
     traj = fem.solve(adapt=jno.solve.remesh(anisotropic=True, every=5, max_dofs=9000))
     assert isinstance(traj, AdaptiveTrajectory) and fem.adapt_history
 
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.08).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.08).domain()
     ys = np.asarray(traj.resample(ref))
     xr = np.asarray(ref.mesh.points)[:, :2]
     base = np.sin(PI * xr[:, 0]) * np.sin(PI * xr[:, 1])
@@ -323,7 +323,7 @@ def test_transient_adaptive_nonlinear_slot_composes():
         nonlinear=jno.solve.newton(max_steps=40, rtol=1e-9, atol=1e-11),
     )
     assert isinstance(traj, AdaptiveTrajectory) and fem.adapt_history
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
     ys = np.asarray(traj.resample(ref))
     assert np.all(np.isfinite(ys)) and float(np.abs(ys).max()) > 1e-3  # a real, finite solution
 
@@ -344,7 +344,7 @@ def test_transient_adaptive_vector_p2_plus_scalar_p1():
     (the transient Taylor-Hood saddle assembles too; here we isolate the transfer, which is what adapt
     touches)."""
     kv, ks = 0.1, 0.04
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.12).domain(time=(0.0, 0.3, 21))
+    d = jno.shape.rect(0, 0, 1, 1, size=0.12).domain(time=(0.0, 0.3, 21))
     u, w = d.fem_symbols(value_shape=(2,), names=("u", "w"), order=2)  # vector P2 (velocity-shaped)
     s, r = d.fem_symbols(names=("s", "r"), order=1)  # scalar P1 (pressure-shaped)
     xi, yi, ti = d.variable("interior", split=True)
@@ -372,7 +372,7 @@ def test_transient_adaptive_vector_p2_plus_scalar_p1():
     traj = fem.solve(adapt=jno.solve.remesh(anisotropic=True, every=5, max_dofs=12000, metric_field=0))
     assert isinstance(traj, AdaptiveTrajectory)
 
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.08).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.08).domain()
     xr = np.asarray(ref.mesh.points)[:, :2]
     b0 = np.sin(PI * xr[:, 0]) * np.sin(PI * xr[:, 1])
     b1 = np.sin(2 * PI * xr[:, 0]) * np.sin(PI * xr[:, 1])
@@ -401,7 +401,7 @@ def test_transient_adaptive_pressure_pin_survives_remesh():
     P1 pressure, advection -> nonlinear -> the fast per-step Newton path), no-slip, ``p.pin()``, adapt on
     velocity: it must re-assemble across remeshes and develop a finite flow (the gauge holding)."""
     nu = 0.1
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.22).domain(time=(0.0, 0.06, 7))
+    d = jno.shape.rect(0, 0, 1, 1, size=0.22).domain(time=(0.0, 0.06, 7))
     u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)  # P2 velocity
     p, q = d.fem_symbols(names=("p", "q"), order=1)  # P1 pressure
     xi, yi, ti = d.variable("interior", split=True)
@@ -425,7 +425,7 @@ def test_transient_adaptive_pressure_pin_survives_remesh():
     assert len(fem.offsets) == 3 and not fem.is_linear  # P2 vel + P1 pressure saddle, nonlinear
     traj = fem.solve(adapt=jno.solve.remesh(anisotropic=True, every=2, max_dofs=4000, metric_field=0))
     assert isinstance(traj, AdaptiveTrajectory) and fem.adapt_history  # remeshed >= once -> pin re-derived each time
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
     yv = np.asarray(traj.resample(ref, field=0))
     assert np.all(np.isfinite(yv)) and float(np.abs(yv[-1]).max()) > 1e-3  # a finite flow developed; the gauge held
 
@@ -445,7 +445,7 @@ def test_builtin_edge_regions_survive_a_remesh():
     """
 
     def build(builtin_left):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain(time=(0.0, 0.2, 6))
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain(time=(0.0, 0.2, 6))
         d.tag("right_edge", lambda x, y: x > 1.0 - 1e-9)
         if builtin_left:
             left = "left"
@@ -467,7 +467,7 @@ def test_builtin_edge_regions_survive_a_remesh():
             ]
         ), d
 
-    ref = jno.Shape.rect(0, 0, 1, 1, size=0.12).domain()
+    ref = jno.shape.rect(0, 0, 1, 1, size=0.12).domain()
     out = {}
     for builtin in (True, False):
         fem, _ = build(builtin)

--- a/tests/test_fem_adaptive_load_path.py
+++ b/tests/test_fem_adaptive_load_path.py
@@ -66,7 +66,7 @@ def _burst_march(nstep, *, power=8.0, peak=14.0, size=0.25):
     An inert state field carries no physics; it is there because ``.i(k)`` is what triggers the march.
     """
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(tau=(0.0, 1.0, nstep))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(tau=(0.0, 1.0, nstep))
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X, tau = [co[0], co[1]], co[-1]
@@ -182,7 +182,7 @@ def test_replay_over_the_frozen_schedule_reproduces_the_pilot():
 # --------------------------------------------------------------------------------------------------
 def _parametric_burst(nstep=5, size=0.3):
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(tau=(0.0, 1.0, nstep))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(tau=(0.0, 1.0, nstep))
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X, tau = [co[0], co[1]], co[-1]
@@ -247,7 +247,7 @@ def test_adaptive_without_a_limit_fails_loud():
 
 def test_limit_in_the_time_slot_fails_loud():
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(time=(0.0, 0.1, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(time=(0.0, 0.1, 5))
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
     ci = d.variable("initial", split=True)
@@ -260,7 +260,7 @@ def test_limit_in_the_time_slot_fails_loud():
 
 def test_tau_slot_without_a_march_fails_loud():
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -326,7 +326,7 @@ def test_the_pilot_scores_the_min_map_on_a_bounded_march():
     cannot finish at all unless it scores the right function.
     """
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(tau=(0.0, 1.0, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(tau=(0.0, 1.0, 5))
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = d.variable("interior", split=True), d.variable("left", split=True)
     X, tau = [co[0], co[1]], co[-1]

--- a/tests/test_fem_additive_terms.py
+++ b/tests/test_fem_additive_terms.py
@@ -29,7 +29,7 @@ def ctx():
     """A 2-D vector Poisson -- the smallest form with components to sum over. x64: FEM is float64."""
     prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=1)
     xi, yi = d.variable("interior", split=True)[:2]
     xb, yb = d.variable("boundary", split=True)[:2]

--- a/tests/test_fem_ams_gradient.py
+++ b/tests/test_fem_ams_gradient.py
@@ -34,7 +34,7 @@ def _assemble(mesh_size, beta):
     """Assembled dense curl-curl (+ β·mass) N1E operator and the stashed edge topology. Meshes are kept
     coarse enough that the assembly fits the (small, 8 GB) dev GPU — this is a numpy/scipy structure
     test, so a refinement *contrast* is all it needs, not a fine mesh."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]

--- a/tests/test_fem_arclength.py
+++ b/tests/test_fem_arclength.py
@@ -53,7 +53,7 @@ def _bratu(nsteps, *, hi=12.0, size=0.08):
     grid); it is deliberately multiplied by zero so it cannot influence the answer — the same device
     `tests/test_fem_adaptive_load_path.py` uses.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.1, size=size).domain(tau=(0.0, hi, nsteps))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.1, size=size).domain(tau=(0.0, hi, nsteps))
     u, phi = d.fem_symbols()
     s, _sp = d.fem_symbols()
     co = d.variable("interior", split=True)
@@ -74,7 +74,7 @@ def _bratu(nsteps, *, hi=12.0, size=0.08):
 
 def _linear_march(nsteps, *, hi=1.0, size=0.25):
     """A LINEAR load path: ``-Delta u = tau`` with the same inert-state march trigger."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(tau=(0.0, hi, nsteps))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(tau=(0.0, hi, nsteps))
     u, phi = d.fem_symbols()
     s, _sp = d.fem_symbols()
     co = d.variable("interior", split=True)

--- a/tests/test_fem_assembly_on_host.py
+++ b/tests/test_fem_assembly_on_host.py
@@ -43,7 +43,7 @@ def _x64():
 
 
 def _poisson(size=0.14):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(names=("u", "v"))
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_fem_block_step.py
+++ b/tests/test_fem_block_step.py
@@ -26,7 +26,7 @@ def _x64():
 def _heat(nonlinear=False):
     """Transient heat on the unit square, IC sin(pi x) sin(pi y), homogeneous Dirichlet."""
     dom = (
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0)
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0)
         .structured(n=12)
         .domain(
             time=(0.0, 0.02, 11),
@@ -98,7 +98,7 @@ def test_block_step_periodic_reduced_space(_x64):
 
     n = 12
     dom = (
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0)
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0)
         .structured(n=n)
         .domain(
             time=(0.0, 0.02, 11),

--- a/tests/test_fem_bounds.py
+++ b/tests/test_fem_bounds.py
@@ -85,7 +85,7 @@ def _obstacle_fem(*, bounded, ny=0.25, nx=0.05):
     Returns ``(fem, domain, equilibrium_term)`` — the term is handed back so a readout can assemble
     the very same expression the solve used (a fresh ``fem_symbols()`` would be a different field)."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, ny, size=nx).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, ny, size=nx).domain()
     d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
     co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
     X = [co[0], co[1]]
@@ -176,7 +176,7 @@ def test_kkt_complementarity_holds_at_the_solution():
 # --------------------------------------------------------------------------------------------------
 def test_a_bound_on_one_block_of_a_coupled_system():
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
     d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
     co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
     X = [co[0], co[1]]
@@ -221,7 +221,7 @@ def test_a_bound_on_one_block_of_a_coupled_system():
 # --------------------------------------------------------------------------------------------------
 def _ratchet_march(*, bounded, nstep=9):
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.08).domain(tau=(0.0, 1.0, nstep))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.08).domain(tau=(0.0, 1.0, nstep))
     d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
     co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
     X, tau = [co[0], co[1]], co[-1]
@@ -257,7 +257,7 @@ def test_bound_constrained_irreversibility_on_a_march():
 def test_a_history_bound_needs_a_load_path():
     """`u.i(-1)` means *the previous load step*, so on a plain domain it refers to nothing."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()  # NO tau grid
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()  # NO tau grid
     d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
     co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
     X = [co[0], co[1]]
@@ -286,7 +286,7 @@ def test_a_slack_bound_changes_nothing():
     """A box far outside the solution range must reproduce the unconstrained answer exactly — the
     min-map has to be the identity wherever no constraint is active."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
     d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
     co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
     X = [co[0], co[1]]
@@ -301,7 +301,7 @@ def test_a_fully_active_bound_pins_the_whole_field():
     """The degenerate extreme: a lower bound above the unconstrained solution everywhere. Every DOF is
     active, so the answer is the bound itself (the Dirichlet ends excepted)."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
     d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
     co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
     X = [co[0], co[1]]
@@ -318,7 +318,7 @@ def test_a_coordinate_expression_bound_matches_its_constant_equivalent():
     grad, inner = _aliases()
 
     def run(spatial):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
+        d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
         d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
         co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
         X = [co[0], co[1]]
@@ -338,7 +338,7 @@ def test_a_tilted_obstacle_shifts_the_contact_set():
     on the right (``-1.5C``), so it obstructs the membrane more there and the contact set shifts left.
     Checks feasibility pointwise against the *expression's own* values, not a single number."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.05).domain()
     d.tag("ends", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9))
     co, ce = d.variable("interior", split=True), d.variable("ends", split=True)
     X = [co[0], co[1]]
@@ -359,7 +359,7 @@ def test_a_tilted_obstacle_shifts_the_contact_set():
 
 
 def test_a_bound_may_not_depend_on_the_live_unknown():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
     u, _phi = d.fem_symbols()
     v, _chi = d.fem_symbols()
     with pytest.raises(ValueError, match="complementarity|live unknown"):
@@ -369,7 +369,7 @@ def test_a_bound_may_not_depend_on_the_live_unknown():
 
 
 def test_bounds_on_something_that_is_not_a_field_fails_loud():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
     co = d.variable("interior", split=True)
     u, _phi = d.fem_symbols()
     with pytest.raises(TypeError, match="fem_symbols|field"):
@@ -380,7 +380,7 @@ def test_bounds_on_something_that_is_not_a_field_fails_loud():
 
 def test_contradictory_box_fails_loud():
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
     co = d.variable("interior", split=True)
     X = [co[0], co[1]]
     u, phi = d.fem_symbols()
@@ -389,7 +389,7 @@ def test_contradictory_box_fails_loud():
 
 
 def test_bounds_needs_at_least_one_side():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 0.25, size=0.1).domain()
     u, _phi = d.fem_symbols()
     with pytest.raises(ValueError, match="lo|hi|at least"):
         u.bounds(None, None)
@@ -407,7 +407,7 @@ def test_a_coordinate_bound_on_a_vector_field_binds_per_node():
     sym, trace, inner = jno.np.symgrad, jno.np.trace, jno.np.inner
     lam, mu = 1.0, 1.0
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
     co = d.variable("interior", split=True)
     X = [co[0], co[1]]
     u, phi = d.fem_symbols(value_shape=(2,))
@@ -439,7 +439,7 @@ def test_a_coordinate_bound_must_be_one_value_per_node():
     """A bound expression that does not reduce to one value per DOF node is refused by name, rather
     than broadcast into a shape that happens to fit."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     co = d.variable("interior", split=True)
     X = [co[0], co[1]]
     u, phi = d.fem_symbols(value_shape=(2,))

--- a/tests/test_fem_by_tag.py
+++ b/tests/test_fem_by_tag.py
@@ -25,7 +25,7 @@ import jno
 
 def _square(size=0.34):
     """Unit square with `left` / `right` boundary tags and the symbols a Robin term needs."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     d.tag("left", lambda x, y: x < 1e-9)
     d.tag("right", lambda x, y: x > 1 - 1e-9)
     u, v = d.fem_symbols()
@@ -108,7 +108,7 @@ def test_the_mask_selects_exactly_the_dirichlet_facets():
 def test_three_tags_each_keep_their_own_value():
     """Extremes: more than two tags, including a zero one -- a zero coefficient must not be confused
     with an absent tag."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.34).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.34).domain()
     d.tag("l", lambda x, y: x < 1e-9)
     d.tag("r", lambda x, y: x > 1 - 1e-9)
     d.tag("b", lambda x, y: y < 1e-9)
@@ -210,8 +210,8 @@ def test_attach_rejects_an_unknown_target():
 def test_a_property_declared_on_both_a_region_and_a_tag_raises_on_read():
     """One name, two meanings: integrated over cells in one place and over facets in another."""
     d = (
-        jno.Shape.rect(0, 0, 1, 1, size=0.5).name("a").attach(rho=1.0)
-        + jno.Shape.rect(0, 0, 2, 1, size=0.5).name("b").attach(rho=2.0)
+        jno.shape.rect(0, 0, 1, 1, size=0.5).name("a").attach(rho=1.0)
+        + jno.shape.rect(0, 0, 2, 1, size=0.5).name("b").attach(rho=2.0)
     ).domain()
     d.tag("edge", lambda x, y: y < 1e-9)
     d.attach("edge", rho=5.0)
@@ -272,7 +272,7 @@ def test_by_tag_on_a_non_nodal_space_raises():
     Rejected explicitly rather than left to chance."""
     pytest.importorskip("pygmsh", reason="pygmsh required for 3D cube meshing")
     inner = jno.np.inner
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     d.tag("x0", lambda x, y, z: x < 1e-9)
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)

--- a/tests/test_fem_cell_metric.py
+++ b/tests/test_fem_cell_metric.py
@@ -31,7 +31,7 @@ def _x64():
 
 
 def _rect(n, lx=1.0, ly=1.0):
-    return jno.Shape.rect(0.0, 0.0, lx, ly).structured(n=n).domain(compute_mesh_connectivity=False)
+    return jno.shape.rect(0.0, 0.0, lx, ly).structured(n=n).domain(compute_mesh_connectivity=False)
 
 
 def _cell_metrics(dom):
@@ -135,7 +135,7 @@ def test_a_path_that_packs_no_jacobian_refuses_by_name(_x64, build):
 def test_a_boundary_term_is_refused_by_the_region_resolver(_x64):
     """A geometry symbol names no region, so pairing it with a boundary test function is refused there --
     the same way `dom.cell_size` already is. Pinned so the two symbols cannot drift apart."""
-    dom = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    dom = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     u, v = dom.fem_symbols()
     xi, yi, _ = dom.variable("interior", split=True)
     xb, yb, _, nx, _ny = dom.variable("boundary", normals=True, split=True)
@@ -156,7 +156,7 @@ def test_cell_metric_carries_a_mesh_gradient(_x64):
     """
     import jax.numpy as jnp
 
-    dom = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    dom = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     ym = dom.variable("mov", where=lambda x, y: (x > 0.15) & (x < 0.85) & (y > 0.15) & (y < 0.85), split=True)[1]
     ym.trainable(name="Y0")
     ids = np.asarray(dom._trainable_coords[0]["ids"], dtype=int)

--- a/tests/test_fem_cell_size.py
+++ b/tests/test_fem_cell_size.py
@@ -25,7 +25,7 @@ def _x64():
 
 
 def _square(n):
-    return jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain(compute_mesh_connectivity=False)
+    return jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain(compute_mesh_connectivity=False)
 
 
 def test_cell_size_resolves_to_mesh_size(_x64):

--- a/tests/test_fem_cellwise.py
+++ b/tests/test_fem_cellwise.py
@@ -87,7 +87,7 @@ def _cantilever_tip(nu, nx, ny, *, bbar, domain=None):
 def test_projecting_a_constant_is_exact():
     """A projection is exact on its own range: P0 of a constant is that constant, so a form built with
     `cellwise(1)` must solve identically to one built with `1`."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -186,7 +186,7 @@ def test_a_cellwise_inside_a_diff_target_raises_and_names_the_ordering():
     """`diff` is pointwise — it evaluates as `grad(sum(...))`, which is the per-point derivative only
     because the quadrature axis is a batch axis. A `cellwise` in the differentiated expression couples
     the points, so the result would silently be the cell-summed derivative."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     u, _phi = d.fem_symbols(value_shape=(2,))
     xi, yi, _ = d.variable("interior", split=True)
     eu = sym(u.bind(x=xi, y=yi), [xi, yi])
@@ -198,7 +198,7 @@ def test_fbar_ordering_with_cellwise_inside_wrt_is_accepted():
     """The counterpart of the refusal above: F-bar puts the projection inside `wrt`, where substitution
     replaces it with the value slot, so it never reaches the differentiated expression. That ordering
     must be ACCEPTED — otherwise the guard would forbid the very form it recommends."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     u, _phi = d.fem_symbols(value_shape=(2,))
     xi, yi, _ = d.variable("interior", split=True)
     eu = sym(u.bind(x=xi, y=yi), [xi, yi])
@@ -208,7 +208,7 @@ def test_fbar_ordering_with_cellwise_inside_wrt_is_accepted():
 
 def test_cellwise_of_an_integral_raises():
     """An already-reduced target has no quadrature axis left to average over."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     u, _phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     with pytest.raises(ValueError, match="Integral"):
@@ -218,7 +218,7 @@ def test_cellwise_of_an_integral_raises():
 def test_cellwise_on_a_boundary_term_raises_rather_than_averaging_the_wrong_points():
     """A surface term's kernel carries facet quadrature, not the cell's, so there is no per-cell mean to
     take. It must raise rather than average over whatever points happen to be in scope."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xt, yt, _ = d.variable("top", split=True)
@@ -241,7 +241,7 @@ def test_a_cellwise_term_is_not_reported_as_spatially_local():
     quadrature point depends on the whole cell, so peeling it would be wrong."""
     from jno.utils.solver.term_kind import classify_term
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     ui, vi = u.bind(x=xi, y=yi), phi.bind(x=xi, y=yi)

--- a/tests/test_fem_complex_field.py
+++ b/tests/test_fem_complex_field.py
@@ -130,7 +130,7 @@ def test_a_parameter_composes_with_a_complex_pair():
     (jnp.asarray(ComplexPair)), so Python never consulted the pair's reflected op. It now
     distributes over (re, im). The parametric complex-pair ASSEMBLY remains its own explicit
     NotImplementedError one layer down -- this pins the algebra, which every spelling needs first."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     u, _v = d.fem_symbols(complex=True)
     xi, yi = d.variable("interior", split=True)[:2]
     ui = u.bind(x=xi, y=yi)
@@ -150,7 +150,7 @@ def test_plain_symbol_2d_parametric_complex_solves():
     import jno.jnp_ops as J
     from jno.utils.solver.linear import sparse_lu_solve
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     u, v = d.fem_symbols()
     xi, yi = d.variable("interior", split=True)[:2]
     xb, yb = d.variable("boundary", split=True)[:2]

--- a/tests/test_fem_complex_fusion.py
+++ b/tests/test_fem_complex_fusion.py
@@ -43,7 +43,7 @@ def complex_fem():
     prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
     try:
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
         u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
         ci = d.variable("interior", split=True)
         x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_fem_complex_single_assembly.py
+++ b/tests/test_fem_complex_single_assembly.py
@@ -73,7 +73,7 @@ def _coo(A):
 
 
 def test_complex_volume_form_assembles_once(monkeypatch):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     calls = _count_assemblies(monkeypatch)
     fem = jno.fem(_terms(d))
     assert len(calls) == 1, f"the steady complex volume form ran {len(calls)} assemblies; one pass suffices"
@@ -85,12 +85,12 @@ def test_single_pass_matches_the_two_leg_reference(monkeypatch):
     The reference comes from the split itself, via the module escape hatch."""
     import jno._fem as F
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     fem = jno.fem(_terms(d))
     (Ar, br), (Ai, bi) = fem._complex_legs
 
     monkeypatch.setattr(F, "_COMPLEX_SINGLE_ASSEMBLY", False)
-    d2 = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d2 = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     ref = jno.fem(_terms(d2))
     (Rr, rr), (Ri, ri) = ref._complex_legs
 
@@ -115,7 +115,7 @@ def test_single_pass_matches_the_two_leg_reference(monkeypatch):
 def test_the_solve_is_right(monkeypatch):
     import scipy.sparse.linalg as spla
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     fem = jno.fem(_terms(d))
     (Ar, br), (Ai, bi) = fem._complex_legs
     ref = spla.spsolve((_coo(Ar) + 1j * _coo(Ai)).tocsc(), np.asarray(br) + 1j * np.asarray(bi))
@@ -125,7 +125,7 @@ def test_the_solve_is_right(monkeypatch):
 
 def test_parametric_complex_keeps_the_leg_split(monkeypatch):
     """A runtime parameter rides the parametric legs (tested elsewhere); the gate must not claim it."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     calls = _count_assemblies(monkeypatch)
     eps = jno.np.parameter((1,), key=jax.random.PRNGKey(0), name="eps_r")
     fem = jno.fem(_terms(d, extra_coeff=(1e-3 + 0.5j) * (1.0 + eps)))
@@ -140,7 +140,7 @@ def test_a_half_cast_operator_is_refused(monkeypatch):
 
     from jno.utils.solver import fem_nonnodal
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     orig = fem_nonnodal.assemble_fem_nonnodal
 
     def _cast_away(*a, **k):

--- a/tests/test_fem_contact_gap.py
+++ b/tests/test_fem_contact_gap.py
@@ -32,9 +32,9 @@ def _x64():
 def _two_body_domain(size=0.4):
     """Two independently meshed blocks, so both sides of the interface are tagged separately."""
     return (
-        jno.Shape.regions(
-            lower=jno.Shape.box(0, 0, 0, 1, 1, 1),
-            upper=jno.Shape.box(0, 0, 1, 1, 1, 2.5),
+        jno.shape.regions(
+            lower=jno.shape.box(0, 0, 0, 1, 1, 1),
+            upper=jno.shape.box(0, 0, 1, 1, 1, 2.5),
             conforming=False,
         )
         .sized(size)
@@ -261,9 +261,9 @@ LAM_, MU_ = E_ * NU_ / (1 - NU_**2), E_ / (2 * (1 + NU_))
 
 def _stacked_blocks(cap_size=0.09, base_size=0.22):
     """Two independently meshed unit squares stacked at y = 1, so the interface is non-matching."""
-    return jno.Shape.regions(
-        base=jno.Shape.rect(0, 0, 1, 1, size=base_size),
-        cap=jno.Shape.rect(0, 1, 1, 2, size=cap_size),
+    return jno.shape.regions(
+        base=jno.shape.rect(0, 0, 1, 1, size=base_size),
+        cap=jno.shape.rect(0, 1, 1, 2, size=cap_size),
         conforming=False,
     ).domain()
 
@@ -633,9 +633,9 @@ def test_augmented_lagrangian_beats_the_penalty_error_at_the_same_c():
     SURFACE state on the secondary face: the machinery is `evolves` + the tau march, no new API."""
     inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
     c, nsteps = 1e3, 8
-    d = jno.Shape.regions(
-        base=jno.Shape.rect(0, 0, 1, 1, size=0.22),
-        cap=jno.Shape.rect(0, 1, 1, 2, size=0.09),
+    d = jno.shape.regions(
+        base=jno.shape.rect(0, 0, 1, 1, size=0.22),
+        cap=jno.shape.rect(0, 1, 1, 2, size=0.09),
         conforming=False,
     ).domain(tau=(0.0, 1.0, nsteps))
     sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)

--- a/tests/test_fem_contact_gear_ratio.py
+++ b/tests/test_fem_contact_gear_ratio.py
@@ -159,12 +159,12 @@ def _solve(theta, drive=9.0e-3, h_rim=0.022, h_hub=0.060, rounds=6, capture=0.06
     sym, tr, inner = n.symgrad, n.trace, n.inner
 
     a, b = _pair(theta)
-    hub_a, hub_b = jno.Shape.disk(0, 0, RHA), jno.Shape.disk(CENTRE, 0, RHB)
-    d = jno.Shape.regions(
+    hub_a, hub_b = jno.shape.disk(0, 0, RHA), jno.shape.disk(CENTRE, 0, RHB)
+    d = jno.shape.regions(
         hubA=hub_a.sized(h_hub),
-        rimA=(jno.Shape.polygon(a) - hub_a).sized(h_rim),
+        rimA=(jno.shape.polygon(a) - hub_a).sized(h_rim),
         hubB=hub_b.sized(h_hub),
-        rimB=(jno.Shape.polygon(b) - hub_b).sized(h_rim),
+        rimB=(jno.shape.polygon(b) - hub_b).sized(h_rim),
         conforming=True,
     ).domain()
     _ = d.built_mesh

--- a/tests/test_fem_contact_search.py
+++ b/tests/test_fem_contact_search.py
@@ -36,8 +36,8 @@ def _x64():
 
 def _stacked_bars(size=0.4, c=1.0e3):
     """Two boxes meeting at z = 1, the upper one loaded into the lower through a penalised gap."""
-    d = jno.Shape.regions(
-        lower=jno.Shape.box(0, 0, 0, 1, 1, 1), upper=jno.Shape.box(0, 0, 1, 1, 1, 2.5), conforming=False
+    d = jno.shape.regions(
+        lower=jno.shape.box(0, 0, 0, 1, 1, 1), upper=jno.shape.box(0, 0, 1, 1, 1, 2.5), conforming=False
     ).domain(size=size)
     _ = d.built_mesh
     sec, main = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
@@ -124,7 +124,7 @@ def test_rounds_must_be_at_least_one():
 # What it refuses, and why — each by name
 # ----------------------------------------------------------------------------------------------
 def test_contact_refuses_a_form_that_declares_no_gap():
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1).domain(size=0.5)
+    d = jno.shape.box(0, 0, 0, 1, 1, 1).domain(size=0.5)
     u, v = d.fem_symbols()
     ci, bb = d.variable("interior", split=True), d.variable("boundary", split=True)
     gu, gv = jno.np.grad(u, [ci[0], ci[1], ci[2]]), jno.np.grad(v, [ci[0], ci[1], ci[2]])
@@ -199,8 +199,8 @@ def _al_contact_march(nsteps=4, c=1.0e3):
     (``lam.i(-1)`` step history plus a ``domain(tau=...)`` grid), so it is what ``contact=`` has to
     compose with. The bonded oracle is ``-0.01`` -- half the platen's ``-0.02``, by symmetry."""
     inner, sym, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
-    d = jno.Shape.regions(
-        base=jno.Shape.rect(0, 0, 1, 1, size=0.30), cap=jno.Shape.rect(0, 1, 1, 2, size=0.16), conforming=False
+    d = jno.shape.regions(
+        base=jno.shape.rect(0, 0, 1, 1, size=0.30), cap=jno.shape.rect(0, 1, 1, 2, size=0.16), conforming=False
     ).domain(tau=(0.0, 1.0, nsteps))
     sides = sorted(t for t in d.built_mesh.cell_sets if "|" in t)
     secondary = next(t for t in sides if t.endswith(".cap"))
@@ -297,8 +297,8 @@ def _block_on_disk(size=0.09):
     is a purely horizontal RIGID translation, ``n . D`` vanishes, so the re-paired ``g0`` *is* the
     deformed gap with nothing left to model.
     """
-    blk = jno.Shape.rect(-0.3, Y0, 0.3, Y0 + 0.4)
-    d = jno.Shape.regions(disk=jno.Shape.disk(0, 0, R_DISK).sized(size), blk=blk.sized(size), conforming=False).domain()
+    blk = jno.shape.rect(-0.3, Y0, 0.3, Y0 + 0.4)
+    d = jno.shape.regions(disk=jno.shape.disk(0, 0, R_DISK).sized(size), blk=blk.sized(size), conforming=False).domain()
     _ = d.built_mesh
     eps = 1e-6
     d.tag("s_blk", lambda x, y: y < Y0 + eps, region="blk")
@@ -388,10 +388,10 @@ def test_the_search_follows_a_slide_of_many_facet_widths():
 # ----------------------------------------------------------------------------------------------
 def _plates_domain(size=0.14):
     """Geometry and tags only — no ``u.gap``, so a caller can exercise the registration itself."""
-    d = jno.Shape.regions(
-        left=jno.Shape.rect(-1.5, 0.0, -0.1, 1.0).sized(size),
-        right=jno.Shape.rect(0.1, 0.0, 1.5, 0.8).sized(size),
-        blk=jno.Shape.rect(-0.6, 1.1, 0.6, 1.5).sized(size),
+    d = jno.shape.regions(
+        left=jno.shape.rect(-1.5, 0.0, -0.1, 1.0).sized(size),
+        right=jno.shape.rect(0.1, 0.0, 1.5, 0.8).sized(size),
+        blk=jno.shape.rect(-0.6, 1.1, 0.6, 1.5).sized(size),
         conforming=False,
     ).domain()
     _ = d.built_mesh
@@ -465,7 +465,7 @@ def test_self_contact_must_be_asked_for_as_a_list():
 def _slotted_block(size=0.075):
     """A C: a 2x1 bar with a 0.2-wide slot cut in from the right. The two slot faces look at each other
     across 0.2 and are the only part of the boundary that does."""
-    body = jno.Shape.rect(0, 0, 2.0, 1.0) - jno.Shape.rect(0.6, 0.4, 2.1, 0.6)
+    body = jno.shape.rect(0, 0, 2.0, 1.0) - jno.shape.rect(0.6, 0.4, 2.1, 0.6)
     d = body.sized(size).domain()
     _ = d.built_mesh
     d.tag("surf", lambda x, y: x**2 >= -1.0)  # one body: its boundary IS the whole boundary
@@ -556,9 +556,9 @@ def _hertz(press):
 
     lam, mu = E_H * NU_H / ((1 + NU_H) * (1 - 2 * NU_H)), E_H / (2 * (1 + NU_H))
     gapy = 0.004
-    d = jno.Shape.regions(
-        cyl=jno.Shape.disk(0.0, R_H + gapy, R_H).sized(H_H),
-        blk=jno.Shape.rect(-1.6, -1.2, 1.6, 0.0).sized(H_H),
+    d = jno.shape.regions(
+        cyl=jno.shape.disk(0.0, R_H + gapy, R_H).sized(H_H),
+        blk=jno.shape.rect(-1.6, -1.2, 1.6, 0.0).sized(H_H),
         conforming=False,
     ).domain()
     _ = d.built_mesh
@@ -660,9 +660,9 @@ def test_the_search_follows_a_large_slide_in_three_dimensions():
     from jno.utils.solver.contact_search import OPEN_GAP
     from jno.utils.solver.fem_utils import _cell_region_mask
 
-    blk = jno.Shape.box(-0.35, -0.35, Z0_3D, 0.35, 0.35, Z0_3D + 0.4)
-    d = jno.Shape.regions(
-        ball=jno.Shape.sphere(0, 0, 0, R_BALL).sized(H_3D), blk=blk.sized(H_3D), conforming=False
+    blk = jno.shape.box(-0.35, -0.35, Z0_3D, 0.35, 0.35, Z0_3D + 0.4)
+    d = jno.shape.regions(
+        ball=jno.shape.sphere(0, 0, 0, R_BALL).sized(H_3D), blk=blk.sized(H_3D), conforming=False
     ).domain()
     _ = d.built_mesh
     e = 1e-6

--- a/tests/test_fem_contact_slide.py
+++ b/tests/test_fem_contact_slide.py
@@ -43,9 +43,9 @@ def _x64():
 def _two_body(size=0.5, conforming=False):
     """Two blocks stacked in z. ``conforming=True`` fuses them into one body — the bonded reference."""
     return (
-        jno.Shape.regions(
-            lower=jno.Shape.box(0, 0, 0, 1, 1, 1),
-            upper=jno.Shape.box(0, 0, 1, 1, 1, 2.0),
+        jno.shape.regions(
+            lower=jno.shape.box(0, 0, 0, 1, 1, 1),
+            upper=jno.shape.box(0, 0, 1, 1, 1, 2.0),
             conforming=conforming,
         )
         .sized(size)

--- a/tests/test_fem_continuation.py
+++ b/tests/test_fem_continuation.py
@@ -37,7 +37,7 @@ def _nonlinear_diffusion(k_value=None):
     ``k`` is a runtime parameter when ``k_value`` is None, and a plain constant otherwise -- the two
     spellings assemble the same problem, which is what the equivalence test needs.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
     u, v = d.fem_symbols(names=("u", "v"), order=1)
     x, y, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_convergence.py
+++ b/tests/test_fem_convergence.py
@@ -252,7 +252,7 @@ def study_poisson_3d():
     g = lambda co: sin(PI * co[0]) * sin(PI * co[1]) * sin(PI * co[2])  # noqa: E731
 
     def solve(ms):
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=ms).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=ms).domain()
         u, w = d.fem_symbols()
         xi, yi, zi = d.variable("interior", split=True)[:3]
         ui, vi = u.bind(x=xi, y=yi, z=zi), w.bind(x=xi, y=yi, z=zi)
@@ -594,7 +594,7 @@ def study_stokes_3d():
     pex = lambda co: sin(co[0]) * sin(co[1]) * sin(co[2]) - C  # noqa: E731
 
     def solve(ms):
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=ms).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=ms).domain()
         u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), order=2)
         p, q = d.fem_symbols(names=("p", "q"), order=1)
         xi, yi, zi = d.variable("interior", split=True)[:3]
@@ -647,7 +647,7 @@ def study_navier_stokes_3d():
     pex = lambda co: sin(co[0]) * sin(co[1]) * sin(co[2]) - C  # noqa: E731
 
     def solve(ms):
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=ms).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=ms).domain()
         u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), order=2)
         p, q = d.fem_symbols(names=("p", "q"), order=1)
         xi, yi, zi = d.variable("interior", split=True)[:3]

--- a/tests/test_fem_coupled_robustness.py
+++ b/tests/test_fem_coupled_robustness.py
@@ -91,7 +91,7 @@ def test_coupled_linear_recovers_across_domains(name):
 def test_coupled_3d_cube_recovers():
     # The same block machinery on a 3-D tetrahedral cube: -lap u + p = y, -lap p + u = x.
     pytest.importorskip("pygmsh", reason="pygmsh required for cube meshing")
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
     u, v = d.fem_symbols(names=("u", "v"))
     p, q = d.fem_symbols(names=("p", "q"))
     co = d.variable("interior", split=True)

--- a/tests/test_fem_cover.py
+++ b/tests/test_fem_cover.py
@@ -218,7 +218,7 @@ def _poisson(space, size, dim=2, rhs=None, bc=0.0):
     import jno
 
     grad, inner = jno.np.grad, jno.np.inner
-    shp = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size) if dim == 2 else jno.Shape.box(0, 0, 0, 1, 1, 1, size=size)
+    shp = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size) if dim == 2 else jno.shape.box(0, 0, 0, 1, 1, 1, size=size)
     d = shp.domain()
     tol = 1e-9
     d.tag("walls", lambda *c: np.logical_or.reduce([(x < tol) | (x > 1 - tol) for x in c]))
@@ -331,7 +331,7 @@ def test_the_null_modes_are_gauged_away_without_changing_the_field():
     grad, inner = jno.np.grad, jno.np.inner
     vals = {}
     for space in ("Lagrange", "cover"):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
         d.tag("west", lambda x, y: x < 1e-9)
         co, cw = d.variable("interior", split=True), d.variable("west", split=True)
         X = [co[0], co[1]]
@@ -349,7 +349,7 @@ def test_an_order_above_one_is_refused_by_name():
     import jno
 
     grad, inner = jno.np.grad, jno.np.inner
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     d.tag("walls", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
     X = [co[0], co[1]]
@@ -441,7 +441,7 @@ def test_the_element_is_exact_on_a_distorted_mesh():
 
     grad, inner = jno.np.grad, jno.np.inner
     rng = np.random.default_rng(7)
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     pts = np.asarray(d.mesh.points)
     tol = 1e-9
     inside = (pts[:, 0] > tol) & (pts[:, 0] < 1 - tol) & (pts[:, 1] > tol) & (pts[:, 1] < 1 - tol)
@@ -503,7 +503,7 @@ def test_the_coordinate_gradient_through_a_cover_solve_matches_finite_difference
 
     rel = {}
     for space in ("Lagrange", "cover"):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
         mv, _, _ = d.variable("mv", where=lambda x, y: (x > 0.2) & (x < 0.8) & (y > 0.2) & (y < 0.8), split=True)
         mv.trainable(name="cx")
         op = d._trainable_coords[0]
@@ -541,7 +541,7 @@ def _heat_cover(space, size=0.12, kappa=0.1, t_end=0.3, nt=21):
 
     import jno
 
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain(time=(0.0, t_end, nt))
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain(time=(0.0, t_end, nt))
     u, phi = d.fem_symbols(space=space)
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_cylinder_benchmark.py
+++ b/tests/test_fem_cylinder_benchmark.py
@@ -63,7 +63,7 @@ def _x64():
 
 def _solve(h_far, h_cyl):
     """Steady NS past the cylinder; returns (cD, cL, dP, probe_offset, fem, classification)."""
-    shape = jno.Shape.rect(0, 0, L, H, size=h_far) - jno.Shape.disk(CX, CY, RR, size=h_cyl)
+    shape = jno.shape.rect(0, 0, L, H, size=h_far) - jno.shape.disk(CX, CY, RR, size=h_cyl)
     d = shape.domain()
     d.tag("inlet", lambda x, y: x < EPS)
     d.tag("walls", lambda x, y: (y < EPS) | (y > H - EPS))

--- a/tests/test_fem_dead_dofs.py
+++ b/tests/test_fem_dead_dofs.py
@@ -39,8 +39,8 @@ def _x64():
 
 def _two_region(size=0.5):
     return (
-        jno.Shape.box(0, 0, 0, 1, 1, 1).name("lower").sized(size)
-        + jno.Shape.box(0, 0, 1, 1, 1, 2).name("upper").sized(size)
+        jno.shape.box(0, 0, 0, 1, 1, 1).name("lower").sized(size)
+        + jno.shape.box(0, 0, 1, 1, 1, 2).name("upper").sized(size)
     ).domain()
 
 
@@ -113,7 +113,7 @@ def test_a_volume_region_pin_covers_the_whole_region():
 
     This test previously asserted the DEFECT (``n_dead == 33 and n_pin == 32``) and read the pin
     through ``tag_node_mask("upper", ...)``. That returns ``None`` for anything that is not a
-    ``domain.tag`` -- and "upper" is a ``Shape.name`` region -- so it raised ``TypeError`` from the
+    ``domain.tag`` -- and "upper" is a ``shape.name`` region -- so it raised ``TypeError`` from the
     commit that introduced it and never once ran its assertions. The behaviour it was guarding was
     then fixed, leaving it wrong twice over.
     """
@@ -134,7 +134,7 @@ def test_a_volume_region_pin_covers_the_whole_region():
     assert dead <= ids, f"the pin misses {len(dead - ids)} of the {len(dead)} ungoverned DOFs"
 
     assert d.tag_node_mask("upper", pts) is None, (
-        "tag_node_mask now resolves a Shape-region name; this test's premise -- that a volume-region "
+        "tag_node_mask now resolves a shape-region name; this test's premise -- that a volume-region "
         "pin must NOT be resolved through it -- needs rechecking"
     )
 

--- a/tests/test_fem_dirichlet_parameters.py
+++ b/tests/test_fem_dirichlet_parameters.py
@@ -23,7 +23,7 @@ import jno
 
 
 def _poisson_pieces(size=0.3, time=None):
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain(**({"time": time} if time else {}))
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain(**({"time": time} if time else {}))
     u, v = d.fem_symbols()
     if time:
         xi, yi, ti = d.variable("interior", split=True)
@@ -198,7 +198,7 @@ def test_recover_boundary_value_linear_transient():
 # breadth: vector per-component; the data-field branch must still work
 # --------------------------------------------------------------------------------------
 def test_vector_field_per_component_parametric_value():
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
     u, v = d.fem_symbols(value_shape=(2,))
     inner, grad = jno.np.inner, jno.np.grad
     xi, yi, _ = d.variable("interior", split=True)
@@ -214,7 +214,7 @@ def test_vector_field_per_component_parametric_value():
 def test_parametric_times_temporal_value_refuses_loudly():
     """`u(top) - g*tau`: the parametric branch would un-ramp the load, the temporal branch would
     un-train the parameter — both silently wrong, so the combination must refuse at build."""
-    d = jno.Shape.rect(0, 0, 0.5, 1, size=0.3).domain(tau=(0.0, 1.0, 4))
+    d = jno.shape.rect(0, 0, 0.5, 1, size=0.3).domain(tau=(0.0, 1.0, 4))
     u, v = d.fem_symbols(value_shape=(2,))
     inner, grad = jno.np.inner, jno.np.grad
     xi, yi, _ = d.variable("interior", split=True)

--- a/tests/test_fem_dirichlet_symmetry.py
+++ b/tests/test_fem_dirichlet_symmetry.py
@@ -62,7 +62,7 @@ def _poisson(g=0.35, size=0.2):
     """Scalar nonlinear Poisson with an INHOMOGENEOUS Dirichlet value (g != 0 is what exercises the
     lift: with g = 0 the projection is the identity and the test would be vacuous)."""
     inner, grad, _s, _t, _i = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -75,7 +75,7 @@ def _elasticity(size=0.5):
     energy's Hessian and is symmetric by construction. (A nonlinear form that is not the gradient of a
     potential has no reason to give a symmetric tangent — that is a property of the physics.)"""
     inner, grad, sym, trace, ident = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co, cb = d.variable("interior", split=True), d.variable("bot", split=True)
     X = [co[0], co[1], co[2]]
@@ -92,7 +92,7 @@ def _elasticity(size=0.5):
 def _advection(b=1.0, size=0.25):
     """A genuinely NON-symmetric operator — the control."""
     inner, grad, _s, _t, _i = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -198,7 +198,7 @@ def test_the_constrained_solution_is_unchanged_and_correct():
     test and not the linear assembly."""
     inner, grad, _s, _t, _i = _aliases()
     g = 0.4
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.05).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.05).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]

--- a/tests/test_fem_element_operator.py
+++ b/tests/test_fem_element_operator.py
@@ -136,7 +136,7 @@ def test_assembled_operator_carries_no_duplicate_triplets():
     pytest.importorskip("shapely", reason="shapely required for the box domain")
     import jno
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain()
     u, phi = d.fem_symbols()
     c = d.variable("interior", split=True)
     cb = d.variable("boundary", split=True)

--- a/tests/test_fem_eval_readout.py
+++ b/tests/test_fem_eval_readout.py
@@ -40,7 +40,7 @@ def test_heat_flux_through_the_walls_equals_the_source():
     the integrated source. This is the thermal reading of the same operation as a reaction force."""
     grad, inner = jno.np.grad, jno.np.inner
     f_src = 3.0
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain()
     d.tag("walls", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
     X = [co[0], co[1]]
@@ -66,7 +66,7 @@ def test_reaction_on_a_loaded_bar_equals_the_applied_body_force():
     operation as the wall flux above."""
     sym, grad, trace, inner = jno.np.sym, jno.np.grad, jno.np.trace, jno.np.inner
     bx, Lx, Ly = 2.5, 2.0, 1.0
-    d = jno.Shape.rect(0.0, 0.0, Lx, Ly, size=0.12).domain()
+    d = jno.shape.rect(0.0, 0.0, Lx, Ly, size=0.12).domain()
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = d.variable("interior", split=True), d.variable("left", split=True)
     X = [co[0], co[1]]
@@ -88,7 +88,7 @@ def test_the_eliminated_system_would_have_returned_zero():
     """The reason this method exists: fem.b (post-elimination) is ZERO on the pinned rows, so the
     naive readout is silently wrong rather than loudly unavailable."""
     grad, inner = jno.np.grad, jno.np.inner
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
     d.tag("walls", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
     X = [co[0], co[1]]
@@ -108,7 +108,7 @@ def test_the_eliminated_system_would_have_returned_zero():
 
 def test_eval_refuses_an_expression_with_no_test_function():
     grad, inner = jno.np.grad, jno.np.inner
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     d.tag("walls", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
     X = [co[0], co[1]]
@@ -120,7 +120,7 @@ def test_eval_refuses_an_expression_with_no_test_function():
 
 
 def test_region_dofs_names_an_unknown_region():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     d.tag("walls", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cw = d.variable("interior", split=True), d.variable("walls", split=True)
     X = [co[0], co[1]]

--- a/tests/test_fem_facet_connectivity.py
+++ b/tests/test_fem_facet_connectivity.py
@@ -65,7 +65,7 @@ def test_boundary_closes_on_a_real_mesh(cell_type):
         mesh = jno.domain(box(0, 0, 1, 1), mesh_size=0.15).built_mesh
         cells = np.asarray(mesh.cells_dict["triangle"])
     else:
-        mesh = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain().built_mesh
+        mesh = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain().built_mesh
         cells = np.asarray(mesh.cells_dict["tetra"])
     conn = build_facet_connectivity(cells, cell_type)
     assert conn.n_bfaces > 0
@@ -119,7 +119,7 @@ def test_shared_boundary_set_matches_the_independent_implementation(cells, cell_
 def test_shared_boundary_set_matches_on_a_real_mesh():
     from jno.domain.mesh_utils import MeshUtils
 
-    cells = np.asarray(jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh.cells_dict["tetra"])
+    cells = np.asarray(jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh.cells_dict["tetra"])
     assert np.array_equal(
         MeshUtils._get_boundary_elements(cells, "tetra"),
         MeshUtils._get_boundary_elements_reference(cells, "tetra"),
@@ -131,7 +131,7 @@ def test_the_face_computation_is_shared_between_equal_but_distinct_arrays():
     connectivity, so an identity-keyed cache scored 0% and both paid. Content keying is the fix."""
     from jno.utils.solver import fem_facets
 
-    cells = np.asarray(jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh.cells_dict["tetra"])
+    cells = np.asarray(jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh.cells_dict["tetra"])
     fem_facets._FACET_CACHE.clear()
     fem_facets.boundary_face_set(cells, "tetra")
     fem_facets.build_facet_connectivity(cells.copy(), "tetrahedron")  # a DIFFERENT object
@@ -171,7 +171,7 @@ def test_boundary_facets_match_the_row_wise_unique(cells, dim, order):
             mesh = jno.domain(box(0, 0, 1, 1), mesh_size=0.15).built_mesh
             pts, cells = np.asarray(mesh.points), np.asarray(mesh.cells_dict["triangle"])
         else:
-            mesh = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh
+            mesh = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh
             pts, cells = np.asarray(mesh.points), np.asarray(mesh.cells_dict["tetra"])
         if order >= 2:  # P2 connectivity: vertices first, then one midpoint per edge
             e = np.sort(np.concatenate([cells[:, [0, 1]], cells[:, [1, 2]], cells[:, [2, 0]]]), axis=1)
@@ -235,8 +235,8 @@ def _face_normals_reference(points, conn, cells, cell_type):
 @pytest.mark.parametrize(
     "shape,cell_key,cell_type",
     [
-        (jno.Shape.rect(0, 0, 1, 1, size=0.12), "triangle", "triangle"),
-        (jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3), "tetra", "tetrahedron"),
+        (jno.shape.rect(0, 0, 1, 1, size=0.12), "triangle", "triangle"),
+        (jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3), "tetra", "tetrahedron"),
     ],
 )
 def test_face_normals_match_the_per_face_loop(shape, cell_key, cell_type):

--- a/tests/test_fem_fieldsplit.py
+++ b/tests/test_fem_fieldsplit.py
@@ -20,7 +20,7 @@ import jno
 
 def _nonlinear_diffusion(size=0.2):
     """-div((1+u^2) grad u) = f — the smallest problem with a genuinely solution-dependent operator."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_finite_strain.py
+++ b/tests/test_fem_finite_strain.py
@@ -30,7 +30,7 @@ def _x64():
 
 
 def _box(size=0.4):
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size).domain()
     d.tag("bdry", lambda x, y, z: (x < 1e-6) | (x > 1 - 1e-6) | (y < 1e-6) | (y > 1 - 1e-6) | (z < 1e-6) | (z > 1 - 1e-6))
     return d
 
@@ -89,7 +89,7 @@ def test_finite_strain_large_stretch_patch_test():
 def test_finite_strain_reduces_to_linear_elasticity_at_small_strain():
     """A cantilever sheared a TINY amount: finite strain and linear elasticity must agree to O(strain²)."""
     shear = 2e-4  # small
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.5).domain()
     d.tag("bot", lambda x, y, z: z < 1e-6)
     d.tag("top", lambda x, y, z: z > 1 - 1e-6)
     u, phi = d.fem_symbols(value_shape=(3,))

--- a/tests/test_fem_follower_normals.py
+++ b/tests/test_fem_follower_normals.py
@@ -37,7 +37,7 @@ def _x64():
 
 def _form(follow, traction=True, size=0.34):
     """Unit square with a unit pressure on its top face. ``follow`` picks which normal that uses."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).sized(size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).sized(size).domain()
     _ = d.built_mesh
     d.tag("top", lambda x, y: y > 1.0 - 1e-9)
     u, phi = d.fem_symbols(value_shape=(2,))
@@ -121,7 +121,7 @@ def test_the_reference_normal_is_still_the_default():
 
 def test_following_needs_an_unambiguous_displacement_field():
     """It has to know which field moves the surface; guessing wrong rotates every traction on it."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).sized(0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).sized(0.4).domain()
     _ = d.built_mesh
     d.tag("top", lambda x, y: y > 1.0 - 1e-9)
     u, phi = d.fem_symbols(value_shape=())  # a SCALAR field: nothing moves the surface

--- a/tests/test_fem_frozen_parameters.py
+++ b/tests/test_fem_frozen_parameters.py
@@ -202,7 +202,7 @@ def test_frozen_jax_initializer_raises():
 
 def _laplace(order, names, size=0.25):
     """``-Δu = 1``, ``u = 0`` on the boundary, at a chosen element order."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     u, phi = d.fem_symbols(order=order, names=names)
     si, sb = d.variable("interior", split=True), d.variable("boundary", split=True)
     xi, yi, xb, yb = si[0], si[1], sb[0], sb[1]

--- a/tests/test_fem_frozen_readout.py
+++ b/tests/test_fem_frozen_readout.py
@@ -43,7 +43,7 @@ def _solve_laplace_2d(d, gfun):
 
 
 def test_frozen_value_readout_is_affine_exact():
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.06).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.06).domain()
     sol, u = _solve_laplace_2d(d, lambda x, y: 3.0 * x - 2.0 * y)
     xb, yb, _ = d.variable("boundary", split=True)
     Tf = u.bind(x=xb, y=yb).freeze(sol)
@@ -53,7 +53,7 @@ def test_frozen_value_readout_is_affine_exact():
 
 
 def test_frozen_gradient_readout_is_affine_exact():
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.06).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.06).domain()
     sol, u = _solve_laplace_2d(d, lambda x, y: 3.0 * x - 2.0 * y)  # ∇T = (3, −2)
     xb, yb, _ = d.variable("boundary", split=True)
     Tf = u.bind(x=xb, y=yb).freeze(sol)
@@ -64,7 +64,7 @@ def test_frozen_gradient_readout_is_affine_exact():
 
 def test_boundary_normal_flux_readout_affine_exact():
     """The headline: ∇T·n written as Tf.x*nx + Tf.y*ny, evaluated, vs analytic (affine ⇒ exact)."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.05).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.05).domain()
     sol, u = _solve_laplace_2d(d, lambda x, y: 3.0 * x - 2.0 * y)
     x, y, t, nx, ny = d.variable("boundary", normals=True, split=True)
     Tf = u.bind(x=x, y=y).freeze(sol)
@@ -76,7 +76,7 @@ def test_boundary_normal_flux_readout_affine_exact():
 
 def test_boundary_normal_flux_readout_harmonic_first_order():
     """On a real harmonic solve T=x²−y² (∇T=(2x,−2y)), ∇T·n is first-order accurate (O(h))."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.045).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.045).domain()
     sol, u = _solve_laplace_2d(d, lambda x, y: x**2 - y**2)
     x, y, t, nx, ny = d.variable("boundary", normals=True, split=True)
     Tf = u.bind(x=x, y=y).freeze(sol)
@@ -90,7 +90,7 @@ def test_boundary_normal_flux_readout_harmonic_first_order():
 
 def test_frozen_gradient_readout_3d_affine_exact():
     """3-D: freeze an affine field on a box, read ∇T·n on the boundary (last `dim` split parts = normals)."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.34).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.34).domain()
     u, phi = d.fem_symbols()
     ci = d.variable("interior", split=True)
     cb = d.variable("boundary", split=True)
@@ -118,7 +118,7 @@ def test_frozen_readout_on_transient_domain_is_correct_and_differentiable():
     """The normals fix: on a TRANSIENT domain the normal tags are time-tiled (like the coords), so the
     boundary-flux readout evaluates correctly — the normals no longer collapse to one point — and it is
     differentiable in the field values (a Stefan velocity feeding back into the solve trains cleanly)."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.1).domain(time=(0.0, 0.3, 11))
+    d = jno.shape.rect(0, 0, 1, 1, size=0.1).domain(time=(0.0, 0.3, 11))
     u, _ = d.fem_symbols()
     pts = np.asarray(d.mesh.points)[:, :2]
     sol = 3.0 * pts[:, 0] - 2.0 * pts[:, 1]  # ∇T = (3, -2)
@@ -143,7 +143,7 @@ def test_frozen_readout_without_domain_fails_loud():
     raise a clear error, not return garbage."""
     from jno.trace import FrozenField
 
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.2).domain()
     u, _ = d.fem_symbols()
     n = len(np.asarray(d.mesh.points))
     bare = FrozenField(u.scalar._expr, jnp.zeros(n))  # no domain / coord_tag
@@ -157,7 +157,7 @@ def test_substitute_refreeze_swaps_state_in_a_static_readout():
     the new state. This is the mechanism that lets a moving-boundary velocity be passed *as a trace*."""
     from jno.trace import frozen_fields_in, refreeze, substitute
 
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.15).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.15).domain()
     u, _ = d.fem_symbols()
     pts = np.asarray(d.mesh.points)[:, :2]
     xb, yb, _, nx, ny = d.variable("boundary", normals=True, split=True)
@@ -184,7 +184,7 @@ def test_vector_frozen_field_as_coefficient_matches_analytic():
     a coefficient in a jno.fem form: the assembler gathers each cell's per-node vec-vectors and interpolates
     them. A LINEAR field is P1-exact, so a frozen vector *source* must equal the same source written
     analytically (to machine precision) -- e.g. a precomputed velocity / prior displacement field."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     u, phi = d.fem_symbols(value_shape=(2,), names=("u", "phi"))
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -210,7 +210,7 @@ def test_vector_frozen_field_as_coefficient_matches_analytic():
 def test_vector_frozen_field_standalone_eval_fails_loud():
     """A standalone ``.eval()`` readout of a VECTOR frozen field is not wired (its values are (n_nodes, vec));
     it must fail loud rather than silently reshape-flatten. (Assembly as a coefficient is supported above.)"""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     u, _ = d.fem_symbols(value_shape=(2,), names=("u", "phi"))
     xb, yb, _ = d.variable("boundary", split=True)
     nvv = int(np.asarray(d.built_mesh.points).shape[0])

--- a/tests/test_fem_geometry_terms.py
+++ b/tests/test_fem_geometry_terms.py
@@ -40,7 +40,7 @@ def _x64():
 
 
 def _dom(size=0.3, t=(0.0, 0.2, 5)):
-    return jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=t)
+    return jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=t)
 
 
 def test_a_coordinate_time_derivative_is_a_geometry_term():
@@ -167,7 +167,7 @@ def test_prescribed_motion_converges_first_order_to_the_analytic_domain():
     that is the documented scheme, and asserting the *rate* is what would catch it silently changing."""
     T, errs = 0.4, []
     for nt in (9, 17, 33):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, T, nt))
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, T, nt))
         _xb, yb, tb = d.variable("boundary", split=True)
         traj = _heat(d, yb.d(tb) - 0.5 * yb).solve()
         ymax = float(traj.meshes[-1][0][:, 1].max())
@@ -185,7 +185,7 @@ def test_the_velocity_is_re_evaluated_on_the_MOVED_mesh():
     y — exponential growth collapsed to a single Euler step over the whole interval (1.2000 rather than
     1.2184), with no error anywhere. Anything less than compounding growth means the re-sample was lost."""
     T, nt = 0.4, 9
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, T, nt))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, T, nt))
     _xb, yb, tb = d.variable("boundary", split=True)
     ymax = float(_heat(d, yb.d(tb) - 0.5 * yb).solve().meshes[-1][0][:, 1].max())
 
@@ -196,7 +196,7 @@ def test_the_velocity_is_re_evaluated_on_the_MOVED_mesh():
 def test_motion_is_per_axis_and_holds_the_untagged_column():
     """Tagging is literal: a term on ``yb`` moves the y column and leaves x alone. That is the lever for
     sliding a node within a wall instead of pushing it through one."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.3, 7))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.3, 7))
     _xb, yb, tb = d.variable("boundary", split=True)
     traj = _heat(d, yb.d(tb) - 0.4).solve()
     p0, p1 = traj.meshes[0][0], traj.meshes[-1][0]
@@ -208,7 +208,7 @@ def test_motion_is_per_axis_and_holds_the_untagged_column():
 def test_an_interior_region_moves_too():
     """The generality the classifier promises, end to end: a ``where=`` region in the middle of the domain
     is driven, and the mesh around it (including the outer boundary) relaxes harmonically to accommodate."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain(time=(0.0, 0.2, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain(time=(0.0, 0.2, 5))
     xc, _yc, tc = d.variable("core", where=lambda x, y: (x - 0.5) ** 2 + (y - 0.5) ** 2 < 0.05, split=True)
     core_ids = np.asarray(jno.trace.Variable._region_vertex_ids(d, "core", np.asarray(d.mesh.points)), dtype=int)
     assert core_ids.size > 0, "the test needs a non-empty interior region"
@@ -222,7 +222,7 @@ def test_an_interior_region_moves_too():
 def test_the_velocity_may_read_the_solved_field():
     """A state-dependent law: the boundary speed is proportional to the solution's own boundary gradient,
     the shape a Stefan condition takes. The frozen field is re-pinned to the live state each step."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.2, 6))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.2, 6))
     u, _v = d.fem_symbols()
     parts = d.variable("boundary", normals=True, split=True)
     xb, yb, tb, nx, ny = parts[0], parts[1], parts[2], parts[-2], parts[-1]
@@ -237,7 +237,7 @@ def test_the_velocity_may_read_the_solved_field():
 def test_a_geometry_term_needs_a_transient_problem():
     """``coord.d(t) - v`` moves the mesh *in time*. On a steady problem there is no time to move through,
     and the term would be silently inert."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, tb = d.variable("boundary", split=True)
@@ -261,7 +261,7 @@ def test_two_terms_may_not_prescribe_the_same_coordinate():
     """Regions overlap freely — a corner belongs to both edges — so two terms naming the same vertex *and*
     the same axis is easy to write by accident. Scattering in list order would silently let the last one
     win, which is a wrong velocity with no symptom."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.2, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.2, 5))
     _xl, yl, tl = d.variable("lo", where=lambda x, y: y < 0.5, split=True)
     _xa, ya, ta = d.variable("all", where=lambda x, y: np.ones_like(x, dtype=bool), split=True)
     with pytest.raises(ValueError, match="only one velocity"):
@@ -271,7 +271,7 @@ def test_two_terms_may_not_prescribe_the_same_coordinate():
 def test_two_terms_may_drive_different_axes_of_one_region():
     """The complement: x and y of the same region are separate degrees of freedom, so a term each is a
     perfectly well-posed 2-D velocity and must be allowed."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.2, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.2, 5))
     xb, yb, tb = d.variable("boundary", split=True)
     traj = _heat(d, xb.d(tb) - 0.2, yb.d(tb) - 0.3).solve()
     p0, p1 = traj.meshes[0][0], traj.meshes[-1][0]
@@ -287,7 +287,7 @@ def test_a_motion_that_would_tangle_the_mesh_raises():
     Note the velocity has to be *differential*. Driving the whole boundary at one constant speed is a rigid
     translation — the interior follows harmonically and nothing inverts however far it goes. ``-4y`` pulls
     the top edge down while the bottom stays put, which folds the domain through itself."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 1.0, 3))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 1.0, 3))
     _xb, yb, tb = d.variable("boundary", split=True)
     with pytest.raises(ValueError, match="inverts or collapses"):
         _heat(d, yb.d(tb) + 4.0 * yb).solve()
@@ -300,7 +300,7 @@ def test_a_position_independent_region_marches_too():
     is a known defect (see the note in ``run_mesh_motion``); it is not asserted here because pinning the
     current wrong behaviour into a test would make the fix look like a regression.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.4, 6))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.4, 6))
     _xb, yb, tb = d.variable("boundary", split=True)
     traj = _heat(d, yb.d(tb) - 0.5).solve()
     p0, p1 = traj.meshes[0][0], traj.meshes[-1][0]
@@ -318,7 +318,7 @@ def test_the_SOLUTION_stays_finite_while_the_mesh_moves():
     So: assert the field. Finite at every frame, obeying the maximum principle (this is heat with u=0 on
     the boundary and u=1 initially, so nothing may exceed those bounds), and actually decaying.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.4, 9))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.4, 9))
     _xb, yb, tb = d.variable("boundary", split=True)
     traj = _heat(d, yb.d(tb) - 0.5 * yb).solve()
     states = [np.asarray(s) for s in traj.states]
@@ -339,7 +339,7 @@ def test_the_solution_matches_a_fixed_mesh_when_the_mesh_does_not_move():
     any of them shows up as a number rather than as a plausible-looking trajectory."""
 
     def _mk(with_motion):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.3, 7))
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain(time=(0.0, 0.3, 7))
         _xb, yb, tb = d.variable("boundary", split=True)
         geom = (yb.d(tb) - 0.0,) if with_motion else ()
         return d, _heat(d, *geom)
@@ -363,7 +363,7 @@ def test_the_solution_matches_a_fixed_mesh_when_the_mesh_does_not_move():
 def _bump_march(n_steps, v=0.5, size=0.1):
     """A Gaussian bump on a mesh translating rigidly in y, with kappa ~ 0 and NO Dirichlet BC. The exact
     answer is 'the field never changes at a fixed spatial point', so any change is pure transfer error."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, n_steps + 1))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, n_steps + 1))
     u, vv = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     _xb, yb, tb = d.variable("boundary", split=True)
@@ -412,7 +412,7 @@ def test_the_transfer_conserves_the_integral_better_than_pointwise_sampling():
         _simplex_measure_divisor,
     )
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.08).domain()
     P = jnp.asarray(np.asarray(d.mesh.points)[:, :2])
     C = np.asarray(d.mesh.cells_dict["triangle"]).astype(np.int64)
     n = P.shape[0]
@@ -451,7 +451,7 @@ def test_the_transfer_between_identical_meshes_is_the_identity():
     version contracted the Jacobian on the wrong axis and returned an error of 5.4e-01 here."""
     from jno.utils.solver.fem_adapt import _l2_transfer_jax
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     P = jnp.asarray(np.asarray(d.mesh.points)[:, :2])
     C = np.asarray(d.mesh.cells_dict["triangle"]).astype(np.int64)
     xy = np.asarray(P)
@@ -475,7 +475,7 @@ def test_the_march_can_be_run_twice():
     therefore applies the same increment from wherever it starts.
     """
     V, T = 0.3, 0.2
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, T, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, T, 5))
     _xb, yb, tb = d.variable("boundary", split=True)
     fem = _heat(d, yb.d(tb) - V)
 
@@ -545,7 +545,7 @@ def test_a_velocity_may_depend_explicitly_on_time(law, expected, stale):
     1.46000. No error either way.
 
     Checked against the closed form rather than against the eager oracle, which takes no ``t``."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.4, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.4, 5))
     _xb, yb, tb = d.variable("boundary", split=True)
     v = (1.0 + tb) if law == "affine" else tb
     ymax = float(_heat(d, yb.d(tb) - v).solve().meshes[-1][0][:, 1].max())
@@ -565,7 +565,7 @@ def test_a_velocity_may_read_a_SECOND_regions_coordinates():
     def run(read_twin):
         # A FRESH domain per solve: `solve()` leaves the domain on the final moved mesh, so a second solve
         # here would re-resolve `y > 1 - 1e-6` against vertices that have already moved past it.
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.4, 5))
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.4, 5))
         d.tag("top", lambda x, n, names: x[:, 1] > 1.0 - 1e-6)
         d.tag("twin", lambda x, n, names: x[:, 1] > 1.0 - 1e-6)  # the same vertices, a different name
         _xt, yt, tt = d.variable("top", split=True)
@@ -585,7 +585,7 @@ def test_a_law_reading_a_region_the_driver_cannot_move_fails_loud():
     mesh, so its values would go stale exactly as the second-tag defect did. Refuse instead."""
     from jno.utils.solver.fem_adapt import _geometry_motion_specs, _geometry_velocity_fn
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.2, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.2, 5))
     _xb, yb, tb = d.variable("boundary", split=True)
     fem = _heat(d, yb.d(tb) - 0.5)
     spec = _geometry_motion_specs(fem, d)[0]
@@ -638,7 +638,7 @@ def test_the_field_gradient_flows_through_a_moving_mesh():
 
 def _vel_case(term_fn, size=0.3, state_fn=None):
     """Build a moving-mesh problem and return (spec, domain, state) for a velocity comparison."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, 5))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, 5))
     u, v = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, tb, nx, ny = d.variable("boundary", normals=True, split=True)
@@ -723,7 +723,7 @@ def test_the_traced_velocity_is_differentiable_in_the_vertex_positions():
 def _ring_case(size=0.12, disp_scale=0.02, seed=0):
     from jno.utils.solver.fem_adapt import _one_ring_cells, _simplex_cell_key
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     dim = int(d.dimension)
     pts = np.asarray(d.mesh.points)[:, :dim].astype(np.float64)
     cells = np.asarray(d.mesh.cells_dict[_simplex_cell_key(dim)]).astype(np.int64)
@@ -825,7 +825,7 @@ def test_the_transfer_is_differentiable_in_the_vertex_positions():
 
 def _stefan(size=0.25, steps=5):
     """A state-reading law, so the interface position depends on the PDE coefficient."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps + 1))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps + 1))
     u, v = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, tb, nx, ny = d.variable("boundary", normals=True, split=True)
@@ -886,7 +886,7 @@ def test_the_interface_position_is_differentiable_in_the_pde_coefficient():
 
 def _law_param_fem(size=0.3, steps=4):
     """``yb.d(tb) - v0*yb`` with the law's rate as an ordinary runtime parameter."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps + 1))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps + 1))
     u, v = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, tb = d.variable("boundary", split=True)
@@ -944,7 +944,7 @@ def _init_mesh_fem(size=0.3, steps=4):
 
     Completes the coordinate table: the region is FREE (its start is a design variable) and the boundary
     is DETERMINED (the march moves it). Those two used to be mutually exclusive."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps + 1))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps + 1))
     u, v = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, tb = d.variable("boundary", split=True)
@@ -1017,7 +1017,7 @@ def test_the_traced_normals_are_outward_and_agree_with_the_domain_s_own():
     # vertices): on a FLAT tag `n . (facet_centre - tag_centroid)` is zero to round-off (1.1e-16) and
     # carries no sign information at all.
     H = 0.620063
-    d = jno.Shape.rect(0.0, 0.0, 0.35, H, size=0.07).domain(time=(0.0, 0.2, 5))
+    d = jno.shape.rect(0.0, 0.0, 0.35, H, size=0.07).domain(time=(0.0, 0.2, 5))
     d.tag("top", lambda x, n, names: x[:, 1] > H - 1e-6)
     d.tag("bottom", lambda x, n, names: x[:, 1] < 1e-6)
     d.variable("top", normals=True, split=True)
@@ -1047,7 +1047,7 @@ def test_the_normals_are_outward_on_a_CONCAVE_boundary():
     from jno.utils.solver.fem_adapt import _facet_outward_sign, _tag_facet_vertex_ids, _vertex_normals_jax
 
     C = np.array([0.5, 0.5])
-    d = (jno.Shape.disk(0.5, 0.5, 0.4) - jno.Shape.disk(0.5, 0.5, 0.15)).domain(size=0.06)
+    d = (jno.shape.disk(0.5, 0.5, 0.4) - jno.shape.disk(0.5, 0.5, 0.15)).domain(size=0.06)
 
     def radial(p):
         r = np.asarray(p)[:, :2] - C
@@ -1081,7 +1081,7 @@ def test_a_geometry_term_marches_in_3D():
     """Nothing in the driver is 2-D, and nothing tested it: every other motion test is a unit square.
     A box driven on z must translate by exactly ``v*T``, since a uniform boundary velocity is a rigid
     translation the harmonic extension reproduces exactly."""
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.45).domain(time=(0.0, 0.2, 4))
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.45).domain(time=(0.0, 0.2, 4))
     u, v = d.fem_symbols()
     xi, yi, zi, ti = d.variable("interior", split=True)
     xb, yb, zb, tb = d.variable("boundary", split=True)
@@ -1199,7 +1199,7 @@ def test_the_in_trace_lagrange_basis_matches_basix_and_differentiates_at_zero(di
 
 def _order_march(order=1, shape=(), vel=0.1, size=0.4, nt=4):
     """A moving-mesh heat problem at a chosen element order and value shape."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, nt))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, nt))
     u, v = d.fem_symbols(order=order, value_shape=shape)
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, tb = d.variable("boundary", split=True)
@@ -1254,7 +1254,7 @@ def test_a_still_mesh_reproduces_the_fixed_mesh_march_at_any_order(order):
     as a plausible-looking trajectory."""
 
     def mk(with_motion):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.3, 7))
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.3, 7))
         u, v = d.fem_symbols(order=order)
         xi, yi, ti = d.variable("interior", split=True)
         xb, yb, tb = d.variable("boundary", split=True)
@@ -1278,7 +1278,7 @@ def test_a_mixed_order_coupled_system_moves_as_one():
     """Two fields of DIFFERENT order in one system — the shape a Taylor-Hood pair takes. Each field's own
     order, connectivity and DOF count drive its own projection; they share the mesh, the quadrature map
     and the point location."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(time=(0.0, 0.2, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(time=(0.0, 0.2, 4))
     a, qa = d.fem_symbols(names=("a", "qa"), order=2)
     b, qb = d.fem_symbols(names=("b", "qb"), order=1)
     xi, yi, ti = d.variable("interior", split=True)
@@ -1321,7 +1321,7 @@ def test_a_non_nodal_family_fails_loud():
     this one."""
     from jno.utils.solver.fem_adapt import _field_layout
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     u, v = d.fem_symbols(space="Morley")
     xi, yi = d.variable("interior", split=True)[:2]
     xb, yb = d.variable("boundary", split=True)[:2]
@@ -1372,7 +1372,7 @@ _MMS_LAMBDA = 2.0 * np.pi**2 * _MMS_KAPPA
 
 
 def _mms(size, nt, c, t_end=0.2, order=1):
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, t_end, nt))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, t_end, nt))
     u, v = d.fem_symbols(order=order)
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, tb = d.variable("boundary", split=True)

--- a/tests/test_fem_graded_mesh.py
+++ b/tests/test_fem_graded_mesh.py
@@ -1,4 +1,4 @@
-"""A graded mesh: ``Shape(..., size=f(x, y, z))`` -> a gmsh ``setSizeCallback``.
+"""A graded mesh: ``shape(..., size=f(x, y, z))`` -> a gmsh ``setSizeCallback``.
 
 ``Size = Union[float, Callable, None]`` (``jno/geometry/shape.py``), and a callable becomes a
 per-position mesh-size callback that composes with every other size control via ``min``
@@ -43,7 +43,7 @@ def _element_sizes(d):
 def test_a_graded_size_callable_actually_grades_the_mesh():
     """The oracle is the callable itself: element size near an edge must track ``f`` there, not some
     average. Without this, `size=` could be silently ignored and the mesh would still look fine."""
-    size, yc, _n = _element_sizes(jno.Shape.rect(0.0, 0.0, LX, LY, size=_graded).domain())
+    size, yc, _n = _element_sizes(jno.shape.rect(0.0, 0.0, LX, LY, size=_graded).domain())
     top = size[yc > LY - 0.25 * BAND].mean()
     bot = size[yc < 0.25 * BAND].mean()
     assert top == pytest.approx(H_FINE, rel=0.5), f"top band should be near {H_FINE * 1e6:.0f} um, got {top * 1e6:.2f}"
@@ -54,8 +54,8 @@ def test_a_graded_size_callable_actually_grades_the_mesh():
 def test_grading_buys_the_resolution_far_cheaper_than_a_uniform_mesh():
     """The whole point. Same size at the fine edge, a fraction of the nodes -- this is what makes a
     thin feature (a melt pool 48 um deep in a 400 um domain) affordable at all."""
-    _s, _y, n_graded = _element_sizes(jno.Shape.rect(0.0, 0.0, LX, LY, size=_graded).domain())
-    _s2, _y2, n_uniform = _element_sizes(jno.Shape.rect(0.0, 0.0, LX, LY, size=H_FINE).domain())
+    _s, _y, n_graded = _element_sizes(jno.shape.rect(0.0, 0.0, LX, LY, size=_graded).domain())
+    _s2, _y2, n_uniform = _element_sizes(jno.shape.rect(0.0, 0.0, LX, LY, size=H_FINE).domain())
     assert n_graded < n_uniform / 5, f"graded {n_graded} vs uniform {n_uniform} -- grading bought little"
 
 
@@ -72,13 +72,13 @@ def test_a_size_callable_of_the_wrong_arity_is_refused_by_name():
     with pytest.raises(TypeError, match=r"f\(x, y, z\)"):
         # `.mesh` forces the build: meshing is LAZY, so `.domain()` alone never reaches the callback
         # and the wrong signature would sail through until something first asked for a mesh.
-        jno.Shape.rect(0.0, 0.0, LX, LY, size=two_arg).domain().mesh
+        jno.shape.rect(0.0, 0.0, LX, LY, size=two_arg).domain().mesh
 
 
 def test_a_graded_mesh_composes_with_a_time_grid():
     """Grading is geometry and the time grid is not, but they meet on the domain -- and a melt-pool
     model needs both at once."""
-    d = jno.Shape.rect(0.0, 0.0, LX, LY, size=_graded).domain(time=(0.0, 1.0e-3, 5))
+    d = jno.shape.rect(0.0, 0.0, LX, LY, size=_graded).domain(time=(0.0, 1.0e-3, 5))
     size, yc, n = _element_sizes(d)
     assert n > 0 and np.isfinite(size).all()
     assert size[yc < 0.25 * BAND].mean() > 3.0 * size[yc > LY - 0.25 * BAND].mean()

--- a/tests/test_fem_hanging_nodes.py
+++ b/tests/test_fem_hanging_nodes.py
@@ -43,7 +43,7 @@ def x64():
 
 
 def _grid(n=4):
-    return jno.Shape.rect(0, 0, 1, 1).quad().structured(n=n).domain(compute_mesh_connectivity=False)
+    return jno.shape.rect(0, 0, 1, 1).quad().structured(n=n).domain(compute_mesh_connectivity=False)
 
 
 def _mark_near(dom, centre, radius):
@@ -237,7 +237,7 @@ def test_a_hanging_node_on_a_tied_interface_is_refused_by_name():
 
 
 def test_local_refinement_of_a_non_quadrilateral_mesh_is_refused_by_name():
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain(compute_mesh_connectivity=False)
+    d = jno.shape.rect(0, 0, 1, 1, size=0.4).domain(compute_mesh_connectivity=False)
     with pytest.raises(NotImplementedError, match="quadrilateral"):
         refine_domain(d, [0])
 
@@ -350,7 +350,7 @@ def test_order_2_is_constrained_correctly_and_beats_the_mesh_it_refined(x64):
 def test_order_2_on_a_refined_HEX_mesh_is_refused_by_name(x64):
     """A hex's 2:1 interface also constrains DOFs lying on a FACE, which needs that face's order-2
     (9-node) basis rather than the edge basis. Refused rather than left partly constrained."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=2).quad().domain(compute_mesh_connectivity=False)
+    d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=2).quad().domain(compute_mesh_connectivity=False)
     d = refine_domain(d, [0])
     u, v = d.fem_symbols(order=2)
     xi, yi, zi = d.variable("interior", split=True)[:3]
@@ -442,7 +442,7 @@ def test_a_complex_field_constrains_both_its_real_and_imaginary_parts(x64):
 def test_a_3d_vector_field_is_constrained_on_a_refined_hex_mesh(x64):
     """vec = 3 on hexes: the Kronecker expansion again, in the dimension where both hanging kinds
     (edge midpoints and face centres) occur at once."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=4).quad().domain(compute_mesh_connectivity=False)
+    d = jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=4).quad().domain(compute_mesh_connectivity=False)
     p = np.asarray(d.mesh.points)[:, :3]
     h = np.asarray(d.mesh.cells_dict["hexahedron"])
     d = refine_domain(d, np.where(np.linalg.norm(p[h].mean(axis=1) - 0.5, axis=1) < 0.3)[0])

--- a/tests/test_fem_hessian.py
+++ b/tests/test_fem_hessian.py
@@ -56,7 +56,7 @@ def _laplacian_K(dim, order, mesh_size):
         ui, vi = u.bind(x=co[0], y=co[1]), phi.bind(x=co[0], y=co[1])
         var = [co[0], co[1]]
     else:
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
         co = d.variable("interior", split=True)
         u, phi = d.fem_symbols(order=order)
         ui, vi = u.bind(x=co[0], y=co[1], z=co[2]), phi.bind(x=co[0], y=co[1], z=co[2])

--- a/tests/test_fem_hex_tie.py
+++ b/tests/test_fem_hex_tie.py
@@ -105,7 +105,7 @@ def test_a_facet_arity_with_no_shape_functions_is_refused():
 
 def _two_hex_blocks(tmp_path, na=4, nb=3):
     """Two hexahedral lattices meeting at x = 1 at DIFFERENT resolutions, with duplicated interface
-    nodes — the configuration `Shape.regions(..., conforming=False)` produces, built directly because
+    nodes — the configuration `shape.regions(..., conforming=False)` produces, built directly because
     that path meshes through gmsh, which cannot hex-mesh."""
 
     def block(x0, x1, n):

--- a/tests/test_fem_higher_order.py
+++ b/tests/test_fem_higher_order.py
@@ -115,7 +115,7 @@ def test_p3_3d_recovers_cubic_exactly():
     pytest.importorskip("pygmsh", reason="pygmsh required for cube meshing")
     # 3D P3 (TET20 via promotion): harmonic cubic u = x^3 - 3x y^2 (independent of z, still harmonic),
     # recovered exactly -- exercises the tet edge + face node placement.
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
     nverts = int(np.asarray(d.mesh.points).shape[0])
     u, phi = d.fem_symbols(order=3)
     co = d.variable("interior", split=True)
@@ -134,7 +134,7 @@ def test_p2_3d_recovers_quadratic_exactly():
     pytest.importorskip("pygmsh", reason="pygmsh required for cube meshing")
     # 3D P2 (TET10 via promotion of the linear cube). u = xy + yz + xz (degree 2,
     # harmonic) recovered exactly; exercises all three edge directions.
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     nverts = int(np.asarray(d.mesh.points).shape[0])
     u, phi = d.fem_symbols(order=2)
     co = d.variable("interior", split=True)

--- a/tests/test_fem_history_march.py
+++ b/tests/test_fem_history_march.py
@@ -78,7 +78,7 @@ def _plastic_march_fem(nstep, peak, *, unload=True, size=0.5, sy=SY):
     """A clamped-base unit cube under a +z body load that ramps with τ (triangular if ``unload`` else
     monotonic 0→peak). Returns the assembled ``jno.fem`` (a pseudo-time march)."""
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain(tau=(0.0, 1.0, nstep))
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain(tau=(0.0, 1.0, nstep))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)
@@ -121,7 +121,7 @@ def test_elastic_control_returns_to_zero():
     """Same load path with NO plasticity (linear elasticity) returns to zero at τ=1 — isolating that the
     permanent set above is the plastic contribution, not a marching artefact."""
     sym, grad, trace, inner, _sqrt, _max, identity = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(tau=(0.0, 1.0, 21))
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(tau=(0.0, 1.0, 21))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)
@@ -159,7 +159,7 @@ def test_first_increment_matches_deformation_theory():
 
     # Deformation-theory reference: the same BVP with ep=0 baked (no history, plain steady solve).
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)
@@ -239,7 +239,7 @@ def test_bdf2_primary_unknown_history_marches_to_static():
         eps = lambda w: sym(grad(w, X))
         return K * trace(eps(u)) * I3 + 2 * MU * (eps(u) - trace(eps(u)) / 3 * I3)
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain(tau=(0.0, T, nstep))
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain(tau=(0.0, T, nstep))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)
@@ -258,7 +258,7 @@ def test_bdf2_primary_unknown_history_marches_to_static():
     traj = np.asarray(fem.solve())  # nothing passed; u.i(-1)/u.i(-2) auto-buffered from the solved u
 
     # Static reference: c·du/dt → 0, the plain elastic BVP under the same load.
-    dS = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
+    dS = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
     dS.tag("bot", lambda x, y, z: z < 1e-6)
     co = dS.variable("interior", split=True)
     cb = dS.variable("bot", split=True)
@@ -288,7 +288,7 @@ def test_surface_qp_history_accumulates_over_the_march():
     # by ∝ k: the per-step peak grows linearly, proving read + evolve + roll all work on face QPs.
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N = 6
-    d = jno.Shape.box(0, 0, 0, 3, 3, 2, size=0.9).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.box(0, 0, 0, 3, 3, 2, size=0.9).domain(tau=(0.0, 1.0, N))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     d.tag("top", lambda x, y, z: z > 2 - 1e-6)
     co = d.variable("interior", split=True)
@@ -336,7 +336,7 @@ def test_stick_slip_friction_caps_at_the_cone():
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     P0, MUF, k_t, D, N = 4.0, 0.3, 400.0, 0.06, 25  # normal pressure, friction coeff, tangential stiffness, drag, steps
     Lz, G = 2.0, MU  # MU (module constant) is the elastic shear modulus; MUF is the friction coefficient
-    d = jno.Shape.box(0, 0, 0, 3, 3, Lz, size=0.9).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.box(0, 0, 0, 3, 3, Lz, size=0.9).domain(tau=(0.0, 1.0, N))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     d.tag("top", lambda x, y, z: z > Lz - 1e-6)
     co = d.variable("interior", split=True)
@@ -390,7 +390,7 @@ def test_multifield_march_leaves_each_block_at_its_own_oracle():
     nstep, peak, size = 6, 5.0, 0.5
 
     def _mesh(**kw):
-        m = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain(**kw)
+        m = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain(**kw)
         m.tag("bot", lambda x, y, z: z < 1e-6)
         return m
 
@@ -454,7 +454,7 @@ def test_multifield_march_leaves_each_block_at_its_own_oracle():
 def _coupled_damage_march(*, irreversible, nstep=7, load=1.5, ell=0.4, gc=1.0, floor=0.3):
     """``(fem, damage_trajectory)`` for one leg of the A/B. ``irreversible`` selects the running max."""
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, nstep))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, nstep))
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = d.variable("interior", split=True), d.variable("left", split=True)
     X, tau = [co[0], co[1]], co[-1]
@@ -517,7 +517,7 @@ def test_gradient_flows_through_a_coupled_march_to_a_material_parameter():
     from jno.utils.solver.newton_krylov import newton_krylov
 
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, 4))
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X, tau = [co[0], co[1]], co[-1]
@@ -577,7 +577,7 @@ def test_gradient_flows_through_a_coupled_march_to_a_material_parameter():
 def test_linear_form_with_step_history_marches_by_exact_superposition(coupled):
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N = 5
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, N))
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -601,7 +601,7 @@ def test_linear_form_with_step_history_marches_by_exact_superposition(coupled):
         assert rel < 1e-9, f"superposition broke: the march is not linear in the state, rel {rel:.2e}"
 
     # And step 0 (virgin state, s = 0) is the plain steady solve of the same BVP.
-    dS = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    dS = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     dS.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = dS.variable("interior", split=True), dS.variable("bdry", split=True)
     XS = [co[0], co[1]]
@@ -618,7 +618,7 @@ def test_history_form_on_non_tau_domain_fails_loud():
     # The plastic physics reads `.i(-1)`, but on a plain (no-`tau`) domain `fem.solve()` has no load path
     # to march over — expect a clear error naming the fix (`domain(tau=...)`).
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()  # NO tau grid
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()  # NO tau grid
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)
@@ -645,7 +645,7 @@ def test_coupled_transient_with_evolves_fails_loud():
     # Lifting the single-field restriction exposed a new route: a COUPLED form reaches the multifield
     # assembler before the single-field transient check, so the `u.t` rejection has to exist there too.
     # Without it the evolution terms would be silently dropped on a coupled transient.
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain(time=(0.0, 0.1, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain(time=(0.0, 0.1, 4))
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _tb = d.variable("boundary", split=True)
     ci = d.variable("initial", split=True)
@@ -672,7 +672,7 @@ def test_internal_state_without_evolves_fails_loud():
     # Reads ep.i(-1) in the weak form but declares NO ep.evolves — the buffer would stay frozen at zero
     # (a silently wrong deformation-theory result). Must be a hard build error.
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain(tau=(0.0, 1.0, 4))
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain(tau=(0.0, 1.0, 4))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)
@@ -704,7 +704,7 @@ def test_internal_state_without_evolves_fails_loud():
 def test_scalar_state_reading_the_bare_trial_keeps_its_rank():
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N = 4
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain(tau=(0.0, 1.0, N))
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X, tau = [co[0], co[1]], co[-1]
@@ -747,7 +747,7 @@ def test_scalar_state_reading_the_bare_trial_keeps_its_rank():
 def test_scalar_gradient_energy_readout_matches_the_closed_form_p1_gradient():
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N = 3
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, N))
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X, tau = [co[0], co[1]], co[-1]
@@ -796,7 +796,7 @@ def test_scalar_gradient_energy_readout_matches_the_closed_form_p1_gradient():
 def test_tau_dependent_dirichlet_drives_the_march():
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N, DELTA, LY = 5, 0.02, 1.0
-    d = jno.Shape.rect(0.0, 0.0, 0.5, LY, size=0.15).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.rect(0.0, 0.0, 0.5, LY, size=0.15).domain(tau=(0.0, 1.0, N))
     d.tag("bot", lambda x, y: y < 1e-9)
     d.tag("top", lambda x, y: y > LY - 1e-9)
     co, cb, ct = (d.variable(r, split=True) for r in ("interior", "bot", "top"))
@@ -841,7 +841,7 @@ def test_tau_dependent_dirichlet_drives_the_march():
 def test_tau_dependent_dirichlet_off_the_march_fails_loud():
     """A path that cannot thread the ramp must say so — dropping it returns a plausible u = 0."""
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, 4))
     d.tag("bot", lambda x, y: y < 1e-9)
     d.tag("top", lambda x, y: y > 1 - 1e-9)
     co, cb, ct = (d.variable(r, split=True) for r in ("interior", "bot", "top"))
@@ -878,7 +878,7 @@ def _yeoh_march(*, order_u, line_search, n_steps=4, load=0.4):
     kb = 2 * (2 * c10) * (1 + nu) / (3 * (1 - 2 * nu))
     W = 4.0
 
-    d = jno.Shape.box(0, 0, 0, W, W, 0.4, size=W / 2).domain(tau=(0.0, 1.0, n_steps))
+    d = jno.shape.box(0, 0, 0, W, W, 0.4, size=W / 2).domain(tau=(0.0, 1.0, n_steps))
     d.tag("bot", lambda x, y, z: y < 1e-9)
     d.tag("top", lambda x, y, z: y > W - 1e-9)
     d.tag("bk", lambda x, y, z: z < 1e-9)
@@ -950,7 +950,7 @@ def test_march_guard_scores_the_min_map_not_the_bare_residual():
     """
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N = 4
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain(tau=(0.0, 1.0, N))
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = (d.variable(r, split=True) for r in ("interior", "left"))
     X = [co[0], co[1]]
@@ -992,7 +992,7 @@ def test_direct_driver_reaches_the_march():
     solve inside a `tau=` path. The answer must be unchanged, and the tangent must actually arrive."""
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N = 4
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, N))
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = (d.variable(r, split=True) for r in ("interior", "left"))
     X = [co[0], co[1]]
@@ -1031,7 +1031,7 @@ def test_direct_staggered_marches_a_coupled_load_path():
     factorization instead of unpreconditioned Krylov — including through the `bounds` min-map."""
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
     N = 4
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, N))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain(tau=(0.0, 1.0, N))
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = (d.variable(r, split=True) for r in ("interior", "left"))
     X = [co[0], co[1]]
@@ -1065,7 +1065,7 @@ def test_adapt_on_a_march_fails_loud():
     Remeshing cannot compose with the march because the per-quadrature-point state would have to be
     transferred onto each new mesh; that is wired for the transient stepper, not for `tau=`."""
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(tau=(0.0, 1.0, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(tau=(0.0, 1.0, 4))
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = d.variable("interior", split=True), d.variable("left", split=True)
     X = [co[0], co[1]]

--- a/tests/test_fem_interface_dirichlet.py
+++ b/tests/test_fem_interface_dirichlet.py
@@ -47,7 +47,7 @@ def _x64():
 
 def _two_region(size=0.22):
     return (
-        jno.Shape.rect(0.0, 0.0, L, H).name("fluid").sized(size) + jno.Shape.rect(X0, -T, X1, 0.0).name("solid").sized(size)
+        jno.shape.rect(0.0, 0.0, L, H).name("fluid").sized(size) + jno.shape.rect(X0, -T, X1, 0.0).name("solid").sized(size)
     ).domain()
 
 
@@ -100,7 +100,7 @@ def test_a_volume_region_dirichlet_works_on_independently_meshed_bodies():
 
     ``_two_region`` above composes with ``+``, which builds through the polygon domain and populates
     ``domain._source_regions``. The classifier gated the volumetric pin on exactly that dict. But
-    ``Shape.regions(..., conforming=False)`` is built by the gmsh emitter, which never writes it, so
+    ``shape.regions(..., conforming=False)`` is built by the gmsh emitter, which never writes it, so
     the pin raised "did you forget the test function?" on precisely the domains the tie machinery
     exists for -- while ``_region_node_ids_from_cells`` was already able to resolve the region's nodes
     from cell topology. The resolution existed; the gate would not let it be reached.
@@ -109,9 +109,9 @@ def test_a_volume_region_dirichlet_works_on_independently_meshed_bodies():
     in the second. Gating on that keeps the guard that matters -- a whole-domain trial-only term really
     is a forgotten test function -- which the last assertion pins.
     """
-    d = jno.Shape.regions(
-        fluid=jno.Shape.rect(0.0, 0.0, L, H).sized(0.22),
-        solid=jno.Shape.rect(X0, -T, X1, 0.0).sized(0.22),
+    d = jno.shape.regions(
+        fluid=jno.shape.rect(0.0, 0.0, L, H).sized(0.22),
+        solid=jno.shape.rect(X0, -T, X1, 0.0).sized(0.22),
         conforming=False,
     ).domain()
     v, psi = d.fem_symbols(value_shape=(2,), names=("v", "psi"), order=2)

--- a/tests/test_fem_les.py
+++ b/tests/test_fem_les.py
@@ -119,7 +119,7 @@ def _nu_t(model, a, b, c, e):
     residual ``-nu_t * integral(w)``; P1 test functions are a partition of unity, so summing that
     block over the unit square returns ``-nu_t`` for a spatially constant nu_t.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     xi, yi = d.variable("interior", split=True)[:2]
     ax = [xi, yi]
     u, v = d.fem_symbols(value_shape=(2,), names=("u_l", "v_l"), order=1)
@@ -172,7 +172,7 @@ def test_each_model_matches_a_textbook_numpy_oracle(name):
 
 def _nu_t_3d(model, G):
     """Same reading, in 3-D: u_i = G_ij x_j on a unit cube, so grad(u) = G exactly on every tet."""
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.7).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.7).domain()
     co = d.variable("interior", split=True)
     ax = [co[0], co[1], co[2]]
     u, v = d.fem_symbols(value_shape=(3,), names=("u3", "v3"), order=1)
@@ -236,7 +236,7 @@ def _solved_shear(model):
     the systems compared have identical structure.
     """
     NU = 1e-2
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     d.tag("all", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     d.point_region("ppin", (0.0, 0.0))
     xi, yi = d.variable("interior", split=True)[:2]

--- a/tests/test_fem_linear_solvers.py
+++ b/tests/test_fem_linear_solvers.py
@@ -384,7 +384,7 @@ def test_a_vector_fem_tangent_now_qualifies_as_symmetric():
     """The case this exists for — a 3-D elasticity tangent, which no bitwise test accepts."""
     nn = jno.np
     inner, grad, symg, trace, ident = nn.inner, nn.grad, nn.sym, nn.trace, nn.identity
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co, cb = d.variable("interior", split=True), d.variable("bot", split=True)
     X, I3 = [co[0], co[1], co[2]], ident(3)
@@ -410,7 +410,7 @@ def test_pardiso_agrees_with_the_iterative_default_on_a_symmetric_tangent():
         pytest.skip("pypardiso present but without the private phase hooks this backend drives")
     nn = jno.np
     inner, grad, symg, trace, ident = nn.inner, nn.grad, nn.sym, nn.trace, nn.identity
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.45).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.45).domain()
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co, cb = d.variable("interior", split=True), d.variable("bot", split=True)
     X, I3 = [co[0], co[1], co[2]], ident(3)

--- a/tests/test_fem_load_path_field.py
+++ b/tests/test_fem_load_path_field.py
@@ -65,7 +65,7 @@ def _j2_stress(u, X, theta, ep_hist):
 def _march(theta_of_Xtau, nstep):
     """Build & solve a clamped-base J2 plasticity march driven by ``theta_of_Xtau(X, tau)``."""
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(tau=(0.0, 1.0, nstep))
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain(tau=(0.0, 1.0, nstep))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)
@@ -110,7 +110,7 @@ def test_load_path_field_matches_analytic_in_tau():
 
 def test_load_path_field_on_plain_domain_fails_loud():
     sym, grad, trace, inner, sqrt, maximum, identity = _aliases()
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()  # NO tau grid, no history
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()  # NO tau grid, no history
     co = d.variable("interior", split=True)
     cb_all = d.variable("boundary", split=True)
     X = [co[0], co[1], co[2]]
@@ -125,7 +125,7 @@ def test_load_path_field_on_plain_domain_fails_loud():
 
 
 def test_frame_count_mismatch_fails_loud():
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain(tau=(0.0, 1.0, 5))
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain(tau=(0.0, 1.0, 5))
     d.tag("bot", lambda x, y, z: z < 1e-6)
     co = d.variable("interior", split=True)
     cb = d.variable("bot", split=True)

--- a/tests/test_fem_morley.py
+++ b/tests/test_fem_morley.py
@@ -190,7 +190,7 @@ def test_morley_periodic_biharmonic_convergence():
     errs, hs = [], []
     with jax.default_device(jax.devices("cpu")[0]):
         for n in (12, 24):
-            d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
+            d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
             xi, yi, _ = d.variable("interior", split=True)
             xl, yl, _ = d.variable("left", split=True)
             xr, yr, _ = d.variable("right", split=True)
@@ -241,7 +241,7 @@ def test_morley_periodic_multifield_decoupled_convergence():
     eps, eph, hs = [], [], []
     with jax.default_device(jax.devices("cpu")[0]):
         for n in (12, 24):
-            d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
+            d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
             xi, yi, _ = d.variable("interior", split=True)
             xl, yl, _ = d.variable("left", split=True)
             xr, yr, _ = d.variable("right", split=True)
@@ -288,7 +288,7 @@ def test_morley_periodic_rejects_argyris_and_nonconforming():
     the C¹ **Argyris** element (extra per-vertex derivative DOFs whose periodic signs are not wired) raises a
     clear ``NotImplementedError`` at assembly rather than silently mis-tying."""
     sin = jno.np.sin
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
     xi, yi, _ = d.variable("interior", split=True)
     xl, yl, _ = d.variable("left", split=True)
     xr, yr, _ = d.variable("right", split=True)
@@ -321,7 +321,7 @@ def test_morley_periodic_rejects_a_bloch_phase():
     problem with ``ValueError: too many values to unpack (expected 4)`` — a plain-periodic tie included.
     The two convergence tests above are the regression for that; this one covers the phase itself."""
     sin = jno.np.sin
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
     xi, yi, _ = d.variable("interior", split=True)
     xl, yl, _ = d.variable("left", split=True)
     xr, yr, _ = d.variable("right", split=True)

--- a/tests/test_fem_mortar_curved_3d.py
+++ b/tests/test_fem_mortar_curved_3d.py
@@ -52,9 +52,9 @@ def _x64():
 def _spheres(h_in, h_out, R=1.0, RO=2.0):
     """A ball in a shell: the interface is a full sphere — curved AND closed, which the 2-D arc-length
     coordinate cannot do at all (it is periodic, so a loop must be cut into arcs first)."""
-    ball = jno.Shape.sphere(0, 0, 0, R)
-    return jno.Shape.regions(
-        ball=ball.sized(h_in), shell=(jno.Shape.sphere(0, 0, 0, RO) - ball).sized(h_out), conforming=False
+    ball = jno.shape.sphere(0, 0, 0, R)
+    return jno.shape.regions(
+        ball=ball.sized(h_in), shell=(jno.shape.sphere(0, 0, 0, RO) - ball).sized(h_out), conforming=False
     ).domain()
 
 

--- a/tests/test_fem_move_mesh.py
+++ b/tests/test_fem_move_mesh.py
@@ -34,11 +34,11 @@ def _x64():
 
 
 def _rect(size, x0=0.0, y0=0.0, x1=1.0, y1=1.0):
-    return jno.Shape.rect(x0, y0, x1, y1, size=size).domain()
+    return jno.shape.rect(x0, y0, x1, y1, size=size).domain()
 
 
 def _box(size):
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
 
 
 def _verts(d):
@@ -181,7 +181,7 @@ def test_p1_stiffness_matvec_matches_the_energy_gradient_oracle():
 
     from jno.utils.solver.fem_adapt import _dirichlet_energy_jax, _mesh_cells, _p1_stiffness_jax
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
     cells, dim = _mesh_cells(d)
     pts = jnp.asarray(np.asarray(d.mesh.points)[:, :dim])
     matvec, diag = _p1_stiffness_jax(pts, cells, dim)
@@ -205,7 +205,7 @@ def test_harmonic_extension_is_differentiable_in_the_prescribed_motion():
 
     from jno.utils.solver.fem_adapt import _harmonic_extension_jax, _mesh_cells
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     cells, dim = _mesh_cells(d)
     pts = jnp.asarray(np.asarray(d.mesh.points)[:, :dim])
     x = np.asarray(pts)
@@ -231,7 +231,7 @@ def test_harmonic_extension_is_differentiable_in_the_vertex_positions():
 
     from jno.utils.solver.fem_adapt import _harmonic_extension_jax, _mesh_cells
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     cells, dim = _mesh_cells(d)
     x = np.asarray(d.mesh.points)[:, :dim]
     is_b = (x[:, 0] < 1e-9) | (x[:, 0] > 1 - 1e-9) | (x[:, 1] < 1e-9) | (x[:, 1] > 1 - 1e-9)

--- a/tests/test_fem_native_lagrange.py
+++ b/tests/test_fem_native_lagrange.py
@@ -357,7 +357,7 @@ def test_3d_tet_poisson_routes_native_and_solves(order):
     """A 3D tet Poisson (Dirichlet on every cube face) is assembled natively and solves the
     manufactured ``sin·sin·sin`` problem; ``fem.points`` indexes the flat solution one-to-one
     (vertices for P1, vertices+edge-midpoints for P2)."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
     u, w = d.fem_symbols(names=("u", "w"), order=order)
     xi, yi, zi = d.variable("interior", split=True)[:3]
     vv = w.bind(x=xi, y=yi, z=zi)
@@ -379,7 +379,7 @@ def test_3d_tet_p2_reproduces_quadratic_exactly():
     tet edge-DOF ordering used by ``_promote_to_quadratic`` (a permutation bug silently scrambles
     the local DOFs) and the robust facet-based boundary-node detection (the geometric containment
     test misses P2 edge-midpoints sitting exactly on a cube face, leaving them unconstrained)."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
     u, w = d.fem_symbols(names=("u", "w"), order=2)
     xi, yi, zi = d.variable("interior", split=True)[:3]
     vv = w.bind(x=xi, y=yi, z=zi)
@@ -402,7 +402,7 @@ def test_3d_tet_neumann_routes_native_and_recovers_flux():
     y/z faces left natural (zero flux, which ``u = x`` satisfies). The native solution recovers ``u = x``
     to the linear-solve tolerance -- pinning the tet-face area element, the parent-basis face
     tabulation and the local-face indexing against ``build_facet_connectivity``."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
     u, w = d.fem_symbols(names=("u", "w"))
     xi, yi, zi = d.variable("interior", split=True)[:3]
     xr, yr, zr = d.variable("right", split=True)[:3]
@@ -427,7 +427,7 @@ def test_3d_tet_multifield_routes_native_and_recovers():
     gate admits 3D now that the assembler is dimension-generic. Manufactured ``u = p = sin·sin·sin``
     with the symmetric coupling ``-Δu + p = (3π²+1)g`` / ``-Δp + u = (3π²+1)g`` (which ``u = p = g``
     solves) is recovered in both blocks."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain()
     u, wu = d.fem_symbols(names=("u", "wu"))
     p, wp = d.fem_symbols(names=("p", "wp"))
     xi, yi, zi = d.variable("interior", split=True)[:3]

--- a/tests/test_fem_navier_stokes_3d.py
+++ b/tests/test_fem_navier_stokes_3d.py
@@ -51,7 +51,7 @@ def _x64():
 
 
 def _build(size, nu, kind, quad_degree=6):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), order=2)
     p, q = d.fem_symbols(names=("p", "q"), order=1)
     xi, yi, zi = d.variable("interior", split=True)[:3]

--- a/tests/test_fem_nedelec_3d.py
+++ b/tests/test_fem_nedelec_3d.py
@@ -67,7 +67,7 @@ def test_nedelec_tet_element_pushforward():
 
 
 def _n1e_cube(mesh_size=0.5):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     coords = d.variable("interior", split=True)
     xi, yi, zi = coords[0], coords[1], coords[2]
@@ -106,7 +106,7 @@ def test_nedelec_tet_curl_curl_exact_bilinear():
 def test_3d_nonnodal_only_nedelec_supported():
     """On a 3D tet mesh only N1E is wired; the 2D-only families (here Morley) must raise a clear
     NotImplementedError rather than silently mis-map their 2D edge/vertex machinery onto a tet."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
     u, phi = d.fem_symbols(space="Morley")
     coords = d.variable("interior", split=True)
     xi, yi, zi = coords[0], coords[1], coords[2]
@@ -124,7 +124,7 @@ def test_pec_tangential_pins_are_boundary_face_edges():
     from jno.utils.solver.fem_nonnodal import _n1e_tangential_pins_3d
     from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
     cells = np.asarray(d.mesh.cells_dict["tetra"])
     top = build_edge_topology(cells, BASIX_TET_EDGES)
     pins = _n1e_tangential_pins_3d([("u", "boundary", 0.0)], d, {"u": 0}, ["N1E"], top, [0])
@@ -150,7 +150,7 @@ def _driven_pec_l2_error(mesh_size):
     boundary. Returns ``(n_dof, ‖E_h − E*‖_L²)`` via ``‖E-E*‖² = EᵀME − 2Eᵀb* + ∫|E*|²`` (``∫|E*|²=¾``)."""
     sin, cos, vec = jno.np.sin, jno.np.cos, jno.np.vector
     pi = np.pi
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]
@@ -187,7 +187,7 @@ def _cavity_eigenvalues(mesh_size):
     from jno.utils.solver.fem_nonnodal import _n1e_tangential_pins_3d
     from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]
@@ -236,7 +236,7 @@ def test_nedelec_tet_field_parameter_kx_matches_analytic_and_differentiates():
     RCWA. A LINEAR ``k(x)`` is reproduced EXACTLY by the P1 basis, so the parametric operator evaluated at
     the field's nodal values must equal the operator assembled with the same coefficient written
     analytically; and the assembly stays differentiable in the full nodal field (the inverse-design payoff)."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     xi, yi, zi, _ = d.variable("interior", split=True)
     kf, _ = d.fem_symbols()  # a P1 coefficient field, independent of the N1E trial
     k = jno.np.parameter(kf, name="k")

--- a/tests/test_fem_nedelec_anisotropic.py
+++ b/tests/test_fem_nedelec_anisotropic.py
@@ -33,7 +33,7 @@ def _x64():
 
 
 def _cube(mesh_size=0.5):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]

--- a/tests/test_fem_nedelec_complex.py
+++ b/tests/test_fem_nedelec_complex.py
@@ -32,7 +32,7 @@ def _x64():
 
 
 def _n1e_cube(mesh_size=0.5):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]

--- a/tests/test_fem_nedelec_impedance.py
+++ b/tests/test_fem_nedelec_impedance.py
@@ -52,7 +52,7 @@ def _x64():
 
 
 def _cube(mesh_size=0.5):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]
@@ -127,7 +127,7 @@ def test_parametric_impedance_surface_mass_matches_and_differentiates():
     surface mass per args, DIFFERENTIABLY (inverse design of a surface impedance). The parametric operator
     at ``k=k0`` equals the constant-coefficient assembly, and a scalar readout's gradient w.r.t. ``k``
     matches central finite differences."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]
@@ -164,7 +164,7 @@ def test_transient_n1e_surface_impedance_reaches_steady_state():
     T, NS, AL, CI = 1.4, 28, 8.0, 3.0  # end time, steps, reaction coeff, impedance coeff (fast decay → converges)
 
     def _build(transient):
-        bx = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6)
+        bx = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6)
         d = bx.domain(time=(0.0, T, NS)) if transient else bx.domain()
         u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
         co = d.variable("interior", split=True)
@@ -199,7 +199,7 @@ def test_neural_impedance_surface_coefficient_matches_and_differentiates():
     (the non-nodal boundary net was previously rejected) and is DIFFERENTIABLE in the network weights — a
     *learned* surface impedance for inverse design. A constant-output net reproduces the scalar-coefficient
     operator exactly, and the operator's gradient w.r.t. the weights is finite and non-zero."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]

--- a/tests/test_fem_nedelec_incident.py
+++ b/tests/test_fem_nedelec_incident.py
@@ -33,7 +33,7 @@ def _x64():
 
 
 def _cube_with_top(mesh_size=0.4):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     d.tag("top", lambda x, y, z: z > 1.0 - 1e-6)  # a single boundary face (z = 1)
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
@@ -88,7 +88,7 @@ def test_combined_absorbing_plus_incident_on_one_face():
     """A single boundary entry may combine the absorbing mass and the incident load —
     ``i k₀·inner(n×u,n×v) + 2 i k₀·inner(g,n×v)`` — and the additive split routes the bilinear part into A
     and the trial-free part into b (equal to authoring them as two separate entries)."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     d.tag("top", lambda x, y, z: z > 1.0 - 1e-6)
     k0 = 2.0
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
@@ -113,7 +113,7 @@ def test_driven_maxwell_end_to_end_solves():
     volume, the i·k₀ impedance absorbing BC on the whole boundary, and a plane-wave incident source on the
     top face — assembles as a complex system and SOLVES to a finite, non-trivial complex field. (The
     impedance term provides radiation damping, so the otherwise-indefinite Helmholtz operator is well posed.)"""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
     d.tag("top", lambda x, y, z: z > 1.0 - 1e-6)
     k0 = 3.0
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")

--- a/tests/test_fem_nedelec_periodic.py
+++ b/tests/test_fem_nedelec_periodic.py
@@ -31,7 +31,7 @@ def _x64():
 
 
 def _periodic_box(size=0.3):
-    d = jno.domain(jno.Shape.box(0, 0, 0, 0.6, 0.6, 1.0, size=size))
+    d = jno.domain(jno.shape.box(0, 0, 0, 0.6, 0.6, 1.0, size=size))
     e = 1e-6
     d.tag("left", lambda x, y, z: x < e)
     d.tag("right", lambda x, y, z: x > 0.6 - e)
@@ -128,7 +128,7 @@ def test_edges_on_tag_matches_on_a_real_mesh():
     from jno._fem import _edges_on_tag
     from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
     cells = np.asarray(d.built_mesh.cells_dict["tetra"])
     ev = build_edge_topology(cells, BASIX_TET_EDGES).edge_vertices
     pts = np.asarray(d.built_mesh.points)

--- a/tests/test_fem_neural_coefficients.py
+++ b/tests/test_fem_neural_coefficients.py
@@ -280,7 +280,7 @@ def test_net_in_robin_boundary_term():
     surface-kernel threading; constant net equals the scalar Robin reference."""
     from jno.jnp_ops import grad, inner
 
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.25).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.25).domain()
     u, w = d.fem_symbols(names=("u", "w"))
     xi, yi = d.variable("interior", split=True)[:2]
     vv = w.bind(x=xi, y=yi)

--- a/tests/test_fem_nonnodal_assembly_memory.py
+++ b/tests/test_fem_nonnodal_assembly_memory.py
@@ -40,7 +40,7 @@ def _x64():
 def _mixed_many_terms(size=0.35):
     """A mixed N1E x Lagrange form with SEVERAL additive volume terms -- the shape that multiplied
     the old path's triplet storage."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     p, q = d.fem_symbols(names=("p", "q"), space="Lagrange")
     ci = d.variable("interior", split=True)

--- a/tests/test_fem_nonnodal_frozen_coefficient.py
+++ b/tests/test_fem_nonnodal_frozen_coefficient.py
@@ -36,7 +36,7 @@ def _x64():
 
 def _curl_curl_with_coefficient(values_fn, n_extra=0, size=0.6):
     """Curl-curl + mass on N1E, loaded through a frozen P1 scalar coefficient."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     w, _wt = d.fem_symbols(names=("w", "wt"))  # Lagrange -- a coefficient, never a solved unknown
     ci = d.variable("interior", split=True)
@@ -113,7 +113,7 @@ def test_a_p0_cell_field_parameter_is_refused_rather_than_misread():
     ``RegionMask`` (``d.by_region``) is the mechanism that works here — one 0/1 per cell, threaded
     through ``_cell_masks`` — so the guard names it.
     """
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     _p0_trial, p0 = d.fem_symbols(names=("m", "mt"), space="P0")
     k = jno.np.parameter(p0, name="k")

--- a/tests/test_fem_nonnodal_mixed_lagrange.py
+++ b/tests/test_fem_nonnodal_mixed_lagrange.py
@@ -48,7 +48,7 @@ def _tgrad(s):  # scalar gradient, TEST side -> (n_quad, n_dof, 3), the rank an 
 def _av(size=0.3, g=None, dirichlet_on_edge_field=False):
     """The A-V operator with jw -> 1: a curl-curl + mass block on N1E, a Laplacian on Lagrange, and
     the grad-V / A coupling that makes it genuinely mixed rather than two independent problems."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     p, q = d.fem_symbols(names=("p", "q"), space="Lagrange")
     ci = d.variable("interior", split=True)
@@ -143,7 +143,7 @@ def test_block_composition_inherits_complex_native():
 
 def _curl_curl(pins=None, size=0.6):
     """Curl-curl + mass on N1E, optionally with caller-supplied ``(dof, value)`` pins."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_fem_nonnodal_sparse_assembly.py
+++ b/tests/test_fem_nonnodal_sparse_assembly.py
@@ -37,7 +37,7 @@ def _x64():
 
 
 def _n1e_cube(mesh_size):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     xi, yi, zi = c[0], c[1], c[2]
@@ -104,7 +104,7 @@ def test_sparse_assembly_scales_past_dense_ceiling():
 # ------------------------------------------------------------------------------------
 def _n1e_cube_param(mesh_size, name="k"):
     """An N1E curl-curl form whose mass coefficient is a P1 NODAL FIELD parameter -- i.e. ε(x)."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     xi, yi, zi, _ = d.variable("interior", split=True)
     kf, _ = d.fem_symbols()  # a P1 coefficient field, independent of the N1E trial
     k = jno.np.parameter(kf, name=name)
@@ -142,7 +142,7 @@ def test_parametric_solve_gradient_matches_finite_differences():
     """The inverse-design payoff, end to end: differentiate a complex driven N1E SOLVE (not just the
     operator) w.r.t. a nodal ε(x) field. Central differences must agree -- the per-element scatter has to
     carry the tangent correctly, not merely produce a plausible matrix."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
     xi, yi, zi, _ = d.variable("interior", split=True)
     kf, _ = d.fem_symbols()
     eps = jno.np.parameter(kf, name="eps")

--- a/tests/test_fem_nonnodal_trainable_coords.py
+++ b/tests/test_fem_nonnodal_trainable_coords.py
@@ -39,7 +39,7 @@ def _curl_curl(size=0.5, trainable_axis=None):
     below is well defined. With ``trainable_axis`` set, that axis of every mesh vertex becomes a
     design variable.
     """
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     pts = np.asarray(d.mesh.points)
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)

--- a/tests/test_fem_operator_compression.py
+++ b/tests/test_fem_operator_compression.py
@@ -69,7 +69,7 @@ def _matvec_matches_uncompressed(A, seed=0):
 
 
 def _poisson_3d(size=0.3):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, phi = d.fem_symbols()
     c = d.variable("interior", split=True)
     cb = d.variable("boundary", split=True)
@@ -99,7 +99,7 @@ def test_compression_does_not_move_the_solution():
 
 
 def _heat_2d(h=0.12, nsteps=6):
-    d = jno.Shape.rect(0, 0, 1, 1).sized(h).domain(time=(0.0, 0.03, nsteps))
+    d = jno.shape.rect(0, 0, 1, 1).sized(h).domain(time=(0.0, 0.03, nsteps))
     u, v = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -164,12 +164,12 @@ def test_1d_steady_operator_is_compressed():
 def _nonlinear(kind):
     """``(1 + u²)∇u·∇v`` — nonlinear in the unknown, so the Jacobian is re-assembled per Newton step."""
     if kind == "3d":
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1).sized(0.3).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1).sized(0.3).domain()
         u, v = d.fem_symbols()
         i, b = d.variable("interior", split=True), d.variable("boundary", split=True)
         a, c = u.bind(x=i[0], y=i[1], z=i[2]), v.bind(x=i[0], y=i[1], z=i[2])
         return jno.fem([(1.0 + a**2) * (a.x * c.x + a.y * c.y + a.z * c.z) - 1.0 * c, u(b[0], b[1], b[2]) - 0.0])
-    d = jno.Shape.rect(0, 0, 1, 1).sized(0.18).domain()
+    d = jno.shape.rect(0, 0, 1, 1).sized(0.18).domain()
     u, v = d.fem_symbols()
     i = d.variable("interior", split=True)
     r, ln = d.variable("right", split=True), d.variable("left", split=True)
@@ -244,7 +244,7 @@ def test_newton_still_converges_on_the_compressed_jacobian():
 
 
 def _poisson_3d_terms(size=0.28):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols()
     i = d.variable("interior", split=True)
     b = d.variable("boundary", split=True)
@@ -330,7 +330,7 @@ def test_chunk_reaches_the_non_nodal_edge_family_assembler():
     pytest.importorskip("pygmsh", reason="pygmsh required for 3-D cube meshing")
     inner, vecf = jno.np.inner, jno.np.vector
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.34).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.34).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -415,7 +415,7 @@ def test_both_assemblers_share_one_chunk_policy():
 def _vertex_fem(space, h):
     """The form each family exists for: 4th-order full-Hessian for the C¹/biharmonic ones, a
     2nd-order form for Hermite (C⁰)."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=h).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=h).domain()
     u, v = d.fem_symbols(space=space)
     c = d.variable("interior", split=True)
     b = d.variable("boundary", split=True)
@@ -497,7 +497,7 @@ def _nonlinear_nonnodal(kind):
     """A genuinely nonlinear weak form, so the tangent depends on the state."""
     inner, vecf = jno.np.inner, jno.np.vector
     if kind == "n1e":  # nu(|B|) curl-curl -- the B-H-curve shape
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.34).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.34).domain()
         u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
         c = d.variable("interior", split=True)
         x, y, z = c[0], c[1], c[2]
@@ -505,7 +505,7 @@ def _nonlinear_nonnodal(kind):
         cu, cv = u.vector.curl(x, y, z), v.vector.curl(x, y, z)
         src = vecf(0.0 * x, 0.0 * x, jno.np.where(x > 0.5, 1.0, 0.0))
         return jno.fem([(1.0 + inner(cu, cu)) * inner(cu, cv) + inner(ui, vi) - inner(src, vi)])
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.22).domain()  # nonlinear biharmonic on Morley
+    d = jno.shape.rect(0, 0, 1, 1, size=0.22).domain()  # nonlinear biharmonic on Morley
     u, v = d.fem_symbols(space="Morley")
     c = d.variable("interior", split=True)
     b = d.variable("boundary", split=True)

--- a/tests/test_fem_per_region.py
+++ b/tests/test_fem_per_region.py
@@ -354,7 +354,7 @@ def test_region_in_transient_form():
 
 def test_region_in_3d():
     """Per-region integration works in 3D (centroid-in-predicate over tetrahedra)."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.18).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.18).domain()
     assert d.dimension == 3
     ball = lambda x, y, z: (x - 0.5) ** 2 + (y - 0.5) ** 2 + (z - 0.5) ** 2 < 0.25**2  # noqa: E731
     d.tag("ball", ball)
@@ -448,7 +448,7 @@ def _n1e_nested_box(mesh_size=0.16):
     on it as a (face-less) surface term -- a pre-existing property of `jno.fem`, unrelated to N1E."""
     c0 = (0.5, 0.5, 0.5)
     r2 = lambda x, y, z: (x - c0[0]) ** 2 + (y - c0[1]) ** 2 + (z - c0[2]) ** 2  # noqa: E731
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     d.tag("core", lambda x, y, z: r2(x, y, z) < 0.22**2)
     d.tag("shell", lambda x, y, z: (r2(x, y, z) >= 0.22**2) & (r2(x, y, z) < 0.36**2))
     d.tag("both", lambda x, y, z: r2(x, y, z) < 0.36**2)
@@ -487,7 +487,7 @@ def test_per_region_n1e_nested_regions_are_exactly_additive():
     inner3 = jno.np.inner
     c0 = (0.5, 0.5, 0.5)
     r2 = lambda x, y, z: (x - c0[0]) ** 2 + (y - c0[1]) ** 2 + (z - c0[2]) ** 2  # noqa: E731
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.16).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.16).domain()
     d.tag("core", lambda x, y, z: r2(x, y, z) < 0.22**2)
     d.tag("shell", lambda x, y, z: (r2(x, y, z) >= 0.22**2) & (r2(x, y, z) < 0.36**2))
     d.tag("both", lambda x, y, z: r2(x, y, z) < 0.36**2)

--- a/tests/test_fem_periodic_bloch.py
+++ b/tests/test_fem_periodic_bloch.py
@@ -32,7 +32,7 @@ def _bloch_strip(kx, *, size=0.1, source="complex", extra_coeff=1.0):
     With ``f = (kx² + π² + 1)·e^{i kx x}·sin(π y)`` the exact solution is the Bloch mode
     ``u* = e^{i kx x}·sin(π y)`` (it satisfies the tie exactly: ``u*(0,y) = e^{-i kx}·u*(1,y)``).
     ``source="real"`` keeps every coefficient real (``f = Re(λ u*)``) — the *real-form* Bloch case."""
-    d = jno.domain(jno.Shape.rect(0, 0, 1.0, 1.0, size=size))
+    d = jno.domain(jno.shape.rect(0, 0, 1.0, 1.0, size=size))
     e = 1e-6
     d.tag("left", lambda x, y: (x < e) & (y > e) & (y < 1 - e))
     d.tag("right", lambda x, y: (x > 1 - e) & (y > e) & (y < 1 - e))
@@ -144,7 +144,7 @@ def test_bloch_complex_transient_marches_the_plane_wave():
     kx = PI / 2
 
     def build(amp):
-        d = jno.domain(jno.Shape.rect(0, 0, 1.0, 1.0, size=0.15), time=(0.0, 0.02, 21))
+        d = jno.domain(jno.shape.rect(0, 0, 1.0, 1.0, size=0.15), time=(0.0, 0.02, 21))
         e = 1e-6
         d.tag("left", lambda x, y: (x < e) & (y > e) & (y < 1 - e))
         d.tag("right", lambda x, y: (x > 1 - e) & (y > e) & (y < 1 - e))
@@ -182,7 +182,7 @@ def test_bloch_complex_transient_marches_the_plane_wave():
 def test_bloch_on_a_real_march_fails_loud():
     """A Bloch phase forces a complex field; a REAL transient (heat) march cannot carry it and must
     say so at build time — it used to surface as a bare while_loop dtype crash at evaluation."""
-    d = jno.domain(jno.Shape.rect(0, 0, 1.0, 1.0, size=0.2), time=(0.0, 0.1, 9))
+    d = jno.domain(jno.shape.rect(0, 0, 1.0, 1.0, size=0.2), time=(0.0, 0.1, 9))
     e = 1e-6
     d.tag("left", lambda x, y: (x < e) & (y > e) & (y < 1 - e))
     d.tag("right", lambda x, y: (x > 1 - e) & (y > e) & (y < 1 - e))
@@ -205,7 +205,7 @@ def test_bloch_on_a_real_march_fails_loud():
 
 def test_bloch_on_a_nonlinear_form_fails_loud():
     """Nonlinear + Bloch: the promotion cannot linearize the form, so it must refuse by name."""
-    d = jno.domain(jno.Shape.rect(0, 0, 1.0, 1.0, size=0.2))
+    d = jno.domain(jno.shape.rect(0, 0, 1.0, 1.0, size=0.2))
     e = 1e-6
     d.tag("left", lambda x, y: (x < e) & (y > e) & (y < 1 - e))
     d.tag("right", lambda x, y: (x > 1 - e) & (y > e) & (y < 1 - e))
@@ -225,7 +225,7 @@ def test_bloch_on_a_nonlinear_form_fails_loud():
 
 def test_bloch_scaled_by_nonconstant_rejected():
     """A tie may be scaled only by a constant scalar; a coordinate-dependent factor is not a Bloch phase."""
-    d = jno.domain(jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5))
+    d = jno.domain(jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5))
     e = 1e-6
     d.tag("left", lambda x, y, z: x < e)
     d.tag("right", lambda x, y, z: x > 1 - e)
@@ -258,7 +258,7 @@ def test_bloch_empty_cell_transmits_at_oblique():
         for deg in (0.0, 20.0, 35.0):
             kx = float(K0 * np.sin(np.deg2rad(deg)))
             kz = float(np.sqrt(K0**2 - kx**2))
-            d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.12))
+            d = jno.domain(jno.shape.box(0, 0, 0, P0, P0, Lz, size=0.12))
             e = 1e-6
             for nm, f in [
                 ("left", lambda x, y, z: x < e),

--- a/tests/test_fem_periodic_multifield.py
+++ b/tests/test_fem_periodic_multifield.py
@@ -85,7 +85,7 @@ def test_block_reduction_sparse_bcoo_matches_dense(_x64):
 
 def _periodic_domain(n):
     dom = (
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0)
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0)
         .structured(n=n)
         .domain(
             time=(0.0, 0.02, 11),

--- a/tests/test_fem_periodic_unstructured.py
+++ b/tests/test_fem_periodic_unstructured.py
@@ -362,7 +362,7 @@ def test_triply_periodic_3d_cube():
 
     pi = np.pi
     e = 1e-6
-    dom = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.13).domain()
+    dom = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.13).domain()
     faces = {
         "xlo": lambda x, y, z: x < e,
         "xhi": lambda x, y, z: x > 1 - e,
@@ -425,7 +425,7 @@ def test_triply_periodic_3d_cube_p2():
 
     pi = np.pi
     e = 1e-6
-    dom = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.28).domain()
+    dom = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.28).domain()
     for nm, p in {
         "xlo": lambda x, y, z: x < e,
         "xhi": lambda x, y, z: x > 1 - e,
@@ -598,13 +598,13 @@ def test_multidirection_on_auto_faces_shares_corners():
 
 
 def test_doubly_periodic_on_shape_rect():
-    """The same doubly-periodic cell on a ``jno.Shape.rect`` domain (gmsh mesh, auto left/right/top/
+    """The same doubly-periodic cell on a ``jno.shape.rect`` domain (gmsh mesh, auto left/right/top/
     bottom): its face tags share corners, so multidirectional periodicity solves. Manufactured
     ``u = cos(2πx) cos(2πy)``."""
     import jno
 
     pi = np.pi
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.07).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.07).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xl, yl, _ = d.variable("left", split=True)

--- a/tests/test_fem_phase_field_sent.py
+++ b/tests/test_fem_phase_field_sent.py
@@ -57,11 +57,11 @@ def _sent(dim, *, h=0.03, thick=0.06, delta=1.4e-2, nout=8, limit=0.5):
     maximum, minimum, diff, ident = n.maximum, n.minimum, n.diff, n.identity
     w = 0.010
     if dim == 2:
-        shape = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=h) - jno.Shape.rect(-0.01, 0.5 - w, 0.5, 0.5 + w, size=h)
+        shape = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=h) - jno.shape.rect(-0.01, 0.5 - w, 0.5, 0.5 + w, size=h)
         top_pred, bot_pred = (lambda x, y: y > 1 - 1e-9), (lambda x, y: y < 1e-9)
         kbulk = LAM + MU  # plane strain
     else:
-        shape = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, thick, size=h) - jno.Shape.box(
+        shape = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, thick, size=h) - jno.shape.box(
             -0.01, 0.5 - w, -0.01, 0.5, 0.5 + w, thick + 0.01, size=h
         )
         top_pred, bot_pred = (lambda x, y, z: y > 1 - 1e-9), (lambda x, y, z: y < 1e-9)

--- a/tests/test_fem_precond_ams.py
+++ b/tests/test_fem_precond_ams.py
@@ -39,7 +39,7 @@ def _x64():
 
 def _curlcurl_source(mesh_size, beta):
     """A driven real curl-curl (+ β·mass) N1E problem: inner(curl u, curl v) + β⟨u,v⟩ − ⟨Js, v⟩."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -53,7 +53,7 @@ def _curlcurl_source(mesh_size, beta):
 def _complex_eddy(mesh_size, freq, eps):
     """A complex eddy operator νK + jω(σ+ε)M with σ nonzero only on a sub-region (copper analog) and a
     small ε mass floor everywhere (the σ=0-in-air ε-gauge), plus a source in the conductor."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -88,7 +88,7 @@ def test_ams_complex_eddy_extreme_scale_matches_lu():
     solve would raise the residual-check error."""
     mu0 = 4 * np.pi * 1e-7
     nu, sigma, omega = 1.0 / mu0, 5.8e7, 2 * np.pi * 1e4  # ν~8e5, jωσ~3.6e12  ⇒  |A| ~ 1e12
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -112,7 +112,7 @@ def test_non_native_precond_complex_extreme_scale_does_not_break_down():
     now *converges to a real answer* instead of breaking down. Regression for the sparse-2n-block route."""
     mu0 = 4 * np.pi * 1e-7
     nu, sigma, omega = 1.0 / mu0, 5.8e7, 2 * np.pi * 1e4  # |A| ~ 1e12
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -249,7 +249,7 @@ def test_ams_needs_the_owning_fem():
 # ------------------------------------------------------------------------------------
 def _driven_maxwell(mesh_size, k0, volume_loss=0.0):
     """curl-curl − k₀²·mass, Silver–Müller impedance ABC on the whole boundary, plane-wave source."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     xi, yi, zi, _ = d.variable("interior", split=True)
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ui, vi = u.bind(x=xi, y=yi, z=zi), v.bind(x=xi, y=yi, z=zi)

--- a/tests/test_fem_promotion_entity_keys.py
+++ b/tests/test_fem_promotion_entity_keys.py
@@ -2,7 +2,7 @@
 
 `_promote_to_degree` synthesises a P{k} node mesh from a P1 one and has to decide when two synthesised
 nodes are the same node. Keying on the coordinate is the right conformity test for ONE body and the
-wrong one for two: a `Shape.regions(..., conforming=False)` interface is coincident *on purpose*, so
+wrong one for two: a `shape.regions(..., conforming=False)` interface is coincident *on purpose*, so
 every node the promotion added there was merged across the bodies and welded them -- silently. It was
 refused outright rather than allowed to be wrong, which is why P2 was unavailable on a non-conforming
 domain, and with it Taylor-Hood (P2 velocity / P1 pressure) on independently meshed bodies.
@@ -60,7 +60,7 @@ def test_a_conforming_p2_mesh_has_exactly_vertices_plus_edges():
 
     On a simplex mesh a P2 node sits on every vertex and every edge, and nowhere else -- so the promoted
     count is fixed by the topology alone, independent of how dedup is keyed."""
-    d = _build(jno.Shape.rect(0.0, 0.0, 2.0, 1.0).sized(0.3).domain())
+    d = _build(jno.shape.rect(0.0, 0.0, 2.0, 1.0).sized(0.3).domain())
     p1 = np.asarray(d.built_mesh.points)
     tri = np.asarray(d.built_mesh.cells_dict["triangle"])
     edges = {frozenset((int(a), int(b))) for t in tri for a, b in ((t[0], t[1]), (t[1], t[2]), (t[2], t[0]))}
@@ -72,9 +72,9 @@ def test_two_independently_meshed_bodies_are_not_welded_at_p2():
     """The defect. Before entity keying this reported 37 shared nodes, all on the interface -- harmless
     for a tie, and wrong for contact, where those DOFs could then never separate."""
     d = _build(
-        jno.Shape.regions(
-            left=jno.Shape.rect(0.0, 0.0, 1.0, 1.0),
-            right=jno.Shape.rect(1.0, 0.0, 2.0, 1.0),
+        jno.shape.regions(
+            left=jno.shape.rect(0.0, 0.0, 1.0, 1.0),
+            right=jno.shape.rect(1.0, 0.0, 2.0, 1.0),
             conforming=False,
         )
         .sized(0.34)
@@ -95,8 +95,8 @@ def test_a_conforming_interface_still_shares_its_nodes():
     CONFORMING, so the two regions must still meet on one shared node set."""
     d = _build(
         (
-            jno.Shape.rect(0.0, 0.0, 1.0, 1.0).name("left").sized(0.34)
-            + jno.Shape.rect(1.0, 0.0, 2.0, 1.0).name("right").sized(0.34)
+            jno.shape.rect(0.0, 0.0, 1.0, 1.0).name("left").sized(0.34)
+            + jno.shape.rect(1.0, 0.0, 2.0, 1.0).name("right").sized(0.34)
         ).domain()
     )
     nl, nr = _region_nodes(d, "left"), _region_nodes(d, "right")
@@ -110,9 +110,9 @@ def test_taylor_hood_now_builds_on_independently_meshed_bodies():
     """What the refusal cost: mixed-order elements were unavailable on a non-conforming domain, so
     P2/P1 Taylor-Hood could not be posed there at all -- and P1/P1 is inf-sup unstable."""
     d = (
-        jno.Shape.regions(
-            left=jno.Shape.rect(0.0, 0.0, 1.0, 1.0),
-            right=jno.Shape.rect(1.0, 0.0, 2.0, 1.0),
+        jno.shape.regions(
+            left=jno.shape.rect(0.0, 0.0, 1.0, 1.0),
+            right=jno.shape.rect(1.0, 0.0, 2.0, 1.0),
             conforming=False,
         )
         .sized(0.34)

--- a/tests/test_fem_quadhex_solve.py
+++ b/tests/test_fem_quadhex_solve.py
@@ -409,13 +409,13 @@ def test_a_high_aspect_ratio_mesh_still_converges():
     assert np.abs(sol - exact).max() < 1e-8
 
 
-# ------------------------------------------------------------------- Shape.quad() (recombination)
+# ------------------------------------------------------------------- shape.quad() (recombination)
 
 
 def test_shape_quad_recombines_arbitrary_geometry():
     """gmsh meshes triangles and recombines them, which is not restricted to boxes: a DISK comes
     back as pure quadrilaterals, with no triangle left behind."""
-    for shape in (jno.Shape.rect(0, 0, 1, 1, size=0.25), jno.Shape.disk(0, 0, 1, size=0.3)):
+    for shape in (jno.shape.rect(0, 0, 1, 1, size=0.25), jno.shape.disk(0, 0, 1, size=0.3)):
         blocks = {c.type: len(c.data) for c in shape.quad().build()[0].cells}
         assert "triangle" not in blocks, f"recombination left triangles: {blocks}"
         assert blocks.get("quad", 0) > 0
@@ -424,7 +424,7 @@ def test_shape_quad_recombines_arbitrary_geometry():
 
 def test_shape_quad_solves_and_converges():
     def err(h):
-        d = jno.Shape.rect(0, 0, 1, 1, size=h).quad().domain()
+        d = jno.shape.rect(0, 0, 1, 1, size=h).quad().domain()
         u, v = d.fem_symbols()
         xi, yi, _ = d.variable("interior", split=True)
         xb, yb, _ = d.variable("boundary", split=True)
@@ -448,7 +448,7 @@ def test_shape_quad_solves_and_converges():
 def test_patch_test_on_a_recombined_disk():
     """The strongest geometric case available: unstructured quads on a curved boundary, where cell
     shapes are irregular by construction. A linear field is still reproduced to machine precision."""
-    d = jno.Shape.disk(0, 0, 1, size=0.15).quad().domain()
+    d = jno.shape.disk(0, 0, 1, size=0.15).quad().domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -467,15 +467,15 @@ def test_shape_quad_refuses_an_unstructured_3d_plan_and_a_curved_one():
     answer depends on whether ``.structured()`` is anywhere in the plan, and requiring it to come
     first would make the chain order-dependent."""
     with pytest.raises(NotImplementedError, match=r"\.structured\(\)"):
-        jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).quad().build()
+        jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).quad().build()
     with pytest.raises(NotImplementedError, match="curved"):
-        jno.Shape.rect(0, 0, 1, 1, size=0.5).quad().curved().build()
+        jno.shape.rect(0, 0, 1, 1, size=0.5).quad().curved().build()
 
 
 def test_shape_quad_survives_the_other_modifiers():
     """`quad()` is a meshing property like `sized()`, so it must propagate through the plan
     operators rather than being dropped by the next transformation."""
-    s = (jno.Shape.rect(0, 0, 2, 1, size=0.4).quad() - jno.Shape.disk(1.0, 0.5, 0.25)).sized(0.25)
+    s = (jno.shape.rect(0, 0, 2, 1, size=0.4).quad() - jno.shape.disk(1.0, 0.5, 0.25)).sized(0.25)
     blocks = {c.type: len(c.data) for c in s.build()[0].cells}
     assert "triangle" not in blocks and blocks.get("quad", 0) > 0
 
@@ -485,9 +485,9 @@ def test_shape_quad_survives_the_other_modifiers():
 
 def test_tri_is_the_explicit_opposite_of_quad():
     """`.tri()` cancels a `.quad()` a shape inherited, and simplices remain the default."""
-    plain = {c.type for c in jno.Shape.rect(0, 0, 1, 1, size=0.4).build()[0].cells}
-    quad = {c.type for c in jno.Shape.rect(0, 0, 1, 1, size=0.4).quad().build()[0].cells}
-    back = {c.type for c in jno.Shape.rect(0, 0, 1, 1, size=0.4).quad().tri().build()[0].cells}
+    plain = {c.type for c in jno.shape.rect(0, 0, 1, 1, size=0.4).build()[0].cells}
+    quad = {c.type for c in jno.shape.rect(0, 0, 1, 1, size=0.4).quad().build()[0].cells}
+    back = {c.type for c in jno.shape.rect(0, 0, 1, 1, size=0.4).quad().tri().build()[0].cells}
     assert "triangle" in plain and "quad" not in plain
     assert "quad" in quad and "triangle" not in quad
     assert back == plain, ".tri() must undo .quad()"
@@ -498,9 +498,9 @@ def test_a_mixed_cell_plan_refuses_rather_than_picking_one():
     is per-surface and the regions conform along a shared edge in 2-D — but the assembler carries
     one element table, so it would build and fail to assemble. Refuse at the mesher, and say what to
     do instead (independent meshes + a mortar tie)."""
-    mixed = jno.Shape.regions(
-        left=jno.Shape.rect(0, 0, 1, 1, size=0.3).quad(),
-        right=jno.Shape.rect(1, 0, 2, 1, size=0.3).tri(),
+    mixed = jno.shape.regions(
+        left=jno.shape.rect(0, 0, 1, 1, size=0.3).quad(),
+        right=jno.shape.rect(1, 0, 2, 1, size=0.3).tri(),
     )
     assert mixed.cell_choices() == frozenset({"quad", "simplex"})
     with pytest.raises(NotImplementedError, match="more than one cell type"):
@@ -509,7 +509,7 @@ def test_a_mixed_cell_plan_refuses_rather_than_picking_one():
 
 def test_one_cell_choice_through_a_plan_is_not_mixed():
     """A single choice, however deep in the plan, must still mesh."""
-    s = (jno.Shape.rect(0, 0, 2, 1, size=0.4).quad() - jno.Shape.disk(1.0, 0.5, 0.25)).sized(0.3)
+    s = (jno.shape.rect(0, 0, 2, 1, size=0.4).quad() - jno.shape.disk(1.0, 0.5, 0.25)).sized(0.3)
     assert s.cell_choices() == frozenset({"quad"})
     assert "quad" in {c.type for c in s.build()[0].cells}
 
@@ -583,9 +583,9 @@ def _quad_poisson():
 
 
 def test_h_adaptivity_on_a_quad_mesh_needs_a_geometry_to_rebuild_from():
-    """There is no mmg for quads, so the remesh stage rebuilds the `Shape` plan at the marked size
+    """There is no mmg for quads, so the remesh stage rebuilds the `shape` plan at the marked size
     field instead — and this domain is built from a raw `Geometries` constructor, so it has no plan.
-    That is the honest refusal for it; a Shape-built quad mesh DOES adapt
+    That is the honest refusal for it; a shape-built quad mesh DOES adapt
     (`tests/test_fem_adapt_quad.py`).
 
     Two rounds, because a single round is solve + estimate and never reaches a remesh at all."""

--- a/tests/test_fem_rebuild_cache.py
+++ b/tests/test_fem_rebuild_cache.py
@@ -34,7 +34,7 @@ def _delta(before):
 
 
 def _poisson2d(size=0.28, k=1.0, f=1.0):
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -86,7 +86,7 @@ def test_zero_and_negative_coefficients_key_distinctly():
 
 def test_3d_rebuild_hits():
     def build():
-        d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.35).domain()
+        d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.35).domain()
         u, v = d.fem_symbols()
         xi, yi, zi, _ = d.variable("interior", split=True)
         xb, yb, zb, _ = d.variable("boundary", split=True)
@@ -109,7 +109,7 @@ def test_parametric_rebuild_hits_and_solves_per_args():
     import jax
 
     def build():
-        d = jno.Shape.rect(0, 0, 1, 1, size=0.28).domain()
+        d = jno.shape.rect(0, 0, 1, 1, size=0.28).domain()
         u, v = d.fem_symbols()
         xi, yi, _ = d.variable("interior", split=True)
         xb, yb, _ = d.variable("boundary", split=True)

--- a/tests/test_fem_refine_hexes.py
+++ b/tests/test_fem_refine_hexes.py
@@ -1,7 +1,7 @@
 """Local refinement of a **hexahedral** mesh, and the two kinds of hanging node it creates.
 
 The 3-D half of hanging-node adaptivity, and the only h-adaptivity a hex mesh can have: mmg adapts
-simplices, and rebuilding a ``Shape`` plan at a finer size field needs a mesher to rebuild *with* --
+simplices, and rebuilding a ``shape`` plan at a finer size field needs a mesher to rebuild *with* --
 gmsh's ``Recombine3DAll`` on a plain box returns tetrahedra and no hexahedra, so there is nothing to
 remesh to. Splitting a hex into 8 needs neither.
 
@@ -232,7 +232,7 @@ def _surface_area(pts, faces):
 
 
 def _box(n):
-    return jno.Shape.box(0, 0, 0, 1, 1, 1).structured(n=n).quad().domain(compute_mesh_connectivity=False)
+    return jno.shape.box(0, 0, 0, 1, 1, 1).structured(n=n).quad().domain(compute_mesh_connectivity=False)
 
 
 def _poisson(dom):

--- a/tests/test_fem_region_coefficient_from_mesh.py
+++ b/tests/test_fem_region_coefficient_from_mesh.py
@@ -2,7 +2,7 @@
 
 ``domain.by_region({"steel": 16.0, "air": 0.026})`` is the per-region material primitive, and it
 resolved a region only from a shapely geometry part, a ``domain.tag`` predicate, or a
-``Shape.regions`` sub-region. A mesh loaded from a ``.msh`` keeps its gmsh physical volumes in
+``shape.regions`` sub-region. A mesh loaded from a ``.msh`` keeps its gmsh physical volumes in
 ``mesh.cell_sets``, which none of those cover -- so the one kind of domain that has materials
 declared *in the file* was the one kind that could not name them in a weak form.
 
@@ -170,7 +170,7 @@ def test_the_volume_term_guard_still_refuses_domain_variable(tmp_path):
 
 def test_attach_works_on_a_mesh_file_region(tmp_path):
     """`domain.attach` documents itself as the way to give properties to a mesh-file domain, "which
-    has no Shape to declare them on" -- but its target classifier enumerated the same three sources,
+    has no shape to declare them on" -- but its target classifier enumerated the same three sources,
     so it raised `unknown target` on exactly that case. A mesh region owns cells by definition and is
     classified `volume` directly: routing it through the facets-vs-cells test would call the outer
     region of any real device ambiguous, since it reaches the boundary."""

--- a/tests/test_fem_relocate.py
+++ b/tests/test_fem_relocate.py
@@ -33,7 +33,7 @@ def _min_detj(pts, cells):
 
 def _peak_scalar(size=0.14, movable=True):
     """Poisson with a sharp off-center peak source; interior nodes (a central box) tagged trainable."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -73,7 +73,7 @@ def test_relocate_requires_trainable_coordinates():
 
 def test_relocate_vector_field():
     """Generality: a vector problem relocates too (the monitor sums over components)."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.16).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.16).domain()
     u, phi = d.fem_symbols(value_shape=(2,))
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -104,7 +104,7 @@ def _mov(d):
 
 def test_relocate_nonlinear():
     """A steady *nonlinear* problem relocates (the objective's solve is a differentiable Newton solve)."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.18).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.18).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -142,7 +142,7 @@ def test_relocate_transient():
 
 def test_relocate_periodic():
     """A *periodic* problem relocates: interior relocation never touches the boundary ties."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.18).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.18).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xl, yl, _ = d.variable("left", where=lambda x, y: x < 1e-6, split=True)
@@ -241,7 +241,7 @@ def test_relocate_beats_a_uniform_mesh_on_an_underresolved_front():
     T, NSTEP, SIZE, EPS = 2.0, 24, 0.06, 0.03
 
     def build(movable):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=SIZE).domain(time=(0.0, T, NSTEP))
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=SIZE).domain(time=(0.0, T, NSTEP))
         d.tag("right_edge", lambda x, y: x > 1.0 - 1e-9)
         u, v = d.fem_symbols()
         xi, yi, ti = d.variable("interior", split=True)
@@ -589,7 +589,7 @@ def test_relocate_monge_ampere_returns_its_best_mesh_not_its_last():
 def _peak_field(order, shape, size=0.14):
     """The same Poisson peak at a chosen element order and value shape; every component carries the
     identical field, which is what makes the scalar and vector runs comparable below."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     xm, ym = d.variable("mov", where=lambda x, y: (x > 0.05) & (x < 0.95) & (y > 0.05) & (y < 0.95), split=True)[:2]
     xm.trainable(name="ix")
     ym.trainable(name="iy")
@@ -660,7 +660,7 @@ L_SHAPE_R = [(0, 0), (1, 0), (1, 0.5), (0.5, 0.5), (0.5, 1), (0, 1)]
 
 def _corner_problem(movable, size=0.12):
     """Poisson on an L-shape: a FIXED singularity at the re-entrant corner, nothing moving."""
-    d = jno.Shape.polygon(L_SHAPE_R, size=size).domain()
+    d = jno.shape.polygon(L_SHAPE_R, size=size).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -738,7 +738,7 @@ def test_the_objective_is_reachable_from_the_public_slot_and_validated():
 def _stokes_with_a_pressure_gauge(size=0.5):
     """Taylor-Hood Stokes in a channel, with `p.pin()` fixing the pressure gauge, and its top wall
     vertices free to slide vertically."""
-    d = jno.Shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
     u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
     p, q = d.fem_symbols(names=("p", "q"), order=1)
     x, y, _ = d.variable("interior", split=True)

--- a/tests/test_fem_relocate_objective.py
+++ b/tests/test_fem_relocate_objective.py
@@ -30,7 +30,7 @@ def _x64():
 
 def _peak(size=0.14, movable=True):
     """Poisson with a sharp off-center peak; a central box of interior nodes is movable."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -98,7 +98,7 @@ def test_the_string_objectives_still_work():
 
 def _channel_with_a_surface_term():
     """Poisson on [0,2]x[0,1] carrying ONE surface term, so the facet quadrature tables get built."""
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.25).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -126,7 +126,7 @@ def test_a_surface_term_without_facet_tables_refuses_by_name():
     """The tables are tabulated at BUILD time and only when the form itself carries a surface term, so
     a surface readout on a purely-volume problem has nothing to integrate against. It must say that
     rather than fail on `NoneType` unpacking six frames inside the element kernel."""
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.3).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -157,7 +157,7 @@ def _stokes_channel(size=0.5):
     the flow must develop a profile, so the channel's shape sets it (``max|du| = 7.2e-02`` for the same
     0.1 displacement) and ``d(objective)/d(vertex)`` genuinely runs through the solve.
     """
-    d = jno.Shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
     # Deform BEFORE tagging. A region's predicate is re-evaluated against the CURRENT points (both by
     # `tag_node_mask` and by relocate, which re-applies every predicate after moving the mesh), so a
     # mesh deformed after tagging leaves the tags describing a geometry that no longer exists -- here

--- a/tests/test_fem_relocate_remesh.py
+++ b/tests/test_fem_relocate_remesh.py
@@ -39,7 +39,7 @@ def _aspect(dom):
 
 def _peak(size=0.2):
     """Poisson with an off-centre peak; a central box of vertices is movable."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -132,7 +132,7 @@ def test_plain_relocate_is_unchanged():
 def _free_surface_channel(size=0.34):
     """Stokes channel with a traction-free top whose vertices may slide vertically -- the free-surface
     problem, whose objective is a SURFACE integral and so exercises the region resolution."""
-    d = jno.Shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 3.0, 1.0, size=size).domain()
     p = np.asarray(d.mesh.points)
     p[:, 1] = p[:, 1] * (1.0 - 0.22 * p[:, 0] / 3.0 * p[:, 1])  # a deliberately wrong wall
     d.mesh.points = p

--- a/tests/test_fem_remesh_multimaterial.py
+++ b/tests/test_fem_remesh_multimaterial.py
@@ -27,9 +27,9 @@ def _tet_volumes(points, tets):
 
 def _two_material_ball_in_box(size=0.34):
     """A sphere embedded in a box: two conforming volume regions with a curved interface."""
-    inner = jno.Shape.sphere(0.5, 0.5, 0.5, 0.28)
-    outer = jno.Shape.box(0, 0, 0, 1, 1, 1)
-    return jno.Shape.regions(ball=inner, block=outer).sized(size).domain()
+    inner = jno.shape.sphere(0.5, 0.5, 0.5, 0.28)
+    outer = jno.shape.box(0, 0, 0, 1, 1, 1)
+    return jno.shape.regions(ball=inner, block=outer).sized(size).domain()
 
 
 def _region_volume(d, name):
@@ -141,7 +141,7 @@ def test_a_tighter_hausdorff_tolerance_tracks_the_surface_more_closely():
 
 def test_a_single_material_mesh_is_unaffected():
     """No named volume region -> the original single-reference path, byte-for-byte behaviour."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain()
     before = set(d.mesh.cell_sets)
     d.refine(np.full(len(d.mesh.points), 0.25))
     assert len(d.mesh.cells_dict["tetra"]) > 0

--- a/tests/test_fem_saddle_generality.py
+++ b/tests/test_fem_saddle_generality.py
@@ -39,7 +39,7 @@ def _odd_saddle_3d(size=0.5):
     Physically this is a Stokes flow with a buoyancy coupling; nothing in the code is allowed to know
     that. The constraint equation is written first in the term list, which -- since block order
     follows TERM order -- puts the constraint field in the MIDDLE of the block stack."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     d.tag("drive", lambda x, y, z: z > 1 - 1e-9)
     d.tag("held", lambda x, y, z: (z < 1e-9) | (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     d.point_region("gauge", (0.0, 0.0, 0.0))

--- a/tests/test_fem_saddle_warning.py
+++ b/tests/test_fem_saddle_warning.py
@@ -38,7 +38,7 @@ def _x64():
 
 def _stokes(size=0.4):
     """Taylor-Hood P2/P1: the canonical saddle system."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), order=2)
     p, q = d.fem_symbols(names=("p", "q"), order=1)
     xi, yi = d.variable("interior", split=True)[:2]
@@ -63,7 +63,7 @@ def _two_coupled_scalars():
     The discriminating case: coupling alone is not a saddle, and a detector that only looked for
     off-diagonal terms would cry wolf on every multiphysics problem in the suite.
     """
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     s1, t1 = d.fem_symbols(names=("s1", "t1"), order=1)
     s2, t2 = d.fem_symbols(names=("s2", "t2"), order=1)
     xi, yi = d.variable("interior", split=True)[:2]
@@ -113,7 +113,7 @@ def test_choosing_a_solver_silences_it(slot):
 
 
 def test_a_problem_with_no_saddle_block_is_silent():
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     a, b = d.fem_symbols(names=("a", "b"), order=1)
     xi, yi = d.variable("interior", split=True)[:2]
     xb, yb = d.variable("boundary", split=True)[:2]

--- a/tests/test_fem_sharding.py
+++ b/tests/test_fem_sharding.py
@@ -68,7 +68,7 @@ def test_shard_argument_is_actually_wired_to_the_solve():
 
     assert "shard" in inspect.signature(jno.fem.__globals__["FEM"].solve).parameters, "FEM.solve must accept shard="
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.35).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.35).domain()
     u, phi = d.fem_symbols()
     c = d.variable("interior", split=True)
     cb = d.variable("boundary", split=True)

--- a/tests/test_fem_slip_bc.py
+++ b/tests/test_fem_slip_bc.py
@@ -40,7 +40,7 @@ def _x64():
 
 def _disk_vector_poisson(size=0.35):
     """A well-posed vector Poisson on a disk, plus the pieces needed to write ``n·u`` on its boundary."""
-    d = jno.Shape.disk(0.0, 0.0, 1.0, size=size).domain()
+    d = jno.shape.disk(0.0, 0.0, 1.0, size=size).domain()
     u, phi = d.fem_symbols(value_shape=(2,))
     _ = phi
     xi, yi, _ = d.variable("interior", split=True)
@@ -233,7 +233,7 @@ def test_rt_normal_flux_still_routes_to_the_edge_dof_path():
     stolen this route — so we check the solve moves when ``g`` moves, which it cannot do if the
     constraint were dropped. The exact per-DOF values are already asserted in the nonnodal suite.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     u, v = d.fem_symbols(value_shape=(2,), names=("u", "v"), space="RT")
     xi, yi, _ = d.variable("interior", split=True)
     cb = d.variable("boundary", normals=True, split=True)
@@ -270,7 +270,7 @@ def _curved_channel_top(zcut, nx=12, ny=3, nz=6, L=2.0, H=1.0, W=1.0, A=0.35):
     h = lambda x: H - 0.5 * A * (1.0 - np.cos(2.0 * np.pi * x / L))  # noqa: E731
     dh = lambda x: -A * (np.pi / L) * np.sin(2.0 * np.pi * x / L)  # noqa: E731
 
-    d = jno.Shape.box(0.0, 0.0, 0.0, L, H, W, size=0.3).structured(n=(nx, ny, nz)).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, L, H, W, size=0.3).structured(n=(nx, ny, nz)).domain()
     P = np.asarray(d.mesh.points).copy()
     P[:, 1] *= h(P[:, 0]) / H  # bend the top; the lattice topology is untouched
     d.mesh.points = P

--- a/tests/test_fem_solve_values.py
+++ b/tests/test_fem_solve_values.py
@@ -30,7 +30,7 @@ def _x64():
 
 def _diffusion(k_value=None):
     """``-div((1 + k u^2) grad u) = 1``; ``k`` runtime when ``k_value`` is None, constant otherwise."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=6).domain()
     u, v = d.fem_symbols(names=("u", "v"), order=1)
     x, y, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -136,7 +136,7 @@ def test_the_verdict_survives_the_jit():
 def test_a_partly_supplied_problem_is_refused_by_name():
     """Naming one of two parameters is neither a solve nor a trace node -- say which is missing rather
     than resolving the rest from somewhere else."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=5).domain()
     u, v = d.fem_symbols(names=("u", "v"), order=1)
     x, y, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -165,7 +165,7 @@ def test_a_parametric_solve_is_differentiable_in_its_parameter():
     which is the entire point of having runtime parameters. Under a trace the verdict is skipped (and
     says so in `stats`), exactly as the in-driver check already does.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34).domain()
     u, v = d.fem_symbols()
     x, y, _t = d.variable("interior", split=True)
     ui, vi = u.bind(x=x, y=y), v.bind(x=x, y=y)

--- a/tests/test_fem_stabilised_flow.py
+++ b/tests/test_fem_stabilised_flow.py
@@ -43,7 +43,7 @@ def _advection_diffusion(n, nu, stabilised):
     The exact solution is monotone in x with a boundary layer of width `nu` at the outflow. Galerkin
     P1 cannot represent it and rings; SUPG adds streamline diffusion and does not.
     """
-    dom = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
+    dom = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=n).domain()
     dom.tag("inflow", lambda x, y: x < 1e-9)
     dom.tag("outflow", lambda x, y: x > 1.0 - 1e-9)
     u, v = dom.fem_symbols()

--- a/tests/test_fem_staggered.py
+++ b/tests/test_fem_staggered.py
@@ -56,7 +56,7 @@ def _convex_pair(size=0.12):
 
     Linear and coercive, so it has one solution and both drivers must find it."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -105,7 +105,7 @@ def test_sweep_order_does_not_change_the_solution():
 # --------------------------------------------------------------------------------------------------
 def _phase_field(load=2.0, ell=0.4, gc=1.0, eta=1e-4, size=0.34):
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = d.variable("interior", split=True), d.variable("left", split=True)
     X = [co[0], co[1]]
@@ -157,7 +157,7 @@ def test_staggered_solves_the_non_convex_energy_that_monolithic_cannot():
 # --------------------------------------------------------------------------------------------------
 def test_gradient_flows_through_the_sweep():
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -209,7 +209,7 @@ def test_a_repeated_field_fails_loud():
 
 def test_a_single_field_problem_fails_loud():
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -299,7 +299,7 @@ def test_direct_staggered_gradient_matches_finite_differences():
     """Differentiability is a requirement, not a nice-to-have. The direct route hangs `custom_root` off
     the root it found and solves the tangent (and its TRANSPOSE, for reverse mode) directly."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
     d.tag("bdry", lambda x, y: (x < 1e-9) | (x > 1 - 1e-9) | (y < 1e-9) | (y > 1 - 1e-9))
     co, cb = d.variable("interior", split=True), d.variable("bdry", split=True)
     X = [co[0], co[1]]
@@ -391,7 +391,7 @@ def test_over_relax_keeps_a_box_constrained_field_feasible():
     extrapolation need not be, so the driver asks the `bounds` wrapper for its projector. Without that
     the damage would leave [0, 1] mid-iteration."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     d.tag("left", lambda x, y: x < 1e-9)
     co, cl = d.variable("interior", split=True), d.variable("left", split=True)
     X = [co[0], co[1]]
@@ -456,7 +456,7 @@ def test_over_relax_on_a_ramped_dirichlet_march_matches_the_unrelaxed_answer():
     (the case that exposed this — g changes every load step, so `g - u_prev` is large at sweep 1) is
     held exactly and the over-relaxed march lands on the same trajectory."""
     grad, inner = _aliases()
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(tau=(0.0, 1.0, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(tau=(0.0, 1.0, 4))
     d.tag("bot", lambda x, y: y < 1e-9)
     d.tag("top", lambda x, y: y > 1 - 1e-9)
     co, cb, ct = (d.variable(r, split=True) for r in ("interior", "bot", "top"))

--- a/tests/test_fem_state_region.py
+++ b/tests/test_fem_state_region.py
@@ -40,9 +40,9 @@ NSTEP = 4
 
 
 def _two_regions(tau=True):
-    d = jno.Shape.regions(
-        left=jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34),
-        right=jno.Shape.rect(1.0, 0.0, 2.0, 1.0, size=0.34),
+    d = jno.shape.regions(
+        left=jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.34),
+        right=jno.shape.rect(1.0, 0.0, 2.0, 1.0, size=0.34),
         conforming=False,
     )
     d = d.domain(tau=(0.0, 1.0, NSTEP)) if tau else d.domain()
@@ -156,8 +156,8 @@ def test_plasticity_in_one_region_leaves_the_other_region_exactly_frozen():
     from tests.test_fem_history_march import SY, _j2_stress
 
     n = jno.np
-    d = jno.Shape.regions(
-        left=jno.Shape.box(0, 0, 0, 1, 1, 1), right=jno.Shape.box(1, 0, 0, 2, 1, 1), conforming=False
+    d = jno.shape.regions(
+        left=jno.shape.box(0, 0, 0, 1, 1, 1), right=jno.shape.box(1, 0, 0, 2, 1, 1), conforming=False
     ).domain(tau=(0.0, 1.0, 3))
     _ = d.built_mesh
     d.tag("lo", lambda x, y, z: x < 1e-9)

--- a/tests/test_fem_stokes_3d.py
+++ b/tests/test_fem_stokes_3d.py
@@ -39,7 +39,7 @@ def _x64():
 
 
 def _stokes_3d(size=0.35, mean_gauge=True):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), order=2)
     p, q = d.fem_symbols(names=("p", "q"), order=1)
     xi, yi, zi = d.variable("interior", split=True)[:3]

--- a/tests/test_fem_tensor_ops.py
+++ b/tests/test_fem_tensor_ops.py
@@ -60,7 +60,7 @@ def _evaluate(expr_of_u):
     ``expr`` must be NONLINEAR in u: `fem.residual` is offered only on a nonlinear or transient
     problem, so a linear probe like ``trace(grad u)`` has to be squared before it can be read here.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     xi, yi = d.variable("interior", split=True)[:2]
     ax = [xi, yi]
     u, v = d.fem_symbols(value_shape=(2,), names=("u_t", "v_t"), order=1)

--- a/tests/test_fem_term_kind.py
+++ b/tests/test_fem_term_kind.py
@@ -18,7 +18,7 @@ def ctx():
     prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
     dom = (
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0)
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0)
         .structured(n=8)
         .domain(
             time=(0.0, 1.0, 3),
@@ -120,7 +120,7 @@ def test_term_kinds_accessor_breaks_down_a_transient_pde():
     jax.config.update("jax_enable_x64", True)
     try:
         dom = (
-            jno.Shape.rect(0.0, 0.0, 1.0, 1.0)
+            jno.shape.rect(0.0, 0.0, 1.0, 1.0)
             .structured(n=8)
             .domain(
                 time=(0.0, 0.1, 3),

--- a/tests/test_fem_tie_dirichlet_conflict.py
+++ b/tests/test_fem_tie_dirichlet_conflict.py
@@ -71,9 +71,9 @@ def _outer(x, y, z):
 def _geom(conforming, size=0.5, **dkw):
     """Two stacked unit blocks, meshed together (``conforming``) or independently (a tied interface)."""
     return (
-        jno.Shape.regions(
-            lower=jno.Shape.box(0, 0, 0, 1, 1, 1),
-            upper=jno.Shape.box(0, 0, 1, 1, 1, 2),
+        jno.shape.regions(
+            lower=jno.shape.box(0, 0, 0, 1, 1, 1),
+            upper=jno.shape.box(0, 0, 1, 1, 1, 2),
             conforming=conforming,
         )
         .sized(size)
@@ -300,7 +300,7 @@ def _mode_defect():
     as a pair: this one localises, that one falsifies.
     """
     d = (
-        jno.Shape.regions(lower=jno.Shape.box(0, 0, 0, 1, 1, 1), upper=jno.Shape.box(0, 0, 1, 1, 1, 2), conforming=False)
+        jno.shape.regions(lower=jno.shape.box(0, 0, 0, 1, 1, 1), upper=jno.shape.box(0, 0, 1, 1, 1, 2), conforming=False)
         .sized(0.5)
         .domain()
     )

--- a/tests/test_fem_topology.py
+++ b/tests/test_fem_topology.py
@@ -129,7 +129,7 @@ def test_edge_numbering_is_first_encounter_order(cells, edges):
 def test_edge_numbering_matches_the_loop_on_a_real_tet_mesh():
     import jno
 
-    cells = np.asarray(jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh.cells_dict["tetra"])
+    cells = np.asarray(jno.shape.box(0, 0, 0, 1, 1, 1, size=0.3).domain().built_mesh.cells_dict["tetra"])
     top = build_edge_topology(cells, BASIX_TET_EDGES)
     ref_ids, ref_signs, ref_verts = _first_encounter_reference(cells, BASIX_TET_EDGES)
     np.testing.assert_array_equal(top.cell_edges, ref_ids)

--- a/tests/test_fem_trainable_coordinates.py
+++ b/tests/test_fem_trainable_coordinates.py
@@ -56,7 +56,7 @@ def _fd_grad(Jf, X0, eps=1e-6):
 
 
 def test_coordinate_gradient_matches_fd_2d():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
     xi, _, _ = d.variable("mv", where=lambda x, y: (x > 0.25) & (x < 0.75) & (y > 0.25) & (y < 0.75), split=True)
     xi.trainable(name="cx")
     op = d._trainable_coords[0]
@@ -77,7 +77,7 @@ def test_coordinate_gradient_matches_fd_2d():
 
 
 def test_coordinate_gradient_matches_fd_3d():
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.34).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.34).domain()
     xi, _, _, _ = d.variable(
         "mv", where=lambda x, y, z: (x > 0.2) & (x < 0.8) & (y > 0.2) & (y < 0.8) & (z > 0.2) & (z < 0.8), split=True
     )
@@ -102,7 +102,7 @@ def test_coordinate_gradient_matches_fd_3d():
 
 def test_only_promoted_region_is_trainable():
     """The design variable is exactly the promoted region's vertices — literal, per-component."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.15).domain()
     pts = np.asarray(d.mesh.points)
     in_box = (pts[:, 0] > 0.25) & (pts[:, 0] < 0.75) & (pts[:, 1] > 0.25) & (pts[:, 1] < 0.75)
     xi, _, _ = d.variable("mv", where=lambda x, y: (x > 0.25) & (x < 0.75) & (y > 0.25) & (y < 0.75), split=True)
@@ -114,7 +114,7 @@ def test_only_promoted_region_is_trainable():
 
 def test_relocation_descent_reduces_objective():
     """The coordinate gradient is usable: descending ∂J/∂X lowers J without tangling the mesh."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     xi, yi, _ = d.variable("mv", where=lambda x, y: (x > 0.2) & (x < 0.8) & (y > 0.2) & (y < 0.8), split=True)
     xi.trainable(name="cx")
     spec = d._trainable_coords[0]
@@ -138,7 +138,7 @@ def test_crux_trains_the_coordinate_parameter():
     """Integration: jno.core discovers the coordinate parameter and moves it (the training path)."""
     import optax
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     xi, _, _ = d.variable("mv", where=lambda x, y: (x > 0.2) & (x < 0.8) & (y > 0.2) & (y < 0.8), split=True)
     cx = xi.trainable(name="cx")
     cx.optimizer(optax.adam(1e-2))
@@ -157,7 +157,7 @@ def test_crux_trains_the_coordinate_parameter():
 def test_coordinate_with_surface_term_builds():
     """Feature 3: trainable coordinates + a Neumann surface term now assemble (the earlier guard is gone;
     the facet normals are JAX — see test_fem_trainable_normals.py for the full FD-vs-autodiff proof)."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
     u, phi = d.fem_symbols()
     xin, yin, _ = d.variable("interior", split=True)
     xb, yb, _tb, nxb, nyb = d.variable("boundary", split=True, normals=True)
@@ -181,7 +181,7 @@ def test_transient_assembly_is_coordinate_parametric():
     The mass matters as much as the operator here: ``M = ∫φᵢφⱼ dx ∝ |K|``, so a static mass on a moving mesh
     keeps the element volumes of the mesh you started from, at O(1/dt).
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.45).domain(time=(0.0, 0.2, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.45).domain(time=(0.0, 0.2, 4))
     u, phi = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -206,7 +206,7 @@ def test_transient_coordinate_gradient_matches_fd():
     """
     from jno.utils.solver.fem_adapt import _transient_march_fn
 
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.45).domain(time=(0.0, 0.2, 4))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.45).domain(time=(0.0, 0.2, 4))
     u, phi = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -240,7 +240,7 @@ def test_transient_coordinate_gradient_matches_fd():
 def test_a_volume_tag_is_promotable_without_a_where_predicate():
     """``domain.variable("interior").trainable()`` — the r-adaptivity API's own example.
 
-    On a gmsh / ``jno.Shape`` domain ``"interior"`` is a VOLUME tag: it lives in ``tag_indices``
+    On a gmsh / ``jno.shape`` domain ``"interior"`` is a VOLUME tag: it lives in ``tag_indices``
     and never in ``_boundary_regions``, and it carries no location function, so both the predicate
     route and the assembler's region resolver had nothing to say about it and this raised
     ``region 'interior' has no location function``. A ``where=`` predicate was the only way in.
@@ -248,7 +248,7 @@ def test_a_volume_tag_is_promotable_without_a_where_predicate():
     A volume tag names every vertex of that volume, the boundary ones included — that is what the
     tag means, and it is what the mesh-motion driver wants. Pass ``where=`` for a strict subset.
     """
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
     n_nodes = int(np.asarray(d.mesh.points).shape[0])
 
     xi, yi, _ = d.variable("interior", split=True)
@@ -265,7 +265,7 @@ def test_a_named_boundary_still_resolves_through_the_existing_route():
     that answer — not the mesh tag's node list — stays authoritative."""
     from jno.utils.solver.fem_native import _region_node_ids_from_pts
 
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
     pts = np.asarray(d.mesh.points)
     expected = sorted(int(i) for i in _region_node_ids_from_pts(d, "left", pts))
 
@@ -274,6 +274,6 @@ def test_a_named_boundary_still_resolves_through_the_existing_route():
 
 
 def test_an_unknown_tag_still_fails_loud():
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.4).domain()
     with pytest.raises(ValueError):
         d.variable("no_such_region", split=True)[0].trainable(name="q")

--- a/tests/test_fem_trainable_normals.py
+++ b/tests/test_fem_trainable_normals.py
@@ -41,7 +41,7 @@ def _frozen_sign(pts, conn, normals_np, dim):
 
 
 def test_face_normals_jax_matches_numpy_2d():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain()
     pts = np.asarray(d.mesh.points)[:, :2]  # the assembler builds geometry from dim-sliced points
     cells = np.asarray(d.mesh.cells_dict["triangle"])
     conn = build_facet_connectivity(cells, "triangle")
@@ -53,7 +53,7 @@ def test_face_normals_jax_matches_numpy_2d():
 
 
 def test_face_normals_jax_matches_numpy_3d():
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.5).domain()
     pts = np.asarray(d.mesh.points)[:, :3]
     cells = np.asarray(d.mesh.cells_dict["tetra"])
     conn = build_facet_connectivity(cells, "tetrahedron")
@@ -66,7 +66,7 @@ def test_face_normals_jax_matches_numpy_3d():
 
 def test_normal_is_differentiable_in_vertices():
     """The JAX normal has a finite, nonzero derivative w.r.t. the facet vertices (numpy normals do not)."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     pts = jnp.asarray(np.asarray(d.mesh.points)[:, :2])
     cells = np.asarray(d.mesh.cells_dict["triangle"])
     conn = build_facet_connectivity(cells, "triangle")
@@ -81,7 +81,7 @@ def test_normal_is_differentiable_in_vertices():
 def test_surface_normal_functional_gradient_matches_fd():
     """End-to-end: a normal-dependent Neumann flux makes a surface functional differentiable in a moving
     boundary coordinate, matching finite differences (the JAX normals flow gradients through the solve)."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
     u, phi = d.fem_symbols()
     xin, yin, _ = d.variable("interior", split=True)
     xb, yb, _tb, nxb, nyb = d.variable("boundary", split=True, normals=True)

--- a/tests/test_fem_trainable_placeholder.py
+++ b/tests/test_fem_trainable_placeholder.py
@@ -30,7 +30,7 @@ def _x64():
 
 
 def _rect(size=0.5):
-    return jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
+    return jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain()
 
 
 def _trivial():

--- a/tests/test_fem_transfer_solution.py
+++ b/tests/test_fem_transfer_solution.py
@@ -30,11 +30,11 @@ def _x64():
 
 
 def _rect(size, x0=0.0, y0=0.0, x1=1.0, y1=1.0):
-    return jno.Shape.rect(x0, y0, x1, y1, size=size).domain()
+    return jno.shape.rect(x0, y0, x1, y1, size=size).domain()
 
 
 def _box(size):
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
 
 
 def _verts(d):

--- a/tests/test_fem_vector_components.py
+++ b/tests/test_fem_vector_components.py
@@ -31,7 +31,7 @@ def _x64():
 
 
 def _cantilever(value_shape=(2,)):
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 0.5, size=0.15).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 0.5, size=0.15).domain()
     d.tag("left", lambda x, n, names: x[:, 0] < 1e-6)
     d.tag("right", lambda x, n, names: x[:, 0] > 2.0 - 1e-6)
     u, v = d.fem_symbols(value_shape=value_shape)
@@ -117,7 +117,7 @@ def test_finite_strain_neo_hookean_in_the_natural_spelling():
         return sol.reshape(len(d.mesh.points), 2)
 
     def solve_scalar(load):
-        d = jno.Shape.rect(0.0, 0.0, 2.0, 0.5, size=0.15).domain()
+        d = jno.shape.rect(0.0, 0.0, 2.0, 0.5, size=0.15).domain()
         d.tag("left", lambda x, n, names: x[:, 0] < 1e-6)
         a, qa = d.fem_symbols(names=("a", "qa"))
         b, qb = d.fem_symbols(names=("b", "qb"))
@@ -147,7 +147,7 @@ def test_decoupled_component_laplacians_match_the_scalar_solve(order):
     """Two decoupled component Laplacians with the source on component 1 only: component 0 must stay
     identically zero and component 1 must equal the plain scalar Poisson solution — at P1 and P2, since
     the component tables are built from the same order-k basis as everything else."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     u, v = d.fem_symbols(value_shape=(2,), order=order)
     xi, yi = d.variable("interior", split=True)[:2]
     xb, yb = d.variable("boundary", split=True)[:2]
@@ -156,7 +156,7 @@ def test_decoupled_component_laplacians_match_the_scalar_solve(order):
     fem = jno.fem([weak, u(xb, yb)[0] - 0.0, u(xb, yb)[1] - 0.0])
     sol = np.asarray(fem.solve()).reshape(-1, 2)
 
-    d2 = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    d2 = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     us, vs = d2.fem_symbols(order=order)
     xi2, yi2 = d2.variable("interior", split=True)[:2]
     xb2, yb2 = d2.variable("boundary", split=True)[:2]
@@ -205,7 +205,7 @@ def test_component_and_whole_field_spellings_mix_in_one_term():
 # the assembler with a raw broadcast error that named nothing.
 # ==================================================================================================
 def _bar(size=0.5):
-    d = jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=size).domain()
+    d = jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=size).domain()
     d.tag("left", lambda x, y: x < 1e-9)
     return d
 

--- a/tests/test_fem_vector_tie.py
+++ b/tests/test_fem_vector_tie.py
@@ -47,9 +47,9 @@ def _x64():
 
 def _split_box(size=0.5, conforming=False, zmid=1.0, ztop=2.0):
     return (
-        jno.Shape.regions(
-            lower=jno.Shape.box(0, 0, 0, 1, 1, zmid),
-            upper=jno.Shape.box(0, 0, zmid, 1, 1, ztop),
+        jno.shape.regions(
+            lower=jno.shape.box(0, 0, 0, 1, 1, zmid),
+            upper=jno.shape.box(0, 0, zmid, 1, 1, ztop),
             conforming=conforming,
         )
         .sized(size)
@@ -217,10 +217,10 @@ def test_one_interface_tied_and_another_in_contact_on_the_same_field():
     from "cannot be expressed" to "assembles".
     """
     d = (
-        jno.Shape.regions(
-            a=jno.Shape.box(0, 0, 0, 1, 1, 1),
-            b=jno.Shape.box(0, 0, 1, 1, 1, 2),
-            c=jno.Shape.box(0, 0, 2, 1, 1, 3),
+        jno.shape.regions(
+            a=jno.shape.box(0, 0, 0, 1, 1, 1),
+            b=jno.shape.box(0, 0, 1, 1, 1, 2),
+            c=jno.shape.box(0, 0, 2, 1, 1, 3),
             conforming=False,
         )
         .sized(0.5)
@@ -259,7 +259,7 @@ def test_a_transient_vector_tie_still_refuses_and_names_the_steady_case():
     scalar. The message must point at what DOES work rather than repeating the old blanket refusal."""
     d = _split_box(0.5).domain_like() if False else _split_box(0.5)
     d = (
-        jno.Shape.regions(lower=jno.Shape.box(0, 0, 0, 1, 1, 1), upper=jno.Shape.box(0, 0, 1, 1, 1, 2), conforming=False)
+        jno.shape.regions(lower=jno.shape.box(0, 0, 0, 1, 1, 1), upper=jno.shape.box(0, 0, 1, 1, 1, 2), conforming=False)
         .sized(0.5)
         .domain(time=(0.0, 1.0, 4))
     )

--- a/tests/test_field_view.py
+++ b/tests/test_field_view.py
@@ -61,7 +61,7 @@ class TestFieldViewNodeConstruction:
 
     @pytest.fixture
     def setup(self):
-        domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain(time=(0.0, 1.0, 4))
+        domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain(time=(0.0, 1.0, 4))
         a = np.zeros((1, 4, 4, 4, 1), dtype=np.float32)
         a_var = domain.variable("a", a)
         x_var, y_var, t_var = domain.variable("interior")
@@ -137,7 +137,7 @@ class TestTemporalTargetCollection:
 
     @pytest.fixture
     def fv(self):
-        domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain(time=(0.0, 1.0, 4))
+        domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain(time=(0.0, 1.0, 4))
         a = np.zeros((1, 4, 4, 4, 1), dtype=np.float32)
         a_var = domain.variable("a", a)
         x_var, _, t_var = domain.variable("interior")
@@ -171,7 +171,7 @@ class TestTemporalTargetCollection:
 
 class TestCoordinateValidation:
     def _setup(self):
-        domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain()
+        domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain()
         a = np.zeros((1, 4, 4, 1), dtype=np.float32)
         a_var = domain.variable("a", a)
         x_var, y_var, _ = domain.variable("interior")
@@ -225,7 +225,7 @@ def _make_spatial_setup(field_values: np.ndarray):
     H, W = field.shape[:2]
     if field.ndim == 2:
         field = field[..., None]
-    domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(H - 1, W - 1)).domain()
+    domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(H - 1, W - 1)).domain()
     a_var = domain.variable("a", field[None])  # add batch dim
     x_var, y_var, _ = domain.variable("interior")
     mesh_pts = jnp.asarray(domain.mesh_connectivity["points"])
@@ -303,7 +303,7 @@ def _make_spatiotemporal_setup(field_values: np.ndarray, t_vals: np.ndarray):
     if field.ndim == 3:
         field = field[..., None]
     t0, t1 = float(t_vals[0]), float(t_vals[-1])
-    domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(H - 1, W - 1)).domain(time=(t0, t1, T))
+    domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(H - 1, W - 1)).domain(time=(t0, t1, T))
     field_b = field[None]  # (1, T, H, W, C)
     a_var = domain.variable("a", field_b)
     x_var, y_var, t_var = domain.variable("interior")
@@ -514,7 +514,7 @@ class TestNonSquareDomain:
         ys = np.linspace(0.0, 1.0, W, dtype=np.float32)
         xx, yy = np.meshgrid(xs, ys, indexing="ij")
         field = (yy**2)[..., None]  # (H, W, 1); ∂²/∂y² = 2
-        domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(H - 1, W - 1)).domain()
+        domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(H - 1, W - 1)).domain()
         a_var = domain.variable("a", field[None])
         x_var, y_var, _ = domain.variable("interior")
         mesh_pts = jnp.asarray(domain.mesh_connectivity["points"])
@@ -598,7 +598,7 @@ class TestMinConsecutiveGuard:
 class TestHigherOrderChainNodes:
     @pytest.fixture
     def fv_xt(self):
-        domain = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain(time=(0.0, 1.0, 4))
+        domain = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=3).domain(time=(0.0, 1.0, 4))
         a = np.zeros((1, 4, 4, 4, 1), dtype=np.float32)
         a_var = domain.variable("a", a)
         x_var, y_var, t_var = domain.variable("interior")

--- a/tests/test_geometric_mg.py
+++ b/tests/test_geometric_mg.py
@@ -29,9 +29,9 @@ def _x64():
 def _poisson(size, dim=2):
     """Structured -Δu = f, u = Π sin(π x_i), homogeneous Dirichlet. Returns (grid, A_mv, b, exact)."""
     shp = (
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size)
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size)
         if dim == 2
-        else jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size)
+        else jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size)
     )
     d = jno.domain(shp.structured())
     grid = d.mesh_connectivity["grid"]

--- a/tests/test_geometry_shape.py
+++ b/tests/test_geometry_shape.py
@@ -1,4 +1,4 @@
-"""Tests for the gmsh-OCC ``Shape`` geometry layer (jno/geometry).
+"""Tests for the gmsh-OCC ``shape`` geometry layer (jno/geometry).
 
 Covers the pure naming/selection algebra (no gmsh), the mesh + ``cell_sets`` contract
 that ``jno.domain`` consumes, per-shape graded sizing, and -- the assertion that drove
@@ -10,16 +10,16 @@ import math
 import numpy as np
 import pytest
 
-from jno.geometry import Path, Shape
+from jno.geometry import Path, shape
 
-gmsh = pytest.importorskip("gmsh", reason="gmsh-OCC required for the Shape mesher")
+gmsh = pytest.importorskip("gmsh", reason="gmsh-OCC required for the shape mesher")
 
 
 # --------------------------------------------------------------------------- pure
 def test_selection_algebra_no_gmsh():
     """edge()/edges_from()/| compose without touching a mesher."""
-    strip = Shape.rect(0, 0, 4, 1)
-    roll = Shape.disk(2, 1, 0.5)
+    strip = shape.rect(0, 0, 4, 1)
+    roll = shape.disk(2, 1, 0.5)
     solid = (strip - roll).extrude(0.7)
 
     # every primitive is reachable; keys are identity-stable through the plan
@@ -34,13 +34,13 @@ def test_selection_algebra_no_gmsh():
 
 def test_extrude_requires_2d():
     with pytest.raises(ValueError):
-        Shape.box(0, 0, 0, 1, 1, 1).extrude(1.0)
+        shape.box(0, 0, 0, 1, 1, 1).extrude(1.0)
 
 
 # --------------------------------------------------------------------------- mesh
 def test_rect_minus_disk_2d_regions():
     """rect - disk: flat 'top' splits into two segments; the dip becomes 'arc'."""
-    mesh, dim, ds = (Shape.rect(0, 0, 4, 1) - Shape.disk(2, 1, 0.5)).build()
+    mesh, dim, ds = (shape.rect(0, 0, 4, 1) - shape.disk(2, 1, 0.5)).build()
     assert dim == 2
     types = {b.type for b in mesh.cells}
     assert types == {"triangle", "line"}
@@ -58,7 +58,7 @@ def test_rect_minus_disk_2d_regions():
 
 def test_extrude_3d_mesh_and_caps():
     """Extrusion yields a tetra volume, one lateral face per base edge, plus front/back caps."""
-    mesh, dim, ds = (Shape.rect(0, 0, 4, 1) - Shape.disk(2, 1, 0.5)).extrude(0.7).build()
+    mesh, dim, ds = (shape.rect(0, 0, 4, 1) - shape.disk(2, 1, 0.5)).extrude(0.7).build()
     assert dim == 3
     assert mesh.cells[0].type == "tetra" and mesh.cells[1].type == "triangle"
 
@@ -83,8 +83,8 @@ def test_extrude_3d_mesh_and_caps():
 
 def test_per_shape_size_grades_mesh():
     """A finer `size` on one shape refines the mesh near its boundary, not globally."""
-    coarse = Shape.rect(0, 0, 4, 1, size=0.2)
-    fine_disk = Shape.disk(2, 1, 0.5, size=0.03)
+    coarse = shape.rect(0, 0, 4, 1, size=0.2)
+    fine_disk = shape.disk(2, 1, 0.5, size=0.03)
     mesh, _dim, ds = (coarse - fine_disk).build()
     pts = mesh.points[:, :2]
     lines = np.asarray(mesh.cells[1].data)
@@ -100,11 +100,11 @@ def test_per_shape_size_grades_mesh():
 
 # ------------------------------------------------------------------- domain bridge
 def test_domain_regions_and_outward_arc_normals():
-    """jno.domain(Shape) exposes every region and gives OUTWARD normals on the concave arc."""
+    """jno.domain(shape) exposes every region and gives OUTWARD normals on the concave arc."""
     import jno
 
     cx, cy, r = 2.0, 1.0, 0.4
-    d = jno.domain((Shape.rect(0, 0, 4, 1, size=0.2) - Shape.disk(cx, cy, r, size=0.08)).extrude(0.6))
+    d = jno.domain((shape.rect(0, 0, 4, 1, size=0.2) - shape.disk(cx, cy, r, size=0.08)).extrude(0.6))
     assert d.dimension == 3
     assert {"interior", "boundary", "arc", "top", "left", "right", "bottom", "front", "back"} <= set(d.avaiable_mesh_tags)
 
@@ -127,7 +127,7 @@ def _sets(mesh):
 
 def test_polygon_edges_auto_named():
     """An L-shaped polygon meshes with one auto-named region per segment (e0..e5)."""
-    mesh, dim, _ds = Shape.polygon([(0, 0), (2, 0), (2, 1), (1, 1), (1, 2), (0, 2)]).build()
+    mesh, dim, _ds = shape.polygon([(0, 0), (2, 0), (2, 1), (1, 1), (1, 2), (0, 2)]).build()
     assert dim == 2
     s = _sets(mesh)
     edges = [f"e{i}" for i in range(6)]
@@ -137,7 +137,7 @@ def test_polygon_edges_auto_named():
 
 def test_cylinder_arbitrary_axis_faces():
     """A cylinder on the x-axis names lateral 'side' and the two caps 'bottom'/'top'."""
-    mesh, dim, _ds = Shape.cylinder(0, 0, 0, 5, 0, 0, 1.0).build()
+    mesh, dim, _ds = shape.cylinder(0, 0, 0, 5, 0, 0, 1.0).build()
     assert dim == 3 and mesh.cells[0].type == "tetra"
     s = _sets(mesh)
     assert {"side", "top", "bottom"} <= set(s)
@@ -146,7 +146,7 @@ def test_cylinder_arbitrary_axis_faces():
 
 def test_box_minus_cylinder_drilled_hole():
     """A through-hole keeps the six box faces and adds the cylinder wall 'side'."""
-    mesh, dim, _ds = (Shape.box(0, 0, 0, 4, 4, 1) - Shape.cylinder(2, 2, -0.5, 0, 0, 2, 0.5)).build()
+    mesh, dim, _ds = (shape.box(0, 0, 0, 4, 4, 1) - shape.cylinder(2, 2, -0.5, 0, 0, 2, 0.5)).build()
     s = _sets(mesh)
     assert {"left", "right", "front", "back", "top", "bottom", "side"} <= set(s)
     assert s["side"] > 0  # the drilled wall
@@ -157,7 +157,7 @@ def test_sphere_concave_dimple_outward_normals():
     import jno
 
     c = np.array([1.0, 1.0, 2.0])
-    d = jno.domain(Shape.box(0, 0, 0, 2, 2, 2) - Shape.sphere(c[0], c[1], c[2], 0.7, size=0.15))
+    d = jno.domain(shape.box(0, 0, 0, 2, 2, 2) - shape.sphere(c[0], c[1], c[2], 0.7, size=0.15))
     n = np.asarray(d.normals_by_tag["surface"])
     pts = d.points[d.tag_indices["surface"]]
     toward_center = c - pts
@@ -172,7 +172,7 @@ _Y = ((0, 0, 0), (0, 1, 0))  # y-axis through the origin
 
 def test_half_donut_tube_and_caps():
     """A disk revolved 180deg about the y-axis: tube 'arc' + two flat end caps 'back'/'front'."""
-    mesh, dim, _ds = Shape.disk(2.0, 0.0, 0.6, size=0.25).revolve(*_Y, angle=math.pi).build()
+    mesh, dim, _ds = shape.disk(2.0, 0.0, 0.6, size=0.25).revolve(*_Y, angle=math.pi).build()
     assert dim == 3
     s = _sets(mesh)
     assert {"arc", "back", "front"} <= set(s)
@@ -182,7 +182,7 @@ def test_half_donut_tube_and_caps():
 
 def test_full_torus_meshes_via_split_fallback():
     """A full (2pi) detached solid of revolution meshes (two-halves fallback) with no caps."""
-    mesh, dim, _ds = Shape.disk(2.0, 0.0, 0.6).revolve(*_Y, angle=2 * math.pi).build()
+    mesh, dim, _ds = shape.disk(2.0, 0.0, 0.6).revolve(*_Y, angle=2 * math.pi).build()
     assert dim == 3
     s = _sets(mesh)
     assert s["arc"] == s["boundary"]  # closed tube, no end caps
@@ -191,7 +191,7 @@ def test_full_torus_meshes_via_split_fallback():
 
 def test_cone_from_revolved_triangle():
     """A triangle touching the axis revolved 2pi -> a cone (single-sweep, no split needed)."""
-    mesh, dim, _ds = Shape.polygon([(0, 0), (1, 0), (0, 2)]).revolve(*_Y, angle=2 * math.pi).build()
+    mesh, dim, _ds = shape.polygon([(0, 0), (1, 0), (0, 2)]).revolve(*_Y, angle=2 * math.pi).build()
     assert dim == 3
     s = _sets(mesh)
     assert s.get("e0", 0) > 0 and s.get("e1", 0) > 0  # base + slant
@@ -199,9 +199,9 @@ def test_cone_from_revolved_triangle():
 
 def test_revolve_requires_2d_and_supported_axis():
     with pytest.raises(ValueError):
-        Shape.box(0, 0, 0, 1, 1, 1).revolve(*_Y, angle=math.pi)
+        shape.box(0, 0, 0, 1, 1, 1).revolve(*_Y, angle=math.pi)
     with pytest.raises(NotImplementedError):  # z-axis not supported
-        Shape.disk(2, 0, 0.5).revolve((0, 0, 0), (0, 0, 1), math.pi).build()
+        shape.disk(2, 0, 0.5).revolve((0, 0, 0), (0, 0, 1), math.pi).build()
 
 
 # ---------------------------------------------------------------- Path (contours)
@@ -242,7 +242,7 @@ def test_path_revolve_makes_sphere():
 # --------------------------------------------------------- transforms (rotate/translate)
 def test_translate_preserves_names_and_position():
     """A translated box keeps its six face-names; the +x face moves with it."""
-    mesh, dim, _ds = Shape.box(0, 0, 0, 1, 1, 1).translate((5, 0, 0)).build()
+    mesh, dim, _ds = shape.box(0, 0, 0, 1, 1, 1).translate((5, 0, 0)).build()
     s = _sets(mesh)
     assert {"left", "right", "top", "bottom", "front", "back"} <= set(s)
     tri, pts = np.asarray(mesh.cells[1].data), mesh.points
@@ -253,7 +253,7 @@ def test_translate_preserves_names_and_position():
 def test_rotate_preserves_face_names():
     """A 90deg-rotated box is no longer axis-aligned -- names survive only via the
     transform-aware classifier (un-rotating the query point back into the box frame)."""
-    mesh, dim, _ds = Shape.box(0, 0, 0, 2, 1, 1).rotate((0, 0, 0), (0, 0, 1), math.pi / 2).build()
+    mesh, dim, _ds = shape.box(0, 0, 0, 2, 1, 1).rotate((0, 0, 0), (0, 0, 1), math.pi / 2).build()
     s = _sets(mesh)
     assert {"left", "right", "top", "bottom", "front", "back"} <= set(s)
 
@@ -262,7 +262,7 @@ def test_transform_composes_with_boolean_and_normals():
     """Names + outward normals survive a boolean followed by a translate."""
     import jno
 
-    d = jno.domain((Shape.box(0, 0, 0, 4, 4, 1) - Shape.cylinder(2, 2, -1, 0, 0, 3, 0.5)).translate((10, 10, 0)))
+    d = jno.domain((shape.box(0, 0, 0, 4, 4, 1) - shape.cylinder(2, 2, -1, 0, 0, 3, 0.5)).translate((10, 10, 0)))
     assert {"side", "top", "left"} <= set(d.avaiable_mesh_tags)  # hole wall + faces survive the move
     assert np.asarray(d.normals_by_tag["top"]).mean(0)[2] > 0.5  # top face still points +z
 
@@ -270,7 +270,7 @@ def test_transform_composes_with_boolean_and_normals():
 # ---------------------------------------------------------------------- fillet
 def test_fillet_all_edges_keeps_flat_faces():
     """Rounding all edges keeps the six flat faces named; blend faces fall into 'boundary'."""
-    mesh, dim, _ds = Shape.box(0, 0, 0, 2, 2, 1).fillet(0.3).build()
+    mesh, dim, _ds = shape.box(0, 0, 0, 2, 2, 1).fillet(0.3).build()
     assert dim == 3 and mesh.cells[0].data.shape[0] > 0
     s = _sets(mesh)
     flat = sum(s.get(f, 0) for f in ("left", "right", "top", "bottom", "front", "back"))
@@ -281,7 +281,7 @@ def test_fillet_all_edges_keeps_flat_faces():
 def test_fillet_predicate_and_after_boolean():
     """A predicate rounds a subset of edges, and fillet composes after a boolean (mid-build sync)."""
     mesh, dim, _ds = (
-        (Shape.box(0, 0, 0, 4, 4, 1) - Shape.cylinder(2, 2, -1, 0, 0, 3, 0.5))
+        (shape.box(0, 0, 0, 4, 4, 1) - shape.cylinder(2, 2, -1, 0, 0, 3, 0.5))
         .fillet(0.15, where=lambda x, y, z: z > 0.9)
         .build()
     )
@@ -292,21 +292,21 @@ def test_fillet_predicate_and_after_boolean():
 def test_fillet_outward_normals_via_domain():
     import jno
 
-    d = jno.domain(Shape.box(0, 0, 0, 2, 2, 2).fillet(0.4))
+    d = jno.domain(shape.box(0, 0, 0, 2, 2, 2).fillet(0.4))
     assert np.asarray(d.normals_by_tag["top"]).mean(0)[2] > 0.9  # flat top still points +z
 
 
 # ------------------------------------------------------------------------- sweep
 def test_sweep_vertical_line_dispatches_to_extrude():
     """A straight vertical sweep IS an extrude -- it reuses the rich naming (caps + lateral 'arc')."""
-    mesh, dim, _ds = Shape.disk(0, 0, 0.3).sweep(Path(0, 0, 0).line_to(0, 0, 3)).build()
+    mesh, dim, _ds = shape.disk(0, 0, 0.3).sweep(Path(0, 0, 0).line_to(0, 0, 3)).build()
     assert dim == 3 and mesh.cells[0].data.shape[0] > 0
     assert {"front", "back", "arc"} <= set(_sets(mesh))  # extrude-quality names, not just boundary
 
 
 def test_sweep_arc_makes_a_bent_pipe():
     """Sweeping along a smooth arc makes a bent pipe (meshes without hanging)."""
-    bent = Shape.disk(0, 0, 0.3).sweep(Path(0, 0, 0).arc_to(2, 0, 2, through=(0.6, 0, 1.4)))
+    bent = shape.disk(0, 0, 0.3).sweep(Path(0, 0, 0).arc_to(2, 0, 2, through=(0.6, 0, 1.4)))
     mesh, dim, _ds = bent.build()
     assert dim == 3 and mesh.cells[0].data.shape[0] > 0
 
@@ -314,13 +314,13 @@ def test_sweep_arc_makes_a_bent_pipe():
 def test_sweep_sharp_corner_is_rejected():
     """A sharp line->line corner self-intersects the swept profile -- reject up front, never hang."""
     with pytest.raises(ValueError):
-        Shape.disk(0, 0, 0.3).sweep(Path(0, 0, 0).line_to(0, 0, 3).line_to(3, 0, 3))
+        shape.disk(0, 0, 0.3).sweep(Path(0, 0, 0).line_to(0, 0, 3).line_to(3, 0, 3))
 
 
 # ------------------------------------------------------------------------- array
 def test_array_linear():
     """A linear array fuses n copies spaced by `step` (pure translate/fuse composition)."""
-    mesh, dim, _ds = Shape.disk(0, 0, 0.2).array(3, step=(1, 0, 0)).build()
+    mesh, dim, _ds = shape.disk(0, 0, 0.2).array(3, step=(1, 0, 0)).build()
     assert dim == 2
     tri = np.asarray(mesh.cells[0].data)
     cx = mesh.points[tri].mean(1)[:, 0]
@@ -329,17 +329,17 @@ def test_array_linear():
 
 def test_array_polar_bolt_circle():
     """A polar array makes a ring of holes: plate - disk.array(n, about=axis)."""
-    holes = Shape.disk(3, 0, 0.3).array(6, about=((0, 0, 0), (0, 0, 1)))
-    mesh, dim, _ds = (Shape.rect(-5, -5, 5, 5) - holes).extrude(0.4).build()
+    holes = shape.disk(3, 0, 0.3).array(6, about=((0, 0, 0), (0, 0, 1)))
+    mesh, dim, _ds = (shape.rect(-5, -5, 5, 5) - holes).extrude(0.4).build()
     assert dim == 3 and mesh.cells[0].data.shape[0] > 0
     assert "arc" in _sets(mesh)  # the six hole walls
 
 
 def test_array_requires_one_mode():
     with pytest.raises(ValueError):
-        Shape.disk(0, 0, 0.2).array(3)  # neither step nor about
+        shape.disk(0, 0, 0.2).array(3)  # neither step nor about
     with pytest.raises(ValueError):
-        Shape.disk(0, 0, 0.2).array(3, step=(1, 0, 0), about=((0, 0, 0), (0, 0, 1)))  # both
+        shape.disk(0, 0, 0.2).array(3, step=(1, 0, 0), about=((0, 0, 0), (0, 0, 1)))  # both
 
 
 # ---------------------------------------------- richer d.tag(f(x, n, name)) predicate
@@ -348,7 +348,7 @@ def test_tag_facet_predicate_normal_name_and_backcompat():
     the classic f(x, y, z) predicate is unaffected."""
     import jno
 
-    d = jno.domain(Shape.box(0, 0, 0, 2, 2, 1))
+    d = jno.domain(shape.box(0, 0, 0, 2, 2, 1))
     d.tag("east", lambda x, n, name: n[:, 0] > 0.9)  # by outward normal -> the +x face
     assert "east" in d.avaiable_mesh_tags
     assert np.asarray(d.normals_by_tag["east"]).mean(0)[0] > 0.9  # points +x
@@ -364,7 +364,7 @@ def test_tag_facet_predicate_normal_name_and_backcompat():
 # ---------------------------------------------------------------- mesh-size control
 def test_size_callable_grades_by_position():
     """A callable size f(x,y,z) refines by position (denser where it is smaller)."""
-    graded = (Shape.rect(0, 0, 4, 1) - Shape.disk(2, 1, 0.4)).extrude(0.6).sized(lambda x, y, z: 0.03 + 0.12 * x)
+    graded = (shape.rect(0, 0, 4, 1) - shape.disk(2, 1, 0.4)).extrude(0.6).sized(lambda x, y, z: 0.03 + 0.12 * x)
     mesh, _dim, _ds = graded.build()
     cells = np.asarray(mesh.cells[0].data)
     cx = mesh.points[cells].mean(1)[:, 0]
@@ -377,19 +377,19 @@ def test_size_callable_grades_by_position():
 
 def test_size_scalar_on_composite_caps_globally():
     """.sized(scalar) on a composite sets a global size cap (denser than the default)."""
-    base = (Shape.rect(0, 0, 4, 1) - Shape.disk(2, 1, 0.4)).extrude(0.6)
-    capped = (Shape.rect(0, 0, 4, 1) - Shape.disk(2, 1, 0.4)).sized(0.15).extrude(0.6)
+    base = (shape.rect(0, 0, 4, 1) - shape.disk(2, 1, 0.4)).extrude(0.6)
+    capped = (shape.rect(0, 0, 4, 1) - shape.disk(2, 1, 0.4)).sized(0.15).extrude(0.6)
     n0 = base.build()[0].cells[0].data.shape[0]
     mesh1, _dim, ds = capped.build()
     assert ds == 0.15 and mesh1.cells[0].data.shape[0] > 3 * n0
 
 
-# --------------------------------------------------------------- Shape.domain() one-liner
+# --------------------------------------------------------------- shape.domain() one-liner
 def test_domain_one_liner():
-    """Shape.domain() builds a jno.domain (forwarding kwargs) as a one-liner + composes with batching."""
+    """shape.domain() builds a jno.domain (forwarding kwargs) as a one-liner + composes with batching."""
     import jno
 
-    d = Shape.rect(0, 0, 1, 1, size=0.3).domain()
+    d = shape.rect(0, 0, 1, 1, size=0.3).domain()
     assert type(d).__name__ == "domain"
 
     # a full FEM solve straight off the one-liner
@@ -401,9 +401,9 @@ def test_domain_one_liner():
     assert fem.dofs > 0 and np.asarray(fem.solve()).shape == (fem.dofs,)
 
     # time= forwards to jno.domain (transient -> has an initial slice); batching binds after .domain()
-    dt = Shape.rect(0, 0, 1, 1, size=0.3).domain(time=(0.0, 1.0, 5))
+    dt = shape.rect(0, 0, 1, 1, size=0.3).domain(time=(0.0, 1.0, 5))
     assert dt.variable("initial", split=True) is not None
-    assert type(8 * Shape.rect(0, 0, 1, 1, size=0.3).domain()).__name__ == "domain"
+    assert type(8 * shape.rect(0, 0, 1, 1, size=0.3).domain()).__name__ == "domain"
 
 
 # --------------------------------------------------------------------------- 1-D curve
@@ -463,15 +463,15 @@ def _cells(shape):
         pytest.param(lambda s: s.sized(0.4), id="sized"),
         pytest.param(lambda s: s.translate((1.0, 0.0)), id="translate"),
         pytest.param(lambda s: s.rotate((0, 0, 0), (0, 0, 1), 0.3), id="rotate"),
-        pytest.param(lambda s: s - Shape.disk(0.5, 0.5, 0.2), id="cut"),
+        pytest.param(lambda s: s - shape.disk(0.5, 0.5, 0.2), id="cut"),
     ],
 )
 def test_a_derivation_carries_the_cell_choice(derive):
-    """Every ``Shape`` method returns a copy with one field changed, and a positional constructor has
+    """Every ``shape`` method returns a copy with one field changed, and a positional constructor has
     to re-list every other field to carry it. ``attach`` did not re-list ``_cell``, so
     ``.quad().attach(k=1.0)`` erased the quadrilateral choice outright -- ``cell_choices()`` came back
     EMPTY and the plan meshed as triangles with no word about it. Hence ``dataclasses.replace``."""
-    derived = derive(Shape.rect(0, 0, 1, 1, size=0.4).quad())
+    derived = derive(shape.rect(0, 0, 1, 1, size=0.4).quad())
     assert derived._cell == "quad"
     assert derived.cell_choices() == frozenset({"quad"})
 
@@ -480,7 +480,7 @@ def test_a_regions_group_meshes_with_its_members_cell():
     """The other half: a regions group is a fresh node carrying no cell of its own, so reading the
     TOP shape's ``_cell`` meshed ``a.quad() + b.quad()`` as 52 triangles while ``cell_choices()``
     already answered {"quad"}. The emitter asks the tree walk, which is the single derivation."""
-    group = Shape.rect(0, 0, 1, 1, size=0.4).quad().name("a") + Shape.rect(1, 0, 2, 1, size=0.4).quad().name("b")
+    group = shape.rect(0, 0, 1, 1, size=0.4).quad().name("a") + shape.rect(1, 0, 2, 1, size=0.4).quad().name("b")
     assert group.cell_choices() == frozenset({"quad"})
     cells = _cells(group)
     assert cells.get("quad", 0) > 0 and "triangle" not in cells, cells
@@ -488,4 +488,4 @@ def test_a_regions_group_meshes_with_its_members_cell():
 
 def test_the_cell_choice_still_reaches_the_mesh_through_a_chain():
     """End to end, since the field being carried is only worth anything if the mesher sees it."""
-    assert "triangle" not in _cells(Shape.rect(0, 0, 1, 1, size=0.4).quad().attach(k=1.0).name("a"))
+    assert "triangle" not in _cells(shape.rect(0, 0, 1, 1, size=0.4).quad().attach(k=1.0).name("a"))

--- a/tests/test_grf.py
+++ b/tests/test_grf.py
@@ -86,7 +86,7 @@ class TestExtremes:
         assert float(np.var(d)) == pytest.approx(1.0, rel=0.15)
 
     def test_rbf_kernel_and_two_dimensions(self):
-        dom = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(7, 7)).domain()
+        dom = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(7, 7)).domain()
         x, y, _ = dom.variable("interior")
         pts = jnp.asarray(np.asarray(dom.context["interior"]).reshape(-1, 2))
         node = jno.noise.grf(x, y, kernel="rbf", length_scale=0.3)

--- a/tests/test_history_index.py
+++ b/tests/test_history_index.py
@@ -27,7 +27,7 @@ def _x64():
 
 
 def _domain():
-    return jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.6).domain()
+    return jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.6).domain()
 
 
 def test_i_builds_history_ref_carrying_base_shape_and_offset():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -172,7 +172,7 @@ class TestRegressions:
         import jno.jnp_ops as jnn
         from jno.tuner import ArchSpace
 
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.5).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.5).domain()
         x, y, _ = dom.variable("interior")
 
         net = jnn.nn.wrap(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(0)))
@@ -1059,7 +1059,7 @@ class TestBoundaryNormal:
     def _make_2d_domain(self):
         import jno
 
-        return jno.Shape.rect(0, 0, 1, 1, size=0.1).domain(compute_mesh_connectivity=True)
+        return jno.shape.rect(0, 0, 1, 1, size=0.1).domain(compute_mesh_connectivity=True)
 
     def _make_1d_domain(self):
         import jno

--- a/tests/test_integration_operators.py
+++ b/tests/test_integration_operators.py
@@ -77,7 +77,7 @@ class TestGaussQuadratureIntegrals:
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+        return jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
 
     def test_gauss_constant_recovers_area(self, dom):
         x, y, _ = dom.variable("interior", split=True)
@@ -133,7 +133,7 @@ class TestJitCompatibleIntegrals:
 
     @pytest.fixture(scope="class")
     def dom_2d(self):
-        return jno.Shape.rect(0, 0, 1, 1, size=0.04).domain()
+        return jno.shape.rect(0, 0, 1, 1, size=0.04).domain()
 
     @pytest.fixture(scope="class")
     def dom_1d(self):
@@ -273,7 +273,7 @@ class TestGradientThroughIntegralLoss:
 
     @pytest.fixture(scope="class")
     def dom(self):
-        return jno.Shape.rect(0, 0, 1, 1, size=0.04).domain()
+        return jno.shape.rect(0, 0, 1, 1, size=0.04).domain()
 
     @pytest.fixture(scope="class")
     def setup(self, dom):
@@ -384,7 +384,7 @@ Covers:
 
 
 def _make_2d_rect_domain(mesh_size=0.05):
-    return jno.Shape.rect(0, 0, 1, 1, size=mesh_size).domain()
+    return jno.shape.rect(0, 0, 1, 1, size=mesh_size).domain()
 
 
 def _eval_integral_expr(expr, domain):

--- a/tests/test_laplacian_fusion.py
+++ b/tests/test_laplacian_fusion.py
@@ -258,7 +258,7 @@ def test_temporal_derivative_does_not_fuse():
 
 def test_weak_form_tree_is_left_alone():
     """FEM trees are lowered by pattern in the variational route; the pass skips them."""
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     u, phi = dom.fem_symbols("u")
     x, y, _ = dom.variable("interior")
     weak = jno.np.inner(u.d(x), phi.d(x)) + jno.np.inner(u.d(y), phi.d(y))
@@ -272,7 +272,7 @@ def test_weak_form_tree_is_left_alone():
 
 
 def _loss_for(build_lap):
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.2).domain()
     x, y, _ = dom.variable("interior")
     net = jno.nn(foundax.mlp(in_features=2, output_dim=1, hidden_dims=8, num_layers=2, key=KEY))
     net.optimizer(optax.adam(1e-9))  # effectively frozen: epoch-0 loss is the pre-update value
@@ -282,7 +282,7 @@ def _loss_for(build_lap):
 
 
 def _reference_laplacian_mse():
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.2).domain()
     pts = jnp.asarray(dom.mesh_connectivity["points"])[:, :2]
     net = foundax.mlp(in_features=2, output_dim=1, hidden_dims=8, num_layers=2, key=KEY)
     H = jax.vmap(jax.hessian(lambda p: net(p[None, :])[0, 0]))(pts)
@@ -305,7 +305,7 @@ def test_every_spelling_matches_the_analytic_laplacian(spelling):
 
 def test_non_laplacian_sums_keep_their_own_meaning():
     """The guard cases must still compute what the user wrote, not a Laplacian."""
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.2).domain()
     pts = jnp.asarray(dom.mesh_connectivity["points"])[:, :2]
     net = foundax.mlp(in_features=2, output_dim=1, hidden_dims=8, num_layers=2, key=KEY)
     H = jax.vmap(jax.hessian(lambda p: net(p[None, :])[0, 0]))(pts)
@@ -324,7 +324,7 @@ def test_non_laplacian_sums_keep_their_own_meaning():
 
 def _compiled_derivative_nodes(build_lap):
     """Derivative-node counts in the constraint tree ``core`` actually compiles."""
-    dom = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain()
+    dom = jno.shape.rect(0, 0, 1, 1, size=0.4).domain()
     x, y, _ = dom.variable("interior")
     net = jno.nn(foundax.mlp(in_features=2, output_dim=1, hidden_dims=4, num_layers=2, key=KEY))
     net.optimizer(optax.adam(1e-3))

--- a/tests/test_lazy_sources.py
+++ b/tests/test_lazy_sources.py
@@ -149,13 +149,13 @@ class TestRefusals:
     def test_missing_time_axis_raises_instead_of_being_rewritten(self):
         """The eager path inserts the (B, T, ...) time axis; a lazy source cannot be rewritten
         without reading it, so the same layout rule is enforced as an error."""
-        d = B * jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(5, 4)).domain(compute_mesh_connectivity=True)
+        d = B * jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(5, 4)).domain(compute_mesh_connectivity=True)
         d.variable("interior")
         with pytest.raises(ValueError, match="time axis"):
             d.variable("_f", Counting(_arr(B, 6, 5, 1)))
 
     def test_correct_layout_is_accepted(self):
-        d = B * jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(5, 4)).domain(compute_mesh_connectivity=True)
+        d = B * jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(5, 4)).domain(compute_mesh_connectivity=True)
         d.variable("interior")
         d.variable("_f", Counting(_arr(B, 1, 6, 5, 1)))
         assert d.context["_f"].shape == (B, 1, 6, 5, 1)

--- a/tests/test_mesh_nodal_measures.py
+++ b/tests/test_mesh_nodal_measures.py
@@ -27,7 +27,7 @@ def annulus():
 
 @pytest.fixture(scope="module")
 def cube():
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain().mesh_connectivity
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain().mesh_connectivity
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -198,7 +198,7 @@ class TestJaxKANWrap:
             seed=0,
         )
 
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.5).domain()
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.5).domain()
         x, y, _ = domain.variable("interior")
 
         net = jnn.nn.wrap(model)

--- a/tests/test_n1e_reconstruction_3d.py
+++ b/tests/test_n1e_reconstruction_3d.py
@@ -36,7 +36,7 @@ def _project_and_reconstruct(mesh_size):
     from jno.utils.solver.fem_nonnodal import n1e_field_at_tet_centroids
     from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]
@@ -77,7 +77,7 @@ def test_reconstruction_is_complex_linear():
     from jno.utils.solver.fem_nonnodal import n1e_field_at_tet_centroids
     from jno.utils.solver.fem_topology import BASIX_TET_EDGES, build_edge_topology
 
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
     x, y, z = c[0], c[1], c[2]

--- a/tests/test_node_eval.py
+++ b/tests/test_node_eval.py
@@ -21,7 +21,7 @@ def _x64():
 
 def _heat(coef, size=0.4, steps=3):
     """Transient heat problem; `coef` may be a float or a jno parameter."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=size).domain(time=(0.0, 0.2, steps))
     u, phi = d.fem_symbols()
     xi, yi, ti = d.variable("interior", split=True)
     ci = d.variable("initial", split=True)
@@ -82,11 +82,11 @@ def test_eval_allows_frozen_parameter():
 
 def test_eval_domain_override_resamples_expression():
     """`domain=` re-samples a Variable expression on another domain."""
-    coarse = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    coarse = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     x, y, _ = coarse.variable("interior", split=True)
     expr = x * y
 
-    fine = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
+    fine = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain()
     fine.variable("interior", split=True)  # register the tag on the new domain
 
     n_coarse = np.asarray(expr.eval()).size
@@ -97,7 +97,7 @@ def test_eval_domain_override_resamples_expression():
 def test_eval_domain_override_rejected_on_solve_node():
     """A solve node owns its mesh; a domain= override would silently return the old solve."""
     _, fem = _heat(1.0, size=0.5)
-    other = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain(time=(0.0, 0.2, 3))
+    other = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.2).domain(time=(0.0, 0.2, 3))
     with pytest.raises(ValueError, match="owns the mesh"):
         fem.solve().eval(domain=other)
 
@@ -123,7 +123,7 @@ def test_field_parameter_keeps_channel_axis():
     ``network * f(field_param)`` in :mod:`jno.rcwa` -- an ``N**2`` boolean-index crash downstream. The two
     tests pin the two halves of the convention: bare parameters keep ``(N,)``, field parameters keep the
     channel axis."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.5).domain()
     _, phi = d.fem_symbols()
     n = len(d.mesh.points)
     rho = jno.np.parameter(phi, name="rho")  # one trainable value per mesh node

--- a/tests/test_operator_composition.py
+++ b/tests/test_operator_composition.py
@@ -36,7 +36,7 @@ class _Lazy:
 
 
 def _grid_domain(batch=None):
-    base = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(G - 1, G - 1)).domain(compute_mesh_connectivity=True)
+    base = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(G - 1, G - 1)).domain(compute_mesh_connectivity=True)
     dom = batch * base if batch else base
     return dom
 

--- a/tests/test_operators_mms.py
+++ b/tests/test_operators_mms.py
@@ -85,7 +85,7 @@ def _build_chamber_with_obstacle(mesh_size: float = 0.06):
 
 def _build_cube_3d(mesh_size: float = 0.10):
     """3-D unit cube via the existing Geometries.cube path (tetrahedral)."""
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(
         compute_mesh_connectivity=True,
     )
 

--- a/tests/test_operators_mms_3d.py
+++ b/tests/test_operators_mms_3d.py
@@ -41,7 +41,7 @@ from jno.differential_operators import DifferentialOperators
 
 
 def _build_cube(mesh_size: float = 0.10):
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(
         compute_mesh_connectivity=True,
     )
 

--- a/tests/test_operators_pipeline.py
+++ b/tests/test_operators_pipeline.py
@@ -112,7 +112,7 @@ class TestMixedSpatialTemporalChain:
 
 
 def _build_cube_3d(mesh_size: float = 0.10):
-    return jno.Shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(
+    return jno.shape.box(0, 0, 0, 1, 1, 1, size=mesh_size).domain(
         compute_mesh_connectivity=True,
     )
 
@@ -262,7 +262,7 @@ class TestWindowedHessian2DPipeline:
         # Coarse mesh + few time steps so the test stays fast — the goal
         # is to drive the windowed path, not measure stencil accuracy
         # (the latter is already covered by Track B's L²-rel tests).
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.2).domain(time=(0.0, 0.1, 3))
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.2).domain(time=(0.0, 0.1, 3))
         x, y, t = dom.variable("interior")
 
         # u(x, y, t) = sin(πx) cos(πy) exp(-2π² t)

--- a/tests/test_optimizer_state_persists.py
+++ b/tests/test_optimizer_state_persists.py
@@ -23,7 +23,7 @@ def _fit(chunks, epochs, lr_schedule):
     # A MESHED domain, so `variable("interior")` is the fixed node set. A mesh-free domain draws
     # fresh points on every call, and that alone changes the answer between runs -- which would
     # mask exactly the effect these tests measure.
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
     x, y, _ = d.variable("interior", split=True)
     net = jno.nn(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(0)))
     net.optimizer(optax.adam(lr_schedule))
@@ -55,7 +55,7 @@ def test_a_warmup_boundary_is_crossed_by_chunked_training():
     it move. With the state restarted per call, and chunks shorter than the boundary, the release
     never happens and the held parameter stays at its initial value forever.
     """
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
     x, y, _ = d.variable("interior", split=True)
     net = jno.nn(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(1)))
     held = jno.np.parameter((1,), key=jax.random.PRNGKey(2), name="held")
@@ -85,7 +85,7 @@ def test_a_fresh_core_starts_the_optimizer_over():
 def test_changing_the_optimizer_reinitialises_rather_than_reusing():
     """A carried state is reused only when it FITS. Swap the optimizer for one with a different
     state and the fresh one is taken, instead of a shape error deep in the update."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.35).domain()
     x, y, _ = d.variable("interior", split=True)
     net = jno.nn(foundax.mlp(in_features=2, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(3)))
     net.optimizer(optax.adam(1e-3))

--- a/tests/test_pdeformer2_bridge.py
+++ b/tests/test_pdeformer2_bridge.py
@@ -87,7 +87,7 @@ def _tiny_pdeformer():
 
 def _heat_problem(mesh_size=0.25, T_end=0.1, N_t=2):
     """A reusable 2-D heat problem fixture."""
-    domain = jno.Shape.rect(0, 0, 1, 1, size=mesh_size).domain(
+    domain = jno.shape.rect(0, 0, 1, 1, size=mesh_size).domain(
         time=(0, T_end, N_t),
     )
     x, y, t = domain.variable("interior")
@@ -341,7 +341,7 @@ class TestBuildTensors:
 
 class TestPDETraceWalker:
     def _setup(self, n_inr=1, n_branches=4):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.5).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.5).domain(
             time=(0, 0.1, 2),
         )
         x, y, t = domain.variable("interior")
@@ -496,7 +496,7 @@ class TestICExtraction:
 
     def test_sign_for_f_minus_u(self):
         """`ini = f - u0` → sign should be +1."""
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(
             time=(0, 0.1, 2),
         )
         x0, y0, t0 = domain.variable("initial")
@@ -517,7 +517,7 @@ class TestICExtraction:
         assert float(val) == pytest.approx(5.0)
 
     def test_pure_eval_substitutes_variable(self):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.4).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.4).domain(
             time=(0, 0.1, 2),
         )
         x0, *_ = domain.variable("initial")
@@ -610,7 +610,7 @@ class TestArgLayout:
         assert _model_call_arg_layout(mc) == (2, 0, 1)
 
     def test_missing_temporal_raises(self):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
         x, y = domain.variable("interior")[:2]
         net = jno.nn.wrap(_tiny_pdeformer())
         mc = net(x, y)
@@ -625,7 +625,7 @@ class TestArgLayout:
 
 class TestHelpers:
     def test_unwrap_loss_strips_mse(self):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
         x, y = domain.variable("interior")[:2]
         expr = (x - y).mse
         assert isinstance(expr, FunctionCall) and getattr(expr, "_name", None) == "mse"
@@ -633,7 +633,7 @@ class TestHelpers:
         assert getattr(inner, "_name", None) != "mse"
 
     def test_unwrap_loss_passthrough(self):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain()
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain()
         x, y = domain.variable("interior")[:2]
         e = x - y
         assert _unwrap_loss(e) is e
@@ -669,7 +669,7 @@ class TestAutoAttach:
         assert isinstance(net.module, PDEformer2Wrapper)
 
     def test_arg_order_baked_into_wrapper(self):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(
             time=(0, 0.1, 2),
         )
         x, y, t = domain.variable("interior")
@@ -699,7 +699,7 @@ class TestAutoAttach:
 
     def test_mixed_pdeformer_and_mlp_models(self):
         """An MLP combined with a PDEformer should leave the MLP untouched."""
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(
             time=(0, 0.1, 2),
         )
         x, y, t = domain.variable("interior")
@@ -725,7 +725,7 @@ class TestAutoAttach:
 
 class TestErrorPaths:
     def test_unsupported_op_in_pde(self):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(
             time=(0, 0.1, 2),
         )
         x, y, t = domain.variable("interior")
@@ -741,7 +741,7 @@ class TestErrorPaths:
 
     def test_no_pde_term_raises(self):
         """If the user only supplies an IC, the bridge should complain."""
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(
             time=(0, 0.1, 2),
         )
         x, y, t = domain.variable("interior")
@@ -765,7 +765,7 @@ class TestBoundaryConditions:
     by the DAG builder but still be trained as normal soft losses."""
 
     def _problem_with_bc(self):
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(
             time=(0, 0.1, 2),
         )
         x, y, t = domain.variable("interior")
@@ -892,7 +892,7 @@ def _dag_view(builder: PDEGraphBuilder, *, include_function_branches: bool = Tru
 
 def _heat_walker_setup(n_inr=2, n_branches=4):
     """Returns (walker, builder, net, (x, y, t, x0, y0, t0))."""
-    domain = jno.Shape.rect(0, 0, 1, 1, size=0.5).domain(
+    domain = jno.shape.rect(0, 0, 1, 1, size=0.5).domain(
         time=(0, 0.1, 2),
     )
     x, y, t = domain.variable("interior")
@@ -1121,7 +1121,7 @@ class TestDAGStructuralCorrectness:
 
     def test_ic_handles_reversed_sign(self):
         """If user writes `ini = f - u0`, IC values still match +f (not -f)."""
-        domain = jno.Shape.rect(0, 0, 1, 1, size=0.5).domain(
+        domain = jno.shape.rect(0, 0, 1, 1, size=0.5).domain(
             time=(0, 0.1, 2),
         )
         x, y, t = domain.variable("interior")

--- a/tests/test_periodic_parametric_integration.py
+++ b/tests/test_periodic_parametric_integration.py
@@ -73,7 +73,7 @@ def make_periodic_domain():
     """Structured (periodic-compatible) rectangular domain on [0,1]^2, with each face named via
     ``domain.tag`` -- required for multi-direction periodicity so the shared corners are recovered."""
     dom = (
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0)
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0)
         .structured(n=N_GRID)
         .domain(
             time=(0.0, T_END, N_TIME),
@@ -288,7 +288,7 @@ class TestPeriodicMeshGuard:
         instead of rejecting it. The full numeric solve on auto faces is verified in
         test_fem_periodic_unstructured.py; this locks in the accept path and the shared-corner mesh
         invariant that unlocks it. The guard still rejects genuinely corner-partitioned tags."""
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.3).domain(  # auto-generated left/right/... tags (no predicate)
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.3).domain(  # auto-generated left/right/... tags (no predicate)
             time=(0.0, T_END, N_TIME),
             compute_mesh_connectivity=False,
         )

--- a/tests/test_plasticity.py
+++ b/tests/test_plasticity.py
@@ -66,7 +66,7 @@ def j2_weak(u, phi, coords, *, sy=SY, H=H, hist=None):
 
 
 def _box(size=0.34):
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=size).domain()
     d.tag("bdry", lambda x, y, z: (x < 1e-6) | (x > 1 - 1e-6) | (y < 1e-6) | (y > 1 - 1e-6) | (z < 1e-6) | (z > 1 - 1e-6))
     return d
 
@@ -111,7 +111,7 @@ def test_plasticity_caps_stress_below_elastic_peak():
     """Genuine BVP (bottom fixed, top sheared past yield, sides free): the plastic peak von Mises is
     bounded by the yield surface, strictly below the (unbounded) elastic peak — yielding limited it."""
     shear = 5.0 * SY / (2 * np.sqrt(3) * MU)
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.4).domain()
     d.tag("bot", lambda x, y, z: z < 1e-6)
     d.tag("top", lambda x, y, z: z > 1 - 1e-6)
     u, phi = d.fem_symbols(value_shape=(3,))
@@ -158,7 +158,7 @@ def test_plasticity_caps_stress_below_elastic_peak():
 def test_gradient_flows_to_material_parameter_through_solve():
     """Inverse-problem readiness: d(response)/d(sigma_y) through the plastic Newton solve matches FD."""
     shear = 4.0 * SY / (2 * np.sqrt(3) * MU)
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.5).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.5).domain()
     d.tag("bot", lambda x, y, z: z < 1e-6)
     d.tag("top", lambda x, y, z: z > 1 - 1e-6)
     u, phi = d.fem_symbols(value_shape=(3,))

--- a/tests/test_polygon_domain_csg.py
+++ b/tests/test_polygon_domain_csg.py
@@ -31,7 +31,7 @@ def test_polygon_domain_accepts_constant_z_vertices():
 
 def test_domain_poly_factory_is_lazy_unlike_meshed_shape_polygon():
     dom = jno.domain.poly(SQUARE_A, name="a")
-    mesh_dom = jno.Shape.polygon(SQUARE_A, size=0.5).domain(compute_mesh_connectivity=False)
+    mesh_dom = jno.shape.polygon(SQUARE_A, size=0.5).domain(compute_mesh_connectivity=False)
 
     assert isinstance(dom, jno.domain.csg)
     assert dom.mesh is None

--- a/tests/test_precond_ams_mixed_build.py
+++ b/tests/test_precond_ams_mixed_build.py
@@ -35,7 +35,7 @@ def _x64():
 
 def _av(size=0.5, w=1.0e4):
     """The A-V pair: curl-curl + j*w*mass on N1E, coupled to a Lagrange scalar through grad V."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     p, q = d.fem_symbols(names=("p", "q"), space="Lagrange")
     ci = d.variable("interior", split=True)
@@ -85,7 +85,7 @@ def test_a_built_ams_composes_into_a_block_preconditioner():
 
 def test_single_field_build_is_unchanged():
     """The existing single-field call must keep working with no `field=`."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]
@@ -104,7 +104,7 @@ def test_single_field_build_is_unchanged():
 
 
 def _real_curl_curl(size=0.4, beta=1.0):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_precond_hypre.py
+++ b/tests/test_precond_hypre.py
@@ -21,7 +21,7 @@ def _x64():
 
 
 def _curl_curl(size=0.4, beta=1.0):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_precond_ilu.py
+++ b/tests/test_precond_ilu.py
@@ -29,7 +29,7 @@ def _x64():
 
 
 def _poisson(size=0.28):
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(names=("u", "v"))
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]
@@ -40,7 +40,7 @@ def _poisson(size=0.28):
 
 def _complex_curl_curl(size=0.45, w=1.0e4):
     """A COMPLEX curl-curl + jw mass — the shape ilu exists for."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_precond_inner_precond.py
+++ b/tests/test_precond_inner_precond.py
@@ -37,7 +37,7 @@ def _x64():
 
 def _spd(size=0.5):
     """curl-curl + mass on N1E — SPD, so an inner CG is well posed."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_precond_real_equivalent.py
+++ b/tests/test_precond_real_equivalent.py
@@ -32,7 +32,7 @@ def _x64():
 
 def _complex_eddy(size=0.34, w=1.0e4):
     """curl-curl + j*w*mass on N1E: complex symmetric, with the mass term making it non-singular."""
-    d = jno.Shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
+    d = jno.shape.box(0, 0, 0, 1, 1, 1, size=size).domain()
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     ci = d.variable("interior", split=True)
     x, y, z = ci[0], ci[1], ci[2]

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -34,7 +34,7 @@ pytest.importorskip("pygmsh", reason="pygmsh required for meshing")
 def test_fem_solve_profile(tmp_path, monkeypatch, capsys):
     """fem.solve(profile=True) profiles the linear solve: returns the field, prints a summary, writes a trace."""
     monkeypatch.chdir(tmp_path)
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.12).domain()
     u, phi = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
@@ -50,7 +50,7 @@ def test_fem_solve_profile(tmp_path, monkeypatch, capsys):
 def test_fdm_solve_profile(tmp_path, monkeypatch, capsys):
     """fdm.solve(profile=True) profiles the strong-form Newton solve — same summary + trace contract."""
     monkeypatch.chdir(tmp_path)
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.1).domain()
     x, y, _ = d.variable("interior", split=True)
     xb, yb, _ = d.variable("boundary", split=True)
     u = d.unknown()

--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -63,7 +63,7 @@ def _build_periodic_problem(dx=0.4):
     uq, cnt = np.unique(Fs, axis=0, return_counts=True)
     BF = uq[cnt == 1]
 
-    d = _domain_from_arrays(jno.Shape.box(0, 0, 0, Lx, Ly, Lz, size=1.0).domain(), P, tets, BF, copy=True)
+    d = _domain_from_arrays(jno.shape.box(0, 0, 0, Lx, Ly, Lz, size=1.0).domain(), P, tets, BF, copy=True)
     d.tag("bottom", lambda x, y, z: z < Eb)
     d.tag("top", lambda x, y, z: z > Lz - Eb)
     d.tag("left", lambda x, y, z: x < Eb)
@@ -328,7 +328,7 @@ def test_parameter_anywhere_wavelength_and_eps_flow():
     import jax.numpy as jnp
 
     P0, Lz = 0.6, 3.2
-    d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
     e = 1e-6
     for nm, f in [
         ("left", lambda x, y, z: x < e),
@@ -391,7 +391,7 @@ def test_incidence_angle_source_parameter_is_differentiable():
     from jno.trace_evaluator import TraceEvaluator
 
     P0, Lz = 0.6, 3.2
-    d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
     e = 1e-6
     for nm, f in [
         ("left", lambda x, y, z: x < e),
@@ -491,7 +491,7 @@ def test_parameter_is_traced_no_solve_args():
     from jno.trace_evaluator import TraceEvaluator
 
     P0, Lz = 0.6, 3.2
-    d = jno.domain(jno.Shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P0, P0, Lz, size=0.2))
     e = 1e-6
     for nm, f in [
         ("left", lambda x, y, z: x < e),

--- a/tests/test_rcwa_aerial.py
+++ b/tests/test_rcwa_aerial.py
@@ -63,7 +63,7 @@ def _sbox(dx=0.07, ny=5):
     tets = np.asarray(tets)
     F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
     uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
-    d = _domain_from_arrays(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2).domain(), Pt, tets, uq[cnt == 1], copy=True)
+    d = _domain_from_arrays(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2).domain(), Pt, tets, uq[cnt == 1], copy=True)
     e = 1e-6
     for nm, f in [
         ("bottom", lambda x, y, z: z < e),
@@ -453,7 +453,7 @@ class _FakeExposure:  # a stub exposure carrying a prescribed bulk image, for te
 
 
 def test_caresist_3d_develops_exposed_stripe():
-    """The 3-D CAResist (a jno.Shape box, periodic in x,y, species diffusing in x,y AND z) develops a printed
+    """The 3-D CAResist (a jno.shape box, periodic in x,y, species diffusing in x,y AND z) develops a printed
     pattern that TRACKS the exposure: seeded from a bulk image with a bright exposed stripe in x, the exposed
     region deprotects and clears while the dark edges stay -- a strong positive correlation with the stripe
     (the periodic-tie prolongation must be right for the developed volume to follow the seed; the pre-fix
@@ -480,7 +480,7 @@ def test_caresist_3d_develops_exposed_stripe():
 @needs_fmmax
 def test_caresist_3d_end_to_end():
     """The 3-D PEB wires end to end through the real optics: exp.develop(CAResist(film=...)) reads the
-    standing-wave bulk image, solves the 3-D reaction-diffusion PEB on a jno.Shape box (periodic x,y via a
+    standing-wave bulk image, solves the 3-D reaction-diffusion PEB on a jno.shape box (periodic x,y via a
     conforming remesh), and returns a finite developed (n, n, nz) volume in [0, 1]."""
     exp = jno.rcwa(_cons(_line), orders=40, grid=40).solve().expose(NA=0.6, source=0.4)
     film = jno.litho.Film(n_resist=1.6, thickness=0.6, n_substrate=4.0, nz=6)
@@ -494,7 +494,7 @@ def test_caresist_3d_end_to_end():
 def test_caresist_3d_is_differentiable_ilt():
     """ILT through the 3-D PEB: jax.grad of a developed-volume loss w.r.t. the mask permittivity matches
     finite difference through the WHOLE chain — RCWA solve → standing-wave bulk image → 3-D reaction-diffusion
-    PEB on a jno.Shape box → developed volume. The rigorous depth-resolved resist stays fully differentiable."""
+    PEB on a jno.shape box → developed volume. The rigorous depth-resolved resist stays fully differentiable."""
     cons, ep = _ilt_cons()
     film = jno.litho.Film(n_resist=1.6, thickness=0.6, n_substrate=4.0, nz=4)
     # Sized to fit an 8 GB GPU. The periodic transient prolongs its whole trajectory back to the full

--- a/tests/test_rcwa_anisotropic.py
+++ b/tests/test_rcwa_anisotropic.py
@@ -73,7 +73,7 @@ def _slab(x, y, z, val):
 
 def _aniso_constraints(exx, eyy, ezz):
     """A uniform diagonal-anisotropic slab diag(exx, eyy, ezz) embedded in vacuum."""
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     (xi, yi, zi), (ui, vi), (cu, cv), bcs = _common(d)
     ex = jno.fn(lambda x, y, z: _slab(x, y, z, exx), [xi, yi, zi])
     ey = jno.fn(lambda x, y, z: _slab(x, y, z, eyy), [xi, yi, zi])
@@ -85,7 +85,7 @@ def _aniso_constraints(exx, eyy, ezz):
 def _tensor_constraints(flat9):
     """A uniform slab with a full 3×3 tensor (row-major ``flat9``): diagonal defaults to 1 outside the slab,
     off-diagonal to 0 (isotropic vacuum ambient). Lets an off-diagonal ε̂ rotate polarization."""
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     (xi, yi, zi), (ui, vi), (cu, cv), bcs = _common(d)
     comps = [
         jno.fn(
@@ -100,7 +100,7 @@ def _tensor_constraints(flat9):
 
 def _scalar_constraints(e):
     """The isotropic reference: the same slab with scalar ε."""
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     (xi, yi, zi), (ui, vi), (cu, cv), bcs = _common(d)
     eps = jno.fn(lambda x, y, z: _slab(x, y, z, e), [xi, yi, zi])
     return [inner(cu, cv) - K0**2 * eps * inner(ui, vi), *bcs]

--- a/tests/test_rcwa_incidence.py
+++ b/tests/test_rcwa_incidence.py
@@ -63,7 +63,7 @@ def _slab_sol(period, orders=80, grid=64):
     tets = np.asarray(tets)
     F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
     uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
-    d = _domain_from_arrays(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2).domain(), Pt, tets, uq[cnt == 1], copy=True)
+    d = _domain_from_arrays(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2).domain(), Pt, tets, uq[cnt == 1], copy=True)
     e = 1e-6
     for nm, f in [
         ("bottom", lambda x, y, z: z < e),

--- a/tests/test_rcwa_pml.py
+++ b/tests/test_rcwa_pml.py
@@ -72,7 +72,7 @@ def _structured_box(Lx, dx=0.1, dz=0.2):
     tets = np.asarray(tets)
     F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
     uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
-    d = _domain_from_arrays(jno.Shape.box(0, 0, 0, Lx, Lx, LZ, size=0.2).domain(), P, tets, uq[cnt == 1], copy=True)
+    d = _domain_from_arrays(jno.shape.box(0, 0, 0, Lx, Lx, LZ, size=0.2).domain(), P, tets, uq[cnt == 1], copy=True)
     e = 1e-6
     for nm, f in [
         ("bottom", lambda x, y, z: z < e),

--- a/tests/test_rcwa_profile.py
+++ b/tests/test_rcwa_profile.py
@@ -40,7 +40,7 @@ P, LZ = 1.1, 3.2
 
 def _slab_cons():
     """A uniform a-Si slab (no lateral structure -> converges at tiny truncation, fast)."""
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     e = 1e-6
     for nm, f in [
         ("left", lambda x, y, z: x < e),

--- a/tests/test_rcwa_smoothing.py
+++ b/tests/test_rcwa_smoothing.py
@@ -75,7 +75,7 @@ def _pillar_cons(d, hw=0.22, eps_val=1.5):
 
 
 def _dom():
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     e = 1e-6  # explicit face predicates -> multidirectional (x AND y) periodicity needs tagged faces
     d.tag("left", lambda x, y, z: x < e)
     d.tag("right", lambda x, y, z: x > P - e)

--- a/tests/test_rcwa_source.py
+++ b/tests/test_rcwa_source.py
@@ -99,7 +99,7 @@ def _sbox(Lx, dx=0.12, dz=0.2):
     tets = np.asarray(tets)
     F = np.concatenate([tets[:, [0, 1, 2]], tets[:, [0, 1, 3]], tets[:, [0, 2, 3]], tets[:, [1, 2, 3]]])
     uq, cnt = np.unique(np.sort(F, 1), axis=0, return_counts=True)
-    d = _domain_from_arrays(jno.Shape.box(0, 0, 0, Lx, Lx, LZ, size=0.2).domain(), P, tets, uq[cnt == 1], copy=True)
+    d = _domain_from_arrays(jno.shape.box(0, 0, 0, Lx, Lx, LZ, size=0.2).domain(), P, tets, uq[cnt == 1], copy=True)
     e = 1e-6
     for nm, f in [
         ("bottom", lambda x, y, z: z < e),

--- a/tests/test_rcwa_vector.py
+++ b/tests/test_rcwa_vector.py
@@ -62,7 +62,7 @@ def _pillar(xi, yi, zi, eps_pillar=11.0):
 
 
 def _scalar_constraints():
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     _tag_faces(d)
     u, phi = d.fem_symbols()
     xi, yi, zi, _ = d.variable("interior", split=True)
@@ -89,7 +89,7 @@ def _scalar_constraints():
 
 
 def _vector_constraints():
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     _tag_faces(d)
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")
     c = d.variable("interior", split=True)
@@ -150,7 +150,7 @@ def _param_pillar(xi, yi, zi, k):
 
 
 def _scalar_inverse_rc():
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     _tag_faces(d)
     k = jno.np.parameter((), name="k").initialize(jax.nn.initializers.constant(0.5))
     u, phi = d.fem_symbols()
@@ -182,7 +182,7 @@ def _scalar_inverse_rc():
 
 
 def _vector_inverse_rc():
-    d = jno.domain(jno.Shape.box(0, 0, 0, P, P, LZ, size=0.2))
+    d = jno.domain(jno.shape.box(0, 0, 0, P, P, LZ, size=0.2))
     _tag_faces(d)
     k = jno.np.parameter((), name="k").initialize(jax.nn.initializers.constant(0.5))
     u, v = d.fem_symbols(value_shape=(3,), names=("u", "v"), space="N1E")

--- a/tests/test_regularize.py
+++ b/tests/test_regularize.py
@@ -21,7 +21,7 @@ import foundax  # noqa: E402
 
 
 def _coord_field():
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.5).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.5).domain()
     x, y, _ = d.variable("interior")
     k_net = jnn.nn.wrap(foundax.mlp(in_features=2, output_dim=1, hidden_dims=8, num_layers=2, key=jax.random.PRNGKey(0)))
     k_net.optimizer(optax.adam(1e-3))

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -94,9 +94,9 @@ def _build_solver_nd(
     time: tuple[float, float, int] | None = None,
 ):
     if spatial_dim == 2:
-        shape = jno.Shape.rect(0, 0, 1, 1, size=0.2)
+        shape = jno.shape.rect(0, 0, 1, 1, size=0.2)
     elif spatial_dim == 3:
-        shape = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.6)
+        shape = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.6)
     else:
         raise ValueError("spatial_dim must be 2 or 3")
 
@@ -517,7 +517,7 @@ def test_boundary_normals_updated_after_resample():
     strategy = RAD(resample_every=1, resample_fraction=0.5, start_epoch=0, k=3)
 
     # mesh_size=0.1 → ~40 boundary nodes in pool, working set = 20 → 2× ratio.
-    domain = 1 * jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+    domain = 1 * jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
     b_vars = domain.variable("boundary", sample=(20, None), normals=True, split=True, resampling_strategy=strategy)
     xb, yb = b_vars[0], b_vars[1]
 
@@ -562,7 +562,7 @@ _BURGERS_NU = 0.01 / np.pi  # classical PINN benchmark value
 
 def _make_burgers_domain(strategy=None, mesh_size=0.15, n_sample=60):
     """Rectangle [-1,1] × [0,1]; x is spatial, y acts as time."""
-    domain = 1 * jno.Shape.rect(-1.0, 0.0, 1.0, 1.0, size=mesh_size).domain()
+    domain = 1 * jno.shape.rect(-1.0, 0.0, 1.0, 1.0, size=mesh_size).domain()
     if strategy is not None:
         domain.variable("interior", sample=(n_sample, None), resampling_strategy=strategy)
     else:
@@ -636,7 +636,7 @@ def test_burgers_rad_resampling_concentrates_near_steep_gradient():
     """
     strategy = RAD(resample_every=20, resample_fraction=0.25, start_epoch=0, k=5)
 
-    domain = 1 * jno.Shape.rect(-1.0, 0.0, 1.0, 1.0, size=0.08).domain()
+    domain = 1 * jno.shape.rect(-1.0, 0.0, 1.0, 1.0, size=0.08).domain()
     vars_all = domain.variable("interior", sample=(60, None), resampling_strategy=strategy)
     x, t = vars_all[0], vars_all[1]
 
@@ -730,7 +730,7 @@ def test_a_resampled_boundary_point_keeps_its_own_normal(strategy):
 
     The oracle is the closed-form normal of the hole, which points at its centre.
     """
-    d = (jno.Shape.rect(0.0, 0.0, 1.0, 1.0) - jno.Shape.disk(0.5, 0.5, 0.2)).domain()
+    d = (jno.shape.rect(0.0, 0.0, 1.0, 1.0) - jno.shape.disk(0.5, 0.5, 0.2)).domain()
     d.variable("arc", sample=(400, None), normals=True, split=True)
     pts = np.asarray(d.context["arc"])[0, 0]
     nrm = np.asarray(d.context["n_arc"])[0, 0]

--- a/tests/test_scheme_families.py
+++ b/tests/test_scheme_families.py
@@ -229,7 +229,7 @@ class TestAFourthFamilyIsAdditive:
     def _frozen(self):
         import numpy as np
 
-        d = jno.Shape.rect(0, 0, 1, 1, size=1 / 8).structured().domain()
+        d = jno.shape.rect(0, 0, 1, 1, size=1 / 8).structured().domain()
         x, y, _ = d.variable("interior")
         P = np.asarray(d.mesh_connectivity["points"])[:, :2]
         u, _v = d.fem_symbols()

--- a/tests/test_shape_attach.py
+++ b/tests/test_shape_attach.py
@@ -1,4 +1,4 @@
-"""``Shape.attach`` — material properties declared on the region, read back as ``d.<name>``.
+"""``shape.attach`` — material properties declared on the region, read back as ``d.<name>``.
 
 ``.attach(k=220.0)`` on a named region makes ``d.k`` the per-region coefficient over every region
 that declared a ``k`` — the same object ``d.by_region({...})`` returns, so it drops straight into a
@@ -6,8 +6,8 @@ weak form. A value may be anything the jNO stack treats as a coefficient: a scal
 symbolic expression, a typed view (``ScalarView`` / ``VectorView`` / ``MatrixView``), a trainable
 ``jno.np.parameter``, or a plain function of the coordinates.
 
-Also covers the two prerequisites the feature exposed: ``by_region`` accepting ``Shape.regions``
-sub-region names at all, and ``Shape.regions`` accepting a ``{name: shape}`` dict for names that are
+Also covers the two prerequisites the feature exposed: ``by_region`` accepting ``shape.regions``
+sub-region names at all, and ``shape.regions`` accepting a ``{name: shape}`` dict for names that are
 not valid Python identifiers.
 
 Boundary-tag attachment (``d.attach("wall", h=25.0)`` → ``d.h`` as a per-facet coefficient) lives in
@@ -24,8 +24,8 @@ import jno
 
 def _two_regions(**kw):
     """A 1x1 inclusion inside a 2x1 plate, each carrying whatever `.attach(...)` kwargs are given."""
-    a = jno.Shape.rect(0, 0, 1, 1, size=0.3).name("a").attach(**kw.get("a", {}))
-    b = jno.Shape.rect(0, 0, 2, 1, size=0.3).name("b").attach(**kw.get("b", {}))
+    a = jno.shape.rect(0, 0, 1, 1, size=0.3).name("a").attach(**kw.get("a", {}))
+    b = jno.shape.rect(0, 0, 2, 1, size=0.3).name("b").attach(**kw.get("b", {}))
     return a + b
 
 
@@ -75,25 +75,25 @@ def test_name_colliding_with_a_domain_attribute_raises_at_build(clash):
 
 
 def test_attach_merges_and_last_wins():
-    s = jno.Shape.rect(0, 0, 1, 1).name("a").attach(k=1.0, eta=9.0).attach(k=2.0)
+    s = jno.shape.rect(0, 0, 1, 1).name("a").attach(k=1.0, eta=9.0).attach(k=2.0)
     assert s._attach == {"k": 2.0, "eta": 9.0}
 
 
 def test_attach_survives_name_sized_and_curved():
-    s = jno.Shape.rect(0, 0, 1, 1).attach(k=1.0).name("a").sized(0.1).curved()
+    s = jno.shape.rect(0, 0, 1, 1).attach(k=1.0).name("a").sized(0.1).curved()
     assert s._attach == {"k": 1.0}
     assert s._region_name == "a"
 
 
 def test_attach_survives_boolean_and_transform_ops():
-    s = (jno.Shape.rect(0, 0, 2, 2).attach(k=1.0) - jno.Shape.rect(0, 0, 1, 1)).translate((1.0, 0.0))
+    s = (jno.shape.rect(0, 0, 2, 2).attach(k=1.0) - jno.shape.rect(0, 0, 1, 1)).translate((1.0, 0.0))
     assert s._attach == {"k": 1.0}
 
 
 def test_attach_does_not_affect_geometric_equality_or_hashing():
     """`_attach` is compare=False: two geometrically identical shapes stay equal (and hashable)
     however they are materialled."""
-    plain = jno.Shape.rect(0, 0, 1, 1)
+    plain = jno.shape.rect(0, 0, 1, 1)
     assert plain == plain.attach(k=1.0)
     assert len({plain, plain.attach(k=1.0)}) == 1
 
@@ -120,20 +120,20 @@ def test_attached_value_may_be_a_jax_array():
 
 
 # --------------------------------------------------------------------------------------
-# attach through the Shape.regions dict form (names that are not Python identifiers)
+# attach through the shape.regions dict form (names that are not Python identifiers)
 # --------------------------------------------------------------------------------------
 def test_attach_through_the_regions_dict_form():
-    d = jno.Shape.regions(
+    d = jno.shape.regions(
         {
-            "Quartz.1": jno.Shape.rect(0, 0, 1, 1, size=0.3).attach(k=1.0),
-            "Quartz.2": jno.Shape.rect(0, 0, 2, 1, size=0.3).attach(k=2.0),
+            "Quartz.1": jno.shape.rect(0, 0, 1, 1, size=0.3).attach(k=1.0),
+            "Quartz.2": jno.shape.rect(0, 0, 2, 1, size=0.3).attach(k=2.0),
         }
     ).domain()
     assert str(d.k) == str(d.by_region({"Quartz.1": 1.0, "Quartz.2": 2.0}))
 
 
 # --------------------------------------------------------------------------------------
-# a Shape-built domain must reach the same machinery a polygon-built one does
+# a shape-built domain must reach the same machinery a polygon-built one does
 # --------------------------------------------------------------------------------------
 def test_region_masks_partition_when_a_background_region_encloses_everything():
     """`by_region` sums RegionMask*value, so the masks have to be a PARTITION. Declaring a bounding
@@ -143,8 +143,8 @@ def test_region_masks_partition_when_a_background_region_encloses_everything():
     k = 0.5 and pulled the solution 780 K cold."""
     from jno.utils.solver.fem_utils import _cell_region_mask
 
-    inner = jno.Shape.rect(2, 2, 4, 4, size=0.5).name("inner")
-    background = jno.Shape.rect(0, 0, 6, 6, size=0.5).name("background")  # encloses `inner`
+    inner = jno.shape.rect(2, 2, 4, 4, size=0.5).name("inner")
+    background = jno.shape.rect(0, 0, 6, 6, size=0.5).name("background")  # encloses `inner`
     d = (inner + background).domain()
 
     masks = np.array([_cell_region_mask(d, nm) for nm in d._shape_regions])
@@ -176,7 +176,7 @@ def test_a_single_named_region_round_trips_its_attachment():
     """`domain.__init__` gated on the `("regions", ...)` node, which a lone named shape is not -- so
     its attachment was collected from nowhere and `d.k` reported a bare "no attribute 'k'". Nothing
     told the user the declaration had been ignored."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.4).name("a").attach(k=2.0).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.4).name("a").attach(k=2.0).domain()
     assert str(d.k) == str(d.by_region({"a": 2.0}))
     assert d.attached("k") == {"a": 2.0}
 
@@ -184,12 +184,12 @@ def test_a_single_named_region_round_trips_its_attachment():
 def test_attach_without_a_name_raises_at_build():
     """The other half of the same hole: with no region name there is nothing to attach to."""
     with pytest.raises(ValueError, match="no region name"):
-        jno.Shape.rect(0, 0, 1, 1, size=0.4).attach(k=2.0).domain()
+        jno.shape.rect(0, 0, 1, 1, size=0.4).attach(k=2.0).domain()
 
 
 def test_a_single_named_region_still_masks_every_cell():
     """The lone region owns the whole mesh, so its coefficient must not restrict anything away."""
-    d = jno.Shape.rect(0, 0, 1, 1, size=0.4).name("a").attach(k=3.0).domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=0.4).name("a").attach(k=3.0).domain()
     np.testing.assert_allclose(_poisson(d, d.k), _poisson(d, 3.0), rtol=1e-5, atol=1e-5)
 
 
@@ -309,8 +309,8 @@ def test_jax_array_attachment_assembles():
 
 def test_attachment_in_3d():
     d = (
-        jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.5).name("a").attach(k=1.0)
-        + jno.Shape.box(0, 0, 0, 2, 1, 1, size=0.5).name("b").attach(k=9.0)
+        jno.shape.box(0, 0, 0, 1, 1, 1, size=0.5).name("a").attach(k=1.0)
+        + jno.shape.box(0, 0, 0, 2, 1, 1, size=0.5).name("b").attach(k=9.0)
     ).domain()
     assert d.attached("k") == {"a": 1.0, "b": 9.0}
     assert "RegionMask(a)" in str(d.k) and "RegionMask(b)" in str(d.k)
@@ -320,7 +320,7 @@ def test_many_regions_all_contribute():
     """Five regions, five different values -- the sum must carry every one of them."""
     shapes = None
     for i in range(5):
-        s = jno.Shape.rect(0, 0, 1 + i, 1, size=0.4).name(f"r{i}").attach(k=float(i))
+        s = jno.shape.rect(0, 0, 1 + i, 1, size=0.4).name(f"r{i}").attach(k=float(i))
         shapes = s if shapes is None else shapes + s
     d = shapes.domain()
     assert d.attached("k") == {f"r{i}": float(i) for i in range(5)}

--- a/tests/test_shape_boundary_traced.py
+++ b/tests/test_shape_boundary_traced.py
@@ -34,7 +34,7 @@ def _x64():
         jax.config.update("jax_enable_x64", prev)
 
 
-S = jno.Shape
+S = jno.shape
 SHAPES = {
     "rect": (S.rect(0, 0, 2, 1), 2),
     "disk": (S.disk(0, 0, 1), 2),

--- a/tests/test_shape_contains.py
+++ b/tests/test_shape_contains.py
@@ -1,4 +1,4 @@
-"""``jno.Shape.contains`` — analytic, shapely-free point-in-region membership (2-D & 3-D).
+"""``jno.shape.contains`` — analytic, shapely-free point-in-region membership (2-D & 3-D).
 
 The point-containment predicate that resolves a geometric ``domain.region(name, shape)`` to a mesh-node
 subset, and the membership test the mesh-free PINN sampler rejects against. Covers CSG (leaf +
@@ -8,48 +8,48 @@ revolve); ``sweep`` and ``fillet`` have none and refuse by name."""
 import numpy as np
 import pytest
 
-from jno.geometry import Shape
+from jno.geometry import shape
 
 
 def test_rect_contains():
-    s = Shape.rect(0.0, 0.0, 1.0, 1.0)
+    s = shape.rect(0.0, 0.0, 1.0, 1.0)
     pts = np.array([[0.5, 0.5], [1.5, 0.5], [-0.1, 0.5], [0.0, 0.0], [1.0, 1.0]])
     assert list(s.contains(pts)) == [True, False, False, True, True]  # corners inclusive
 
 
 def test_disk_contains():
-    s = Shape.disk(0.0, 0.0, 1.0)
+    s = shape.disk(0.0, 0.0, 1.0)
     pts = np.array([[0.0, 0.0], [0.9, 0.0], [1.1, 0.0], [0.7, 0.7]])
     assert list(s.contains(pts)) == [True, True, False, True]  # (0.7,0.7): r≈0.99 < 1
 
 
 def test_polygon_contains_triangle():
-    s = Shape.polygon([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)])
+    s = shape.polygon([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)])
     pts = np.array([[0.2, 0.2], [0.6, 0.6], [0.9, 0.9], [-0.1, 0.5]])
     assert list(s.contains(pts)) == [True, False, False, False]  # (0.6,0.6) is outside x+y<1
 
 
 def test_box_contains():
-    s = Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+    s = shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
     pts = np.array([[0.5, 0.5, 0.5], [0.5, 0.5, 1.5], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
     assert list(s.contains(pts)) == [True, False, True, True]
 
 
 def test_sphere_contains():
-    s = Shape.sphere(0.0, 0.0, 0.0, 1.0)
+    s = shape.sphere(0.0, 0.0, 0.0, 1.0)
     pts = np.array([[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [1.0, 1.0, 1.0]])
     assert list(s.contains(pts)) == [True, True, False]  # (.5,.5,.5): r≈0.87<1; (1,1,1): r≈1.73>1
 
 
 def test_cylinder_contains():
-    s = Shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.0)  # axis +z, height 2, radius 1
+    s = shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.0)  # axis +z, height 2, radius 1
     pts = np.array([[0.0, 0.0, 1.0], [0.9, 0.0, 1.0], [1.1, 0.0, 1.0], [0.0, 0.0, 2.5], [0.0, 0.0, -0.1]])
     assert list(s.contains(pts)) == [True, True, False, False, False]
 
 
 def test_cut_fuse_inter():
-    a = Shape.rect(0.0, 0.0, 0.6, 1.0)
-    b = Shape.rect(0.4, 0.0, 1.0, 1.0)  # overlap x∈[0.4,0.6]
+    a = shape.rect(0.0, 0.0, 0.6, 1.0)
+    b = shape.rect(0.4, 0.0, 1.0, 1.0)  # overlap x∈[0.4,0.6]
     pts = np.array([[0.2, 0.5], [0.5, 0.5], [0.8, 0.5]])  # in A only / both / in B only
     assert list((a - b).contains(pts)) == [True, False, False]  # cut: A minus B
     assert list((a | b).contains(pts)) == [True, True, True]  # fuse: union
@@ -65,7 +65,7 @@ def test_difference_matches_shapely():
     diff = a_s.difference(b_s)
     rng = np.random.default_rng(0)
     pts = rng.uniform(-0.1, 1.1, size=(500, 2))
-    ours = (Shape.rect(0.0, 0.0, 0.6, 1.0) - Shape.rect(0.4, 0.0, 1.0, 1.0)).contains(pts)
+    ours = (shape.rect(0.0, 0.0, 0.6, 1.0) - shape.rect(0.4, 0.0, 1.0, 1.0)).contains(pts)
     theirs = np.asarray(shp.contains_xy(diff.buffer(1e-9), pts[:, 0], pts[:, 1]))
     assert np.array_equal(ours, theirs)
 
@@ -73,18 +73,18 @@ def test_difference_matches_shapely():
 def test_rigid_and_sweep_transforms_are_analytic():
     """translate/rotate/extrude/revolve map the query point into the child's frame, so membership
     stays closed-form; each is checked against the geometry it is supposed to describe."""
-    box = Shape.rect(0.0, 0.0, 1.0, 1.0).extrude(2.0)  # the unit square swept to height 2
+    box = shape.rect(0.0, 0.0, 1.0, 1.0).extrude(2.0)  # the unit square swept to height 2
     pts = np.array([[0.5, 0.5, 1.0], [0.5, 0.5, 2.5], [1.5, 0.5, 1.0], [0.5, 0.5, 0.0]])
     assert list(box.contains(pts)) == [True, False, False, True]  # the z=0 cap is inclusive
 
-    moved = Shape.rect(0.0, 0.0, 1.0, 1.0).translate((5.0, 0.0, 0.0))
+    moved = shape.rect(0.0, 0.0, 1.0, 1.0).translate((5.0, 0.0, 0.0))
     assert list(moved.contains(np.array([[5.5, 0.5], [0.5, 0.5]]))) == [True, False]
 
-    turned = Shape.rect(0.0, 0.0, 2.0, 1.0).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), np.pi / 2)
+    turned = shape.rect(0.0, 0.0, 2.0, 1.0).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), np.pi / 2)
     assert list(turned.contains(np.array([[-0.5, 1.0], [1.0, 0.5]]))) == [True, False]
 
     # the profile x in [1, 2] swept a full turn about +y is the ring 1 <= sqrt(x^2+z^2) <= 2
-    ring = Shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * np.pi)
+    ring = shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * np.pi)
     pts = np.array([[1.5, 0.5, 0.0], [0.0, 0.5, 1.5], [0.5, 0.5, 0.0], [1.5, 1.5, 0.0]])
     assert list(ring.contains(pts)) == [True, True, False, False]
 
@@ -97,7 +97,7 @@ def test_fillet_membership_comes_from_the_tessellation():
     untouched. A membership test that merely recursed to the un-filleted solid would say the corner
     is still there.
     """
-    solid = Shape.rect(0.0, 0.0, 1.0, 1.0).extrude(1.0).fillet(0.1).size(0.15)
+    solid = shape.rect(0.0, 0.0, 1.0, 1.0).extrude(1.0).fillet(0.1).size(0.15)
     assert not solid.is_analytic()
     pts = np.array(
         [
@@ -113,7 +113,7 @@ def test_fillet_membership_comes_from_the_tessellation():
 def test_cut_keeps_its_own_cut_surface():
     """``A - B`` retains the surface it was cut along — that is where a mesh puts nodes, so
     testing the subtrahend inclusively would drop every node on a hole's boundary."""
-    holed = Shape.rect(0.0, 0.0, 1.0, 1.0) - Shape.disk(0.5, 0.5, 0.25)
+    holed = shape.rect(0.0, 0.0, 1.0, 1.0) - shape.disk(0.5, 0.5, 0.25)
     on_hole = np.array([[0.75, 0.5], [0.5, 0.75], [0.25, 0.5]])  # exactly at radius 0.25
     assert holed.contains(on_hole).all()
     assert not holed.contains(np.array([[0.5, 0.5]])).any()  # the hole's middle is still out

--- a/tests/test_shape_nonconforming.py
+++ b/tests/test_shape_nonconforming.py
@@ -1,6 +1,6 @@
-"""Non-conforming multi-body meshes — ``Shape.regions(..., conforming=False)``.
+"""Non-conforming multi-body meshes — ``shape.regions(..., conforming=False)``.
 
-``Shape.regions`` fragments its pieces so a shared interface meshes conforming (one set of nodes, no
+``shape.regions`` fragments its pieces so a shared interface meshes conforming (one set of nodes, no
 tie needed). ``conforming=False`` skips the fragment: each piece is meshed independently, so two
 touching regions end up with two **coincident but non-matching** surfaces and duplicated nodes. Gluing
 those with ``u(A) - u(B)`` in ``jno.fem`` is what lets two bodies meshed at different resolutions be
@@ -33,9 +33,9 @@ _LOWER_TOP, _UPPER_TOP = 1.0, 2.5
 def _bar(conforming, size):
     """A 1x1x2.5 bar as two stacked blocks, either fragmented or independently meshed."""
     return (
-        jno.Shape.regions(
-            lower=jno.Shape.box(0, 0, 0, 1, 1, _LOWER_TOP),
-            upper=jno.Shape.box(0, 0, _LOWER_TOP, 1, 1, _UPPER_TOP),
+        jno.shape.regions(
+            lower=jno.shape.box(0, 0, 0, 1, 1, _LOWER_TOP),
+            upper=jno.shape.box(0, 0, _LOWER_TOP, 1, 1, _UPPER_TOP),
             conforming=conforming,
         )
         .sized(size)
@@ -157,9 +157,9 @@ def test_the_tie_is_what_makes_the_field_continuous():
 
 def _stack(base_size, film_size):
     """Two stacked blocks sharing a full face, meshed independently at their own resolutions."""
-    return jno.Shape.regions(
-        base=jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=base_size),
-        film=jno.Shape.rect(0.0, 1.0, 2.0, 1.4, size=film_size),
+    return jno.shape.regions(
+        base=jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=base_size),
+        film=jno.shape.rect(0.0, 1.0, 2.0, 1.4, size=film_size),
         conforming=False,
     ).domain()
 
@@ -263,9 +263,9 @@ def _lap2(u, phi, r):
 
 def _graded_stack():
     """Coarse base under a finer film, meshed independently — a genuinely non-matching interface."""
-    return jno.Shape.regions(
-        base=jno.Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.25),
-        film=jno.Shape.rect(0.0, 1.0, 2.0, 1.4, size=0.08),
+    return jno.shape.regions(
+        base=jno.shape.rect(0.0, 0.0, 2.0, 1.0, size=0.25),
+        film=jno.shape.rect(0.0, 1.0, 2.0, 1.4, size=0.08),
         conforming=False,
     ).domain()
 
@@ -420,4 +420,4 @@ def test_p2_on_a_nonconforming_domain_keeps_the_bodies_apart():
 
 def test_conforming_is_a_reserved_region_name():
     with pytest.raises(TypeError, match="must be a bool"):
-        jno.Shape.regions(a=jno.Shape.box(0, 0, 0, 1, 1, 1), b=jno.Shape.box(0, 0, 1, 1, 1, 2), conforming="no")
+        jno.shape.regions(a=jno.shape.box(0, 0, 0, 1, 1, 1), b=jno.shape.box(0, 0, 1, 1, 1, 2), conforming="no")

--- a/tests/test_shape_nonconforming_multiface.py
+++ b/tests/test_shape_nonconforming_multiface.py
@@ -49,10 +49,10 @@ _X0, _X1, _TOP = 1.5, 1.8, 1.2
 
 def _channel():
     """The beam as its own body, meshed independently of the fluid around it."""
-    notch = jno.Shape.rect(_X0, -0.1, _X1, _TOP)  # cut BELOW y=0 so the notch opens onto the floor
-    return jno.Shape.regions(
-        fluid=(jno.Shape.rect(0.0, 0.0, _L, _H) - notch).sized(0.12),
-        beam=jno.Shape.rect(_X0, 0.0, _X1, _TOP).sized(0.09),
+    notch = jno.shape.rect(_X0, -0.1, _X1, _TOP)  # cut BELOW y=0 so the notch opens onto the floor
+    return jno.shape.regions(
+        fluid=(jno.shape.rect(0.0, 0.0, _L, _H) - notch).sized(0.12),
+        beam=jno.shape.rect(_X0, 0.0, _X1, _TOP).sized(0.09),
         conforming=False,
     ).domain()
 
@@ -138,10 +138,10 @@ def test_the_tie_glues_across_every_face():
     """
 
     def solve(conforming):
-        notch = jno.Shape.rect(_X0, -0.1, _X1, _TOP)
-        d = jno.Shape.regions(
-            fluid=(jno.Shape.rect(0.0, 0.0, _L, _H) - notch).sized(0.12),
-            beam=jno.Shape.rect(_X0, 0.0, _X1, _TOP).sized(0.09),
+        notch = jno.shape.rect(_X0, -0.1, _X1, _TOP)
+        d = jno.shape.regions(
+            fluid=(jno.shape.rect(0.0, 0.0, _L, _H) - notch).sized(0.12),
+            beam=jno.shape.rect(_X0, 0.0, _X1, _TOP).sized(0.09),
             conforming=conforming,
         ).domain()
         u, v = d.fem_symbols()

--- a/tests/test_shape_regions.py
+++ b/tests/test_shape_regions.py
@@ -1,4 +1,4 @@
-"""Multi-material domains via ``jno.Shape.regions`` — conforming meshes + region tags.
+"""Multi-material domains via ``jno.shape.regions`` — conforming meshes + region tags.
 
 The pieces are fragmented so element edges align with every material interface, and each
 volume cell is assigned to the first region whose shape contains its centroid (exact, because
@@ -25,9 +25,9 @@ def _tri_areas(points, tri):
 def test_regions_split_is_exact_and_conforming():
     """A disk inclusion in a plate: the two region cell-sets partition the cells and their areas
     match the analytic areas (only the disk's polygonal facetting differs, ~1%)."""
-    plate = jno.Shape.rect(0, 0, 2, 1)
-    disk = jno.Shape.disk(1, 0.5, 0.3)
-    mesh, dim, _ = jno.Shape.regions(inclusion=disk, matrix=plate).sized(0.05).build()
+    plate = jno.shape.rect(0, 0, 2, 1)
+    disk = jno.shape.disk(1, 0.5, 0.3)
+    mesh, dim, _ = jno.shape.regions(inclusion=disk, matrix=plate).sized(0.05).build()
 
     tri = mesh.cells[0].data
     inc = mesh.cell_sets["inclusion"][0]
@@ -42,7 +42,7 @@ def test_regions_split_is_exact_and_conforming():
 
 
 def test_regions_expose_variable_sets_and_external_boundary():
-    d = jno.Shape.regions(inclusion=jno.Shape.disk(1, 0.5, 0.3), matrix=jno.Shape.rect(0, 0, 2, 1)).sized(0.08).domain()
+    d = jno.shape.regions(inclusion=jno.shape.disk(1, 0.5, 0.3), matrix=jno.shape.rect(0, 0, 2, 1)).sized(0.08).domain()
     # region tags queryable
     for tag in ("interior", "inclusion", "matrix", "boundary"):
         d.variable(tag)  # must not raise
@@ -59,7 +59,7 @@ def test_regions_priority_is_keyword_order():
     """Overlapping regions resolve by keyword order: the disk overlaps the plate, and the disk's
     label wins because it is listed first."""
     mesh, _, _ = (
-        jno.Shape.regions(inclusion=jno.Shape.disk(1, 0.5, 0.3), matrix=jno.Shape.rect(0, 0, 2, 1)).sized(0.08).build()
+        jno.shape.regions(inclusion=jno.shape.disk(1, 0.5, 0.3), matrix=jno.shape.rect(0, 0, 2, 1)).sized(0.08).build()
     )
     tri = mesh.points[mesh.cells[0].data][:, :, :2]
     cent = tri.mean(axis=1)
@@ -69,9 +69,9 @@ def test_regions_priority_is_keyword_order():
 
 
 def test_regions_3d_box_with_spherical_core():
-    core = jno.Shape.sphere(0.5, 0.5, 0.5, 0.25)
-    shell = jno.Shape.box(0, 0, 0, 1, 1, 1)
-    d = jno.Shape.regions(core=core, shell=shell).sized(0.12).domain()
+    core = jno.shape.sphere(0.5, 0.5, 0.5, 0.25)
+    shell = jno.shape.box(0, 0, 0, 1, 1, 1)
+    d = jno.shape.regions(core=core, shell=shell).sized(0.12).domain()
     assert d.dimension == 3
     assert d._mesh_pool["core"].shape[0] > 0
     assert d._mesh_pool["shell"].shape[0] > 0
@@ -81,51 +81,51 @@ def test_regions_3d_box_with_spherical_core():
 
 
 def test_regions_contains_is_union():
-    sh = jno.Shape.regions(inclusion=jno.Shape.disk(1, 0.5, 0.3), matrix=jno.Shape.rect(0, 0, 2, 1))
+    sh = jno.shape.regions(inclusion=jno.shape.disk(1, 0.5, 0.3), matrix=jno.shape.rect(0, 0, 2, 1))
     mask = sh.contains(np.array([[1.0, 0.5], [0.05, 0.05], [5.0, 5.0]]))
     assert mask.tolist() == [True, True, False]
 
 
 def test_regions_requires_two_regions_of_same_dim():
     with pytest.raises(ValueError, match="at least two"):
-        jno.Shape.regions(only=jno.Shape.rect(0, 0, 1, 1))
+        jno.shape.regions(only=jno.shape.rect(0, 0, 1, 1))
     with pytest.raises(ValueError, match="dimension"):
-        jno.Shape.regions(a=jno.Shape.rect(0, 0, 1, 1), b=jno.Shape.box(0, 0, 0, 1, 1, 1))
+        jno.shape.regions(a=jno.shape.rect(0, 0, 1, 1), b=jno.shape.box(0, 0, 0, 1, 1, 1))
 
 
 def test_name_plus_operator_matches_regions():
-    """``a.name(x) + b.name(y)`` is sugar for ``Shape.regions(x=a, y=b)`` — same plan."""
-    core = jno.Shape.disk(1, 0.5, 0.3)
-    plate = jno.Shape.rect(0, 0, 2, 1)
+    """``a.name(x) + b.name(y)`` is sugar for ``shape.regions(x=a, y=b)`` — same plan."""
+    core = jno.shape.disk(1, 0.5, 0.3)
+    plate = jno.shape.rect(0, 0, 2, 1)
     plus = core.name("inclusion") + plate.name("matrix")
-    kw = jno.Shape.regions(inclusion=core, matrix=plate)
+    kw = jno.shape.regions(inclusion=core, matrix=plate)
     assert plus._node[0] == "regions"
     assert [n for n, _ in plus._node[1]] == [n for n, _ in kw._node[1]] == ["inclusion", "matrix"]
 
 
 def test_name_survives_sized():
     """``.sized()`` after ``.name()`` keeps the region label (mesh size rides along)."""
-    d = (jno.Shape.disk(1, 0.5, 0.3).name("core").sized(0.05) + jno.Shape.rect(0, 0, 2, 1).name("bg")).domain()
+    d = (jno.shape.disk(1, 0.5, 0.3).name("core").sized(0.05) + jno.shape.rect(0, 0, 2, 1).name("bg")).domain()
     assert d._mesh_pool["core"].shape[0] > 0
     assert d._mesh_pool["bg"].shape[0] > 0
 
 
 def test_plus_is_nary_with_priority_order():
-    a = jno.Shape.disk(0.5, 0.5, 0.2).name("a")
-    b = jno.Shape.disk(1.5, 0.5, 0.2).name("b")
-    bg = jno.Shape.rect(0, 0, 2, 1).name("bg")
+    a = jno.shape.disk(0.5, 0.5, 0.2).name("a")
+    b = jno.shape.disk(1.5, 0.5, 0.2).name("b")
+    bg = jno.shape.rect(0, 0, 2, 1).name("bg")
     d = (a + b + bg).sized(0.08).domain()
     assert {"a", "b", "bg"}.issubset(d._mesh_pool)
 
 
 def test_plus_requires_named_operands():
     with pytest.raises(ValueError, match=r"\.name"):
-        _ = jno.Shape.disk(0, 0, 1) + jno.Shape.rect(0, 0, 1, 1)
+        _ = jno.shape.disk(0, 0, 1) + jno.shape.rect(0, 0, 1, 1)
 
 
 def test_interface_is_auto_named_by_region_pair():
     """The facets between two materials are exposed as a tag named by the region pair, sorted."""
-    d = (jno.Shape.disk(1, 0.5, 0.3).name("inclusion") + jno.Shape.rect(0, 0, 2, 1).name("matrix")).sized(0.06).domain()
+    d = (jno.shape.disk(1, 0.5, 0.3).name("inclusion") + jno.shape.rect(0, 0, 2, 1).name("matrix")).sized(0.06).domain()
     assert d.interface_tags() == ["inclusion|matrix"]
     d.variable("inclusion|matrix")  # must not raise
     assert d._mesh_pool["inclusion|matrix"].shape[0] > 0
@@ -137,8 +137,8 @@ def test_interface_is_auto_named_by_region_pair():
 def test_two_interfaces_between_same_materials_stay_separable():
     """Two disjoint same-material inclusions give two topologically separate interfaces of the same
     pair: the union ``a|b`` plus the connected components ``a|b.0`` / ``a|b.1`` (kept separable)."""
-    incl = jno.Shape.disk(0.5, 0.5, 0.2) | jno.Shape.disk(1.5, 0.5, 0.2)
-    d = (incl.name("inclusion") + jno.Shape.rect(0, 0, 2, 1).name("matrix")).sized(0.05).domain()
+    incl = jno.shape.disk(0.5, 0.5, 0.2) | jno.shape.disk(1.5, 0.5, 0.2)
+    d = (incl.name("inclusion") + jno.shape.rect(0, 0, 2, 1).name("matrix")).sized(0.05).domain()
     ifaces = sorted(k for k in d.interface_tags() if k.startswith("inclusion|matrix"))
     assert ifaces == ["inclusion|matrix", "inclusion|matrix.0", "inclusion|matrix.1"]
     for k in ("inclusion|matrix.0", "inclusion|matrix.1"):
@@ -148,16 +148,16 @@ def test_two_interfaces_between_same_materials_stay_separable():
 def test_interface_multiface_boundary_is_one_tag():
     """A box inclusion has SIX faces but ONE connected interface with the surrounding material —
     grouping is by topology, so it is a single ``inner|outer`` tag, not six per-face tags."""
-    inner = jno.Shape.box(0.3, 0.3, 0.3, 0.7, 0.7, 0.7)
-    outer = jno.Shape.box(0, 0, 0, 1, 1, 1)
-    d = jno.Shape.regions(inner=inner, outer=outer).sized(0.13).domain()
+    inner = jno.shape.box(0.3, 0.3, 0.3, 0.7, 0.7, 0.7)
+    outer = jno.shape.box(0, 0, 0, 1, 1, 1)
+    d = jno.shape.regions(inner=inner, outer=outer).sized(0.13).domain()
     assert [k for k in d.interface_tags() if k.startswith("inner|outer")] == ["inner|outer"]
     assert d._mesh_pool["inner|outer"].shape[0] > 0
 
 
 def test_interface_3d_box_sphere():
     d = (
-        jno.Shape.regions(core=jno.Shape.sphere(0.5, 0.5, 0.5, 0.25), shell=jno.Shape.box(0, 0, 0, 1, 1, 1))
+        jno.shape.regions(core=jno.shape.sphere(0.5, 0.5, 0.5, 0.25), shell=jno.shape.box(0, 0, 0, 1, 1, 1))
         .sized(0.12)
         .domain()
     )
@@ -173,7 +173,7 @@ def test_fem_term_restricts_to_a_shape_region():
     prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
     try:
-        d = jno.Shape.regions(inclusion=jno.Shape.disk(1, 0.5, 0.3), matrix=jno.Shape.rect(0, 0, 2, 1)).sized(0.05).domain()
+        d = jno.shape.regions(inclusion=jno.shape.disk(1, 0.5, 0.3), matrix=jno.shape.rect(0, 0, 2, 1)).sized(0.05).domain()
         u, phi = d.fem_symbols()
         xi, yi, _ = d.variable("interior", split=True)
         xd, yd, _ = d.variable("inclusion", split=True)
@@ -191,11 +191,11 @@ def test_fem_term_restricts_to_a_shape_region():
 # naming regions that are not Python identifiers, and sizing them
 # ==========================================================================
 def test_regions_accepts_a_dict_for_non_identifier_names():
-    """`Shape.regions(**named)` cannot express "Quartz.1" — a dot is not a valid keyword."""
-    s = jno.Shape.regions(
+    """`shape.regions(**named)` cannot express "Quartz.1" — a dot is not a valid keyword."""
+    s = jno.shape.regions(
         {
-            "Quartz.1": jno.Shape.rect(0, 0, 1, 1, size=0.3),
-            "Quartz.2": jno.Shape.rect(0, 0, 2, 1, size=0.3),
+            "Quartz.1": jno.shape.rect(0, 0, 1, 1, size=0.3),
+            "Quartz.2": jno.shape.rect(0, 0, 2, 1, size=0.3),
         }
     )
     assert [n for n, _ in s._node[1]] == ["Quartz.1", "Quartz.2"]
@@ -203,34 +203,34 @@ def test_regions_accepts_a_dict_for_non_identifier_names():
 
 
 def test_regions_dict_and_keywords_compose():
-    s = jno.Shape.regions(
-        {"a.1": jno.Shape.rect(0, 0, 1, 1, size=0.3)},
-        b=jno.Shape.rect(0, 0, 2, 1, size=0.3),
+    s = jno.shape.regions(
+        {"a.1": jno.shape.rect(0, 0, 1, 1, size=0.3)},
+        b=jno.shape.rect(0, 0, 2, 1, size=0.3),
     )
     assert [n for n, _ in s._node[1]] == ["a.1", "b"]  # dict entries first, then keywords
 
 
 def test_regions_rejects_a_non_dict_positional():
     with pytest.raises(TypeError, match="must be a .* dict"):
-        jno.Shape.regions(jno.Shape.rect(0, 0, 1, 1), b=jno.Shape.rect(0, 0, 2, 1))
+        jno.shape.regions(jno.shape.rect(0, 0, 1, 1), b=jno.shape.rect(0, 0, 2, 1))
 
 
 def test_size_is_an_alias_for_sized():
-    assert jno.Shape.rect(0, 0, 1, 1).size(0.25)._size == jno.Shape.rect(0, 0, 1, 1).sized(0.25)._size
+    assert jno.shape.rect(0, 0, 1, 1).size(0.25)._size == jno.shape.rect(0, 0, 1, 1).sized(0.25)._size
 
 
 # ==========================================================================
-# by_region over Shape region names
+# by_region over shape region names
 # ==========================================================================
 def _two_named_regions():
-    a = jno.Shape.rect(0, 0, 1, 1, size=0.3).name("a")
-    b = jno.Shape.rect(0, 0, 2, 1, size=0.3).name("b")
+    a = jno.shape.rect(0, 0, 1, 1, size=0.3).name("a")
+    b = jno.shape.rect(0, 0, 2, 1, size=0.3).name("b")
     return (a + b).domain()
 
 
 def test_by_region_accepts_shape_region_names():
     """Before this, `by_region` validated only against geometry parts and tag predicates, so a
-    Shape-built multi-material domain could not use it at all."""
+    shape-built multi-material domain could not use it at all."""
     d = _two_named_regions()
     expr = d.by_region({"a": 1.0, "b": 2.0})
     assert "RegionMask(a)" in str(expr) and "RegionMask(b)" in str(expr)

--- a/tests/test_shape_sample_traced.py
+++ b/tests/test_shape_sample_traced.py
@@ -32,7 +32,7 @@ def _x64():
         jax.config.update("jax_enable_x64", prev)
 
 
-S = jno.Shape
+S = jno.shape
 SHAPES = {
     "rect - disk": (S.rect(0, 0, 2, 1) - S.disk(0.7, 0.5, 0.28), 2),
     "polygon": (S.polygon([(0, 0), (2, 0), (1.6, 1), (0.5, 1.2)]), 2),

--- a/tests/test_shape_sampling.py
+++ b/tests/test_shape_sampling.py
@@ -1,4 +1,4 @@
-"""``jno.Shape`` mesh-free sampling — the analytic geometry a PINN draws collocation points from.
+"""``jno.shape`` mesh-free sampling — the analytic geometry a PINN draws collocation points from.
 
 Three things have to hold for this to replace mesh nodes as the collocation source:
 
@@ -17,7 +17,7 @@ import math
 import numpy as np
 import pytest
 
-from jno.geometry import Shape
+from jno.geometry import shape
 
 pytestmark = pytest.mark.filterwarnings("ignore")
 
@@ -37,14 +37,14 @@ def _mc_volume(shape, n=200_000, seed=0):
 
 
 def test_bounds_are_exact_for_primitives():
-    assert Shape.rect(0.0, 0.0, 2.0, 1.0).bounds() == ((0.0, 0.0, 0.0), (2.0, 1.0, 0.0))
-    assert Shape.box(0.0, 0.0, 0.0, 2.0, 1.0, 3.0).bounds() == ((0.0, 0.0, 0.0), (2.0, 1.0, 3.0))
-    lo, hi = Shape.disk(1.0, 2.0, 0.5).bounds()
+    assert shape.rect(0.0, 0.0, 2.0, 1.0).bounds() == ((0.0, 0.0, 0.0), (2.0, 1.0, 0.0))
+    assert shape.box(0.0, 0.0, 0.0, 2.0, 1.0, 3.0).bounds() == ((0.0, 0.0, 0.0), (2.0, 1.0, 3.0))
+    lo, hi = shape.disk(1.0, 2.0, 0.5).bounds()
     assert np.allclose(lo, (0.5, 1.5, 0.0)) and np.allclose(hi, (1.5, 2.5, 0.0))
-    lo, hi = Shape.sphere(1.0, 1.0, 1.0, 2.0).bounds()
+    lo, hi = shape.sphere(1.0, 1.0, 1.0, 2.0).bounds()
     assert np.allclose(lo, (-1.0, -1.0, -1.0)) and np.allclose(hi, (3.0, 3.0, 3.0))
     # a cylinder's box is the caps' centres widened by the disc projected on each axis
-    lo, hi = Shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0).bounds()
+    lo, hi = shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0).bounds()
     assert np.allclose(lo, (-1.0, -1.0, 0.0)) and np.allclose(hi, (1.0, 1.0, 4.0))
 
 
@@ -52,17 +52,17 @@ def test_bounds_bound_the_shape_under_csg_and_transforms():
     """A box that is not a superset silently truncates the sampler, so assert containment
     directly: every point of the shape must lie inside the reported box."""
     shapes = [
-        Shape.rect(0.0, 0.0, 1.0, 1.0) - Shape.disk(0.5, 0.5, 0.25),
-        Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0) - Shape.sphere(0.5, 0.5, 0.5, 0.3),
-        Shape.rect(0.0, 0.0, 2.0, 1.0) | Shape.disk(3.0, 0.0, 1.0),
-        Shape.rect(0.0, 0.0, 2.0, 1.0).translate((5.0, 7.0, 0.0)),
-        Shape.rect(0.0, 0.0, 2.0, 1.0).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), math.pi / 6),
-        Shape.disk(0.0, 0.0, 1.0).extrude(3.0),
-        Shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi),
+        shape.rect(0.0, 0.0, 1.0, 1.0) - shape.disk(0.5, 0.5, 0.25),
+        shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0) - shape.sphere(0.5, 0.5, 0.5, 0.3),
+        shape.rect(0.0, 0.0, 2.0, 1.0) | shape.disk(3.0, 0.0, 1.0),
+        shape.rect(0.0, 0.0, 2.0, 1.0).translate((5.0, 7.0, 0.0)),
+        shape.rect(0.0, 0.0, 2.0, 1.0).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), math.pi / 6),
+        shape.disk(0.0, 0.0, 1.0).extrude(3.0),
+        shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi),
     ]
-    for shape in shapes:
-        lo, hi = (np.asarray(v, dtype=float) for v in shape.bounds())
-        pts = shape.sample_interior(4000, np.random.default_rng(0))
+    for shp in shapes:
+        lo, hi = (np.asarray(v, dtype=float) for v in shp.bounds())
+        pts = shp.sample_interior(4000, np.random.default_rng(0))
         assert (pts >= lo - 1e-9).all() and (pts <= hi + 1e-9).all()
 
 
@@ -72,7 +72,7 @@ def test_bounds_come_from_the_tessellation_without_a_closed_form():
     Rounding the edges of the unit cube removes material only near them, so the extent is unchanged
     -- which is what makes this a check on the answer and not just on the plumbing.
     """
-    solid = Shape.rect(0.0, 0.0, 1.0, 1.0).extrude(1.0).fillet(0.05).size(0.2)
+    solid = shape.rect(0.0, 0.0, 1.0, 1.0).extrude(1.0).fillet(0.05).size(0.2)
     assert not solid.is_analytic()
     lo, hi = solid.bounds()
     assert np.allclose(lo, (0.0, 0.0, 0.0), atol=1e-9)
@@ -85,17 +85,17 @@ def test_bounds_come_from_the_tessellation_without_a_closed_form():
 @pytest.mark.parametrize(
     "shape",
     [
-        Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.2),
-        (Shape.rect(0.0, 0.0, 1.0, 1.0) - Shape.disk(0.5, 0.5, 0.25)).sized(0.06),
-        Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.3),
-        (Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0) - Shape.sphere(0.5, 0.5, 0.5, 0.3)).sized(0.15),
-        Shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0, size=0.5),
-        Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.2).translate((5.0, 7.0, 0.0)),
-        Shape.rect(0.0, 0.0, 2.0, 1.0, size=0.2).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), math.pi / 6),
-        Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).extrude(2.0),
-        Shape.disk(0.0, 0.0, 1.0, size=0.3).extrude(3.0),
-        Shape.rect(1.0, 0.0, 2.0, 1.0, size=0.25).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi),
-        Shape.rect(1.0, 0.0, 2.0, 1.0, size=0.25).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), math.pi),
+        shape.rect(0.0, 0.0, 2.0, 1.0, size=0.2),
+        (shape.rect(0.0, 0.0, 1.0, 1.0) - shape.disk(0.5, 0.5, 0.25)).sized(0.06),
+        shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.3),
+        (shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0) - shape.sphere(0.5, 0.5, 0.5, 0.3)).sized(0.15),
+        shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0, size=0.5),
+        shape.rect(0.0, 0.0, 2.0, 1.0, size=0.2).translate((5.0, 7.0, 0.0)),
+        shape.rect(0.0, 0.0, 2.0, 1.0, size=0.2).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), math.pi / 6),
+        shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).extrude(2.0),
+        shape.disk(0.0, 0.0, 1.0, size=0.3).extrude(3.0),
+        shape.rect(1.0, 0.0, 2.0, 1.0, size=0.25).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi),
+        shape.rect(1.0, 0.0, 2.0, 1.0, size=0.25).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), math.pi),
     ],
     ids=[
         "rect",
@@ -126,15 +126,15 @@ def test_contains_accepts_every_node_of_the_mesh_it_describes(shape):
 @pytest.mark.parametrize(
     "shape, volume",
     [
-        (Shape.rect(0.0, 0.0, 2.0, 1.0), 2.0),
-        (Shape.rect(0.0, 0.0, 1.0, 1.0) - Shape.disk(0.5, 0.5, 0.25), 1.0 - math.pi / 16),
-        (Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0), 1.0),
-        (Shape.sphere(0.0, 0.0, 0.0, 1.0), 4.0 / 3.0 * math.pi),
-        (Shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0), 4.0 * math.pi),
-        (Shape.rect(0.0, 0.0, 1.0, 1.0).extrude(2.0), 2.0),
-        (Shape.disk(0.0, 0.0, 1.0).extrude(3.0), 3.0 * math.pi),
+        (shape.rect(0.0, 0.0, 2.0, 1.0), 2.0),
+        (shape.rect(0.0, 0.0, 1.0, 1.0) - shape.disk(0.5, 0.5, 0.25), 1.0 - math.pi / 16),
+        (shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0), 1.0),
+        (shape.sphere(0.0, 0.0, 0.0, 1.0), 4.0 / 3.0 * math.pi),
+        (shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0), 4.0 * math.pi),
+        (shape.rect(0.0, 0.0, 1.0, 1.0).extrude(2.0), 2.0),
+        (shape.disk(0.0, 0.0, 1.0).extrude(3.0), 3.0 * math.pi),
         # profile x in [1,2] swept about +y: the ring pi*(2^2 - 1^2) * height 1
-        (Shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi), 3.0 * math.pi),
+        (shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi), 3.0 * math.pi),
     ],
     ids=["rect", "rect-disk", "box", "sphere", "cylinder", "extrude", "disk-extrude", "revolve"],
 )
@@ -143,10 +143,10 @@ def test_membership_reproduces_the_analytic_volume(shape, volume):
 
 
 def test_sampled_points_are_inside_and_fill_the_shape():
-    shape = Shape.rect(0.0, 0.0, 1.0, 1.0) - Shape.disk(0.5, 0.5, 0.25)
-    pts = shape.sample_interior(20_000, np.random.default_rng(0))
+    geom = shape.rect(0.0, 0.0, 1.0, 1.0) - shape.disk(0.5, 0.5, 0.25)
+    pts = geom.sample_interior(20_000, np.random.default_rng(0))
     assert pts.shape == (20_000, 3)
-    assert shape.contains(pts, tol=0.0).all()
+    assert geom.contains(pts, tol=0.0).all()
     # and they cover it: on a 10x10 grid the only cells left empty are the ones the hole swallows
     # whole, so the coverage gap IS the hole rather than a blind spot of the sampler.
     hist, xe, ye = np.histogram2d(pts[:, 0], pts[:, 1], bins=10, range=[[0, 1], [0, 1]])
@@ -159,18 +159,18 @@ def test_sampled_points_are_inside_and_fill_the_shape():
 def test_draws_are_continuous_not_a_fixed_point_set():
     """The whole point of mesh-free sampling: successive draws are different points, and the
     count is not capped by any node set."""
-    shape = Shape.disk(0.0, 0.0, 1.0)
+    geom = shape.disk(0.0, 0.0, 1.0)
     rng = np.random.default_rng(0)
-    a = shape.sample_interior(500, rng)
-    b = shape.sample_interior(500, rng)
+    a = geom.sample_interior(500, rng)
+    b = geom.sample_interior(500, rng)
     assert not np.allclose(np.sort(a, axis=0), np.sort(b, axis=0))
-    # far more points than a mesh of this shape would ever have nodes, with no cap and no warning
-    many = shape.sample_interior(200_000, rng)
+    # far more points than a mesh of this geom would ever have nodes, with no cap and no warning
+    many = geom.sample_interior(200_000, rng)
     assert len(many) == 200_000 and len(np.unique(many, axis=0)) == 200_000
 
 
 def test_a_vanishing_shape_raises_instead_of_returning_short():
-    empty = Shape.disk(0.0, 0.0, 1.0) & Shape.disk(10.0, 0.0, 1.0)  # disjoint -> empty intersection
+    empty = shape.disk(0.0, 0.0, 1.0) & shape.disk(10.0, 0.0, 1.0)  # disjoint -> empty intersection
     with pytest.raises(RuntimeError, match="vanishing|empty"):
         empty.sample_interior(10, np.random.default_rng(0), max_rounds=3)
 
@@ -181,20 +181,20 @@ def test_a_vanishing_shape_raises_instead_of_returning_short():
 @pytest.mark.parametrize(
     "shape",
     [
-        Shape.rect(0.0, 0.0, 2.0, 1.0),
-        Shape.disk(1.0, 2.0, 0.5),
-        Shape.box(0.0, 0.0, 0.0, 2.0, 1.0, 3.0),
-        Shape.sphere(0.0, 0.0, 0.0, 1.0),
-        Shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0),
-        Shape.rect(0.0, 0.0, 1.0, 1.0) - Shape.disk(0.5, 0.5, 0.25),
-        Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0) - Shape.sphere(0.5, 0.5, 0.5, 0.3),
-        Shape.rect(0.0, 0.0, 2.0, 1.0).translate((5.0, 7.0, 0.0)),
-        Shape.rect(0.0, 0.0, 2.0, 1.0).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), math.pi / 6),
-        Shape.disk(0.0, 0.0, 1.0).extrude(3.0),
+        shape.rect(0.0, 0.0, 2.0, 1.0),
+        shape.disk(1.0, 2.0, 0.5),
+        shape.box(0.0, 0.0, 0.0, 2.0, 1.0, 3.0),
+        shape.sphere(0.0, 0.0, 0.0, 1.0),
+        shape.cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0),
+        shape.rect(0.0, 0.0, 1.0, 1.0) - shape.disk(0.5, 0.5, 0.25),
+        shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0) - shape.sphere(0.5, 0.5, 0.5, 0.3),
+        shape.rect(0.0, 0.0, 2.0, 1.0).translate((5.0, 7.0, 0.0)),
+        shape.rect(0.0, 0.0, 2.0, 1.0).rotate((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), math.pi / 6),
+        shape.disk(0.0, 0.0, 1.0).extrude(3.0),
         # a ring swept about +y, and the half sweep whose flat end caps must also come out outward
-        Shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi),
-        Shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), math.pi),
-        Shape.rect(0.0, 0.0, 3.0, 1.0).revolve((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), 2 * math.pi),
+        shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 2 * math.pi),
+        shape.rect(1.0, 0.0, 2.0, 1.0).revolve((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), math.pi),
+        shape.rect(0.0, 0.0, 3.0, 1.0).revolve((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), 2 * math.pi),
     ],
     ids=[
         "rect",
@@ -227,7 +227,7 @@ def test_boundary_points_are_on_the_surface_with_outward_unit_normals(shape):
 def test_boundary_points_are_exact_not_faceted():
     """A circle's samples lie on the circle to machine precision and the normal is exactly radial
     — the property a tessellation cannot provide (its points sit on chords)."""
-    disk = Shape.disk(1.0, 2.0, 0.5)
+    disk = shape.disk(1.0, 2.0, 0.5)
     pts, nrm = disk.sample_boundary(5000, np.random.default_rng(0))
     radial = pts[:, :2] - np.array([1.0, 2.0])
     assert np.allclose(np.linalg.norm(radial, axis=1), 0.5, atol=1e-14)
@@ -236,7 +236,7 @@ def test_boundary_points_are_exact_not_faceted():
 
 def test_boundary_draw_is_uniform_by_measure():
     """A 2x1 rectangle: each edge should receive its own length's share of the draws."""
-    pts, _ = Shape.rect(0.0, 0.0, 2.0, 1.0).sample_boundary(80_000, np.random.default_rng(0))
+    pts, _ = shape.rect(0.0, 0.0, 2.0, 1.0).sample_boundary(80_000, np.random.default_rng(0))
     on = {
         "bottom": np.isclose(pts[:, 1], 0.0),
         "top": np.isclose(pts[:, 1], 1.0),
@@ -251,8 +251,8 @@ def test_boundary_draw_is_uniform_by_measure():
 def test_a_cut_away_surface_contributes_no_boundary_points():
     """Half of the disk's circle lies outside the rectangle after the cut; no sample may land
     there, or the boundary draw would include a surface the solid does not have."""
-    shape = Shape.rect(0.0, 0.0, 1.0, 1.0) - Shape.disk(0.0, 0.5, 0.25)  # bite out of the left edge
-    pts, _ = shape.sample_boundary(20_000, np.random.default_rng(0))
+    geom = shape.rect(0.0, 0.0, 1.0, 1.0) - shape.disk(0.0, 0.5, 0.25)  # bite out of the left edge
+    pts, _ = geom.sample_boundary(20_000, np.random.default_rng(0))
     assert (pts[:, 0] >= -1e-12).all()  # nothing on the half-circle at x < 0
 
 

--- a/tests/test_shape_structured.py
+++ b/tests/test_shape_structured.py
@@ -1,8 +1,8 @@
-"""``Shape.structured()`` — a regular lattice as a property of the shape.
+"""``shape.structured()`` — a regular lattice as a property of the shape.
 
 A regular box had four spellings, each with a different subset of the features: the cell choice on
 one, the ``jno.fdm`` grid descriptor on another, the region names on a third, and hexahedra only on
-the one that was not part of the ``Shape`` DSL at all — ``Shape.quad()``'s own 3-D refusal pointed
+the one that was not part of the ``shape`` DSL at all — ``shape.quad()``'s own 3-D refusal pointed
 the reader at ``jno.domain.equi_distant_box(cell='hex')``, a different front door.
 
 ``.structured()`` is the single one, and it sits beside ``.quad()`` / ``.curved()`` / ``.sized()``
@@ -18,9 +18,9 @@ import pytest
 
 import jno
 from jno.domain.geometries import Geometries
-from jno.geometry import Shape
+from jno.geometry import shape
 
-gmsh = pytest.importorskip("gmsh", reason="the unstructured control needs the Shape mesher")
+gmsh = pytest.importorskip("gmsh", reason="the unstructured control needs the shape mesher")
 
 
 def _dom(shape, **kw):
@@ -50,8 +50,8 @@ def _same_mesh(a, b):
 
 @pytest.mark.parametrize("cell", [None, "quad"])
 def test_a_structured_rect_is_the_lattice_builders_own_mesh(cell):
-    shape = Shape.rect(0, 0, 1, 1).structured(n=4)
-    new = _dom(shape.quad() if cell else shape)
+    geom = shape.rect(0, 0, 1, 1).structured(n=4)
+    new = _dom(geom.quad() if cell else geom)
     old = jno.domain(
         constructor=Geometries.equi_distant_rect(nx=4, ny=4, cell=cell or "triangle"),
         compute_mesh_connectivity=False,
@@ -61,8 +61,8 @@ def test_a_structured_rect_is_the_lattice_builders_own_mesh(cell):
 
 @pytest.mark.parametrize("cell", [None, "quad"])
 def test_a_structured_box_is_the_lattice_builders_own_mesh(cell):
-    shape = Shape.box(0, 0, 0, 1, 1, 1).structured(n=3)
-    new = _dom(shape.quad() if cell else shape)
+    geom = shape.box(0, 0, 0, 1, 1, 1).structured(n=3)
+    new = _dom(geom.quad() if cell else geom)
     old = jno.domain(
         constructor=Geometries.equi_distant_box(nx=3, ny=3, nz=3, cell="hex" if cell else "tetra"),
         compute_mesh_connectivity=False,
@@ -73,7 +73,7 @@ def test_a_structured_box_is_the_lattice_builders_own_mesh(cell):
 def test_the_foundation_model_grid_is_reproducible():
     """`jno.domain.poseidon(nx, ny)` is an nx x ny NODE grid, i.e. nx-1 cells — the one place the
     cells-vs-nodes convention is felt, since these models speak in pixel resolution."""
-    d = _dom(Shape.rect(0, 0, 1, 1).structured(n=15))
+    d = _dom(shape.rect(0, 0, 1, 1).structured(n=15))
     assert d.grid["shape"] == (16, 16)
     assert len(d.mesh.points) == 16 * 16
 
@@ -82,15 +82,15 @@ def test_the_foundation_model_grid_is_reproducible():
 
 
 def test_structured_unlocks_quad_in_3d():
-    d = _dom(Shape.box(0, 0, 0, 1, 1, 1).structured(n=3).quad())
+    d = _dom(shape.box(0, 0, 0, 1, 1, 1).structured(n=3).quad())
     assert _blocks(d)["hexahedron"] == 27
 
 
 def test_quad_and_structured_compose_in_either_order():
     """A chain should not care about order — which is why the 3-D refusal lives at build time rather
     than inside ``.quad()``, where it could only see half the plan."""
-    a = _dom(Shape.box(0, 0, 0, 1, 1, 1).structured(n=3).quad())
-    b = _dom(Shape.box(0, 0, 0, 1, 1, 1).quad().structured(n=3))
+    a = _dom(shape.box(0, 0, 0, 1, 1, 1).structured(n=3).quad())
+    b = _dom(shape.box(0, 0, 0, 1, 1, 1).quad().structured(n=3))
     assert _same_mesh(a, b)
 
 
@@ -103,12 +103,12 @@ def test_an_unstructured_3d_quad_is_refused_and_names_the_fix():
     actually meets.
     """
     with pytest.raises(NotImplementedError, match=r"\.structured\(\)"):
-        _blocks(_dom(Shape.box(0, 0, 0, 1, 1, 1, size=0.5).quad()))
+        _blocks(_dom(shape.box(0, 0, 0, 1, 1, 1, size=0.5).quad()))
 
 
 def test_a_structured_hex_domain_solves():
     """The point of a mesh is that a weak form runs on it."""
-    d = Shape.box(0, 0, 0, 1, 1, 1).structured(n=3).quad().domain()
+    d = shape.box(0, 0, 0, 1, 1, 1).structured(n=3).quad().domain()
     u, v = d.fem_symbols()
     ci, cb = d.variable("interior", split=True), d.variable("boundary", split=True)
     ui, vi = u.bind(x=ci[0], y=ci[1], z=ci[2]), v.bind(x=ci[0], y=ci[1], z=ci[2])
@@ -121,32 +121,32 @@ def test_a_structured_hex_domain_solves():
 
 
 def test_the_cell_counts_come_from_size_when_n_is_absent():
-    d = _dom(Shape.rect(0, 0, 1, 1, size=0.25).structured())
+    d = _dom(shape.rect(0, 0, 1, 1, size=0.25).structured())
     assert d.grid["shape"] == (5, 5)
     np.testing.assert_allclose(d.grid["spacing"], (0.25, 0.25))
 
 
-@pytest.mark.parametrize("n,shape", [(4, (5, 5, 5)), ((4, 2, 3), (5, 3, 4))])
-def test_n_counts_cells_scalar_or_per_axis(n, shape):
-    d = _dom(Shape.box(0, 0, 0, 1, 1, 1).structured(n=n))
-    assert d.grid["shape"] == shape
+@pytest.mark.parametrize("n,expected", [(4, (5, 5, 5)), ((4, 2, 3), (5, 3, 4))])
+def test_n_counts_cells_scalar_or_per_axis(n, expected):
+    d = _dom(shape.box(0, 0, 0, 1, 1, 1).structured(n=n))
+    assert d.grid["shape"] == expected
 
 
 def test_the_grid_descriptor_describes_a_non_unit_box():
-    d = _dom(Shape.box(-1, -2, 0, 3, 1, 5).structured(n=(4, 2, 3)))
+    d = _dom(shape.box(-1, -2, 0, 3, 1, 5).structured(n=(4, 2, 3)))
     assert d.grid["origin"] == (-1.0, -2.0, 0.0)
     np.testing.assert_allclose(d.grid["spacing"], (1.0, 1.5, 5.0 / 3.0))
 
 
 def test_a_nodal_field_reshapes_to_the_grid():
     """What the descriptor is for: C-ordered nodes, so `u.reshape(grid["shape"])` is the image."""
-    d = _dom(Shape.rect(0, 0, 1, 1).structured(n=5))
+    d = _dom(shape.rect(0, 0, 1, 1).structured(n=5))
     x = np.asarray(d.mesh.points)[:, 0].reshape(d.grid["shape"])
     assert np.allclose(x, x[:, :1])  # x varies along axis 0 only
 
 
 def test_an_unstructured_domain_has_no_grid():
-    assert _dom(Shape.rect(0, 0, 1, 1, size=0.4)).grid is None
+    assert _dom(shape.rect(0, 0, 1, 1, size=0.4)).grid is None
 
 
 # -------------------------------------------------------------------- refusals, each naming a reason
@@ -155,9 +155,9 @@ def test_an_unstructured_domain_has_no_grid():
 @pytest.mark.parametrize(
     "plan,match",
     [
-        pytest.param(lambda: Shape.rect(0, 0, 1, 1) - Shape.disk(0.5, 0.5, 0.2), "'cut' plan", id="csg"),
-        pytest.param(lambda: Shape.disk(0, 0, 1), "this is a disk", id="disk"),
-        pytest.param(lambda: Shape.rect(0, 0, 1, 1, size=lambda x, y: 0.1), "graded mesh", id="graded-size"),
+        pytest.param(lambda: shape.rect(0, 0, 1, 1) - shape.disk(0.5, 0.5, 0.2), "'cut' plan", id="csg"),
+        pytest.param(lambda: shape.disk(0, 0, 1), "this is a disk", id="disk"),
+        pytest.param(lambda: shape.rect(0, 0, 1, 1, size=lambda x, y: 0.1), "graded mesh", id="graded-size"),
     ],
 )
 def test_an_unstructurable_plan_is_refused_by_name(plan, match):
@@ -167,25 +167,25 @@ def test_an_unstructurable_plan_is_refused_by_name(plan, match):
 
 def test_structured_and_curved_is_refused():
     with pytest.raises(NotImplementedError, match="9-/27-node"):
-        _dom(Shape.rect(0, 0, 1, 1).structured(n=4).curved())
+        _dom(shape.rect(0, 0, 1, 1).structured(n=4).curved())
 
 
 def test_a_graded_size_is_accepted_when_the_counts_are_explicit():
     """The refusal is about deriving counts, not about the callable itself — so saying the counts
     outright is enough. Worth pinning: the two are easy to conflate into one blanket refusal."""
-    d = _dom(Shape.rect(0, 0, 1, 1, size=lambda x, y: 0.1).structured(n=4))
+    d = _dom(shape.rect(0, 0, 1, 1, size=lambda x, y: 0.1).structured(n=4))
     assert d.grid["shape"] == (5, 5)
 
 
 @pytest.mark.parametrize("n", [(4, 4, 4), (4,)])
 def test_the_wrong_number_of_axes_is_refused(n):
     with pytest.raises(ValueError, match="cell counts"):
-        Shape.rect(0, 0, 1, 1).structured(n=n)
+        shape.rect(0, 0, 1, 1).structured(n=n)
 
 
 def test_a_zero_cell_axis_is_refused():
     with pytest.raises(ValueError, match="at least one cell"):
-        Shape.rect(0, 0, 1, 1).structured(n=(4, 0))
+        shape.rect(0, 0, 1, 1).structured(n=(4, 0))
 
 
 # ------------------------------------------------------------------------------ the rest of the DSL
@@ -195,7 +195,7 @@ def test_a_named_region_survives_the_lattice_path():
     """The lattice constructor replaces the shape, and the region name and attachments are read off
     the shape — so they used to be dropped silently, `d.k` reporting "no attribute" on a plan that
     plainly attached one."""
-    d = _dom(Shape.rect(0, 0, 1, 1).structured(n=3).name("steel").attach(k=2.0))
+    d = _dom(shape.rect(0, 0, 1, 1).structured(n=3).name("steel").attach(k=2.0))
     assert "steel" in d.avaiable_mesh_tags
     assert d.k is not None
     assert len(np.atleast_1d(d.tag_indices["steel"])) == 16
@@ -203,23 +203,23 @@ def test_a_named_region_survives_the_lattice_path():
 
 def test_the_named_faces_come_with_the_lattice():
     """A structured domain gets its faces named without a gmsh model to classify."""
-    d = _dom(Shape.box(0, 0, 0, 1, 1, 1).structured(n=2))
+    d = _dom(shape.box(0, 0, 0, 1, 1, 1).structured(n=2))
     assert {"left", "right", "bottom", "top", "front", "back", "boundary", "interior"} <= set(d.avaiable_mesh_tags)
 
 
 @pytest.mark.parametrize("n", [2, (2, 2)])
 def test_the_smallest_lattice_is_two_cells_per_axis(n):
     """Two is the floor, so the 3-point edge stencil is defined; a coarser request is raised to it."""
-    assert _dom(Shape.rect(0, 0, 1, 1).structured(n=n)).grid["shape"] == (3, 3)
+    assert _dom(shape.rect(0, 0, 1, 1).structured(n=n)).grid["shape"] == (3, 3)
 
 
 def test_one_cell_is_raised_to_the_floor_not_refused():
-    assert _dom(Shape.rect(0, 0, 1, 1).structured(n=1)).grid["shape"] == (3, 3)
+    assert _dom(shape.rect(0, 0, 1, 1).structured(n=1)).grid["shape"] == (3, 3)
 
 
 def test_a_strongly_anisotropic_slab_builds_and_solves():
     """The extreme end: 64 cells one way, 2 the others."""
-    d = Shape.box(0, 0, 0, 1, 0.05, 0.05).structured(n=(64, 2, 2)).quad().domain()
+    d = shape.box(0, 0, 0, 1, 0.05, 0.05).structured(n=(64, 2, 2)).quad().domain()
     assert _blocks(d)["hexahedron"] == 64 * 2 * 2
     u, v = d.fem_symbols()
     ci, cb = d.variable("interior", split=True), d.variable("boundary", split=True)

--- a/tests/test_shape_tessellation.py
+++ b/tests/test_shape_tessellation.py
@@ -1,7 +1,7 @@
-"""A ``Shape`` whose boundary has no closed form is served by meshing that boundary and nothing else.
+"""A ``shape`` whose boundary has no closed form is served by meshing that boundary and nothing else.
 
 ``sweep`` follows an arbitrary path and ``fillet`` removes material near edges, so neither has
-analytic membership nor an analytic boundary. :meth:`Shape.tessellate` meshes the perimeter (2-D) /
+analytic membership nor an analytic boundary. :meth:`shape.tessellate` meshes the perimeter (2-D) /
 surface (3-D) once -- no volume fill -- and answers all three questions from that one artifact:
 where the surface is, which way it faces, and what is inside.
 
@@ -28,7 +28,7 @@ def _angles(got, exact):
 
 
 def test_tessellate_meshes_the_boundary_and_not_the_volume():
-    bm = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.3).tessellate()
+    bm = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.3).tessellate()
     assert isinstance(bm, BoundaryMesh)
     assert bm.facets.shape[1] == 3, "the boundary of a 3-D shape is triangles"
     assert bm.dim == 3
@@ -38,21 +38,21 @@ def test_tessellate_meshes_the_boundary_and_not_the_volume():
 
 
 def test_a_2d_shape_tessellates_to_its_perimeter():
-    bm = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).size(0.25).tessellate()
+    bm = jno.shape.rect(0.0, 0.0, 1.0, 1.0).size(0.25).tessellate()
     assert bm.facets.shape[1] == 2, "the boundary of a 2-D shape is line segments"
     assert bm.measures.sum() == pytest.approx(4.0, abs=1e-12), "the perimeter of a unit square"
 
 
 def test_the_mesher_runs_once_and_is_cached():
-    s = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.15).size(0.3)
+    s = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.15).size(0.3)
     assert s.tessellate() is s.tessellate()
 
 
 @pytest.mark.parametrize(
     "shape, measure, name",
     [
-        (jno.Shape.rect(0.0, 0.0, 2.0, 3.0).size(0.3), 10.0, "rectangle perimeter"),
-        (jno.Shape.box(0.0, 0.0, 0.0, 1.0, 2.0, 3.0).size(0.4), 22.0, "box surface area"),
+        (jno.shape.rect(0.0, 0.0, 2.0, 3.0).size(0.3), 10.0, "rectangle perimeter"),
+        (jno.shape.box(0.0, 0.0, 0.0, 1.0, 2.0, 3.0).size(0.4), 22.0, "box surface area"),
     ],
 )
 def test_flat_boundaries_are_measured_exactly(shape, measure, name):
@@ -62,7 +62,7 @@ def test_flat_boundaries_are_measured_exactly(shape, measure, name):
 
 def test_a_curved_boundary_is_a_chord_and_converges_from_below():
     """Facets are straight, so they under-measure a curve -- and the deficit falls with h."""
-    got = [jno.Shape.disk(0.0, 0.0, 1.0).size(h).tessellate().measures.sum() for h in (0.4, 0.2, 0.1, 0.05)]
+    got = [jno.shape.disk(0.0, 0.0, 1.0).size(h).tessellate().measures.sum() for h in (0.4, 0.2, 0.1, 0.05)]
     assert all(g < 2 * np.pi for g in got), f"a chord cannot be longer than its arc: {got}"
     err = [2 * np.pi - g for g in got]
     assert err[0] > err[1] > err[2] > err[3], f"not converging: {err}"
@@ -74,8 +74,8 @@ def test_a_curved_boundary_is_a_chord_and_converges_from_below():
 @pytest.mark.parametrize(
     "shape, exact",
     [
-        (jno.Shape.rect(0.0, 0.0, 1.0, 1.0).size(0.2), None),
-        (jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.3), None),
+        (jno.shape.rect(0.0, 0.0, 1.0, 1.0).size(0.2), None),
+        (jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.3), None),
     ],
 )
 def test_a_facet_normal_is_exact_at_a_crease(shape, exact):
@@ -95,8 +95,8 @@ def test_a_facet_normal_is_exact_at_a_crease(shape, exact):
 @pytest.mark.parametrize(
     "shape, exact, sizes",
     [
-        (jno.Shape.disk(0.0, 0.0, 1.0), lambda p: p / np.linalg.norm(p, axis=1, keepdims=True), (0.4, 0.2, 0.1)),
-        (jno.Shape.sphere(0.0, 0.0, 0.0, 1.0), lambda p: p / np.linalg.norm(p, axis=1, keepdims=True), (0.5, 0.25, 0.125)),
+        (jno.shape.disk(0.0, 0.0, 1.0), lambda p: p / np.linalg.norm(p, axis=1, keepdims=True), (0.4, 0.2, 0.1)),
+        (jno.shape.sphere(0.0, 0.0, 0.0, 1.0), lambda p: p / np.linalg.norm(p, axis=1, keepdims=True), (0.5, 0.25, 0.125)),
     ],
     ids=["disk", "sphere"],
 )
@@ -117,10 +117,10 @@ def test_a_facet_normal_is_first_order_on_a_curved_boundary(shape, exact, sizes)
 
 def test_normals_point_out_of_the_shape():
     for shape in (
-        jno.Shape.rect(0.0, 0.0, 1.0, 1.0).size(0.2),
-        jno.Shape.disk(0.0, 0.0, 1.0).size(0.2),
-        jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.4),
-        jno.Shape.sphere(0.0, 0.0, 0.0, 1.0).size(0.3),
+        jno.shape.rect(0.0, 0.0, 1.0, 1.0).size(0.2),
+        jno.shape.disk(0.0, 0.0, 1.0).size(0.2),
+        jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.4),
+        jno.shape.sphere(0.0, 0.0, 0.0, 1.0).size(0.3),
     ):
         bm = shape.tessellate()
         pts, nrm = bm.sample_boundary(2000, np.random.default_rng(1))
@@ -144,7 +144,7 @@ def _disagreement(shape, n=20000, seed=0):
 
 @pytest.mark.parametrize(
     "shape",
-    [jno.Shape.rect(0.0, 0.0, 1.0, 1.0).size(0.15), jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.2)],
+    [jno.shape.rect(0.0, 0.0, 1.0, 1.0).size(0.15), jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).size(0.2)],
     ids=["rect", "box"],
 )
 def test_ray_cast_membership_is_exact_on_a_polyhedron(shape):
@@ -155,9 +155,9 @@ def test_ray_cast_membership_is_exact_on_a_polyhedron(shape):
 @pytest.mark.parametrize(
     "make, sizes",
     [
-        (lambda h: jno.Shape.disk(0.5, 0.5, 0.4).size(h), (0.3, 0.15, 0.075)),
-        (lambda h: jno.Shape.sphere(0.5, 0.5, 0.5, 0.4).size(h), (0.3, 0.15, 0.075)),
-        (lambda h: (jno.Shape.rect(0.0, 0.0, 1.0, 1.0) - jno.Shape.disk(0.5, 0.5, 0.2)).size(h), (0.2, 0.1, 0.05)),
+        (lambda h: jno.shape.disk(0.5, 0.5, 0.4).size(h), (0.3, 0.15, 0.075)),
+        (lambda h: jno.shape.sphere(0.5, 0.5, 0.5, 0.4).size(h), (0.3, 0.15, 0.075)),
+        (lambda h: (jno.shape.rect(0.0, 0.0, 1.0, 1.0) - jno.shape.disk(0.5, 0.5, 0.2)).size(h), (0.2, 0.1, 0.05)),
     ],
     ids=["disk", "sphere", "csg-with-a-hole"],
 )
@@ -173,7 +173,7 @@ def test_ray_cast_membership_converges_to_the_closed_form_on_a_curve(make, sizes
 
 
 def test_interior_draws_land_inside_and_boundary_draws_land_on_the_surface():
-    bm = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.2).size(0.2).tessellate()
+    bm = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.2).size(0.2).tessellate()
     q = bm.sample_interior(2000, np.random.default_rng(0))
     assert bm.contains(q).all()
     lo, hi = (np.asarray(v) for v in bm.bounds())
@@ -182,7 +182,7 @@ def test_interior_draws_land_inside_and_boundary_draws_land_on_the_surface():
 
 def test_two_interior_draws_differ():
     """The tessellated path is still continuous: points come from the facets, not from a node set."""
-    bm = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.2).size(0.25).tessellate()
+    bm = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.2).size(0.25).tessellate()
     a = bm.sample_interior(500, np.random.default_rng(0))
     b = bm.sample_interior(500, np.random.default_rng(1))
     assert not np.allclose(np.sort(a, axis=0), np.sort(b, axis=0))
@@ -194,8 +194,8 @@ def test_two_interior_draws_differ():
 @pytest.mark.parametrize(
     "make",
     [
-        lambda: jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.2),
-        lambda: jno.Shape.rect(0.0, 0.0, 1.0, 1.0).extrude(1.0).fillet(0.15),
+        lambda: jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.2),
+        lambda: jno.shape.rect(0.0, 0.0, 1.0, 1.0).extrude(1.0).fillet(0.15),
     ],
     ids=["filleted-box", "filleted-extrusion"],
 )
@@ -214,7 +214,7 @@ def test_a_plan_with_no_closed_form_is_sampled_through_its_tessellation(make):
 
 def test_a_filleted_solid_makes_a_mesh_free_domain():
     """The payoff: no volume mesh, and the faces are still named."""
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.15).size(0.25).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0).fillet(0.15).size(0.25).domain()
     assert d.__dict__.get("_mesh") is None, "constructing must not run the volume mesher"
     assert {"interior", "boundary"} <= set(d._geometry_tags)
     d.variable("interior", sample=(700, None), split=True)
@@ -227,7 +227,7 @@ def test_a_straight_sweep_is_an_extrusion_and_never_needs_the_tessellation():
     """Sweeping along a straight line is an extrusion, and the DSL rewrites it as one -- so it keeps
     the analytic path and no mesher runs at all. Worth pinning, because it means the tessellation is
     not what serves a straight sweep."""
-    tube = jno.Shape.disk(0.0, 0.0, 0.3).sweep(jno.Path(0, 0, 0).line_to(0, 0, 3))
+    tube = jno.shape.disk(0.0, 0.0, 0.3).sweep(jno.Path(0, 0, 0).line_to(0, 0, 3))
     assert tube._node[0] == "extrude"
     assert tube.is_analytic()
     q = tube.size(0.3).sample_interior(400, np.random.default_rng(0))
@@ -244,11 +244,11 @@ def test_a_surface_the_mesher_leaves_open_is_refused_by_name():
     so refining makes it worse. A gentler arc with a thinner profile is open too. The message says
     as much and sends the caller to `.build()`.
     """
-    bent = jno.Shape.disk(0.0, 0.0, 0.3).sweep(jno.Path(0, 0, 0).arc_to(2, 0, 2, through=(0.6, 0, 1.4)))
+    bent = jno.shape.disk(0.0, 0.0, 0.3).sweep(jno.Path(0, 0, 0).arc_to(2, 0, 2, through=(0.6, 0, 1.4)))
     with pytest.raises(RuntimeError, match="not a closed manifold"):
         bent.size(0.3).tessellate()
 
 
 def test_the_refusal_names_a_method_that_exists():
     """The error a caller reaches for has to point somewhere real."""
-    assert hasattr(jno.Shape, "tessellate")
+    assert hasattr(jno.shape, "tessellate")

--- a/tests/test_simp_continuation.py
+++ b/tests/test_simp_continuation.py
@@ -119,7 +119,7 @@ def test_penal_as_a_runtime_exponent_scales_the_stiffness():
     """
     inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
     lam, mu = 0.3 / (1 - 0.09), 1 / 2.6
-    d = jno.Shape.rect(0, 0, 2, 1, size=0.5).domain()
+    d = jno.shape.rect(0, 0, 2, 1, size=0.5).domain()
     n_cells = int(d._cells_p1().shape[0])
     u, phi = d.fem_symbols(value_shape=(2,))
     _r, s = d.fem_symbols(space="P0", names=("r", "s"))

--- a/tests/test_solver_lu_backends.py
+++ b/tests/test_solver_lu_backends.py
@@ -156,7 +156,7 @@ def test_gradients_match_finite_differences_on_a_non_symmetric_system():
 @requires_cudss
 def test_composes_as_a_fem_linear_slot():
     """It must be a drop-in for the `linear=` slot, not a standalone function."""
-    d = jno.Shape.rectangle(1.0, 1.0).domain(resolution=8)
+    d = jno.shape.rectangle(1.0, 1.0).domain(resolution=8)
     u, phi = d.fem_symbols()
     fem = jno.fem([jno.np.inner(jno.np.grad(u, d.coords), jno.np.grad(phi, d.coords)) - phi, u("boundary")])
     sol = fem.solve(linear=jno.solve.lu(backend="cudss"))

--- a/tests/test_spectral_scheme.py
+++ b/tests/test_spectral_scheme.py
@@ -33,7 +33,7 @@ def _x64():
 
 
 def _grid(n=16, x1=1.0, y1=1.0):
-    d = jno.Shape.rect(0.0, 0.0, x1, y1, size=min(x1, y1) / n).structured().domain()
+    d = jno.shape.rect(0.0, 0.0, x1, y1, size=min(x1, y1) / n).structured().domain()
     shape, spacing = _uniform_grid_spec(d, d.mesh_connectivity["points"].shape[0])
     P = np.asarray(d.mesh_connectivity["points"])[:, :2]
     return d, shape, spacing, P
@@ -112,7 +112,7 @@ class TestGridConventions:
 
 class TestRefusals:
     def test_unstructured_domain_raises_and_names_the_fix(self):
-        d = jno.domain(jno.Shape.disk(0.0, 0.0, 1.0, size=0.3))
+        d = jno.domain(jno.shape.disk(0.0, 0.0, 1.0, size=0.3))
         with pytest.raises(ValueError, match=r"structured\(\)"):
             _uniform_grid_spec(d, d.mesh_connectivity["points"].shape[0])
 
@@ -211,7 +211,7 @@ class TestSecondDerivatives:
     def test_three_dimensional_laplacian(self):
         from jno.trace_evaluator import _spectral_second_moments, _uniform_grid_spec
 
-        d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=1 / 6).structured().domain()
+        d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=1 / 6).structured().domain()
         shape, spacing = _uniform_grid_spec(d, d.mesh_connectivity["points"].shape[0])
         P = np.asarray(d.mesh_connectivity["points"])[:, :3]
         u = np.sin(2 * np.pi * P[:, 0]) * np.sin(2 * np.pi * P[:, 1]) * np.sin(2 * np.pi * P[:, 2])
@@ -234,7 +234,7 @@ class TestCosineVariant:
     """
 
     def _line(self, n=32):
-        d = jno.Shape.rect(0, 0, 1, 1, size=1 / n).structured().domain()
+        d = jno.shape.rect(0, 0, 1, 1, size=1 / n).structured().domain()
         shape, spacing = _uniform_grid_spec(d, d.mesh_connectivity["points"].shape[0])
         P = np.asarray(d.mesh_connectivity["points"])[:, :2]
         return shape, spacing, P
@@ -285,7 +285,7 @@ def test_finite_difference_also_reaches_a_stored_field():
     distinction so the docs cannot drift back to the stronger claim.
     """
     _, shape, spacing, P = _grid(n=16)
-    d = jno.Shape.rect(0, 0, 1, 1, size=1 / 16).structured().domain()
+    d = jno.shape.rect(0, 0, 1, 1, size=1 / 16).structured().domain()
     x, y = P[:, 0], P[:, 1]
     u = np.sin(2 * np.pi * x) * np.cos(4 * np.pi * y)
     ux = 2 * np.pi * np.cos(2 * np.pi * x) * np.cos(4 * np.pi * y)

--- a/tests/test_symbol_positional_time.py
+++ b/tests/test_symbol_positional_time.py
@@ -25,7 +25,7 @@ def _x64():
 def _periodic_transient(splat: bool):
     """Doubly-periodic transient solve; ties+IC written with either `u(*c)` or `u(c[0], c[1])`."""
     pitch, t_end, steps = 100.0, 45.0, 4
-    d = jno.Shape.rect(0.0, 0.0, pitch, pitch, size=pitch / 6).domain(time=(0.0, t_end, steps))
+    d = jno.shape.rect(0.0, 0.0, pitch, pitch, size=pitch / 6).domain(time=(0.0, t_end, steps))
     d.tag("left", lambda x, _: x < 1e-4)
     d.tag("right", lambda x, _: x > pitch - 1e-4)
     d.tag("bottom", lambda _, y: y < 1e-4)
@@ -78,7 +78,7 @@ def test_third_positional_coord_still_binds_z_in_3d():
     every dof Dirichlet-pinned, u ≡ 0 the correct answer, and the assertion vacuously broken.
     At 0.35 the mesh has 3 interior nodes (measured).
     """
-    d = jno.Shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.35).domain()
+    d = jno.shape.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, size=0.35).domain()
     u, phi = d.fem_symbols()
     xi, yi, zi, _ = d.variable("interior", split=True)
     cb = d.variable("boundary", split=True)  # (x, y, z, t)

--- a/tests/test_tag_region_surfaces.py
+++ b/tests/test_tag_region_surfaces.py
@@ -44,9 +44,9 @@ def _x64():
 @pytest.fixture(scope="module")
 def two_bodies():
     """Disjoint on purpose: nothing but ``region=`` can tell the two surfaces apart."""
-    d = jno.Shape.regions(
-        A=jno.Shape.rect(*BOX["A"][:1], 0, BOX["A"][1], 1).sized(0.25),
-        B=jno.Shape.rect(BOX["B"][0], 0, BOX["B"][1], 1).sized(0.17),
+    d = jno.shape.regions(
+        A=jno.shape.rect(*BOX["A"][:1], 0, BOX["A"][1], 1).sized(0.25),
+        B=jno.shape.rect(BOX["B"][0], 0, BOX["B"][1], 1).sized(0.17),
         conforming=False,
     ).domain()
     _ = d.built_mesh
@@ -153,8 +153,8 @@ def test_touching_bodies_keep_their_own_interface_side(hB, label):
     owner is on the tag; the exterior boundary, which carries no owner, falls back to cell topology —
     safe there, because two bodies' exterior faces cannot coincide.
     """
-    d = jno.Shape.regions(
-        A=jno.Shape.rect(0, 0, 1, 1).sized(0.25), B=jno.Shape.rect(1, 0, 2, 1).sized(hB), conforming=False
+    d = jno.shape.regions(
+        A=jno.shape.rect(0, 0, 1, 1).sized(0.25), B=jno.shape.rect(1, 0, 2, 1).sized(hB), conforming=False
     ).domain()
     _ = d.built_mesh
     everywhere = lambda x, y: x**2 >= -1.0  # noqa: E731
@@ -193,9 +193,9 @@ def test_a_region_scoped_dirichlet_works_at_any_element_order(order):
     Both ``x^2 - y^2`` and ``2xy`` are harmonic and lie in the P2 space, so the discrete solution is the
     exact one and any deviation is a condition that was not imposed.
     """
-    d = jno.Shape.regions(
-        A=jno.Shape.rect(*BOX["A"][:1], 0, BOX["A"][1], 1).sized(0.34),
-        B=jno.Shape.rect(BOX["B"][0], 0, BOX["B"][1], 1).sized(0.34),
+    d = jno.shape.regions(
+        A=jno.shape.rect(*BOX["A"][:1], 0, BOX["A"][1], 1).sized(0.34),
+        B=jno.shape.rect(BOX["B"][0], 0, BOX["B"][1], 1).sized(0.34),
         conforming=False,
     ).domain()
     _ = d.built_mesh

--- a/tests/test_tensor_layout.py
+++ b/tests/test_tensor_layout.py
@@ -16,7 +16,7 @@ B, H, W, C = 4, 8, 5, 1  # H != W so a mix-up is visible
 
 
 def _steady(nx=H, ny=W, batch=B):
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(nx - 1, ny - 1)).domain(compute_mesh_connectivity=True)
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0).structured(n=(nx - 1, ny - 1)).domain(compute_mesh_connectivity=True)
     dom = batch * d
     dom.variable("interior")
     return dom
@@ -84,7 +84,7 @@ class TestLeftAlone:
 class TestTimeDependent:
     def _dom(self, n_t=3):
         d = (
-            jno.Shape.rect(0.0, 0.0, 1.0, 1.0)
+            jno.shape.rect(0.0, 0.0, 1.0, 1.0)
             .structured(n=(H - 1, W - 1))
             .domain(
                 compute_mesh_connectivity=True,

--- a/tests/test_topology_optimisation.py
+++ b/tests/test_topology_optimisation.py
@@ -44,7 +44,7 @@ def _cantilever(size=0.16, move=0.15):
     """Clamped left edge, downward traction on the right. Returns (crux, rho, n_nodes)."""
     inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
 
-    d = jno.Shape.rect(0, 0, 2, 1, size=size).domain()
+    d = jno.shape.rect(0, 0, 2, 1, size=size).domain()
     u, phi = d.fem_symbols(value_shape=(2,))
     _r, s = d.fem_symbols(names=("r", "s"))
     xi, yi, _ = d.variable("interior", split=True)
@@ -128,7 +128,7 @@ class TestComplianceMinimisation:
         results = {}
         for budget in (0.25, 0.5):
             inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
-            d = jno.Shape.rect(0, 0, 2, 1, size=0.2).domain()
+            d = jno.shape.rect(0, 0, 2, 1, size=0.2).domain()
             u, phi = d.fem_symbols(value_shape=(2,))
             _r, s = d.fem_symbols(names=("r", "s"))
             xi, yi, _ = d.variable("interior", split=True)
@@ -177,7 +177,7 @@ class TestP0DensityParameter:
     @staticmethod
     def _build(size=0.5):
         inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
-        d = jno.Shape.rect(0, 0, 2, 1, size=size).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=size).domain()
         u, phi = d.fem_symbols(value_shape=(2,))
         _r, s = d.fem_symbols(space="P0", names=("r", "s"))
         xi, yi, _ = d.variable("interior", split=True)
@@ -196,7 +196,7 @@ class TestP0DensityParameter:
         return d, np.asarray(d._cells_p1()), fem
 
     def test_the_parameter_is_sized_by_cells_not_nodes(self):
-        d = jno.Shape.rect(0, 0, 2, 1, size=0.5).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=0.5).domain()
         _r, s = d.fem_symbols(space="P0", names=("r", "s"))
         n_cells = int(np.asarray(d._cells_p1()).shape[0])
         n_nodes = int(np.asarray(d.built_mesh.points).shape[0])
@@ -248,7 +248,7 @@ class TestP0DensityParameter:
         inner, symgrad, trace = jno.np.inner, jno.np.symgrad, jno.np.trace
 
         def assemble(space):
-            d = jno.Shape.rect(0, 0, 2, 1, size=0.5).domain()
+            d = jno.shape.rect(0, 0, 2, 1, size=0.5).domain()
             u, phi = d.fem_symbols(value_shape=(2,))
             _r, s = d.fem_symbols(names=("r", "s")) if space == "P1" else d.fem_symbols(space="P0", names=("r", "s"))
             xi, yi, _ = d.variable("interior", split=True)
@@ -310,7 +310,7 @@ class TestPatchFilter:
         assert f(1.0, [1, 1], False) == pytest.approx(1.0)
 
     def test_the_vectorised_filter_matches_the_literal_formula(self):
-        d = jno.Shape.rect(0, 0, 2, 1, size=0.25).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=0.25).domain()
         topo = d.patch_topology()
         n_cells = int(d._cells_p1().shape[0])
         assert topo["size"].max() >= 5, "the mesh must contain patches big enough to exercise eq. (18)"
@@ -347,7 +347,7 @@ class TestPatchFilter:
         The sharpest single check that the walk and the padding are right: any mis-indexed
         neighbour would read a padded zero and pull the product below one.
         """
-        d = jno.Shape.rect(0, 0, 2, 1, size=0.2).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=0.2).domain()
         n_cells = int(d._cells_p1().shape[0])
         out = np.asarray(d.patch_filter()(jnp.ones(n_cells, dtype=jnp.float64)))
         np.testing.assert_allclose(out, 1.0, atol=1e-12)
@@ -361,7 +361,7 @@ class TestPatchFilter:
         **SIMP finishes the job**, since the stiffness carries ``rho_bar ** penal`` and 0.18 cubed
         is under 1 % of solid, which is why the paper also raises ``penal`` as it converges.
         """
-        d = jno.Shape.rect(0, 0, 2, 1, size=0.2).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=0.2).domain()
         topo = d.patch_topology()
         n_cells = int(d._cells_p1().shape[0])
         # Pick an element all of whose patches are interior, so no vertex takes the boundary rule.
@@ -376,7 +376,7 @@ class TestPatchFilter:
         assert np.abs(np.delete(out, k) - np.delete(r, k)).max() < 1e-3
 
     def test_the_node_and_the_filter_agree_and_the_node_carries_a_gradient(self):
-        d = jno.Shape.rect(0, 0, 2, 1, size=0.25).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=0.25).domain()
         _r, s = d.fem_symbols(space="P0", names=("r", "s"))
         rho = jno.np.parameter(s, name="rho_patch")
         n_cells = int(d._cells_p1().shape[0])
@@ -388,7 +388,7 @@ class TestPatchFilter:
 
     def test_a_nodal_density_is_refused(self):
         """The reference element of a patch is an ELEMENT; a nodal field has none."""
-        d = jno.Shape.rect(0, 0, 2, 1, size=0.4).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=0.4).domain()
         _r, s = d.fem_symbols(names=("r", "s"))
         with pytest.raises(TypeError, match="P0"):
             jno.np.parameter(s, name="rho_nodal").patch()
@@ -399,7 +399,7 @@ class TestPerimeter:
 
     @staticmethod
     def _setup(size=2.0):
-        d = jno.Shape.rect(0, 0, 60, 30, size=size).domain()
+        d = jno.shape.rect(0, 0, 60, 30, size=size).domain()
         _r, s = d.fem_symbols(space="P0", names=("r", "s"))
         rho = jno.np.parameter(s, name="rho_perim")
         cells = np.asarray(d._cells_p1())
@@ -441,7 +441,7 @@ class TestPerimeter:
             assert f(1.0) == pytest.approx(1.0, abs=1e-12)
 
     def test_a_nodal_density_is_refused(self):
-        d = jno.Shape.rect(0, 0, 2, 1, size=0.4).domain()
+        d = jno.shape.rect(0, 0, 2, 1, size=0.4).domain()
         _r, s = d.fem_symbols(names=("r", "s"))
         with pytest.raises(TypeError, match="P0"):
             jno.np.parameter(s, name="rho_nodal_p").perimeter()
@@ -457,8 +457,8 @@ class TestCrossMeshTransfer:
     """
 
     def test_a_constant_field_survives_transfer(self):
-        coarse = jno.Shape.rect(0, 0, 60, 30, size=4.0).domain()
-        fine = jno.Shape.rect(0, 0, 60, 30, size=1.5).domain()
+        coarse = jno.shape.rect(0, 0, 60, 30, size=4.0).domain()
+        fine = jno.shape.rect(0, 0, 60, 30, size=1.5).domain()
         vals = np.full(int(coarse._cells_p1().shape[0]), 0.7)
         out = coarse.transfer_cell_field(vals, fine)
         assert out.shape == (int(fine._cells_p1().shape[0]),)
@@ -466,8 +466,8 @@ class TestCrossMeshTransfer:
 
     def test_a_region_lands_in_the_right_place(self):
         """A bar transfers to a bar: the geometry, not just the values, must survive."""
-        coarse = jno.Shape.rect(0, 0, 60, 30, size=2.0).domain()
-        fine = jno.Shape.rect(0, 0, 60, 30, size=1.0).domain()
+        coarse = jno.shape.rect(0, 0, 60, 30, size=2.0).domain()
+        fine = jno.shape.rect(0, 0, 60, 30, size=1.0).domain()
         c_cen = np.asarray(coarse.mesh.points)[:, :2][coarse._cells_p1()].mean(axis=1)
         bar = np.where(np.abs(c_cen[:, 1] - 15.0) < 6.0, 1.0, 0.0)
 
@@ -484,8 +484,8 @@ class TestCrossMeshTransfer:
         """The source domain still holds the positions it was BUILT with, so a mesh moved by
         `.trainable()` has to pass its deformed coordinates explicitly — otherwise the transfer
         reads the design off the wrong geometry and silently reports the wrong answer."""
-        coarse = jno.Shape.rect(0, 0, 60, 30, size=3.0).domain()
-        fine = jno.Shape.rect(0, 0, 60, 30, size=1.5).domain()
+        coarse = jno.shape.rect(0, 0, 60, 30, size=3.0).domain()
+        fine = jno.shape.rect(0, 0, 60, 30, size=1.5).domain()
         pts = np.asarray(coarse.mesh.points)[:, :2]
         cells = coarse._cells_p1()
         bar = np.where(np.abs(pts[cells].mean(axis=1)[:, 1] - 15.0) < 4.0, 1.0, 0.0)
@@ -502,8 +502,8 @@ class TestCrossMeshTransfer:
         assert moved.sum() == pytest.approx(same.sum(), rel=0.25)
 
     def test_a_mis_sized_field_is_refused(self):
-        coarse = jno.Shape.rect(0, 0, 60, 30, size=4.0).domain()
-        fine = jno.Shape.rect(0, 0, 60, 30, size=2.0).domain()
+        coarse = jno.shape.rect(0, 0, 60, 30, size=4.0).domain()
+        fine = jno.shape.rect(0, 0, 60, 30, size=2.0).domain()
         with pytest.raises(ValueError, match="entries but this mesh has"):
             coarse.transfer_cell_field(np.ones(3), fine)
 
@@ -525,7 +525,7 @@ class TestFacetTractionTotal:
     @staticmethod
     def _resultant(size, pad, span=2.0, L=60.0, H=30.0):
         tol = 1e-6 * L
-        d = jno.Shape.rect(0, 0, L, H, size=size).domain()
+        d = jno.shape.rect(0, 0, L, H, size=size).domain()
         u, phi = d.fem_symbols(value_shape=(2,))
         _r, s = d.fem_symbols(space="P0", names=("r", "s"))
         xi, yi, _ = d.variable("interior", split=True)

--- a/tests/test_trace_unary_plus.py
+++ b/tests/test_trace_unary_plus.py
@@ -19,7 +19,7 @@ import jno.jnp_ops as J
 
 def _views():
     """One live instance of every trace class that defines ``__neg__``, so the two stay in step."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     u, v = d.fem_symbols()
     xi, yi, _ = d.variable("interior", split=True)
     vec, _ = d.fem_symbols(value_shape=(2,), names=("w", "q"))
@@ -45,7 +45,7 @@ def test_unary_plus_matches_no_operator_numerically():
     """The whole point: a term written with ``+`` must solve identically to the same term without it."""
 
     def build(sign):
-        d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+        d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
         u, phi = d.fem_symbols()
         xi, yi, _ = d.variable("interior", split=True)
         xb, yb, _ = d.variable("boundary", split=True)
@@ -63,7 +63,7 @@ def test_unary_plus_matches_no_operator_numerically():
 
 def test_signed_source_list_builds():
     """The spelling that motivated this: a stoichiometric source list mixing both signs."""
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.1, 3))
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.3).domain(time=(0.0, 0.1, 3))
     a, pa = d.fem_symbols(names=("a", "pa"))
     b, pb = d.fem_symbols(names=("b", "pb"))
     xi, yi, ti = d.variable("interior", split=True)

--- a/tests/test_tune_sequence.py
+++ b/tests/test_tune_sequence.py
@@ -27,7 +27,7 @@ def _x64():
 
 
 def _poisson():
-    d = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
+    d = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.25).domain()
     u, v = d.fem_symbols()
     xi, yi = d.variable("interior", split=True)[:2]
     xb, yb = d.variable("boundary", split=True)[:2]
@@ -88,7 +88,7 @@ def test_the_walls_fail_loud():
         crux.sweep(space_mixed)
 
     # a core with no FEM behind its constraints has nothing to march
-    d2 = jno.Shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
+    d2 = jno.shape.rect(0.0, 0.0, 1.0, 1.0, size=0.4).domain()
     x = d2.variable("interior", split=True)[0]
     crux_nofem = jno.core([(x * 0.0).mae], domain=d2)
     space3 = jnn.tune.space()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1224,7 +1224,7 @@ class TestCruxEvalAcceptsViews:
         import foundax
 
         net = jno.nn.wrap(foundax.mlp(in_features=2, hidden_dims=4, num_layers=2, key=jax.random.PRNGKey(0)))
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.5).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.5).domain()
         x, y, _ = dom.variable("interior")
         u = net(x, y)
         crux = jno.core([u.mse])
@@ -1415,7 +1415,7 @@ def lshape():
 @pytest.fixture(scope="module")
 def cube3d():
     """3-D unit cube on a tetrahedral mesh — built once."""
-    dom = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain(compute_mesh_connectivity=True)
+    dom = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.25).domain(compute_mesh_connectivity=True)
     v = dom.variable("interior")
     x, y, z = v[0], v[1], v[2]
     pts = np.asarray(dom.mesh_connectivity["points"])

--- a/tests/test_vpinn_integration.py
+++ b/tests/test_vpinn_integration.py
@@ -32,7 +32,7 @@ def _same_to_precision(_a, b, *, slack=32.0):
 
 def make_domain(mesh_size=0.35):
     """Create a small rectangular domain for fast VPINN tests."""
-    return jno.Shape.rect(0, 0, 1, 1, size=mesh_size).domain()
+    return jno.shape.rect(0, 0, 1, 1, size=mesh_size).domain()
 
 
 def init_vpinn_fem(dom, with_neumann_tags=True):
@@ -442,7 +442,7 @@ class TestVpinnScopeRefusals:
         The mesh must be fine enough to have INTERIOR nodes: the Dirichlet declaration masks every
         boundary test function, so a cube coarse enough that all its nodes lie on the surface gives an
         identically-zero residual -- correct, and useless to assert on."""
-        dom = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+        dom = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
         u, phi = dom.fem_symbols()
         si = dom.variable("interior", split=True)
         xi, yi, zi = si[0], si[1], si[2]
@@ -658,7 +658,7 @@ class TestVpinnCoupledAsVector:
     def test_the_coupled_system_is_expressible_and_correct_as_a_vector_field(self):
         """Oracle: solve the SAME form with an FEM trial. If FEM recovers (s, 2s), the vector
         rewrite of the coupled system is right -- which is what the refusal message asserts."""
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.12).domain()
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.12).domain()
         u, phi = dom.fem_symbols(value_shape=(2,))
         xi, yi, _ = dom.variable("interior", split=True)
         xb, yb, _ = dom.variable("boundary", split=True)
@@ -808,7 +808,7 @@ class TestVpinnTransientRefusal:
 
     @staticmethod
     def _heat(with_ic, ic_value=0.0, nsteps=5):
-        dom = jno.Shape.rect(0, 0, 1, 1, size=0.25).domain(time=(0.0, 0.1, nsteps))
+        dom = jno.shape.rect(0, 0, 1, 1, size=0.25).domain(time=(0.0, 0.1, nsteps))
         u, phi = dom.fem_symbols()
         si = dom.variable("interior", split=True)
         xi, yi, ti = si[0], si[1], si[2]
@@ -861,7 +861,7 @@ class TestVpinn3D:
 
     @staticmethod
     def _cube(vec=False):
-        dom = jno.Shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
+        dom = jno.shape.box(0, 0, 0, 1, 1, 1, size=0.4).domain()
         u, phi = dom.fem_symbols(value_shape=(3,) if vec else ())
         si = dom.variable("interior", split=True)
         xi, yi, zi = si[0], si[1], si[2]

--- a/tests/test_workflow_correctness.py
+++ b/tests/test_workflow_correctness.py
@@ -370,7 +370,7 @@ class TestDivergenceCorrectness:
 
     @pytest.fixture(scope="class")
     def dom2d(self):
-        return jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+        return jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
 
     def test_divergence_of_identity_field_is_two(self, dom2d):
         x, y, _ = dom2d.variable("interior")
@@ -408,7 +408,7 @@ class TestCurlCorrectness:
 
     @pytest.fixture(scope="class")
     def dom2d(self):
-        return jno.Shape.rect(0, 0, 1, 1, size=0.1).domain()
+        return jno.shape.rect(0, 0, 1, 1, size=0.1).domain()
 
     def test_curl_2d_of_rotation_field_is_constant_two(self, dom2d):
         """curl_2d(-y, x) = ∂x/∂x - ∂(-y)/∂y = 1 - (-1) = 2."""


### PR DESCRIPTION
`jno.Shape` was the only capitalised name in the public API — `jno.domain`, `jno.core`, `jno.fem`, `jno.fdm` are all lowercase. This renames the class and keeps `Shape` as an alias, so the 29 tutorials and any downstream script keep working.

1510 occurrences across 285 files. `jno.Shape`, `jno.geometry.Shape` and `jno.geometry.shape.Shape` all still resolve.

## What a find-and-replace gets wrong

Three real breakages, none of which lint alone catches:

* **`from . import shape` silently changes meaning.** It used to return the submodule, because the class was `Shape`; the package namespace now binds that name to the class. `jno/geometry/path.py` asked the class for `_LEAF_KEYS`, so `Path.face()` and `Path.curve()` both raised `AttributeError`. It imports what it wants by name instead.
* **`shape = shape.rect(...)` and `for shape in shapes:`** make `shape` local to the whole function, so the class reference on the right-hand side raises `UnboundLocalError`. Ruff flags these as F823; the locals are renamed.
* **`isinstance(src, _shape)`** in `domain_class.py` had collapsed to `isinstance(shape, shape)` — the local variable and the class became one name, so a periodic re-mesh would raise `TypeError`.

## What keeps its capital S

29 occurrences, where the word is the ordinary noun or a verb and never the class: `Shape of the parameter tensor`, the `| Key | Shape |` tables in the explainability docs, `# Shape expansions: (N_i, N_j, M)`, and `"""Shape a mesh-field gradient back to the caller's convention."""`.

## Verification

`ruff format --check` and `ruff check` clean. Full per-file suite run on GPU against a clean `main` checkout at the same commit: **14 failed / 126 passed on both**, identical tests — every failure is pre-existing on `main` (GPU-only; CI is CPU and green). No regressions.