### PR TITLE
A curved interface reaches its mortar coupling again, and the follower traction is read off the right rows

### DIFF
--- a/jno/utils/solver/fem_utils.py
+++ b/jno/utils/solver/fem_utils.py
@@ -2764,7 +2764,7 @@ def _covers_local_3d(s_facets: np.ndarray, m_facets: np.ndarray, pts3: np.ndarra
     surfaces pass however they curve; two genuinely mismatched ones still fail, which is what keeps a
     ragged interface on the collocated path.
     """
-    from .contact_search import facet_geometry, project_points
+    from .contact_search import project_points
 
     P = np.asarray(pts3, dtype=float)
     sf = np.asarray(s_facets, dtype=int)
@@ -2774,8 +2774,16 @@ def _covers_local_3d(s_facets: np.ndarray, m_facets: np.ndarray, pts3: np.ndarra
     q = P[np.unique(sf[:, :3])]
     ids, w, _g0, _a = project_points(q, mf, P, np.tile(np.eye(1, P.shape[1], 0), (len(q), 1)))
     proj = np.einsum("qk,qkd->qd", w, P[ids])
-    _V, _c, rad = facet_geometry(mf, P)
-    return bool(np.linalg.norm(proj - q, axis=1).max() <= 0.25 * float(np.median(rad)))
+    # Judge each vertex against the facet it actually landed on, not against the median facet of the
+    # mesh. A chord's distance from the surface it approximates grows with THAT chord, and gmsh
+    # grades a curved surface: here a sphere meshed at 0.4 has a median facet radius of 0.23 and a
+    # largest of 0.54. Two vertices sitting over those big facets were 0.11 away -- 0.22 of their own
+    # facet, comfortably inside the fraction below -- and the median-based bound rejected the whole
+    # interface for it, sending a perfectly coincident pair to collocation.
+    nv = 2 if P.shape[1] == 2 else 3
+    Vq = P[np.asarray(ids, dtype=int)[:, :nv]]
+    local_rad = np.linalg.norm(Vq - Vq.mean(axis=1)[:, None, :], axis=2).max(axis=1)
+    return bool(np.all(np.linalg.norm(proj - q, axis=1) <= 0.25 * local_rad))
 
 
 def _main_covers_secondary_3d(s_facets: np.ndarray, m_facets: np.ndarray, loc: np.ndarray) -> bool:

--- a/tests/test_fem_follower_normals.py
+++ b/tests/test_fem_follower_normals.py
@@ -92,8 +92,15 @@ def test_a_following_normal_rotates_the_traction_by_exactly_the_body_rotation(de
         return np.asarray(op.residual(uu, None)).reshape(-1)
 
     r0 = res(fem_none, u)
-    t_ref = (res(fem_ref, u) - r0).reshape(-1, 2).sum(axis=0)
-    t_fol = (res(fem_fol, u) - r0).reshape(-1, 2).sum(axis=0)
+    # Sum the FREE rows only. A clamped row holds no force -- it holds the constraint equation, and
+    # the scale that equation is written at is a convention: the assembled path pins at the local
+    # diagonal magnitude (so the operator stays uniformly scaled for the iterative solvers), the
+    # residual path at one. The two do not cancel in a difference taken across both paths, and what
+    # survives swamps the traction being measured -- it read 175.78deg for a 10deg rotation. The
+    # traction lives on the free DOFs; read it there.
+    free = ~(np.asarray(d0.mesh.points)[:, 1] < 1e-9)
+    t_ref = (res(fem_ref, u) - r0).reshape(-1, 2)[free].sum(axis=0)
+    t_fol = (res(fem_fol, u) - r0).reshape(-1, 2)[free].sum(axis=0)
     assert isinstance(fem_fol._op, tuple) is False, (
         "a following normal depends on the unknown, so the form must route to the residual path -- "
         "assembled-linear would build A and b at u=0, where the two normals coincide"

--- a/tests/test_fem_mortar_curved_3d.py
+++ b/tests/test_fem_mortar_curved_3d.py
@@ -147,13 +147,17 @@ def test_a_curved_interface_reaches_the_integrated_coupling():
 def test_the_patch_error_is_the_faceting_and_nothing_more(h_in, h_out):
     """The residual is the two triangulations disagreeing about where the sphere is, not the coupling.
 
-    Its scale is the sagitta of a chord of length `h` on radius 1, `h^2/8`. Measured, the ratio sits at
-    0.52-0.54 across a 3x range of `h` and the error falls at second order (rates 2.07 and 1.97) --
-    a constant ratio over that range is what says the two are the same quantity. An inconsistent
-    coupling would stall at a fixed error instead of tracking it down.
+    Its scale is the sagitta of a chord of length `h` on radius 1, `h^2/8`. Measured, the error stays
+    UNDER that sagitta across a 3x range of `h` (ratios 0.91, 0.62, 0.65) and falls at second order
+    (rates 2.56 and 1.86) -- tracking `h^2` is what says the two are the same quantity. An
+    inconsistent coupling would stall at a fixed error instead of following it down.
+
+    The ratios were re-measured once the shell stopped being meshed at the ball's size: the earlier
+    0.52-0.54 came from a mesh where both sides were ~0.4 regardless of what the shell asked for, so
+    the two triangulations were far more alike than the test meant them to be.
     """
     coupling, err = _patch(_spheres(h_in, h_out))
     if coupling == "conforming":
         pytest.skip("gmsh produced matching surfaces here; there is no mortar to measure")
     assert coupling == "mortar", f"got {coupling!r}"
-    assert err < 0.8 * h_in**2 / 8.0, f"error {err:.3e} exceeds the faceting scale {h_in**2 / 8:.3e}"
+    assert err < h_in**2 / 8.0, f"error {err:.3e} exceeds the faceting scale {h_in**2 / 8:.3e}"


### PR DESCRIPTION
The five nightly failures left after the mmg/slide guards. One is a real bug in the tie; the other is a test reading a convention.

## The tie: a curved interface fell back to collocation

`test_a_curved_interface_reaches_the_integrated_coupling` is written to pin exactly this ("It used to report `collocated` on this exact geometry, with a patch error of 9.8e-01"), and the regression returned as soon as the mesher started honouring per-region sizes.

`_covers_local_3d` asks whether every secondary vertex sits on the main surface, and compared each distance against `0.25 ×` the **median** facet radius of the whole surface. A chord's distance from the surface it approximates grows with *that* chord, and gmsh grades a curved one: this sphere has a median facet radius of 0.23 and a largest of 0.54. Two vertices of 199 sat over those big facets, 0.11 away — **0.22 of their own facet**, inside the fraction — and the median-based bound rejected the whole interface for it, sending a perfectly coincident pair to a coupling that ties but does not pass the patch test.

Measured against the facet each vertex actually lands on, which is what the docstring already described: *"nearer than a fraction of a facet radius"*, singular.

### Why now

The mesh changed, correctly. The test asks for `ball` at 0.40 and `shell` at 0.29; on a unit sphere those are 198 and 394 interface facets, which is what the current mesher produces. Before, the shell came out at 212 — essentially the ball's size, ignoring the 0.29 it asked for. The coverage flaw was latent the whole time; honouring the requested sizes is what exposed it.

That also means the patch-error bound was calibrated against a mesh whose two sides were far more alike than the test intended, so it is re-measured here:

| `h_in` | error | sagitta `h²/8` | ratio |
|---|---|---|---|
| 0.40 | 1.81e-02 | 2.00e-02 | 0.91 |
| 0.20 | 3.08e-03 | 5.00e-03 | 0.62 |
| 0.14 | 1.59e-03 | 2.45e-03 | 0.65 |

Convergence rates 2.56 and 1.86 — still second order, which is the claim the test exists to make. The bound is now "under the sagitta" rather than an `0.8` constant fitted to the old mesh, and the docstring's recorded numbers are updated to match.

## The follower traction: nothing was wrong with it

The test isolates the traction by differencing two residuals, and summed **every** row including the clamped bottom. A clamped row holds no force — it holds the constraint equation, and the scale it is written at is a convention. The assembled path pins at the local diagonal magnitude (deliberately: it keeps the operator uniformly scaled for the H(curl) iterative stack), the residual path pins at one. This test compares a linear form against a nonlinear one, so it read one convention against the other, and the difference did not cancel: a 10° body rotation measured as **175.78°**.

Summed over the free DOFs, where the traction lives, it rotates by **10.00°** for 10°. `fem_1d.py`'s own docstring predicted this failure mode: *"Read the imposed value off the SOLUTION, never off the load vector."*

## Verification

`ruff format --check` and `ruff check` clean. Full per-file suite on GPU: the four affected files (`follower_normals`, `mortar_curved_3d`, `adapt_complex`, `contact_slide`) all pass. The 6 files still failing are byte-identical to `main` — **6 failed / 85 passed on both**, same tests — and are a separate pre-existing set that does not reproduce on CPU.