### PR TITLE
Geometry sampling draws from a reproducible stream

### DIFF
--- a/jno/domain/domain_class.py
+++ b/jno/domain/domain_class.py
@@ -1173,7 +1173,7 @@ class domain(MeshIOMixin):
                 name,
                 self._tag_predicates.get(base),
                 max(10 * n_now, 1000),
-                _np.random.default_rng(),
+                self._geometry_sample_rng(),
                 kind == "boundary",
             )
 
@@ -2738,13 +2738,30 @@ class domain(MeshIOMixin):
             f"names appears to be empty on this geometry."
         )
 
+    def _geometry_sample_rng(self):
+        """The generator geometry sampling draws from: reproducible per domain, and advancing.
+
+        Seeded once and then carried, so a run repeats exactly while successive draws on the same
+        domain still differ -- the resampling strategies rely on the second property and every test
+        that measures a sampled distribution relies on the first. This was `default_rng()`, i.e. OS
+        entropy, and nothing a caller could do made it repeat: `test_burgers_rad_...` drew a
+        different working set every run, its starting mean |x| wandered between 0.47 and 0.53 here
+        and 0.446 on CI, and the drop it asserts rode that spread from 0.25 down to 0.08 -- through
+        a threshold of 0.10. The reference clouds below were already pinned for the same reason.
+        """
+        rng = getattr(self, "_sample_rng", None)
+        if rng is None:
+            rng = np.random.default_rng(0)
+            self._sample_rng = rng
+        return rng
+
     def _sample_geometry_tag(self, tag, source_tag, n_samples, normals, batch_count, apply_time_value):
         """Fill ``context[tag]`` from the geometry, in the ``(B, T, N, D)`` layout ``sample`` uses."""
         kind, name = self._geometry_tags[source_tag]
         predicate = self._tag_predicates.get(source_tag)
         if name is not None or kind == "boundary":
             kind = "boundary"
-        rng = np.random.default_rng()
+        rng = self._geometry_sample_rng()
         want_normals = bool(normals) and kind == "boundary"
         if normals and kind != "boundary":
             raise ValueError(f"normals are only available on a boundary tag, and '{source_tag}' is interior.")


### PR DESCRIPTION
The Sep 9 nightly failed on `test_burgers_rad_resampling_concentrates_near_steep_gradient`. The same commit then passed the Sep 10 and Sep 11 nightlies with no code change — which is the whole problem: the test was a coin flip.

## Why it flips

`_sample_geometry_tag` drew its working set from `np.random.default_rng()` — OS entropy, with no way for any caller to make it repeat. Every shape-backed domain therefore sampled different points on every run.

The mesh is not the variable here; it is deterministic (421 points, byte-identical across runs). The 60-point working set drawn from it was not. The test starts from that draw and asserts RAD pulls the points toward the shock, mean `|x|` dropping by ≥0.10:

| | initial mean \|x\| | drop |
|---|---|---|
| local run 1 | 0.4847 | 0.165 |
| local run 2 | 0.5186 | 0.211 |
| local run 3 | 0.5329 | 0.248 |
| CI (Sep 9) | 0.4459 | **0.081** ← below the 0.10 threshold |

The assertion was sound; the ground it stood on moved.

## The change

Seeded once per domain and carried, so a run repeats exactly while successive draws on the same domain still differ — the resampling strategies depend on the second property, and any test measuring a sampled distribution depends on the first.

This is the convention the same file already uses for its reference clouds: `default_rng(0)  # fixed: a reference cloud must not wobble between reads`. Geometry sampling was the one path that had never been pinned.

## After

Bit-identical across runs: drop **0.1654** on CPU (three runs, same to four decimals) and **0.1691** on GPU, against the 0.10 threshold. A 65% margin instead of a lottery.

## Verification

`ruff format --check` and `ruff check` clean. Full per-file suite on GPU: no regressions — the failing set is the same pre-existing one as `main`, and `test_fem_assembly_on_host.py` appearing in that list is a resource-pressure flake (passes in isolation on this branch twice and on clean `main`).