### PR TITLE
Drop the dead BC exports, and three other things nothing reaches

### DIFF
--- a/jno/__init__.py
+++ b/jno/__init__.py
@@ -78,7 +78,6 @@ from .utils.config import (
     wandb_finish,
 )
 from .utils.load_save import load, save
-from .utils.solver.fem_route import dirichlet, neumann
 
 # Mirror the submodule on the package namespace and add a short alias.
 numpy = np
@@ -193,8 +192,6 @@ __all__ = [
     "FemLinearSystem",
     "GroupedAssembly",
     "FemResidualOperator",
-    "dirichlet",
-    "neumann",
     "numpy",
     "nn",
     "np",

--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -1538,13 +1538,13 @@ class domain(MeshIOMixin):
         Returns
         -------
         object
-            Boundary-condition descriptor for use with ``init_fem(..., bcs=...)``.
+            Boundary-condition descriptor for use with ``init_fem_native(..., bcs=...)``.
         """
         try:
             from ..utils.solver.fem_route import dirichlet as _dirichlet_bc
         except ImportError as e:
             raise ImportError(
-                "FEM support is not available. Install the FEM/dev extras to use domain.dirichlet(...) and init_fem(...)."
+                "FEM support is not available. Install the FEM/dev extras to use domain.dirichlet(...) and init_fem_native(...)."
             ) from e
         return _dirichlet_bc(tags, values)
 
@@ -1560,13 +1560,13 @@ class domain(MeshIOMixin):
         Returns
         -------
         object
-            Boundary-condition descriptor for use with ``init_fem(..., bcs=...)``.
+            Boundary-condition descriptor for use with ``init_fem_native(..., bcs=...)``.
         """
         try:
             from ..utils.solver.fem_route import neumann as _neumann_bc
         except ImportError as e:
             raise ImportError(
-                "FEM support is not available. Install the FEM/dev extras to use domain.neumann(...) and init_fem(...)."
+                "FEM support is not available. Install the FEM/dev extras to use domain.neumann(...) and init_fem_native(...)."
             ) from e
         return _neumann_bc(tags)
 
@@ -1576,7 +1576,7 @@ class domain(MeshIOMixin):
 
         Example
         -------
-            domain.init_fem(
+            domain.init_fem_native(
                 bcs=[domain.periodic(("left", "right"), ("bottom", "top"))],
             )
         """
@@ -1584,7 +1584,7 @@ class domain(MeshIOMixin):
             from ..utils.solver.fem_route import periodic as _periodic_bc
         except ImportError as e:
             raise ImportError(
-                "FEM support is not available. Install the FEM/dev extras to use domain.periodic(...) and init_fem(...)."
+                "FEM support is not available. Install the FEM/dev extras to use domain.periodic(...) and init_fem_native(...)."
             ) from e
         return _periodic_bc(*pairs)
 

--- a/jno/domain/enclosure.py
+++ b/jno/domain/enclosure.py
@@ -360,7 +360,7 @@ def _chord_test_setup(geoms, union, r, z):
     return sdf, 2.0 * cell
 
 
-def _solid_polygon_visibility_3d(domain, elem_tag, P, length, phi, n_seg: int = 0, occluders=None):
+def _solid_polygon_visibility_3d(domain, elem_tag, P, length, phi, occluders=None):
     r"""Point-to-point visibility **per azimuth** for the true 3-D ray between axisymmetric rings.
 
     ``P`` is an ``(M, 2)`` array of ``(r, z)`` points -- pass the kernel's own quadrature points
@@ -394,8 +394,6 @@ def _solid_polygon_visibility_3d(domain, elem_tag, P, length, phi, n_seg: int = 
 
     Visibility is EVEN in ``phi`` (the chord depends on the azimuth only through ``cos phi`` and, in
     ``rho``, ``sin^2 phi``), so only the half-grid is computed and the rest mirrored.
-
-    ``n_seg`` is accepted and ignored; it is a vestige of the fixed-stride implementation.
 
     ``occluders`` is the OPAQUE-SOLID model the chords are traced against:
 
@@ -796,7 +794,6 @@ def _refine_near_pairs(
     n_gl_phi=6,
     k_azim=3.0,
     k_merid=3.0,
-    n_seg=256,
     chunk=96,
     log=None,
     occluders=None,

--- a/jno/trace_compiler.py
+++ b/jno/trace_compiler.py
@@ -46,7 +46,6 @@ from .trace import (
     Placeholder,
     TunableModule,
     TunableModuleCall,
-    Variable,
     collect_tags,
 )
 
@@ -409,64 +408,6 @@ class TraceCompiler:
 
         visit(expr)
         return layers
-
-    # ------------------------------------------------------------------
-    # Shape inference (legacy — kept for offline tools)
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _infer_arg_shapes(call_args: List, tensor_dims: Dict[str, tuple], existing_params: Dict) -> List[tuple]:
-        """Infer the *normalised* argument shapes for a ModelCall."""
-        TraceEvaluator = _get_evaluator_class()
-        abstract_ctx = {
-            tag: jax.ShapeDtypeStruct(tuple(shape), _default_float_dtype()) for tag, shape in tensor_dims.items()
-        }
-
-        def eval_and_normalize(context):
-            evaluator = TraceEvaluator(existing_params)
-            ctx = evaluator._EvalCtx(context, {}, jax.random.PRNGKey(0))
-
-            arg_values = []
-            arg_sources = []
-            for arg in call_args:
-                val = evaluator._dispatch(arg, ctx)
-                arg_values.append(val)
-                is_spatial = isinstance(arg, Variable) and arg.tag in context
-                arg_sources.append(is_spatial)
-
-            N = 1
-            for val, is_spatial in zip(arg_values, arg_sources):
-                if is_spatial:
-                    val = jnp.asarray(val)
-                    if val.ndim >= 1:
-                        N = max(N, val.shape[0])
-
-            def normalize_arg(val, is_spatial):
-                val = jnp.asarray(val)
-                if is_spatial:
-                    if val.ndim == 0:
-                        return jnp.full((N, 1), val)
-                    elif val.ndim == 1:
-                        return val[:, jnp.newaxis]
-                    else:
-                        return val
-                else:
-                    if val.ndim == 0:
-                        return val[jnp.newaxis]
-                    else:
-                        return val
-
-            normalized = tuple(normalize_arg(v, s) for v, s in zip(arg_values, arg_sources))
-
-            # Keep shape inference consistent with TraceEvaluator._eval_flax_module_call.
-            _model = None
-            # In this function you only have call_args, not the model object.
-            # So either pass model into _infer_arg_shapes later, or leave this alone
-            # if this function is no longer used for Equinox-foundax initialization.
-            return normalized
-
-        abstract_results = jax.eval_shape(eval_and_normalize, abstract_ctx)
-        return [r.shape for r in abstract_results]
 
     # ------------------------------------------------------------------
     # Weight utilities


### PR DESCRIPTION
Four removals, each verified unreachable before deleting. −72 lines.

## `jno.dirichlet` / `jno.neumann`

Exported from the package root and called from nowhere — not by a test, not by a tutorial, not by the library itself. The boundary-conditions page already tells the reader they do not exist:

> There is no separate `jno.dirichlet(...)`/`neumann(...)` call — every condition is just a term

so the export contradicted the documentation it shipped with. **`domain.dirichlet(...)` is untouched** — that is the spelling the docs teach, and it still works.

This is the one breaking change here: anyone calling `jno.dirichlet(...)` would need `domain.dirichlet(...)`. Nothing in this repository does.

## `TraceCompiler._infer_arg_shapes`

54 lines under a "legacy — kept for offline tools" banner. The only thing referencing it is a comment about it (`# So either pass model into _infer_arg_shapes later, or leave this alone`). Its `Variable` import went unused with it.

## `n_seg`

A parameter on `_solid_polygon_visibility_3d` and `_refine_near_pairs` whose own docstring said "accepted and ignored; it is a vestige of the fixed-stride implementation". No caller passes it; `occluders` is always passed by keyword, so dropping it shifts nothing.

## `init_fem(...)` in six docstrings

There is no `init_fem` — the method is `init_fem_native`. The docstrings pointed users at a name that does not exist.

## Verification

`ruff format --check` and `ruff check` clean. Full per-file suite on GPU matches the `main` baseline exactly: the same 10 pre-existing GPU-only failures, no new ones. Two files that failed during the run (`test_explainability.py`, `test_fem_eigs_nonsymmetric.py`) pass in isolation on both this branch and clean `main` — that was GPU contention from a concurrent baseline run, not this change.