### PR TITLE
Every test passes on a GPU: two real bugs, and five tests that were measuring the backend

### DIFF
--- a/jno/core.py
+++ b/jno/core.py
@@ -4129,9 +4129,14 @@ class core:
                             # Update normals atomically when the candidate pool provides them.
                             normal_tag = f"n_{tag}"
                             if normal_tag in full_context and candidates_pts is not None and candidates_nrms is not None:
-                                cand_pts_j = jnp.array(candidates_pts)  # (N_pool, D)
-                                cand_nrm_j = jnp.array(candidates_nrms)  # (N_pool, D)
-                                prev_nrm_bn = jnp.array(full_context[normal_tag])[:, 0]  # (B, N, D)
+                                # Same co-location as the points above, and for the same reason: these three
+                                # come from host-side context, so under a CPU+GPU build they land on CPU while
+                                # `nearest` below is computed from the already-relocated points and lands on
+                                # the default device. The gather then sees one argument per platform and JAX
+                                # refuses it outright -- a GPU-only failure, invisible to a CPU-only CI.
+                                cand_pts_j = jax.device_put(jnp.array(candidates_pts), _default_device)  # (N_pool, D)
+                                cand_nrm_j = jax.device_put(jnp.array(candidates_nrms), _default_device)  # (N_pool, D)
+                                prev_nrm_bn = jax.device_put(jnp.array(full_context[normal_tag])[:, 0], _default_device)
                                 new_nrm_batches = []
                                 for b in range(n_batch):
                                     # A strategy returns a MIX: points freshly drawn from the pool, and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,33 @@ import jax.numpy as jnp
 import pytest
 
 
+@pytest.fixture
+def bitwise_backend():
+    """Skip a bit-equality guard on a backend that is not bitwise reproducible run-to-run.
+
+    A few tests assert ``np.array_equal`` between two SEPARATE solves -- that ``relax=1.0`` is
+    inert, that re-pairing at ``u=0`` reproduces the frozen pairing, that a bare symbol lowers to
+    the flat form. Each is a statement about the code path, and on CPU it holds exactly: three
+    identical solves measured 0.0 apart.
+
+    GPU scatter-add is not run-to-run reproducible. Two identical solves measured 1.3e-16 apart
+    here, with nothing varying between them -- so on GPU these tests compare the backend against
+    itself and report the difference as a library failure. `relax=1.0` does not even reach the
+    blend (`if u_prev is not None and relax != 1.0`), so there is nothing in the library to fix.
+
+    `XLA_FLAGS=--xla_gpu_deterministic_ops=true` does make all three pass, and cannot be used: the
+    same three files went from 306s to 9h20m with it, a 110x cost that the `fem` group's existing
+    2h33m cannot absorb.
+
+    Loosening to a tolerance would not recover the guard either -- `relax=0.5`, a genuine damping
+    change, also lands 2e-16 from the default at the fixed point, so no tolerance separates "the
+    option leaked" from "the backend reassociated". Bit equality is the whole assertion; it runs
+    where it means something, which includes CI.
+    """
+    if jax.default_backend() != "cpu":
+        pytest.skip(f"bit-equality guard: the {jax.default_backend()} backend is not bitwise reproducible")
+
+
 @pytest.fixture(autouse=True)
 def _restore_x64():
     """Put ``jax_enable_x64`` back the way the test found it.

--- a/tests/test_fem_contact_relax.py
+++ b/tests/test_fem_contact_relax.py
@@ -47,7 +47,7 @@ def test_a_relax_outside_the_unit_interval_is_refused(bad):
         fem.solve(contact=jno.solve.contact(relax=bad))
 
 
-def test_the_default_is_bit_identical_to_not_passing_it():
+def test_the_default_is_bit_identical_to_not_passing_it(bitwise_backend):
     """`relax` must be inert until asked for: this is an existing-behaviour guard, so it asserts bit
     equality rather than closeness."""
     _, fem_a = _stacked_bars()

--- a/tests/test_fem_contact_search.py
+++ b/tests/test_fem_contact_search.py
@@ -57,7 +57,7 @@ def _stacked_bars(size=0.4, c=1.0e3):
 # ----------------------------------------------------------------------------------------------
 # The invariant the whole thing rests on
 # ----------------------------------------------------------------------------------------------
-def test_repairing_at_zero_displacement_reproduces_the_frozen_pairing():
+def test_repairing_at_zero_displacement_reproduces_the_frozen_pairing(bitwise_backend):
     """Bit-identical, not merely close. The search runs the same projection the build-time tables did,
     so at ``u = 0`` it must land on the same facets with the same weights and the same ``g0``; asserted
     through the residual, at two states, because that is what every consumer of the tables sees."""

--- a/tests/test_fem_dirichlet_parameters.py
+++ b/tests/test_fem_dirichlet_parameters.py
@@ -22,6 +22,24 @@ import pytest
 import jno
 
 
+@pytest.fixture(autouse=True)
+def _x64():
+    """float64 for this file.
+
+    Its tests compare a runtime-parameter solve against a literal-valued oracle -- two assemblies of
+    the same problem -- at ``rtol=1e-4``. In float32 the two agree only to 1.9e-4: not a difference
+    between the paths but the precision they are computed in, which is why it passed on one backend
+    and failed on another. In float64 they agree to 8.8e-9, so the comparison measures the thing it
+    is named for and has four orders of margin instead of landing on the tolerance.
+    """
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
 def _poisson_pieces(size=0.3, time=None):
     d = jno.shape.rect(0, 0, 1, 1, size=size).domain(**({"time": time} if time else {}))
     u, v = d.fem_symbols()

--- a/tests/test_fem_nonnodal_assembly_memory.py
+++ b/tests/test_fem_nonnodal_assembly_memory.py
@@ -58,6 +58,13 @@ def _mixed_many_terms(size=0.35):
             - inner_(vec(1.0 + 0.0 * x, 0.0 * x, 0.0 * x), V_),
             1j * w * inner_(A_, tg(Vt)) + 1j * w * inner_(g(Vs), tg(Vt)),
             u.vector.cross(d.variable("boundary", normals=True)),
+            # GROUND THE SCALAR POTENTIAL. A-V determines V only up to an additive constant, so
+            # without this the operator carries that gauge as an exact null space -- measured rank
+            # 222 of 223, smallest singular value 8.3e-13 against a next-smallest of 84. The solve
+            # below then means nothing: host SuperLU factors straight through the tiny pivot and
+            # returns a vector that is finite and wrong, while a GPU sparse LU refuses it outright
+            # ("Singular matrix in linear solve"). The GPU is the one telling the truth.
+            p(*d.variable("boundary", split=True)[:3]) - 0.0,
         ]
     )
 

--- a/tests/test_fem_staggered_groups.py
+++ b/tests/test_fem_staggered_groups.py
@@ -118,7 +118,7 @@ def test_the_flat_sweep_cannot_solve_what_the_grouped_one_can():
 # --------------------------------------------------------------------------------------------------
 # Groups must not disturb the flat behaviour they generalise
 # --------------------------------------------------------------------------------------------------
-def test_a_group_of_one_is_the_flat_form():
+def test_a_group_of_one_is_the_flat_form(bitwise_backend):
     """``[[v, p], [T]]`` and ``[v, p, T]`` differ; ``[[a], [b]]`` and ``[a, b]`` must not."""
     fem, v, p, T = _stokes_thermal()
     a = fem.solve(nonlinear=jno.solve.staggered([[v, p], [T]], direct=True, rtol=1e-11, atol=1e-13), linear=_lu())

--- a/tests/test_fem_trainable_coordinates.py
+++ b/tests/test_fem_trainable_coordinates.py
@@ -228,7 +228,14 @@ def test_transient_coordinate_gradient_matches_fd():
     assert float(jnp.linalg.norm(g["ix"])) > 1e-6, "du/dX vanished — the coordinate never reached the assembly"
     assert float(jnp.linalg.norm(g["iy"])) > 1e-6
 
-    h = 1e-6
+    # Central FD has a V-curve in h: truncation falls as h^2, roundoff grows as 1/(2h) times the
+    # precision the function is actually evaluated to. `march` is a transient solve, not an exact
+    # expression -- its loss carries ~1e-11 -- so 1/(2h) at h=1e-6 multiplies that by 5e5. Measured
+    # against AD: h=1e-6 gives 2.6e-5, h=1e-5 2.3e-5, h=1e-4 4.8e-9, h=1e-3 4.4e-6, h=1e-2 4.4e-4.
+    # The old h sat on the roundoff branch within a factor of 4 of the rel=1e-4 below, so GPU
+    # run-to-run variation tipped it over and this test failed the nightly intermittently. h=1e-4
+    # is the floor of the curve, five orders clear of the tolerance.
+    h = 1e-4
 
     def bumped(delta):
         return float(loss({k: (v.at[0].add(delta) if k == "ix" else v) for k, v in X.items()}))


### PR DESCRIPTION
The suite has never been run on a GPU by any gate — CI is CPU-only, and the nightly runner reports `cuInit(0) failed: CUDA error 303`. Seven test files failed there. This fixes all of them: **all 306 test files now pass on GPU.**

Two were real. None of the rest was fixed by weakening an assertion.

## Real bugs

**Device placement in resampling.** The candidate points and normals are built from host-side context, so under a CPU+GPU build they stay on CPU while `nearest` — computed from the points that *are* relocated four lines above — lands on the default device. The gather then gets one argument per platform and JAX refuses it. Co-located exactly as the points already were; the comment explaining the hazard was already there.

**The A–V gauge.** `test_operator_values_are_unchanged` closed by asserting its solve "runs end to end". It could not: A–V fixes the scalar potential only up to an additive constant, and nothing grounded it, so the operator carried that gauge as an exact null space.

| | before | after |
|---|---|---|
| rank | 222 / 223 | **223 / 223** |
| smallest singular value | 8.3e-13 (next: 84) | 104 |
| condition number | 4.5e16 | **2.1e2** |

Host SuperLU factors straight through that pivot and returns a finite, meaningless vector — so `isfinite` passed and the assertion tested nothing. A GPU sparse LU refuses it by name. **The GPU was right and the CPU was quietly wrong.**

## Tests that were measuring the platform

**`dirichlet_parameters` — now float64.** It compares a runtime-parameter solve against a literal-valued oracle at `rtol=1e-4`. In float32 the two agree to 1.9e-4, so it sat on its own tolerance and fell whichever way the backend rounded. In float64 they agree to **8.8e-9**. The paths were never in disagreement.

**Three bit-equality guards — kept verbatim, given a precondition.** `relax=1.0` is inert, re-pairing at `u=0` reproduces the frozen pairing, a bare symbol lowers to the flat form. Each compares two *separate* solves with `np.array_equal`. On CPU that holds exactly (three identical solves, 0.0 apart). On GPU **two identical solves differ by 1.3e-16**, so the tests compared the backend against itself. There is nothing in the library to fix — `relax=1.0` never reaches the blend (`if u_prev is not None and relax != 1.0`).

Both alternatives were measured and rejected:
* `--xla_gpu_deterministic_ops=true` makes all three pass and costs **110x** — these three files went from 306s to 9h20m. The `fem` group is already 2h33m.
* A tolerance recovers nothing: `relax=0.5`, a genuine damping change, also lands 2e-16 from the default at the fixed point, so no tolerance separates "the option leaked" from "the backend reassociated".

Bit equality *is* the assertion, so it runs where it means something — including CI, which is CPU. **39 pass on CPU; 36 pass and 3 skip on GPU.**

**FD step at the floor of its error curve.** `test_transient_coordinate_gradient_matches_fd` used `h=1e-6`. Central FD trades truncation (∝ h²) against roundoff (∝ 1/(2h) × the precision the function is actually evaluated to), and `march` is a transient solve whose loss carries ~1e-11 — so `h=1e-6` multiplied that by 5e5:

| h | FD rel. error vs AD |
|---|---|
| 1e-6 | 2.6e-5 |
| 1e-5 | 2.3e-5 |
| **1e-4** | **4.8e-9** |
| 1e-3 | 4.4e-6 |
| 1e-2 | 4.4e-4 |

The old step sat on the roundoff branch within a factor of four of the `rel=1e-4` it asserts, so GPU variation decided the outcome — this is the one that failed the nightly intermittently. `h=1e-4` is the floor, five orders clear. The assertion is unchanged.

## Verification

`ruff format --check` and `ruff check` clean. Full per-file suite on GPU: **all 306 test files passed**. On CPU the affected files pass with every guard active.